### PR TITLE
Derive Ord and PartialOrd for LogId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
-## Changed
+## Added
 
 - Derive `Ord` and `PartialOrd` for `LogId` [#201](https://github.com/p2panda/p2panda/pull/201)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
+## Changed
+
+- Derive `Ord` and `PartialOrd` for `LogId` [#201](https://github.com/p2panda/p2panda/pull/201)
+
 ## [0.3.0]
 
 Released on 2022-02-02: :package: `p2panda-js`

--- a/p2panda-rs/src/entry/log_id.rs
+++ b/p2panda-rs/src/entry/log_id.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::entry::error::LogIdError;
 
 /// Authors can write entries to multiple logs identified by log ids.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, StdHash)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, PartialOrd, Serialize, StdHash)]
 pub struct LogId(u64);
 
 impl LogId {


### PR DESCRIPTION
This is required for https://github.com/p2panda/aquadoggo/pull/66 

I am not adding tests for this because it's ridiculous.

## 📋 Checklist

- [ ] ~~Add tests that cover your changes~~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
