### PR TITLE
Access secret group member list

### DIFF
--- a/p2panda-rs/src/identity/author.rs
+++ b/p2panda-rs/src/identity/author.rs
@@ -9,7 +9,7 @@ use crate::identity::AuthorError;
 use crate::Validate;
 
 /// Authors are hex encoded ed25519 public key strings.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(
     feature = "db-sqlx",
     derive(sqlx::Type, sqlx::FromRow),

--- a/p2panda-rs/src/secret_group/error.rs
+++ b/p2panda-rs/src/secret_group/error.rs
@@ -38,6 +38,10 @@ pub enum SecretGroupError {
     #[error("could not decode long-term secret")]
     LTSDecodingError,
 
+    /// Member's public key cannot be decoded as an ED25519 public key.
+    #[error("member's public key is not a valid ED25519 public key")]
+    InvalidMemberPublicKey,
+
     /// Decoding failed with unknown value.
     #[error("unknown value found during decoding")]
     UnknownValue,

--- a/p2panda-rs/src/secret_group/mls/group.rs
+++ b/p2panda-rs/src/secret_group/mls/group.rs
@@ -185,6 +185,11 @@ impl MlsGroup {
     pub fn is_active(&self) -> bool {
         self.0.is_active()
     }
+
+    /// Return members
+    pub fn members(&self) -> Result<Vec<Credential>, MlsError> {
+        Ok(self.0.members())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds a new method `members` on secret groups that returns a vector of the group members as p2panda `Author` instances.

This will fail with a `SecretGroupError` if the MLS group has members which are not using ED25519 public keys.

## 📋 Checklist

- [x] Add tests that cover your changes
~~- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`~~
~~- [ ] Link this PR to any issues it closes~~
~~- [ ] New files contain a SPDX license header~~
