### PR TITLE
Update Codecov GitHub action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -143,6 +143,4 @@ jobs:
           args: --manifest-path ${{ env.cargo_manifest }} --skip-clean --locked
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Highlights are marked with a pancake 🥞
 - Make clippy happy, add CI for linter checks [#153](https://github.com/p2panda/p2panda/pull/153) `rs`
 - Clean up documentation and update new terminology [#170](https://github.com/p2panda/p2panda/pull/170) `rs` `js`
 - Improve CI, make it faster, add code coverage report [#173](https://github.com/p2panda/p2panda/pull/173) `rs` `js`
+- Update Codecov GH action [#176](https://github.com/p2panda/p2panda/pull/176) `rs`
 
 ## [0.2.1]
 


### PR DESCRIPTION
Version 1 is deprecated, read here: https://github.com/codecov/codecov-action. Also, no token is required for public repositories.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
