### PR TITLE
Add SPDX license headers to all files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -629,12 +629,13 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    p2panda, a peer-to-peer communications protocol for secure,
+    energy-efficient, offline- and local-first web applications.
+    Copyright (C) 2021 p2panda contributors
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,

--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ Visit the corresponding folders for development instructions:
 
 ## License
 
-GNU Affero General Public License v3.0 `AGPL-3.0`
+GNU Affero General Public License v3.0 [`AGPL-3.0-or-later`](LICENSE)

--- a/p2panda-js/README.md
+++ b/p2panda-js/README.md
@@ -128,4 +128,4 @@ localStorage.debug = 'p2panda*';
 
 ## License
 
-GNU Affero General Public License v3.0 `AGPL-3.0`
+GNU Affero General Public License v3.0 [`AGPL-3.0-or-later`](LICENSE)

--- a/p2panda-js/src/index.ts
+++ b/p2panda-js/src/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import fetch from 'node-fetch';
 import Headers from 'fetch-headers';
 

--- a/p2panda-js/src/instance.ts
+++ b/p2panda-js/src/instance.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import debug from 'debug';
 
 import { Session } from '~/index';

--- a/p2panda-js/src/keyPair.ts
+++ b/p2panda-js/src/keyPair.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import wasm from './wasm';
 
 /**

--- a/p2panda-js/src/session.ts
+++ b/p2panda-js/src/session.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import { RequestManager, HTTPTransport, Client } from '@open-rpc/client-js';
 import debug from 'debug';
 

--- a/p2panda-js/src/types.ts
+++ b/p2panda-js/src/types.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Arguments for publishing the next entry
  */

--- a/p2panda-js/src/utils.ts
+++ b/p2panda-js/src/utils.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import { Fields, FieldsTagged } from './types';
 
 /**

--- a/p2panda-js/src/wasm-adapter/browser.ts
+++ b/p2panda-js/src/wasm-adapter/browser.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import wasmBase64 from 'wasm-web/index_bg.wasm';
 import wasmInit, * as wasmLib from 'wasm-web';
 

--- a/p2panda-js/src/wasm-adapter/index.d.ts
+++ b/p2panda-js/src/wasm-adapter/index.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /* tslint:disable */
 /* eslint-disable */
 /**

--- a/p2panda-js/src/wasm-adapter/index.ts
+++ b/p2panda-js/src/wasm-adapter/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 // We need var requires to make sure that only the right wasm source
 // is imported.
 /* eslint-disable @typescript-eslint/no-var-requires */

--- a/p2panda-js/src/wasm-adapter/node.ts
+++ b/p2panda-js/src/wasm-adapter/node.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 type WasmNode = typeof import('wasm-node');
 
 const wasm: Promise<WasmNode> = import('wasm-node').then((lib) => {

--- a/p2panda-js/src/wasm.ts
+++ b/p2panda-js/src/wasm.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import { initializeWasm } from './wasm-adapter';
 
 // Helper to extract resolved promise

--- a/p2panda-js/test/instance.test.ts
+++ b/p2panda-js/test/instance.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import { expect } from 'chai';
 
 // @ts-expect-error bundle import has no type

--- a/p2panda-js/test/keyPair.test.ts
+++ b/p2panda-js/test/keyPair.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import chai, { expect, assert } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/p2panda-js/test/session.test.ts
+++ b/p2panda-js/test/session.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import chai, { assert, expect } from 'chai';
 import sinon from 'sinon';
 import chaiAsPromised from 'chai-as-promised';

--- a/p2panda-js/test/test-setup.ts
+++ b/p2panda-js/test/test-setup.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import openrpcSchema from './openrpc-template.json';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 import fs from 'fs';

--- a/p2panda-js/test/utils.test.ts
+++ b/p2panda-js/test/utils.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import { expect } from 'chai';
 
 import { marshallRequestFields, marshallResponseFields } from '../src/utils';

--- a/p2panda-js/test/wasm.test.ts
+++ b/p2panda-js/test/wasm.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import { expect } from 'chai';
 
 // @ts-expect-error bundle import has no type

--- a/p2panda-js/webpack.config.ts
+++ b/p2panda-js/webpack.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import configBrowser from './webpack/webpack.browser';
 import configNode from './webpack/webpack.node';
 

--- a/p2panda-js/webpack/webpack.browser.ts
+++ b/p2panda-js/webpack/webpack.browser.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import * as webpack from 'webpack';
 
 import config, { tsRule } from './webpack.common';

--- a/p2panda-js/webpack/webpack.common.ts
+++ b/p2panda-js/webpack/webpack.common.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import * as path from 'path';
 import * as webpack from 'webpack';
 

--- a/p2panda-js/webpack/webpack.node.ts
+++ b/p2panda-js/webpack/webpack.node.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 import * as webpack from 'webpack';
 
 import config, { tsRule } from './webpack.common';

--- a/p2panda-rs/README.md
+++ b/p2panda-rs/README.md
@@ -65,4 +65,4 @@ wasm-pack build
 
 ## License
 
-GNU Affero General Public License v3.0 `AGPL-3.0`
+GNU Affero General Public License v3.0 [`AGPL-3.0-or-later`](LICENSE)

--- a/p2panda-rs/src/entry/decode.rs
+++ b/p2panda-rs/src/entry/decode.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::convert::TryInto;
 
 use arrayvec::ArrayVec;

--- a/p2panda-rs/src/entry/encode.rs
+++ b/p2panda-rs/src/entry/encode.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::convert::TryFrom;
 
 use bamboo_rs_core::entry::MAX_ENTRY_SIZE;

--- a/p2panda-rs/src/entry/entry.rs
+++ b/p2panda-rs/src/entry/entry.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use bamboo_rs_core::entry::is_lipmaa_required;
 use serde::{Deserialize, Serialize};
 

--- a/p2panda-rs/src/entry/entry_signed.rs
+++ b/p2panda-rs/src/entry/entry_signed.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::convert::{TryFrom, TryInto};
 
 use arrayvec::ArrayVec;

--- a/p2panda-rs/src/entry/error.rs
+++ b/p2panda-rs/src/entry/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use thiserror::Error;
 
 /// Error types for methods of `Entry` struct.

--- a/p2panda-rs/src/entry/log_id.rs
+++ b/p2panda-rs/src/entry/log_id.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use serde::{Deserialize, Serialize};
 
 /// Authors can write entries to multiple logs identified by log ids.

--- a/p2panda-rs/src/entry/mod.rs
+++ b/p2panda-rs/src/entry/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 //! Create, sign, encode and decode [`Bamboo`] entries.
 //!
 //! Bamboo entries are the main data type of p2panda. Entries are organized in a distributed,

--- a/p2panda-rs/src/entry/seq_num.rs
+++ b/p2panda-rs/src/entry/seq_num.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use bamboo_rs_core::lipmaa;
 use serde::{Deserialize, Serialize};
 

--- a/p2panda-rs/src/entry/tests.rs
+++ b/p2panda-rs/src/entry/tests.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::convert::TryFrom;
 
 use rstest::{fixture, rstest};

--- a/p2panda-rs/src/hash/error.rs
+++ b/p2panda-rs/src/hash/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use thiserror::Error;
 
 /// Custom error types for `Hash`.

--- a/p2panda-rs/src/hash/hash.rs
+++ b/p2panda-rs/src/hash/hash.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::convert::TryFrom;
 
 use arrayvec::ArrayVec;

--- a/p2panda-rs/src/hash/mod.rs
+++ b/p2panda-rs/src/hash/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 //! Hash type of p2panda using BLAKE2b algorithm wrapped in [`YAMF`] "Yet-Another-Multi-Format"
 //! according to the Bamboo specification.
 //!

--- a/p2panda-rs/src/identity/author.rs
+++ b/p2panda-rs/src/identity/author.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::convert::TryFrom;
 
 use ed25519_dalek::{PublicKey, PUBLIC_KEY_LENGTH};

--- a/p2panda-rs/src/identity/error.rs
+++ b/p2panda-rs/src/identity/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use thiserror::Error;
 
 /// Custom error types for key-pairs.

--- a/p2panda-rs/src/identity/key_pair.rs
+++ b/p2panda-rs/src/identity/key_pair.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::convert::TryFrom;
 
 use ed25519_dalek::{Keypair as Ed25519Keypair, PublicKey, SecretKey, Signature, Signer};

--- a/p2panda-rs/src/identity/mod.rs
+++ b/p2panda-rs/src/identity/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 //! Generates and maintains Ed25519 key pairs with the secret and public (Author) counterparts.
 mod author;
 mod error;

--- a/p2panda-rs/src/lib.rs
+++ b/p2panda-rs/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 //! # p2panda-rs
 //!
 //! This library provides all tools required to write a client for the [p2panda] network. It is

--- a/p2panda-rs/src/message/error.rs
+++ b/p2panda-rs/src/message/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use thiserror::Error;
 
 /// Error types for methods of `Message` struct.

--- a/p2panda-rs/src/message/message.rs
+++ b/p2panda-rs/src/message/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::collections::btree_map::Iter;
 use std::collections::BTreeMap;
 

--- a/p2panda-rs/src/message/message_encoded.rs
+++ b/p2panda-rs/src/message/message_encoded.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::convert::TryFrom;
 
 use serde::{Deserialize, Serialize};

--- a/p2panda-rs/src/message/mod.rs
+++ b/p2panda-rs/src/message/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 //! Create, encode and decode p2panda messages.
 //!
 //! Messages describe data mutations in the p2panda network. Authors send messages to create,

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+

--- a/p2panda-rs/src/schema/message.rs
+++ b/p2panda-rs/src/schema/message.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /// This schema is used to verify the data integrity of all incoming messages. This does only
 /// validate the "meta" message schema and does not check against user data fields as this is part
 /// of an additional process called user schema validation.

--- a/p2panda-rs/src/schema/mod.rs
+++ b/p2panda-rs/src/schema/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 //! Validations for message payloads and definitions of system schemas.
 //!
 //! This uses [`Concise Data Definition Language`] (CDDL) internally to verify CBOR data of p2panda

--- a/p2panda-rs/src/wasm.rs
+++ b/p2panda-rs/src/wasm.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 //! Methods exported for WebAssembly targets.
 //!
 //! Wrappers for these methods are available in [p2panda-js], which allows idiomatic usage of


### PR DESCRIPTION
This PR adds short SPDX license identifiers in all files: https://spdx.github.io/spdx-spec/appendix-V-using-SPDX-short-identifiers-in-source-files/