### PR TITLE
Sketch for global operation CDDL

### DIFF
--- a/p2panda-rs/src/schema/fields.rs
+++ b/p2panda-rs/src/schema/fields.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// CDDL types.
+#[derive(Clone, Debug, Copy)]
+#[allow(missing_docs)]
+pub enum Type {
+    Bool,
+    Int,
+    Float,
+    Tstr,
+    Relation,
+}
+
+/// CDDL schema type string formats.
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let cddl_type = match self {
+            Type::Bool => "bool",
+            Type::Int => "int",
+            Type::Float => "float",
+            Type::Tstr => "tstr",
+            Type::Relation => "tstr .regexp \"[0-9a-f]{68}\"",
+        };
+        write!(f, "{}", cddl_type)
+    }
+}
+
+/// CDDL field types.
+#[derive(Clone, Debug)]
+pub enum Field {
+    String(String),
+    Type(Type),
+    Struct(Group),
+}
+
+/// Format each different data type into a schema string.
+impl fmt::Display for Field {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Field::String(s) => write!(f, "\"{}\"", s),
+            Field::Type(cddl_type) => write!(f, "{}", cddl_type),
+            Field::Struct(group) => write!(f, "{{ {} }}", group),
+        }
+    }
+}
+
+/// Struct for building and representing CDDL groups. CDDL uses groups to define reusable data
+/// structures they can be merged into schema or used in Vectors, Tables and Structs.
+#[derive(Clone, Debug)]
+pub struct Group {
+    #[allow(dead_code)] // Remove when schema module is used.
+    name: String,
+    fields: BTreeMap<String, Field>,
+}
+
+impl Group {
+    /// Create a new CDDL group.
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            fields: BTreeMap::new(),
+        }
+    }
+
+    /// Add a field to the group.
+    pub fn add_field(&mut self, key: &str, field_type: Field) {
+        self.fields.insert(key.to_owned(), field_type);
+    }
+}
+
+impl fmt::Display for Group {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let map = &self.fields;
+        write!(f, "( ")?;
+        for (count, value) in map.iter().enumerate() {
+            // For every element except the first, add a comma
+            if count != 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}: {}", value.0, value.1)?;
+        }
+        write!(f, " )")
+    }
+}

--- a/p2panda-rs/src/schema/mod.rs
+++ b/p2panda-rs/src/schema/mod.rs
@@ -10,13 +10,16 @@
 use cddl::validator::cbor;
 
 mod error;
+mod fields;
 mod operation;
 #[allow(clippy::module_inception)]
 mod schema;
+mod system;
 
 pub use error::SchemaError;
 pub use operation::OPERATION_SCHEMA;
-pub use schema::{Schema, SchemaBuilder, Type};
+pub use schema::{Schema, SchemaBuilder};
+pub use system::get_system_cddl;
 
 /// Checks CBOR bytes against CDDL schemas.
 ///

--- a/p2panda-rs/src/schema/mod.rs
+++ b/p2panda-rs/src/schema/mod.rs
@@ -18,7 +18,7 @@ mod system;
 
 pub use error::SchemaError;
 pub use operation::OPERATION_SCHEMA;
-pub use schema::{Schema, SchemaBuilder};
+pub use schema::{Schema, SchemaBuilder, ValidateOperation};
 pub use system::get_system_cddl;
 
 /// Checks CBOR bytes against CDDL schemas.

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -5,13 +5,13 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::fmt;
 
+use super::fields::{Field, Group, Type};
 use cddl::lexer::Lexer;
 use cddl::parser::Parser;
 #[cfg(not(target_arch = "wasm32"))]
 use cddl::validate_cbor_from_slice;
 #[cfg(not(target_arch = "wasm32"))]
 use cddl::validator::cbor;
-use super::fields::{Field, Group, Type};
 
 use crate::hash::Hash;
 #[cfg(not(target_arch = "wasm32"))]

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -202,7 +202,7 @@ impl fmt::Display for Schema {
 
 impl ValidateOperation for Schema {}
 
-trait ValidateOperation
+pub trait ValidateOperation
 where
     Self: fmt::Display,
 {

--- a/p2panda-rs/src/schema/system.rs
+++ b/p2panda-rs/src/schema/system.rs
@@ -4,6 +4,8 @@ use crate::hash::Hash;
 use crate::schema::fields::Type;
 use crate::schema::SchemaBuilder;
 
+use super::Schema;
+
 /// Make CDDL definition for operations from a given schema
 fn make_schema_cddl(
     schema_name: &str,
@@ -24,42 +26,53 @@ fn make_schema_cddl(
         hash = tstr .regexp "[0-9a-f]{{68}}"
 
         operation-body-{name}-{hash} = (
-            action: "create", fields: operation-fields-{name}-{hash}"#,
+            action: "create",
+            fields: operation-fields-{name}-{hash}
+        )
+        "#,
         hash = hash,
         name = schema_name
     );
 
     if can_update {
         schema.push_str(&format!(
-            r#" //
-        action: "update", fields: operation-fields-{name}-{hash}, previousOperations: [1* hash]"#,
+            r#"
+        operation-body-{name}-{hash} //= (
+            action: "update",
+            fields: operation-fields-{name}-{hash},
+            previousOperations: [1* hash]
+        )
+        "#,
             hash = hash,
             name = schema_name
         ));
     }
 
     if can_delete {
-        schema.push_str(
-            r#" //
-        action: "delete", previousOperations: [1* hash]"#,
-        );
+        schema.push_str(&format!(
+            r#"
+        operation-body-{name}-{hash} //= (
+            action: "delete",
+            previousOperations: [1* hash]
+        )
+        "#,
+            hash = hash,
+            name = schema_name
+        ));
     }
 
-    // Close operation-body definition
-    schema.push_str("\n\t)\n");
-
     // Insert definition for operation fields from schema builder
-    schema.push_str(&format!("{}", &fields_schema_builder));
+    schema.push_str(&format!("\n\t{}", &fields_schema_builder));
 
     schema
 }
 
 /// Create CDDL definition for bookmarks schema
-fn get_bookmarks_schema() -> (String, String) {
+fn get_bookmarks_schema() -> Schema {
     let schema_name = "bookmarks";
-    let schema_hash: String = Hash::new_from_bytes(vec![1, 2, 3]).unwrap().as_str().into();
+    let schema_hash = Hash::new_from_bytes(vec![1, 2, 3]).unwrap();
 
-    let fields_label = format!("operation-fields-{}-{}", schema_name, schema_hash);
+    let fields_label = format!("operation-fields-{}-{}", schema_name, schema_hash.as_str());
     let mut fields_schema = SchemaBuilder::new(fields_label);
     fields_schema
         .add_operation_field("title".into(), Type::Tstr)
@@ -71,22 +84,29 @@ fn get_bookmarks_schema() -> (String, String) {
         .add_operation_field("created".into(), Type::Tstr)
         .unwrap();
 
-    let cddl = make_schema_cddl(schema_name, &schema_hash, &fields_schema, true, true);
-
-    (schema_hash, cddl)
+    let cddl = make_schema_cddl(
+        schema_name,
+        schema_hash.as_str(),
+        &fields_schema,
+        true,
+        false,
+    );
+    Schema::new(&schema_hash, &cddl).unwrap()
 }
 
 /// Returns global CDDL definition that validates all registered schemas' operations
 pub fn get_system_cddl() -> String {
     // (Hash, CDDL) pairs of all known schemas
-    let system_schemas: [(String, String); 1] = [get_bookmarks_schema()];
+    let system_schemas: [Schema; 1] = [get_bookmarks_schema()];
 
     // Concatenated into one string
     let system_schema_cddl = system_schemas
         .iter()
-        .map(|(_, schema)| format!("{}\n\n", schema))
+        .map(|schema| format!("{}\n\n", schema))
         .reduce(|cur, acc| format!("{}\n\n{}", acc, cur))
         .unwrap();
+
+    // println!("{}", system_schema_cddl);
 
     system_schema_cddl
 }
@@ -97,10 +117,11 @@ mod tests {
     use crate::{
         hash::Hash,
         operation::{Operation, OperationEncoded, OperationFields, OperationValue},
+        schema::{ValidateOperation, Schema},
     };
 
     #[test]
-    fn test_validate_with_system_cddl() {
+    fn test_validate_correct_system_cddl() {
         use std::convert::TryFrom;
 
         let schema_hash = Hash::new_from_bytes(vec![1, 2, 3]).unwrap();
@@ -116,11 +137,39 @@ mod tests {
         fields
             .add("created", OperationValue::Text("2022-01-31".into()))
             .unwrap();
+        let prev_ops: Vec<Hash> = vec![Hash::new_from_bytes(vec![1, 2, 3]).unwrap()];
+        let operation = Operation::new_update(schema_hash.clone(), prev_ops, fields).unwrap();
 
-        let operation = Operation::new_create(schema_hash, fields).unwrap();
+        let cddl = get_system_cddl();
+        // This instance of `Schema` is not representing a specific schema but the entirety of
+        // registered schemas.
+        let system_cddl = Schema::new(&schema_hash, &cddl).unwrap();
+
+        let operation_encoded = OperationEncoded::try_from(&operation).unwrap();
+        assert!(system_cddl.validate_operation(operation_encoded.to_bytes()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_failing_system_cddl() {
+        use std::convert::TryFrom;
+
+        let schema_hash = Hash::new_from_bytes(vec![1, 2, 3]).unwrap();
+
+        // Create test operation
+        let mut fields = OperationFields::new();
+        fields
+            .add("title", OperationValue::Text("p2panda".into()))
+            .unwrap();
+        fields
+            .add("url", OperationValue::Text("https://p2panda.org".into()))
+            .unwrap();
+
+        let operation = Operation::new_create(schema_hash.clone(), fields).unwrap();
 
         let cddl = get_system_cddl();
         let operation_encoded = OperationEncoded::try_from(&operation).unwrap();
-        cddl::validate_cbor_from_slice(&cddl, &operation_encoded.to_bytes()).unwrap();
+
+        let system_cddl = Schema::new(&schema_hash, &cddl).unwrap();
+        assert!(system_cddl.validate_operation(operation_encoded.to_bytes()).is_err());
     }
 }

--- a/p2panda-rs/src/schema/system.rs
+++ b/p2panda-rs/src/schema/system.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use crate::hash::Hash;
+use crate::schema::fields::Type;
+use crate::schema::SchemaBuilder;
+
+/// Make CDDL definition for operations from a given schema
+fn make_schema_cddl(
+    schema_name: &str,
+    hash: &str,
+    fields_schema_builder: &SchemaBuilder,
+    can_update: bool,
+    can_delete: bool,
+) -> String {
+    let mut schema = format!(
+        r#"; System schema {name}
+
+        {name} = {{
+            schema: "{hash}",
+            version: 1,
+            operation-body-{name}-{hash},
+        }}
+
+        hash = tstr .regexp "[0-9a-f]{{68}}"
+
+        operation-body-{name}-{hash} = (
+            action: "create", fields: operation-fields-{name}-{hash}"#,
+        hash = hash,
+        name = schema_name
+    );
+
+    if can_update {
+        schema.push_str(&format!(
+            r#" //
+        action: "update", fields: operation-fields-{name}-{hash}, previousOperations: [1* hash]"#,
+            hash = hash,
+            name = schema_name
+        ));
+    }
+
+    if can_delete {
+        schema.push_str(
+            r#" //
+        action: "delete", previousOperations: [1* hash]"#,
+        );
+    }
+
+    // Close operation-body definition
+    schema.push_str("\n\t)\n");
+
+    // Insert definition for operation fields from schema builder
+    schema.push_str(&format!("{}", &fields_schema_builder));
+
+    schema
+}
+
+/// Create CDDL definition for bookmarks schema
+fn get_bookmarks_schema() -> (String, String) {
+    let schema_name = "bookmarks";
+    let schema_hash: String = Hash::new_from_bytes(vec![1, 2, 3]).unwrap().as_str().into();
+
+    let fields_label = format!("operation-fields-{}-{}", schema_name, schema_hash);
+    let mut fields_schema = SchemaBuilder::new(fields_label);
+    fields_schema
+        .add_operation_field("title".into(), Type::Tstr)
+        .unwrap();
+    fields_schema
+        .add_operation_field("url".into(), Type::Tstr)
+        .unwrap();
+    fields_schema
+        .add_operation_field("created".into(), Type::Tstr)
+        .unwrap();
+
+    let cddl = make_schema_cddl(schema_name, &schema_hash, &fields_schema, true, true);
+
+    (schema_hash, cddl)
+}
+
+/// Returns global CDDL definition that validates all registered schemas' operations
+pub fn get_system_cddl() -> String {
+    // (Hash, CDDL) pairs of all known schemas
+    let system_schemas: [(String, String); 1] = [get_bookmarks_schema()];
+
+    // Concatenated into one string
+    let system_schema_cddl = system_schemas
+        .iter()
+        .map(|(_, schema)| format!("{}\n\n", schema))
+        .reduce(|cur, acc| format!("{}\n\n{}", acc, cur))
+        .unwrap();
+
+    system_schema_cddl
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_system_cddl;
+    use crate::{
+        hash::Hash,
+        operation::{Operation, OperationEncoded, OperationFields, OperationValue},
+    };
+
+    #[test]
+    fn test_validate_with_system_cddl() {
+        use std::convert::TryFrom;
+
+        let schema_hash = Hash::new_from_bytes(vec![1, 2, 3]).unwrap();
+
+        // Create test operation
+        let mut fields = OperationFields::new();
+        fields
+            .add("title", OperationValue::Text("p2panda".into()))
+            .unwrap();
+        fields
+            .add("url", OperationValue::Text("https://p2panda.org".into()))
+            .unwrap();
+        fields
+            .add("created", OperationValue::Text("2022-01-31".into()))
+            .unwrap();
+
+        let operation = Operation::new_create(schema_hash, fields).unwrap();
+
+        let cddl = get_system_cddl();
+        let operation_encoded = OperationEncoded::try_from(&operation).unwrap();
+        cddl::validate_cbor_from_slice(&cddl, &operation_encoded.to_bytes()).unwrap();
+    }
+}

--- a/p2panda-rs/src/schema/system.rs
+++ b/p2panda-rs/src/schema/system.rs
@@ -6,6 +6,32 @@ use crate::schema::SchemaBuilder;
 
 use super::Schema;
 
+// type SchemaStore = BTreeMap<String, Schemas>;
+
+// enum Schemas {
+//     Application(Schema),
+//     System(SystemSchema)
+// }
+
+// enum SystemSchema {
+//     KeyGroup(Schema),
+//     ApplicationSchema(Schema)
+// }
+
+
+// // Loaded from database + hard coded system schemas
+
+// if (schema_store.valid_operation(operation)) {
+//     materialise()
+// }
+
+// if (schema_store.valid_query(query: AbstractQuery)) {
+//     fetch(query.to_sql())
+// }
+
+// schema_store.schemas().map(|schema| todo!() )
+
+
 /// Make CDDL definition for operations from a given schema
 fn make_schema_cddl(
     schema_name: &str,
@@ -142,6 +168,7 @@ mod tests {
         let operation = Operation::new_update(schema_hash.clone(), prev_ops, fields).unwrap();
 
         let cddl = get_system_cddl();
+        println!("{}", cddl);
         // This instance of `Schema` is not representing a specific schema but the entirety of
         // registered schemas.
         let system_cddl = Schema::new(&schema_hash, &cddl).unwrap();
@@ -173,6 +200,7 @@ mod tests {
         let operation_encoded = OperationEncoded::try_from(&operation).unwrap();
 
         let system_cddl = Schema::new(&schema_hash, &cddl).unwrap();
+        println!("{}", system_cddl.validate_operation(operation_encoded.to_bytes()).unwrap_err());
         assert!(system_cddl
             .validate_operation(operation_encoded.to_bytes())
             .is_err());

--- a/p2panda-rs/src/schema/system.rs
+++ b/p2panda-rs/src/schema/system.rs
@@ -112,6 +112,7 @@ pub fn get_system_cddl() -> String {
 }
 
 #[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
 mod tests {
     use super::get_system_cddl;
     use crate::{

--- a/p2panda-rs/src/schema/system.rs
+++ b/p2panda-rs/src/schema/system.rs
@@ -118,7 +118,7 @@ mod tests {
     use crate::{
         hash::Hash,
         operation::{Operation, OperationEncoded, OperationFields, OperationValue},
-        schema::{ValidateOperation, Schema},
+        schema::{Schema, ValidateOperation},
     };
 
     #[test]
@@ -147,7 +147,9 @@ mod tests {
         let system_cddl = Schema::new(&schema_hash, &cddl).unwrap();
 
         let operation_encoded = OperationEncoded::try_from(&operation).unwrap();
-        assert!(system_cddl.validate_operation(operation_encoded.to_bytes()).is_ok());
+        assert!(system_cddl
+            .validate_operation(operation_encoded.to_bytes())
+            .is_ok());
     }
 
     #[test]
@@ -171,6 +173,8 @@ mod tests {
         let operation_encoded = OperationEncoded::try_from(&operation).unwrap();
 
         let system_cddl = Schema::new(&schema_hash, &cddl).unwrap();
-        assert!(system_cddl.validate_operation(operation_encoded.to_bytes()).is_err());
+        assert!(system_cddl
+            .validate_operation(operation_encoded.to_bytes())
+            .is_err());
     }
 }


### PR DESCRIPTION
Sketch to create a global representation of all valid operations in a single CDDL definition that can be used to test encoded operations for whether they are fit to be materialised.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
- [ ] Check if descriptions and terminology match `handbook` content (and visa-versa) 
