### PR TITLE
Add serde attributes to all structs

### DIFF
--- a/p2panda-rs/src/atomic/author.rs
+++ b/p2panda-rs/src/atomic/author.rs
@@ -1,5 +1,6 @@
 use anyhow::bail;
 use ed25519_dalek::PUBLIC_KEY_LENGTH;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::atomic::Validation;
@@ -19,7 +20,7 @@ pub enum AuthorError {
 }
 
 /// Authors are hex encoded ed25519 public key strings.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Author(String);
 
 impl Author {

--- a/p2panda-rs/src/atomic/entry.rs
+++ b/p2panda-rs/src/atomic/entry.rs
@@ -3,6 +3,7 @@ use std::convert::{TryFrom, TryInto};
 use anyhow::bail;
 use arrayvec::ArrayVec;
 use bamboo_rs_core::{Entry as BambooEntry, YamfHash};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::atomic::{EntrySigned, Hash, LogId, Message, MessageEncoded, SeqNum, Validation};
@@ -20,7 +21,7 @@ use crate::Result;
 /// why a message instance is required during entry signing.
 ///
 /// [`Bamboo specification`]: https://github.com/AljoschaMeyer/bamboo
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Entry {
     /// Hash of previous Bamboo entry.
     entry_hash_backlink: Option<Hash>,

--- a/p2panda-rs/src/atomic/entry_signed.rs
+++ b/p2panda-rs/src/atomic/entry_signed.rs
@@ -5,6 +5,7 @@ use arrayvec::ArrayVec;
 use bamboo_rs_core::entry::MAX_ENTRY_SIZE;
 use bamboo_rs_core::{Entry as BambooEntry, Signature as BambooSignature};
 use ed25519_dalek::PublicKey;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::atomic::{Entry, Hash, MessageEncoded, Validation};
@@ -25,7 +26,7 @@ pub enum EntrySignedError {
 }
 
 /// Bamboo entry bytes represented in hex encoding format.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EntrySigned(String);
 
 impl EntrySigned {

--- a/p2panda-rs/src/atomic/log_id.rs
+++ b/p2panda-rs/src/atomic/log_id.rs
@@ -1,5 +1,7 @@
+use serde::{Deserialize, Serialize};
+
 /// Authors can write entries to multiple logs identified by log ids.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LogId(u64);
 
 impl LogId {

--- a/p2panda-rs/src/atomic/message_encoded.rs
+++ b/p2panda-rs/src/atomic/message_encoded.rs
@@ -9,7 +9,7 @@ use crate::schema::{validate_schema, MESSAGE_SCHEMA};
 use crate::Result;
 
 /// Custom error types for `MessageEncoded`.
-#[derive(Error, Debug, Serialize, Deserialize)]
+#[derive(Error, Debug)]
 pub enum MessageEncodedError {
     /// Message contains invalid fields.
     #[error("invalid message schema: {0}")]

--- a/p2panda-rs/src/atomic/message_encoded.rs
+++ b/p2panda-rs/src/atomic/message_encoded.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::atomic::{Hash, Message, Validation};
@@ -8,7 +9,7 @@ use crate::schema::{validate_schema, MESSAGE_SCHEMA};
 use crate::Result;
 
 /// Custom error types for `MessageEncoded`.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize, Deserialize)]
 pub enum MessageEncodedError {
     /// Message contains invalid fields.
     #[error("invalid message schema: {0}")]
@@ -24,7 +25,7 @@ pub enum MessageEncodedError {
 }
 
 /// Message represented in hex encoded CBOR format.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MessageEncoded(String);
 
 impl MessageEncoded {

--- a/p2panda-rs/src/atomic/seq_num.rs
+++ b/p2panda-rs/src/atomic/seq_num.rs
@@ -1,5 +1,6 @@
 use anyhow::bail;
 use bamboo_rs_core::lipmaa;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::atomic::Validation;
@@ -18,7 +19,7 @@ pub enum SeqNumError {
 }
 
 /// Sequence number describing the position of an entry in its append-only log.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SeqNum(u64);
 
 impl SeqNum {

--- a/p2panda-rs/src/key_pair.rs
+++ b/p2panda-rs/src/key_pair.rs
@@ -4,6 +4,7 @@ use std::convert::TryFrom;
 use ed25519_dalek::SignatureError;
 use ed25519_dalek::{Keypair as Ed25519Keypair, PublicKey, SecretKey, Signature, Signer};
 use rand::rngs::OsRng;
+use serde::{Deserialize, Serialize};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(target_arch = "wasm32")]
@@ -11,7 +12,7 @@ use wasm_bindgen::JsValue;
 
 /// Ed25519 key pair for authors to sign bamboo entries with.
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct KeyPair(Ed25519Keypair);
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]


### PR DESCRIPTION
This functionality is not behind any feature flag as `serde` is used already in a couple of structs by default.

Closes: https://github.com/p2panda/p2panda/issues/36