### PR TITLE
Add test to check main fn of generate-test-data

### DIFF
--- a/p2panda-rs/src/test_utils/generate_test_data.rs
+++ b/p2panda-rs/src/test_utils/generate_test_data.rs
@@ -185,4 +185,10 @@ mod tests {
         // Both should be equal
         assert_eq!(generated_test_data_json, fixture_test_data_json);
     }
+
+    #[test]
+    fn test_main() {
+        // Check that example values actually work
+        crate::main();
+    }
 }


### PR DESCRIPTION
I noticed the low test coverage in this module and added a test that just runs the `main()` to check that the given example values don't result in errors.

## 📋 Checklist

- [ ] ~~Add tests that cover your changes~~
- [ ] ~~Add this PR to the _Unreleased_ section in `CHANGELOG.md`~~
- [ ] ~~Link this PR to any issues it closes~~
- [ ] ~~New files contain a SPDX license header~~
- [ ] ~~Check if descriptions and terminology match `handbook` content (and visa-versa)~~
