### PR TITLE
Minor API changes

### DIFF
--- a/p2panda-rs/src/entry/decode.rs
+++ b/p2panda-rs/src/entry/decode.rs
@@ -23,7 +23,10 @@ pub fn decode_entry(
     let entry: BambooEntry<ArrayVec<[u8; 64]>, ArrayVec<[u8; 64]>> = entry_encoded.into();
 
     let message = match message_encoded {
-        Some(msg) => Some(Message::from(&entry_encoded.validate_message(msg)?)),
+        Some(msg) => {
+            entry_encoded.validate_message(msg)?;
+            Some(Message::from(msg))
+        }
         None => None,
     };
 

--- a/p2panda-rs/src/entry/entry_signed.rs
+++ b/p2panda-rs/src/entry/entry_signed.rs
@@ -72,7 +72,7 @@ impl EntrySigned {
     pub fn validate_message(
         &self,
         message_encoded: &MessageEncoded,
-    ) -> Result<MessageEncoded, EntrySignedError> {
+    ) -> Result<(), EntrySignedError> {
         // Convert to Entry from bamboo_rs_core first
         let entry: BambooEntry<ArrayVec<[u8; 64]>, ArrayVec<[u8; 64]>> = self.into();
 
@@ -81,7 +81,8 @@ impl EntrySigned {
         if yamf_hash != entry.payload_hash {
             return Err(EntrySignedError::MessageHashMismatch);
         }
-        Ok(message_encoded.to_owned())
+
+        Ok(())
     }
 }
 

--- a/p2panda-rs/src/entry/tests.rs
+++ b/p2panda-rs/src/entry/tests.rs
@@ -144,8 +144,8 @@ fn fixture_sign_encode(fixture: PandaTestFixture) {
 
     // fixture EntrySigned hash should equal newly encoded EntrySigned hash.
     assert_eq!(
-        fixture.entry_signed_encoded.hash().as_hex(),
-        entry_signed_encoded.hash().as_hex()
+        fixture.entry_signed_encoded.hash().as_str(),
+        entry_signed_encoded.hash().as_str()
     );
 }
 

--- a/p2panda-rs/src/hash/hash.rs
+++ b/p2panda-rs/src/hash/hash.rs
@@ -55,7 +55,7 @@ impl Hash {
     }
 
     /// Returns hash as hex string.
-    pub fn as_hex(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         self.0.as_str()
     }
 }

--- a/p2panda-rs/src/message/message.rs
+++ b/p2panda-rs/src/message/message.rs
@@ -176,7 +176,7 @@ impl MessageFields {
     }
 
     /// Returns an iterator of existing message fields.
-    pub fn iterator(&self) -> Iter<String, MessageValue> {
+    pub fn iter(&self) -> Iter<String, MessageValue> {
         self.0.iter()
     }
 }
@@ -308,8 +308,8 @@ impl Message {
     }
 
     /// Returns schema of message.
-    pub fn schema(&self) -> Hash {
-        self.schema.clone()
+    pub fn schema(&self) -> &Hash {
+        &self.schema
     }
 
     /// Returns id of message.
@@ -467,7 +467,7 @@ mod tests {
             .add("b", MessageValue::Text("penguin".to_owned()))
             .unwrap();
 
-        let mut field_iterator = fields.iterator();
+        let mut field_iterator = fields.iter();
 
         assert_eq!(
             field_iterator.next().unwrap().1,

--- a/p2panda-rs/src/message/message_encoded.rs
+++ b/p2panda-rs/src/message/message_encoded.rs
@@ -119,7 +119,7 @@ mod tests {
 
         assert!(message.is_update());
         assert!(message.has_id());
-        assert_eq!(message.schema().as_hex(), "00402dc25d32dfb400bb295b663d4706bc47f0cb4f1edff277c737afc8a9232330ae9884fcf6d02141a785c5fd82c196b973e8427efc0c04d0444dcc3059220b9eda");
+        assert_eq!(message.schema().as_str(), "00402dc25d32dfb400bb295b663d4706bc47f0cb4f1edff277c737afc8a9232330ae9884fcf6d02141a785c5fd82c196b973e8427efc0c04d0444dcc3059220b9eda");
 
         let fields = message.fields().unwrap();
 

--- a/p2panda-rs/src/wasm.rs
+++ b/p2panda-rs/src/wasm.rs
@@ -15,7 +15,9 @@ use wasm_bindgen::JsValue;
 use crate::entry::{decode_entry as decode, sign_and_encode, Entry, EntrySigned, LogId, SeqNum};
 use crate::hash::Hash;
 use crate::identity::KeyPair;
-use crate::message::{Message, MessageEncoded, MessageFields as MessageFieldsNonWasm, MessageValue};
+use crate::message::{
+    Message, MessageEncoded, MessageFields as MessageFieldsNonWasm, MessageValue,
+};
 
 // Converts any Rust Error type into js_sys:Error while keeping its error
 // message. This helps propagating errors similar like we do in Rust but in
@@ -174,8 +176,8 @@ pub fn sign_encode_entry(
     // Serialize result to JSON
     let result = jserr!(wasm_bindgen::JsValue::from_serde(&SignEncodeEntryResult {
         entry_encoded: entry_signed.as_str().into(),
-        entry_hash: entry_signed.hash().as_hex().into(),
-        message_hash: message_encoded.hash().as_hex().into(),
+        entry_hash: entry_signed.hash().as_str().into(),
+        message_hash: message_encoded.hash().as_str().into(),
     }));
     Ok(result)
 }


### PR DESCRIPTION
Some small changes for API consistency:

* Rename `as_hex` to `as_str` for consistency with similar methods
* Rename `MessageFields::iterator` to `iter` for consistency
* Return all getter values by reference when possible
* Do not return anything when validating something

Closes: #50 