### PR TITLE
Doc code examples

### DIFF
--- a/p2panda-rs/src/atomic/author.rs
+++ b/p2panda-rs/src/atomic/author.rs
@@ -30,6 +30,25 @@ pub struct Author(String);
 
 impl Author {
     /// Validates and wraps author string into a new `Author` instance.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # extern crate p2panda_rs;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use p2panda_rs::key_pair::KeyPair;
+    /// use p2panda_rs::atomic::Author;
+    ///
+    /// // Generate new Ed25519 key pair
+    /// let key_pair = KeyPair::new();
+    /// let public_key = key_pair.public_key();
+    ///
+    /// // Create an `Author` instance from a public key string
+    /// let author = Author::new(&key_pair.public_key())?;
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn new(value: &str) -> Result<Self, AuthorError> {
         let author = Self(String::from(value));
         author.validate()?;

--- a/p2panda-rs/src/atomic/entry.rs
+++ b/p2panda-rs/src/atomic/entry.rs
@@ -83,8 +83,6 @@ pub enum EntryError {
 /// # let BACKLINK_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
 /// # let SKIPLINK_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
 /// # let SCHEMA_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
-/// # let LOG_ID: i64 = 1;
-/// # let SEQ_NUM: i64 = 2;
 /// 
 /// // Create schema hash
 /// let schema_hash = Hash::new(SCHEMA_HASH_STR)?;
@@ -97,10 +95,10 @@ pub enum EntryError {
 /// let message = Message::new_create(schema_hash, fields)?;
 ///
 /// // Create log ID from i64
-/// let log_id = LogId::new(LOG_ID);
+/// let log_id = LogId::new(1);
 ///
 /// // Create sequence number from i64
-/// let seq_no = SeqNum::new(SEQ_NUM)?;
+/// let seq_no = SeqNum::new(2)?;
 ///
 /// // Create skiplink hash from string
 /// let skiplink_hash = Hash::new(&SKIPLINK_HASH_STR)?;

--- a/p2panda-rs/src/atomic/entry.rs
+++ b/p2panda-rs/src/atomic/entry.rs
@@ -80,12 +80,12 @@ pub enum EntryError {
 /// use p2panda_rs::atomic::{Entry, Hash, LogId, Message, MessageFields, MessageValue, SeqNum};
 ///
 /// // == ENTRY IN EXISTING LOG ==
-/// # let BACKLINK_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
-/// # let SKIPLINK_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
-/// # let SCHEMA_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
+/// # let backlink_hash_string = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
+/// # let skiplink_hash_string = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
+/// # let schema_hash_string = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
 /// 
 /// // Create schema hash
-/// let schema_hash = Hash::new(SCHEMA_HASH_STR)?;
+/// let schema_hash = Hash::new(schema_hash_string)?;
 ///
 /// // Create a MessageFields instance and add a text field string with the key "title"
 /// let mut fields = MessageFields::new();
@@ -101,10 +101,10 @@ pub enum EntryError {
 /// let seq_no = SeqNum::new(2)?;
 ///
 /// // Create skiplink hash from string
-/// let skiplink_hash = Hash::new(&SKIPLINK_HASH_STR)?;
+/// let skiplink_hash = Hash::new(&skiplink_hash_string)?;
 ///
 /// // Create backlink hash from string
-/// let backlink_hash = Hash::new(&BACKLINK_HASH_STR)?;
+/// let backlink_hash = Hash::new(&backlink_hash_string)?;
 ///
 /// // Create entry
 /// let next_entry = Entry::new(

--- a/p2panda-rs/src/atomic/entry.rs
+++ b/p2panda-rs/src/atomic/entry.rs
@@ -41,6 +41,87 @@ pub enum EntryError {
 /// why a message instance is required during entry signing.
 ///
 /// [`Bamboo specification`]: https://github.com/AljoschaMeyer/bamboo
+///
+/// ## Example
+///
+/// ```
+/// # extern crate p2panda_rs;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use p2panda_rs::atomic::{Entry, Hash, LogId, Message, MessageFields, MessageValue, SeqNum};
+/// # let SCHEMA_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
+///
+/// // == FIRST ENTRY IN NEW LOG == //
+///
+/// // Create schema hash
+/// let schema_hash = Hash::new(SCHEMA_HASH_STR)?;
+///
+/// // Create a MessageFields instance and add a text field string with the key "title"
+/// let mut fields = MessageFields::new();
+/// fields.add("title", MessageValue::Text("Hello, Panda!".to_owned()))?;
+///
+/// // Create a message containing the above fields
+/// let message = Message::new_create(schema_hash, fields)?;
+///
+/// // Create the first Entry in a log
+/// let entry = Entry::new(
+///     &LogId::default(),
+///     &message,
+///     None,
+///     None,
+///     None,
+/// )?;
+/// # Ok(())
+/// # }
+///```
+/// ## Example
+///```
+/// # extern crate p2panda_rs;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use p2panda_rs::atomic::{Entry, Hash, LogId, Message, MessageFields, MessageValue, SeqNum};
+///
+/// // == ENTRY IN EXISTING LOG ==
+/// # let BACKLINK_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
+/// # let SKIPLINK_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
+/// # let SCHEMA_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
+/// # let LOG_ID: i64 = 1;
+/// # let SEQ_NUM: i64 = 2;
+/// 
+/// // Create schema hash
+/// let schema_hash = Hash::new(SCHEMA_HASH_STR)?;
+///
+/// // Create a MessageFields instance and add a text field string with the key "title"
+/// let mut fields = MessageFields::new();
+/// fields.add("title", MessageValue::Text("Hello, Panda!".to_owned()))?;
+///
+/// // Create a message containing the above fields
+/// let message = Message::new_create(schema_hash, fields)?;
+///
+/// // Create log ID from i64
+/// let log_id = LogId::new(LOG_ID);
+///
+/// // Create sequence number from i64
+/// let seq_no = SeqNum::new(SEQ_NUM)?;
+///
+/// // Create skiplink hash from string
+/// let skiplink_hash = Hash::new(&SKIPLINK_HASH_STR)?;
+///
+/// // Create backlink hash from string
+/// let backlink_hash = Hash::new(&BACKLINK_HASH_STR)?;
+///
+/// // Create entry
+/// let next_entry = Entry::new(
+///     &log_id,
+///     &message,
+///     Some(&skiplink_hash),
+///     Some(&backlink_hash),
+///     Some(&seq_no),
+/// )?;
+/// # Ok(())
+/// # }
+/// ```
+///
+
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Entry {

--- a/p2panda-rs/src/atomic/entry_signed.rs
+++ b/p2panda-rs/src/atomic/entry_signed.rs
@@ -116,6 +116,41 @@ impl TryFrom<&[u8]> for EntrySigned {
 /// [`EntrySigned`] instance.
 ///
 /// After conversion the result is ready to be sent to a p2panda node.
+///
+/// ## Example
+///
+/// ```
+/// # extern crate p2panda_rs;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::convert::TryFrom;
+/// use p2panda_rs::atomic::{Entry, EntrySigned, Hash, LogId, Message, MessageFields, MessageValue};
+/// use p2panda_rs::key_pair::KeyPair;
+/// # let SCHEMA_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
+///
+/// // Generate Ed25519 key pair to sign entry with
+/// let key_pair = KeyPair::new();
+///
+/// // Create message
+/// let schema_hash = Hash::new(SCHEMA_HASH_STR)?;
+/// let mut fields = MessageFields::new();
+/// fields.add("title", MessageValue::Text("Hello, Panda!".to_owned()))?;
+/// let message = Message::new_create(schema_hash, fields)?;
+///
+/// // Create entry
+/// let entry = Entry::new(
+///     &LogId::default(),
+///     &message,
+///     None,
+///     None,
+///     None,
+/// )?;
+///
+/// // Sign and encode entry
+/// let entry_signed_encoded = EntrySigned::try_from((&entry, &key_pair))?;
+/// # Ok(())
+/// # }
+///```
+
 impl TryFrom<(&Entry, &KeyPair)> for EntrySigned {
     type Error = EntrySignedError;
 

--- a/p2panda-rs/src/atomic/entry_signed.rs
+++ b/p2panda-rs/src/atomic/entry_signed.rs
@@ -125,13 +125,12 @@ impl TryFrom<&[u8]> for EntrySigned {
 /// use std::convert::TryFrom;
 /// use p2panda_rs::atomic::{Entry, EntrySigned, Hash, LogId, Message, MessageFields, MessageValue};
 /// use p2panda_rs::key_pair::KeyPair;
-/// # let SCHEMA_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
 ///
 /// // Generate Ed25519 key pair to sign entry with
 /// let key_pair = KeyPair::new();
 ///
 /// // Create message
-/// let schema_hash = Hash::new(SCHEMA_HASH_STR)?;
+/// let schema_hash = Hash::new("004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8")?;
 /// let mut fields = MessageFields::new();
 /// fields.add("title", MessageValue::Text("Hello, Panda!".to_owned()))?;
 /// let message = Message::new_create(schema_hash, fields)?;

--- a/p2panda-rs/src/atomic/message.rs
+++ b/p2panda-rs/src/atomic/message.rs
@@ -89,7 +89,7 @@ pub enum MessageValue {
 /// a `MessageFields` instance is attached to a `Message`, the message's schema determines which
 /// fields may be used.
 ///
-/// Internally message fields use sorted B-Tree maps to assure ordering of the fields.  If the
+/// Internally message fields use sorted B-Tree maps to assure ordering of the fields. If the
 /// message fields would not be sorted consistently we would get different hash results for the
 /// same contents.
 ///
@@ -217,6 +217,31 @@ pub enum MessageError {
 
 impl Message {
     /// Returns new create message.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # extern crate p2panda_rs;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use p2panda_rs::atomic::Message;
+    /// use p2panda_rs::atomic::Hash;
+    /// use p2panda_rs::atomic::{MessageFields, MessageValue};
+    ///
+    /// let SCHEMA_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
+    /// let schema_msg_hash = Hash::new(SCHEMA_HASH_STR)?;
+    /// let mut msg_fields = MessageFields::new();
+    ///
+    /// msg_fields
+    ///     .add("Zoo", MessageValue::Text("Pandas, Doggos, Cats, and Parrots!".to_owned()))
+    ///     .unwrap();
+    ///
+    /// let create_message = Message::new_create(schema_msg_hash, msg_fields)?;
+    ///
+    /// assert_eq!(Message::is_create(&create_message), true);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn new_create(schema: Hash, fields: MessageFields) -> Result<Self, MessageError> {
         let message = Self {
             action: MessageAction::Create,
@@ -419,11 +444,8 @@ mod tests {
             .add("b", MessageValue::Text("penguin".to_owned()))
             .unwrap();
 
-        let first_message = Message::new_create(
-            Hash::new_from_bytes(vec![1, 255, 0]).unwrap(),
-            fields,
-        )
-        .unwrap();
+        let first_message =
+            Message::new_create(Hash::new_from_bytes(vec![1, 255, 0]).unwrap(), fields).unwrap();
 
         // Create second test message with same values but different order of fields
         let mut second_fields = MessageFields::new();

--- a/p2panda-rs/src/atomic/message.rs
+++ b/p2panda-rs/src/atomic/message.rs
@@ -227,8 +227,8 @@ impl Message {
     /// use p2panda_rs::atomic::Hash;
     /// use p2panda_rs::atomic::{MessageFields, MessageValue};
     ///
-    /// let SCHEMA_HASH_STR = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
-    /// let schema_msg_hash = Hash::new(SCHEMA_HASH_STR)?;
+    /// let schema_hash_string = "004069db5208a271c53de8a1b6220e6a4d7fcccd89e6c0c7e75c833e34dc68d932624f2ccf27513f42fb7d0e4390a99b225bad41ba14a6297537246dbe4e6ce150e8";
+    /// let schema_msg_hash = Hash::new(schema_hash_string)?;
     /// let mut msg_fields = MessageFields::new();
     ///
     /// msg_fields

--- a/p2panda-rs/src/atomic/seq_num.rs
+++ b/p2panda-rs/src/atomic/seq_num.rs
@@ -23,6 +23,20 @@ pub struct SeqNum(i64);
 
 impl SeqNum {
     /// Validates and wraps value into a new `SeqNum` instance.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # extern crate p2panda_rs;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use p2panda_rs::atomic::SeqNum;
+    ///
+    /// // Generate new sequence number
+    /// let seq_num = SeqNum::new(value: i64);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn new(value: i64) -> Result<Self, SeqNumError> {
         let seq_num = Self(value);
         seq_num.validate()?;
@@ -30,6 +44,23 @@ impl SeqNum {
     }
 
     /// Return sequence number of the previous entry (backlink).
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # extern crate p2panda_rs;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use p2panda_rs::atomic::SeqNum;
+    ///
+    /// // Generate new sequence number
+    /// let seq_num = SeqNum::new(value: i64);
+    ///
+    /// // Return backlink (sequence number of the previous entry)
+    /// let backlink = seq_num - 1;
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn backlink_seq_num(&self) -> Option<Self> {
         Self::new(self.0 - 1).ok()
     }

--- a/p2panda-rs/src/atomic/seq_num.rs
+++ b/p2panda-rs/src/atomic/seq_num.rs
@@ -52,11 +52,10 @@ impl SeqNum {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use p2panda_rs::atomic::SeqNum;
     ///
-    /// // Generate new sequence number
-    /// let seq_num = SeqNum::new(2);
+    ///
     ///
     /// // Return backlink (sequence number of the previous entry)
-    /// let backlink = SeqNum::backlink_seq_num(..);
+    ///
     ///
     /// # Ok(())
     /// # }

--- a/p2panda-rs/src/atomic/seq_num.rs
+++ b/p2panda-rs/src/atomic/seq_num.rs
@@ -32,7 +32,7 @@ impl SeqNum {
     /// use p2panda_rs::atomic::SeqNum;
     ///
     /// // Generate new sequence number
-    /// let seq_num = SeqNum::new(value: i64);
+    /// let seq_num = SeqNum::new(2);
     ///
     /// # Ok(())
     /// # }
@@ -53,10 +53,10 @@ impl SeqNum {
     /// use p2panda_rs::atomic::SeqNum;
     ///
     /// // Generate new sequence number
-    /// let seq_num = SeqNum::new(value: i64);
+    /// let seq_num = SeqNum::new(2);
     ///
     /// // Return backlink (sequence number of the previous entry)
-    /// let backlink = seq_num - 1;
+    /// let backlink = SeqNum::backlink_seq_num(..);
     ///
     /// # Ok(())
     /// # }

--- a/p2panda-rs/src/atomic/seq_num.rs
+++ b/p2panda-rs/src/atomic/seq_num.rs
@@ -32,7 +32,7 @@ impl SeqNum {
     /// use p2panda_rs::atomic::SeqNum;
     ///
     /// // Generate new sequence number
-    /// let seq_num = SeqNum::new(2);
+    /// let seq_num = SeqNum::new(2)?;
     ///
     /// # Ok(())
     /// # }
@@ -52,11 +52,11 @@ impl SeqNum {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use p2panda_rs::atomic::SeqNum;
     ///
-    ///
-    ///
     /// // Return backlink (sequence number of the previous entry)
+    /// let seq_num = SeqNum::new(2)?;
+    /// let backlink = seq_num.backlink_seq_num();
     ///
-    ///
+    /// assert_eq!(backlink, Some(SeqNum::new(1)?));
     /// # Ok(())
     /// # }
     /// ```

--- a/p2panda-rs/src/key_pair.rs
+++ b/p2panda-rs/src/key_pair.rs
@@ -44,10 +44,13 @@ impl KeyPair {
     /// ```
     /// # extern crate p2panda_rs;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # use p2panda_rs::key_pair::KeyPair;
+    /// use p2panda_rs::key_pair::KeyPair;
+    ///
     /// // Generate new Ed25519 key pair
     /// let key_pair = KeyPair::new();
     ///
+    /// println!("{}", key_pair.public_key());
+    /// println!("{}", key_pair.private_key());
     /// # Ok(())
     /// # }
     /// ```
@@ -73,12 +76,16 @@ impl KeyPair {
     /// ```
     /// # extern crate p2panda_rs;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # use p2panda_rs::key_pair::KeyPair;
+    /// use p2panda_rs::key_pair::KeyPair;
+    ///
     /// // Generate new Ed25519 key pair
     /// let key_pair = KeyPair::new();
-    /// // Derive a key pair from a private key 
-    /// let new_key_pair = KeyPair::from_private_key(key_pair.private_key());
     ///
+    /// // Derive a key pair from a private key 
+    /// let key_pair_derived = KeyPair::from_private_key(key_pair.private_key());
+    ///
+    /// assert_eq!(key_pair.public_key_bytes(), key_pair_derived.public_key_bytes());
+    /// assert_eq!(key_pair.private_key_bytes(), key_pair_derived.private_key_bytes());
     /// # Ok(())
     /// # }
     /// ```

--- a/p2panda-rs/src/key_pair.rs
+++ b/p2panda-rs/src/key_pair.rs
@@ -38,7 +38,20 @@ impl KeyPair {
     /// so make sure to only run this in trusted environments.
     ///
     /// [`getrandom`]: https://docs.rs/getrandom/0.2.1/getrandom/
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # extern crate p2panda_rs;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use p2panda_rs::key_pair::KeyPair;
+    /// // Generate new Ed25519 key pair
+    /// let key_pair = KeyPair::new();
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
     pub fn new() -> Self {
         let mut csprng: OsRng = OsRng {};
         let key_pair = Ed25519Keypair::generate(&mut csprng);
@@ -54,6 +67,22 @@ impl KeyPair {
     /// crate.
     ///
     /// [`ed25519-dalek`]: https://docs.rs/ed25519-dalek/1.0.1/ed25519_dalek/struct.Keypair.html#warning
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # extern crate p2panda_rs;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use p2panda_rs::key_pair::KeyPair;
+    /// // Generate new Ed25519 key pair
+    /// let key_pair = KeyPair::new();
+    /// // Derive a key pair from a private key 
+    /// let new_key_pair = KeyPair::from_private_key(key_pair.private_key());
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+
     #[cfg(not(target_arch = "wasm32"))]
     pub fn from_private_key(private_key: String) -> Result<Self, KeyPairError> {
         from_private_key(private_key)
@@ -92,6 +121,23 @@ impl KeyPair {
     }
 
     /// Sign a message using this key pair.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # extern crate p2panda_rs;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use p2panda_rs::key_pair::KeyPair;
+    /// // Generate new Ed25519 key pair
+    /// let key_pair = KeyPair::new();
+    /// // Sign a message with this key pair
+    /// let message = b"test";
+    /// let signature = key_pair.sign(message);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+
     pub fn sign(&self, message: &[u8]) -> Box<[u8]> {
         Box::from(self.0.sign(message).to_bytes())
     }

--- a/p2panda-rs/src/key_pair.rs
+++ b/p2panda-rs/src/key_pair.rs
@@ -82,7 +82,7 @@ impl KeyPair {
     /// let key_pair = KeyPair::new();
     ///
     /// // Derive a key pair from a private key 
-    /// let key_pair_derived = KeyPair::from_private_key(key_pair.private_key());
+    /// let key_pair_derived = KeyPair::from_private_key(key_pair.private_key())?;
     ///
     /// assert_eq!(key_pair.public_key_bytes(), key_pair_derived.public_key_bytes());
     /// assert_eq!(key_pair.private_key_bytes(), key_pair_derived.private_key_bytes());

--- a/p2panda-rs/src/key_pair.rs
+++ b/p2panda-rs/src/key_pair.rs
@@ -54,7 +54,7 @@ impl KeyPair {
     /// # Ok(())
     /// # }
     /// ```
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
     pub fn new() -> Self {
         let mut csprng: OsRng = OsRng {};
         let key_pair = Ed25519Keypair::generate(&mut csprng);

--- a/p2panda-rs/src/key_pair.rs
+++ b/p2panda-rs/src/key_pair.rs
@@ -134,13 +134,16 @@ impl KeyPair {
     /// ```
     /// # extern crate p2panda_rs;
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # use p2panda_rs::key_pair::KeyPair;
+    /// use p2panda_rs::key_pair::KeyPair;
+    ///
     /// // Generate new Ed25519 key pair
     /// let key_pair = KeyPair::new();
+    ///
     /// // Sign a message with this key pair
     /// let message = b"test";
     /// let signature = key_pair.sign(message);
     ///
+    /// assert!(key_pair.verify(message, &signature).is_ok());
     /// # Ok(())
     /// # }
     /// ```

--- a/p2panda-rs/src/lib.rs
+++ b/p2panda-rs/src/lib.rs
@@ -39,6 +39,7 @@
     missing_copy_implementations,
     missing_debug_implementations,
     missing_docs,
+    missing_doc_code_examples,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,

--- a/p2panda-rs/src/lib.rs
+++ b/p2panda-rs/src/lib.rs
@@ -13,9 +13,9 @@
 //! ```
 //! # extern crate p2panda_rs;
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # use std::convert::TryFrom;
-//! # use p2panda_rs::key_pair::KeyPair;
-//! # use p2panda_rs::atomic::{Entry, EntrySigned, Hash, LogId, SeqNum, Message, MessageFields, MessageValue};
+//! use std::convert::TryFrom;
+//! use p2panda_rs::key_pair::KeyPair;
+//! use p2panda_rs::atomic::{Entry, EntrySigned, Hash, LogId, SeqNum, Message, MessageFields, MessageValue};
 //! # let profile_schema = Hash::new_from_bytes(vec![1, 2, 3])?;
 //! // Generate new Ed25519 key pair
 //! let key_pair = KeyPair::new();


### PR DESCRIPTION
This PR is for updating p2panda-rs rust docs to include lots of code examples. I suggest we use this example as a template:

https://github.com/p2panda/p2panda/blob/6e692522de42b849ec507e8f0c84b119195aacd0/p2panda-rs/src/key_pair.rs#L42-L56

SOME NOTES:

- when running `cargo doc` or `cargo build` we now get warnings for code documentation which doesn't have an accompanying code example. We probably won't make examples for all of these, but it's fun to see them being crossed off ;-p
- the extra wrapping around each test (hidden with a `#`) is needed so the examples can actually be run and tested during compilation.
- I quite like showing the `use` import at the top, and then either printing some result or using `assert!` to demonstrate what we are expecting. I looked through the [rand](https://docs.rs/rand/0.8.3/rand/seq/trait.SliceRandom.html) crate for inspiration. Any other thoughts on how we style these are welcome though.
- we shouldn't use `unwrap()` in code examples
- great documentation for rust docs [here](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html)

Relevant commands:

```
# build and open the generated docs in browser
cargo doc --open

# run tests (includes testing example code)
cargo test
```

Let's try and do as much as we can this week then merge beginning of next week, just so we don't get out of date with main. ;-p :+1:

