### PR TITLE
Add sqlx Type traits to atomic structs

### DIFF
--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -21,7 +21,9 @@ demangle-name-section = true
 dwarf-debug-info = false
 
 [features]
-default = ["sqlx"]
+default = []
+# Adds sql database support for atomic structs via sqlx crate.
+db-sqlx = ["sqlx"]
 
 [lib]
 crate-type = ["cdylib"]
@@ -36,9 +38,11 @@ hex = "0.4.2"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_cbor = "0.11.1"
 serde_repr = "0.1.6"
-sqlx = { version = "0.5.1", features = ["runtime-async-std-native-tls", "any", "sqlite", "mysql", "postgres"], optional = true }
 thiserror = "1.0.23"
 yamf-hash = "0.1.2"
+
+# Optional dependencies (behind feature flags)
+sqlx = { version = "0.5.1", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rand = "0.7.3"

--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -20,6 +20,9 @@ debug-js-glue = false
 demangle-name-section = true
 dwarf-debug-info = false
 
+[features]
+default = ["sqlx"]
+
 [lib]
 crate-type = ["cdylib"]
 
@@ -33,6 +36,7 @@ hex = "0.4.2"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_cbor = "0.11.1"
 serde_repr = "0.1.6"
+sqlx = { version = "0.5.1", features = ["runtime-async-std-native-tls", "any", "sqlite", "mysql", "postgres"], optional = true }
 thiserror = "1.0.23"
 yamf-hash = "0.1.2"
 

--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -22,7 +22,7 @@ dwarf-debug-info = false
 
 [features]
 default = []
-# Adds sql database support for atomic structs via sqlx crate.
+# Adds sql database support for atomic structs via sqlx crate
 db-sqlx = ["sqlx"]
 
 [lib]

--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = "1.0.23"
 yamf-hash = "0.1.2"
 
 # Optional dependencies (behind feature flags)
-sqlx = { version = "0.5.1", optional = true }
+sqlx = { version = "0.5.1", features = ["runtime-async-std-native-tls", "all-databases"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rand = "0.7.3"

--- a/p2panda-rs/src/atomic/author.rs
+++ b/p2panda-rs/src/atomic/author.rs
@@ -20,8 +20,7 @@ pub enum AuthorError {
 
 /// Authors are hex encoded ed25519 public key strings.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "db-sqlx", sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
 pub struct Author(String);
 
 impl Author {

--- a/p2panda-rs/src/atomic/author.rs
+++ b/p2panda-rs/src/atomic/author.rs
@@ -20,7 +20,7 @@ pub enum AuthorError {
 
 /// Authors are hex encoded ed25519 public key strings.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type, sqlx::FromRow), sqlx(transparent))]
 pub struct Author(String);
 
 impl Author {

--- a/p2panda-rs/src/atomic/author.rs
+++ b/p2panda-rs/src/atomic/author.rs
@@ -20,6 +20,8 @@ pub enum AuthorError {
 
 /// Authors are hex encoded ed25519 public key strings.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(transparent))]
 pub struct Author(String);
 
 impl Author {

--- a/p2panda-rs/src/atomic/author.rs
+++ b/p2panda-rs/src/atomic/author.rs
@@ -20,8 +20,8 @@ pub enum AuthorError {
 
 /// Authors are hex encoded ed25519 public key strings.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "sqlx", sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "db-sqlx", sqlx(transparent))]
 pub struct Author(String);
 
 impl Author {

--- a/p2panda-rs/src/atomic/entry.rs
+++ b/p2panda-rs/src/atomic/entry.rs
@@ -169,9 +169,9 @@ impl TryFrom<(&EntrySigned, Option<&MessageEncoded>)> for Entry {
         Ok(Entry {
             entry_hash_backlink,
             entry_hash_skiplink,
-            log_id: LogId::new(entry.log_id),
+            log_id: LogId::new(entry.log_id as i64),
             message,
-            seq_num: SeqNum::new(entry.seq_num)?,
+            seq_num: SeqNum::new(entry.seq_num as i64)?,
         })
     }
 }

--- a/p2panda-rs/src/atomic/entry_signed.rs
+++ b/p2panda-rs/src/atomic/entry_signed.rs
@@ -26,7 +26,7 @@ pub enum EntrySignedError {
 
 /// Bamboo entry bytes represented in hex encoding format.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type, sqlx::FromRow), sqlx(transparent))]
 pub struct EntrySigned(String);
 
 impl EntrySigned {
@@ -54,8 +54,8 @@ impl EntrySigned {
     }
 
     /// Returns payload size (number of bytes) of total encoded entry.
-    pub fn size(&self) -> u64 {
-        self.0.len() as u64 / 2
+    pub fn size(&self) -> i64 {
+        self.0.len() as i64 / 2
     }
 }
 
@@ -99,12 +99,12 @@ impl TryFrom<(&Entry, &KeyPair)> for EntrySigned {
         // Create bamboo entry. See: https://github.com/AljoschaMeyer/bamboo#encoding for encoding
         // details and definition of entry fields.
         let mut entry: BambooEntry<_, &[u8]> = BambooEntry {
-            log_id: entry.log_id().as_u64(),
+            log_id: entry.log_id().as_i64() as u64,
             is_end_of_feed: false,
             payload_hash: message_hash.into(),
-            payload_size: message_size,
+            payload_size: message_size as u64,
             author: PublicKey::from_bytes(&key_pair.public_key_bytes())?,
-            seq_num: entry.seq_num().as_u64(),
+            seq_num: entry.seq_num().as_i64() as u64,
             backlink,
             lipmaa_link,
             sig: None,

--- a/p2panda-rs/src/atomic/entry_signed.rs
+++ b/p2panda-rs/src/atomic/entry_signed.rs
@@ -26,6 +26,7 @@ pub enum EntrySignedError {
 
 /// Bamboo entry bytes represented in hex encoding format.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
 pub struct EntrySigned(String);
 
 impl EntrySigned {

--- a/p2panda-rs/src/atomic/hash.rs
+++ b/p2panda-rs/src/atomic/hash.rs
@@ -37,8 +37,7 @@ pub enum HashError {
 ///
 /// [`YAMF`]: https://github.com/bamboo-rs/yamf-hash
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "db-sqlx", sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
 pub struct Hash(String);
 
 impl Hash {

--- a/p2panda-rs/src/atomic/hash.rs
+++ b/p2panda-rs/src/atomic/hash.rs
@@ -37,7 +37,7 @@ pub enum HashError {
 ///
 /// [`YAMF`]: https://github.com/bamboo-rs/yamf-hash
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type, sqlx::FromRow), sqlx(transparent))]
 pub struct Hash(String);
 
 impl Hash {

--- a/p2panda-rs/src/atomic/hash.rs
+++ b/p2panda-rs/src/atomic/hash.rs
@@ -37,6 +37,8 @@ pub enum HashError {
 ///
 /// [`YAMF`]: https://github.com/bamboo-rs/yamf-hash
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(transparent))]
 pub struct Hash(String);
 
 impl Hash {

--- a/p2panda-rs/src/atomic/hash.rs
+++ b/p2panda-rs/src/atomic/hash.rs
@@ -37,8 +37,8 @@ pub enum HashError {
 ///
 /// [`YAMF`]: https://github.com/bamboo-rs/yamf-hash
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "sqlx", sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "db-sqlx", sqlx(transparent))]
 pub struct Hash(String);
 
 impl Hash {

--- a/p2panda-rs/src/atomic/log_id.rs
+++ b/p2panda-rs/src/atomic/log_id.rs
@@ -1,5 +1,7 @@
 /// Authors can write entries to multiple logs identified by log ids.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(transparent))]
 pub struct LogId(u64);
 
 impl LogId {

--- a/p2panda-rs/src/atomic/log_id.rs
+++ b/p2panda-rs/src/atomic/log_id.rs
@@ -1,7 +1,6 @@
 /// Authors can write entries to multiple logs identified by log ids.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "db-sqlx", sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
 pub struct LogId(u64);
 
 impl LogId {

--- a/p2panda-rs/src/atomic/log_id.rs
+++ b/p2panda-rs/src/atomic/log_id.rs
@@ -1,11 +1,11 @@
 /// Authors can write entries to multiple logs identified by log ids.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
-pub struct LogId(u64);
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type, sqlx::FromRow), sqlx(transparent))]
+pub struct LogId(i64);
 
 impl LogId {
     /// Validates and wraps log id value into a new `LogId` instance.
-    pub fn new(value: u64) -> Self {
+    pub fn new(value: i64) -> Self {
         Self(value)
     }
 
@@ -21,8 +21,8 @@ impl LogId {
         self.0 % 2 == 0
     }
 
-    /// Returns `LogId` as u64 integer.
-    pub fn as_u64(&self) -> u64 {
+    /// Returns `LogId` as i64 integer.
+    pub fn as_i64(&self) -> i64 {
         self.0
     }
 }

--- a/p2panda-rs/src/atomic/log_id.rs
+++ b/p2panda-rs/src/atomic/log_id.rs
@@ -1,7 +1,7 @@
 /// Authors can write entries to multiple logs identified by log ids.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "sqlx", sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "db-sqlx", sqlx(transparent))]
 pub struct LogId(u64);
 
 impl LogId {

--- a/p2panda-rs/src/atomic/message_encoded.rs
+++ b/p2panda-rs/src/atomic/message_encoded.rs
@@ -25,7 +25,7 @@ pub enum MessageEncodedError {
 
 /// Message represented in hex encoded CBOR format.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type, sqlx::FromRow), sqlx(transparent))]
 pub struct MessageEncoded(String);
 
 impl MessageEncoded {
@@ -54,9 +54,9 @@ impl MessageEncoded {
     }
 
     /// Returns payload size (number of bytes) of encoded message.
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> i64 {
         // Divide by 2 as every byte is represented by 2 hex chars.
-        self.0.len() as u64 / 2
+        self.0.len() as i64 / 2
     }
 }
 

--- a/p2panda-rs/src/atomic/message_encoded.rs
+++ b/p2panda-rs/src/atomic/message_encoded.rs
@@ -25,6 +25,8 @@ pub enum MessageEncodedError {
 
 /// Message represented in hex encoded CBOR format.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(transparent))]
 pub struct MessageEncoded(String);
 
 impl MessageEncoded {

--- a/p2panda-rs/src/atomic/message_encoded.rs
+++ b/p2panda-rs/src/atomic/message_encoded.rs
@@ -25,8 +25,7 @@ pub enum MessageEncodedError {
 
 /// Message represented in hex encoded CBOR format.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "db-sqlx", sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
 pub struct MessageEncoded(String);
 
 impl MessageEncoded {

--- a/p2panda-rs/src/atomic/message_encoded.rs
+++ b/p2panda-rs/src/atomic/message_encoded.rs
@@ -25,8 +25,8 @@ pub enum MessageEncodedError {
 
 /// Message represented in hex encoded CBOR format.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "sqlx", sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "db-sqlx", sqlx(transparent))]
 pub struct MessageEncoded(String);
 
 impl MessageEncoded {

--- a/p2panda-rs/src/atomic/seq_num.rs
+++ b/p2panda-rs/src/atomic/seq_num.rs
@@ -19,8 +19,8 @@ pub enum SeqNumError {
 
 /// Sequence number describing the position of an entry in its append-only log.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "sqlx", sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "db-sqlx", sqlx(transparent))]
 pub struct SeqNum(u64);
 
 impl SeqNum {

--- a/p2panda-rs/src/atomic/seq_num.rs
+++ b/p2panda-rs/src/atomic/seq_num.rs
@@ -24,7 +24,7 @@ pub struct SeqNum(i64);
 
 impl SeqNum {
     /// Validates and wraps value into a new `SeqNum` instance.
-    pub fn new(value: i64) -> Result<Self, SeqNumError> {
+    pub fn new(value: i64) -> Result<Self> {
         let seq_num = Self(value);
         seq_num.validate()?;
         Ok(seq_num)

--- a/p2panda-rs/src/atomic/seq_num.rs
+++ b/p2panda-rs/src/atomic/seq_num.rs
@@ -19,8 +19,7 @@ pub enum SeqNumError {
 
 /// Sequence number describing the position of an entry in its append-only log.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type))]
-#[cfg_attr(feature = "db-sqlx", sqlx(transparent))]
+#[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
 pub struct SeqNum(u64);
 
 impl SeqNum {

--- a/p2panda-rs/src/atomic/seq_num.rs
+++ b/p2panda-rs/src/atomic/seq_num.rs
@@ -19,6 +19,8 @@ pub enum SeqNumError {
 
 /// Sequence number describing the position of an entry in its append-only log.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(transparent))]
 pub struct SeqNum(u64);
 
 impl SeqNum {

--- a/p2panda-rs/src/atomic/seq_num.rs
+++ b/p2panda-rs/src/atomic/seq_num.rs
@@ -6,7 +6,7 @@ use crate::atomic::Validation;
 use crate::Result;
 
 /// Start counting entries from here.
-pub const FIRST_SEQ_NUM: u64 = 1;
+pub const FIRST_SEQ_NUM: i64 = 1;
 
 /// Custom error types for `SeqNum`.
 #[derive(Error, Debug)]
@@ -20,11 +20,11 @@ pub enum SeqNumError {
 /// Sequence number describing the position of an entry in its append-only log.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "db-sqlx", derive(sqlx::Type), sqlx(transparent))]
-pub struct SeqNum(u64);
+pub struct SeqNum(i64);
 
 impl SeqNum {
     /// Validates and wraps value into a new `SeqNum` instance.
-    pub fn new(value: u64) -> Result<Self> {
+    pub fn new(value: i64) -> Result<Self, SeqNumError> {
         let seq_num = Self(value);
         seq_num.validate()?;
         Ok(seq_num)
@@ -41,7 +41,7 @@ impl SeqNum {
     ///
     /// [`Bamboo specification`]: https://github.com/AljoschaMeyer/bamboo#links-and-entry-verification
     pub fn skiplink_seq_num(&self) -> Option<Self> {
-        Some(Self(lipmaa(self.0) + FIRST_SEQ_NUM))
+        Some(Self(lipmaa(self.0 as u64) as i64 + FIRST_SEQ_NUM))
     }
 
     /// Returns true when sequence number marks first entry in log.
@@ -49,8 +49,8 @@ impl SeqNum {
         self.0 == FIRST_SEQ_NUM
     }
 
-    /// Returns `SeqNum` as u64 integer.
-    pub fn as_u64(&self) -> u64 {
+    /// Returns `SeqNum` as i64 integer.
+    pub fn as_i64(&self) -> i64 {
         self.0
     }
 }


### PR DESCRIPTION
Adds SQL database support for atomic structs via [sqlx](https://docs.rs/sqlx/0.5.1/sqlx/) crate, behind a `db-sqlx` feature flag. This allows programs like `aquadoggo` to interact easier with `p2panda-rs` for sql queries and avoids unnecessary wrapping of atomic structs inside the aquadoggo code.

**Notes:**

* The `Type` trait is not added to `Entry` and `Message` as they are more complex structs which are not stored in the database 1:1.
* [SQLite does not support `u64` integers](https://github.com/launchbadge/sqlx/issues/499) as in the Bamboo specification. To make this work all integers had to be changed to `i64` :cry:
* Later we can add something like `db-diesel` to support other sql libraries like diesel-rs.

Closes: https://github.com/p2panda/p2panda/issues/37