### PR TITLE
Use deprecated linter name for now as it breaks some building pipelines

### DIFF
--- a/p2panda-rs/src/lib.rs
+++ b/p2panda-rs/src/lib.rs
@@ -45,8 +45,8 @@
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,
+    missing_doc_code_examples,
     missing_docs,
-    rustdoc::missing_doc_code_examples,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,


### PR DESCRIPTION
This will help fixing: https://github.com/p2panda/aquadoggo/issues/40
Related ticket for the future: https://github.com/p2panda/p2panda/issues/120