### PR TITLE
Use hex-encoded key method as defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,24 @@ Utility library for p2panda applications.
 Use this in a Webpack 5 setup by enabling the [experimental `syncWebAssembly`
 option](https://webpack.js.org/configuration/experiments/).
 
-Create a key pair:
+### Create Ed25519 key pair
 
-```
+```js
 import('sesamoid').then(({ KeyPair }) => {
+  // Generates a new Ed25519 key pair using Crypto.getRandomBytes as a
+  // pseudorandom number generator:
   const keyPair = new KeyPair();
-  const public = keypair.publicKeyBytes(); // UInt8Array
-  const private = keypair.privateKeyBytes();
+
+  // Returns public and private keys as hex-encoded strings:
+  const publicKey = keypair.publicKey();
+  const privateKey = keypair.privateKey();
+
+  // Returns public and private keys as byte arrays (Uint8Array):
+  const publicKey = keypair.publicKeyBytes();
+  const privateKey = keypair.privateKeyBytes();
+
+  // Derive an Ed25510 key pair from a hex-encoded private key:
+  const keyPair = KeyPair.fromPrivateKey(privateKey);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ option](https://webpack.js.org/configuration/experiments/).
 ```js
 import('sesamoid').then(({ KeyPair }) => {
   // Generates a new Ed25519 key pair using Crypto.randomBytes as
-  // Cryptographically secure pseudorandom number generator:
+  // cryptographically secure pseudorandom number generator:
   const keyPair = new KeyPair();
 
   // Returns public and private keys as hex-encoded strings:
@@ -28,7 +28,7 @@ import('sesamoid').then(({ KeyPair }) => {
   const publicKey = keypair.publicKeyBytes();
   const privateKey = keypair.privateKeyBytes();
 
-  // Derive an Ed25510 key pair from a hex-encoded private key:
+  // Derive an Ed25519 key pair from a hex-encoded private key:
   const keyPair = KeyPair.fromPrivateKey(privateKey);
 });
 ```

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ option](https://webpack.js.org/configuration/experiments/).
 
 ```js
 import('sesamoid').then(({ KeyPair }) => {
-  // Generates a new Ed25519 key pair using Crypto.getRandomBytes as a
-  // pseudorandom number generator:
+  // Generates a new Ed25519 key pair using Crypto.randomBytes as
+  // Cryptographically secure pseudorandom number generator:
   const keyPair = new KeyPair();
 
   // Returns public and private keys as hex-encoded strings:
@@ -35,7 +35,7 @@ import('sesamoid').then(({ KeyPair }) => {
 
 ## Development
 
-```
+```bash
 # Run tests
 cargo test
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@ impl KeyPair {
         }
     }
 
-    #[wasm_bindgen(js_name = fromPrivateKeyHex)]
-    pub fn from_hex(private_key: String) -> Self {
+    #[wasm_bindgen(js_name = fromPrivateKey)]
+    pub fn from_private_key(private_key: String) -> Self {
         let bytes = hex::decode(private_key).unwrap();
         let secret_key = SecretKey::from_bytes(&bytes).unwrap();
         let public_key: PublicKey = (&secret_key).into();
@@ -38,6 +38,16 @@ impl KeyPair {
             public: public_key,
             private: secret_key,
         }
+    }
+
+    #[wasm_bindgen(js_name = publicKey)]
+    pub fn public_key(&self) -> String {
+        hex::encode(self.public.to_bytes())
+    }
+
+    #[wasm_bindgen(js_name = privateKey)]
+    pub fn private_key(&self) -> String {
+        hex::encode(self.private.to_bytes())
     }
 
     #[wasm_bindgen(js_name = publicKeyBytes)]
@@ -49,16 +59,6 @@ impl KeyPair {
     pub fn private_key_bytes(&self) -> Box<[u8]> {
         Box::from(self.private.to_bytes())
     }
-
-    #[wasm_bindgen(js_name = publicKeyHex)]
-    pub fn public_key_hex(&self) -> String {
-        hex::encode(self.public.to_bytes())
-    }
-
-    #[wasm_bindgen(js_name = privateKeyHex)]
-    pub fn private_key_hex(&self) -> String {
-        hex::encode(self.private.to_bytes())
-    }
 }
 
 #[cfg(test)]
@@ -69,16 +69,16 @@ mod tests {
     #[test]
     fn makes_keypair() {
         let key_pair = KeyPair::new();
+        assert_eq!(key_pair.public_key().len(), PUBLIC_KEY_LENGTH * 2);
+        assert_eq!(key_pair.private_key().len(), PUBLIC_KEY_LENGTH * 2);
         assert_eq!(key_pair.public_key_bytes().len(), PUBLIC_KEY_LENGTH);
         assert_eq!(key_pair.private_key_bytes().len(), SECRET_KEY_LENGTH);
-        assert_eq!(key_pair.public_key_hex().len(), PUBLIC_KEY_LENGTH * 2);
-        assert_eq!(key_pair.private_key_hex().len(), PUBLIC_KEY_LENGTH * 2);
     }
 
     #[test]
-    fn key_pair_from_bytes() {
+    fn key_pair_from_private_key() {
         let key_pair = KeyPair::new();
-        let key_pair2 = KeyPair::from_hex(key_pair.private_key_hex());
+        let key_pair2 = KeyPair::from_private_key(key_pair.private_key());
         assert_eq!(key_pair.public_key_bytes(), key_pair2.public_key_bytes());
         assert_eq!(key_pair.private_key_bytes(), key_pair2.private_key_bytes());
     }


### PR DESCRIPTION
Renames the `KeyPair` methods which makes the hex encoded representation of the keys the library API default:

* `privateKeyHex` to `privateKey`
* `publicKeyHex` to `publicKey` 

This should make the API more clear for JavaScript clients as they will need to use the hex version anyways for storing private keys (as LocalStorage for example only accepts strings) or displaying the public address of an user. The bytes representation is secondary and mostly only used for Bamboo encoding or message verification (which is handled internally by sesamoid anyways).

Also, this should behave similar to our ideas to use something like `toJSON` or `fromJSON` (see https://hackmd.io/kRb3ma1AQhyhMCQKBnBTKQ) just without using actually JSON but only the private key string.

```js
const keyPair = new KeyPair();
window.localStorage.setItem('privateKey', keyPair.privateKey());

const newKeyPair = KeyPair.fromPrivateKey(window.localStorage.getItem('privateKey'));

console.log(`My address is ${newKeyPair.publicKey()}`);
```