### PR TITLE
Update Rust dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,14 @@ Highlights are marked with a pancake 🥞
 - Update `ed25519` crate to `1.3.0` and deprecated `Signature` API [#137](https://github.com/p2panda/p2panda/pull/137) `rs`
 - Use new `Operation` naming which replaces `Message` [#156](https://github.com/p2panda/p2panda/pull/156) _BREAKING_ `rs` `js`
 - Remove distinction of system and application log ids [#154](https://github.com/p2panda/p2panda/pull/154) `rs`
-- Update dependencies, remove deprecated eslint-loader [#155](https://github.com/p2panda/p2panda/pull/155) `js`
+- Update JavaScript dependencies, remove deprecated eslint-loader [#155](https://github.com/p2panda/p2panda/pull/155) `js`
 - Split utils modules in `test_utils` into utils.rs and constants.rs [#157](https://github.com/p2panda/p2panda/pull/157) `rs`
 - Use traits for validation methods in `Schema` [#160](https://github.com/p2panda/p2panda/pull/160) `rs`
 - Add `previous_operations` field in `Operation` [#163](https://github.com/p2panda/p2panda/pull/163) _BREAKING_ `rs` `js`
 - Introduce `OperationWithMeta` struct [#163](https://github.com/p2panda/p2panda/pull/163) `rs`
 - Update API and mocks to reflect yasmf hash and document flow changes [#165](https://github.com/p2panda/p2panda/pull/165) _BREAKING_ `rs` `js`
 - Change to new `rustdoc::missing_doc_code_examples` linter name [#168](https://github.com/p2panda/p2panda/pull/168) `rs`
+- Update Rust dependencies [#171](https://github.com/p2panda/p2panda/pull/171) `rs`
 
 ### Campfires and boiling pots to sit around
 

--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -40,12 +40,12 @@ cddl = "0.8.7"
 ed25519 = "1.3.0"
 ed25519-dalek = "1.0.1"
 hex = "0.4.3"
-serde = { version = "1.0.130", features = ["derive"] }
+serde = { version = "1.0.132", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_repr = "0.1.7"
-serde_json = "1.0.59"
-thiserror = "1.0.29"
-tls_codec = { version = "0.2.0-pre.2", features = [
+serde_json = "1.0.73"
+thiserror = "1.0.30"
+tls_codec = { version = "0.2.0-pre.3", features = [
   "derive",
   "serde_serialize",
 ] }
@@ -81,12 +81,12 @@ branch = "p2panda"
 rand = "0.7.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = "0.1.6"
+console_error_panic_hook = "0.1.7"
 js-sys = "0.3.55"
 rand = { version = "0.7.3", features = ["wasm-bindgen"] }
 wasm-bindgen = "0.2.78"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.28"
-rstest = "0.11.0"
+rstest = "0.12.0"
 rstest_reuse = "0.1.3"


### PR DESCRIPTION
Updates a couple of our Rust dependencies except `arrayvec` and `rand`.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
