### PR TITLE
Add tests for size and signature method of EntrySigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Highlights are marked with a pancake 🥞
 - `test_utils` module containing `rstest` fixtures, mock `Node` and `Client` structs, test data helper for `p2panda-js` [#116](https://github.com/p2panda/p2panda/pull/116) `rs`
 - Reconciliation logic /w DAG for materialisation module [#129](https://github.com/p2panda/p2panda/pull/129) `rs`
 - `Instance` which encapsulates the materialised view of a reduced collection of `Operations` [#161](https://github.com/p2panda/p2panda/pull/161) `rs`
+- Retrieve unsigned bytes to verify `Entry` signatures manually #[197](https://github.com/p2panda/p2panda/pull/197/files) `rs`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Highlights are marked with a pancake 🥞
 - `test_utils` module containing `rstest` fixtures, mock `Node` and `Client` structs, test data helper for `p2panda-js` [#116](https://github.com/p2panda/p2panda/pull/116) `rs`
 - Reconciliation logic /w DAG for materialisation module [#129](https://github.com/p2panda/p2panda/pull/129) `rs`
 - `Instance` which encapsulates the materialised view of a reduced collection of `Operations` [#161](https://github.com/p2panda/p2panda/pull/161) `rs`
-- Retrieve unsigned bytes to verify `Entry` signatures manually #[197](https://github.com/p2panda/p2panda/pull/197/files) `rs`
+- Retrieve unsigned bytes to verify `Entry` signatures manually [#197](https://github.com/p2panda/p2panda/pull/197/files) `rs`
 
 ### Changed
 

--- a/p2panda-rs/src/entry/entry_signed.rs
+++ b/p2panda-rs/src/entry/entry_signed.rs
@@ -125,7 +125,31 @@ impl Validate for EntrySigned {
 
 #[cfg(test)]
 mod tests {
-    use super::EntrySigned;
+    use rstest::rstest;
+    use std::convert::TryInto;
+
+    use crate::entry::EntrySigned;
+    use crate::{
+        identity::KeyPair,
+        test_utils::fixtures::{entry_signed_encoded, key_pair},
+    };
+
+    #[rstest]
+    fn test_entry_signed(entry_signed_encoded: EntrySigned, key_pair: KeyPair) {
+        let signature = entry_signed_encoded.signature();
+        let verification = KeyPair::verify(
+            key_pair.public_key(),
+            &entry_signed_encoded.to_bytes(),
+            &signature
+        );
+        assert!(verification.is_ok(), "{:?}", verification.unwrap_err())
+    }
+
+    #[rstest]
+    fn test_size(entry_signed_encoded: EntrySigned) {
+        let size: usize = entry_signed_encoded.size().try_into().unwrap();
+        assert_eq!(size, entry_signed_encoded.to_bytes().len())
+    }
 
     #[test]
     fn validate() {

--- a/p2panda-rs/src/identity/key_pair.rs
+++ b/p2panda-rs/src/identity/key_pair.rs
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::convert::TryFrom;
-
-use arrayvec::ArrayVec;
 use ed25519_dalek::{Keypair as Ed25519Keypair, PublicKey, SecretKey, Signature, Signer, Verifier};
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 
-use crate::{entry::SIGNATURE_SIZE, hash::HASH_SIZE, identity::KeyPairError};
+use crate::identity::KeyPairError;
 
 /// Ed25519 key pair for authors to sign Bamboo entries with.
 #[derive(Debug, Serialize, Deserialize)]

--- a/p2panda-rs/src/identity/key_pair.rs
+++ b/p2panda-rs/src/identity/key_pair.rs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::convert::TryFrom;
+
+use arrayvec::ArrayVec;
 use ed25519_dalek::{Keypair as Ed25519Keypair, PublicKey, SecretKey, Signature, Signer, Verifier};
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 
-use crate::identity::KeyPairError;
+use crate::{entry::SIGNATURE_SIZE, hash::HASH_SIZE, identity::KeyPairError};
 
 /// Ed25519 key pair for authors to sign Bamboo entries with.
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Text coverage showed that some parts of `EntrySigned` were not covered. I added these tests but the signature seems to be broken. We don't use it anywhere.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
