### PR TITLE
Fix js field type determination

### DIFF
--- a/p2panda-js/src/document/document.ts
+++ b/p2panda-js/src/document/document.ts
@@ -4,9 +4,12 @@ import wasm from '~/wasm';
 import { getOperationFields } from '~/operation';
 import { marshallRequestFields } from '~/utils';
 import { signPublishEntry } from '~/entry';
+import debug from 'debug';
 
 import type { Context } from '~/session';
 import type { Fields } from '~/types';
+
+const log = debug('p2panda-js:document');
 
 /**
  * Signs and publishes a CREATE operation for the given application data and
@@ -19,6 +22,8 @@ export const createDocument = async (
   { keyPair, schema, session }: Context,
 ): Promise<string> => {
   const { encodeCreateOperation } = await wasm;
+
+  log(`Creating document`, fields);
 
   const fieldsTagged = marshallRequestFields(fields);
   const operationFields = await getOperationFields(fieldsTagged);
@@ -46,6 +51,12 @@ export const updateDocument = async (
   { keyPair, schema, session }: Context,
 ): Promise<string> => {
   const { encodeUpdateOperation } = await wasm;
+
+  log(`Updating document`, {
+    document: documentId,
+    previousOperations,
+    fields,
+  });
 
   const fieldsTagged = marshallRequestFields(fields);
   const operationFields = await getOperationFields(fieldsTagged);
@@ -80,6 +91,8 @@ export const deleteDocument = async (
   { keyPair, schema, session }: Context,
 ): Promise<string> => {
   const { encodeDeleteOperation } = await wasm;
+
+  log('Deleting document', { document: documentId, previousOperations });
 
   const encodedOperation = encodeDeleteOperation(schema, previousOperations);
 

--- a/p2panda-js/src/utils.ts
+++ b/p2panda-js/src/utils.ts
@@ -15,18 +15,25 @@ const FIELD_TYPE_MAPPING = {
  * While we don't have proper schema support in the node this function just
  * guesses the schema's field type from a supplied fields record.
  *
+ * Returns null when a key has no value.
+ *
  * @param fields assumed to be correct operation fields for an instance
- * @param field name of the field for which to look up the type
+ * @param key name of the field for which to look up the type
  * @returns field type
  */
 const getFieldType = (
   fields: Fields,
-  field: string,
-): 'string' | 'bool' | 'int' => {
-  const type = typeof fields[field];
+  key: string,
+): 'string' | 'bool' | 'int' | null => {
+  const type = typeof fields[key];
+
+  if (type === 'undefined') {
+    // Return null if a key has no value
+    return null;
+  }
 
   if (!Object.keys(FIELD_TYPE_MAPPING).includes(type)) {
-    throw new Error(`Unsupported field type: ${typeof field}`);
+    throw new Error(`Unsupported field type: ${type}`);
   }
 
   // @ts-expect-error we have made sure that `type` is a key of `mapping`
@@ -66,6 +73,9 @@ export const marshallRequestFields = (fields: Fields): FieldsTagged => {
         break;
       case 'bool':
         map.set(key, { value: value as boolean, type: 'bool' });
+        break;
+      case null:
+        // Skip fields that have no value
         break;
       default:
         map.set(key, { value: value as string, type: 'str' });


### PR DESCRIPTION
Fixes the behavior of `getFieldType`

Now, operation fields with undefined values
result in a return value `null`, which then causes
these fields not to be included in the published operation.

I am not adding tests because this will be replaced once we have access to schema definitions and don't need to rely on value introspection to determine field types.

## 📋 Checklist

- [ ] ~~Add tests that cover your changes~~
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
- [ ] Check if descriptions and terminology match `handbook` content (and visa-versa) 
