### PR TITLE
Get author and signature of signed entry

### DIFF
--- a/p2panda-rs/src/atomic/author.rs
+++ b/p2panda-rs/src/atomic/author.rs
@@ -1,7 +1,5 @@
-
 use std::convert::TryFrom;
 
-use anyhow::bail;
 use ed25519_dalek::{PublicKey, PUBLIC_KEY_LENGTH};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -37,9 +35,9 @@ impl Author {
 
 /// Convert Ed25519 `PublicKey` to `Author` instance.
 impl TryFrom<PublicKey> for Author {
-    type Error = anyhow::Error;
+    type Error = AuthorError;
 
-    fn try_from(public_key: PublicKey) -> std::result::Result<Self, Self::Error> {
+    fn try_from(public_key: PublicKey) -> Result<Self, Self::Error> {
         Self::new(&hex::encode(public_key.to_bytes()))
     }
 }

--- a/p2panda-rs/src/atomic/author.rs
+++ b/p2panda-rs/src/atomic/author.rs
@@ -1,5 +1,7 @@
+use std::convert::TryFrom;
+
 use anyhow::bail;
-use ed25519_dalek::PUBLIC_KEY_LENGTH;
+use ed25519_dalek::{PublicKey, PUBLIC_KEY_LENGTH};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -30,6 +32,15 @@ impl Author {
         let author = Self(String::from(value));
         author.validate()?;
         Ok(author)
+    }
+}
+
+/// Convert Ed25519 `PublicKey` to `Author` instance.
+impl TryFrom<PublicKey> for Author {
+    type Error = anyhow::Error;
+
+    fn try_from(public_key: PublicKey) -> std::result::Result<Self, Self::Error> {
+        Self::new(&hex::encode(public_key.to_bytes()))
     }
 }
 

--- a/p2panda-rs/src/schema/mod.rs
+++ b/p2panda-rs/src/schema/mod.rs
@@ -36,11 +36,11 @@ pub fn validate_schema(cddl_schema: &str, bytes: Vec<u8>) -> Result<(), error::S
                 .collect::<Vec<String>>()
                 .join(", ");
 
-            return Err(error::SchemaError::InvalidSchema(err_str));
+            Err(error::SchemaError::InvalidSchema(err_str))
         }
-        Err(cbor::Error::CBORParsing(_err)) => return Err(error::SchemaError::InvalidCBOR),
+        Err(cbor::Error::CBORParsing(_err)) => Err(error::SchemaError::InvalidCBOR),
         Err(cbor::Error::CDDLParsing(err)) => {
-            panic!(err);
+            panic!("Parsing CDDL error: {}", err);
         }
         _ => Ok(()),
     }


### PR DESCRIPTION
* Add `TryFrom` conversion trait to convert Ed25519 `PublicKey` to `Author` instance
* Add getter methods to `EntrySigned` returning `signature` and `author`