### PR TITLE
Update `ed25519` crate and Signature API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Highlights are marked with a pancake 🥞
 - `SchemaBuilder` and `Schema` structs for working with CDDL definitions [#78](https://github.com/p2panda/p2panda/pull/78) `rs`
 - `test_utils` module containing `rstest` fixtures, mock `Node` and `Client` structs, test data helper for `p2panda-js` [#116](https://github.com/p2panda/p2panda/pull/116) `rs`
 
+### Changed
+
+- Update `ed25519` crate to `1.3.0` and deprecated `Signature` API [#137](https://github.com/p2panda/p2panda/pull/137) `rs`
+
 ## [0.2.1]
 
 Released on 2021-10-26: :package: `p2panda-js` :package: `p2panda-rs`

--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -36,6 +36,7 @@ crate-type = ["cdylib", "rlib"]
 arrayvec = "0.5.2"
 bamboo-rs-core = "0.1.0"
 cddl = "0.8.7"
+ed25519 = "1.3.0"
 ed25519-dalek = "1.0.1"
 hex = "0.4.3"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/p2panda-rs/src/entry/entry_signed.rs
+++ b/p2panda-rs/src/entry/entry_signed.rs
@@ -4,7 +4,7 @@ use std::convert::{TryFrom, TryInto};
 
 use arrayvec::ArrayVec;
 use bamboo_rs_core::{Entry as BambooEntry, YamfHash};
-use ed25519_dalek::Signature;
+use ed25519_dalek::ed25519::Signature;
 use serde::{Deserialize, Serialize};
 
 use crate::entry::EntrySignedError;
@@ -49,7 +49,7 @@ impl EntrySigned {
 
         // Convert into Ed25519 Signature instance
         let array_vec = entry.sig.unwrap().0;
-        Signature::new(array_vec.into_inner().unwrap())
+        Signature::from_bytes(&array_vec.into_inner().unwrap()).unwrap()
     }
 
     /// Returns encoded entry as string.


### PR DESCRIPTION
The internally used `ed25519` crate inside of `ed25519-dalek` (yes, its confusing) was updated and changed its `Signature` API. Since `openmls` already uses the latest version, we should do the same.

The `ed25519` addition in `Cargo.toml` is optional, but I thought its nice to make that update explicit and not something magic happening when running `cargo update`.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
