### PR TITLE
Fix Webkit build by removing BigInt usage

### DIFF
--- a/p2panda-js/test/index.test.ts
+++ b/p2panda-js/test/index.test.ts
@@ -56,7 +56,7 @@ describe('Entries', () => {
       null,
       null,
       null,
-      BigInt(LOG_ID),
+      LOG_ID,
     );
 
     expect(entryHash.length).to.eq(132);

--- a/p2panda-rs/src/wasm.rs
+++ b/p2panda-rs/src/wasm.rs
@@ -122,14 +122,18 @@ struct SignEncodeEntryResult {
 ///
 /// `entry_backlink_hash`, `entry_skiplink_hash`, `previous_seq_num` and `log_id` are obtained by
 /// querying the `getEntryArguments` method of a p2panda node.
+///
+/// `previous_seq_num` and `log_id` are `i32` parameters even though they
+/// have 64 bits in the bamboo spec. Webkit doesn't support `BigInt` so
+/// it can't handle those large values.
 #[wasm_bindgen(js_name = signEncodeEntry)]
 pub fn sign_encode_entry(
     key_pair: &KeyPair,
     encoded_message: String,
     entry_skiplink_hash: Option<String>,
     entry_backlink_hash: Option<String>,
-    previous_seq_num: Option<i64>,
-    log_id: i64,
+    previous_seq_num: Option<i32>,
+    log_id: i32,
 ) -> Result<JsValue, JsValue> {
     // If skiplink_hash exists construct Hash
     let skiplink_hash = match entry_skiplink_hash {
@@ -145,7 +149,7 @@ pub fn sign_encode_entry(
 
     // If seq_num exists construct SeqNum
     let seq_num = match previous_seq_num {
-        Some(num) => Some(jserr!(SeqNum::new(num))),
+        Some(num) => Some(jserr!(SeqNum::new(num.into()))),
         None => None,
     };
 
@@ -155,7 +159,7 @@ pub fn sign_encode_entry(
 
     // Create Entry instance
     let entry = jserr!(Entry::new(
-        &LogId::new(log_id),
+        &LogId::new(log_id.into()),
         &message,
         skiplink_hash.as_ref(),
         backlink_hash.as_ref(),


### PR DESCRIPTION
WebKit doesn't support `BigInt` so we can not use it in the wasm api.

Followed-up by https://github.com/p2panda/beep-boop/pull/24