### PR TITLE
Better CDDL error strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Highlights are marked with a pancake 🥞
 
 - Fix determination of field types in p2panda-js [#202](https://github.com/p2panda/p2panda/pull/202)
 
+## Everything burrito
+
+- Easier to read CDDL schema error strings [#207](https://github.com/p2panda/p2panda/pull/207)
+
 ## [0.3.0]
 
 Released on 2022-02-02: :package: `p2panda-js`

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -3,11 +3,12 @@
 use thiserror::Error;
 
 /// Custom error types for schema validation.
-#[derive(Error, Debug)]
+#[derive(Error)]
 pub enum SchemaError {
     /// Operation contains invalid fields.
-    #[error("invalid operation schema: {0}")]
-    InvalidSchema(String),
+    // Note: We pretty-print the vector of error strings to get line breaks
+    #[error("invalid operation schema: {0:#?}")]
+    InvalidSchema(Vec<String>),
 
     /// Operation can't be deserialised from invalid CBOR encoding.
     #[error("invalid CBOR format")]
@@ -32,4 +33,12 @@ pub enum SchemaError {
     /// `Operation` error.
     #[error("error while creating operation")]
     OperationError(#[from] crate::operation::OperationError),
+}
+
+impl std::fmt::Debug for SchemaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // We want to format based on `Display` ("{}") instead of `Debug` ("{:?}") to respect line
+        // breaks from the displayed error messages.
+        f.write_str(format!("{}", self).as_ref())
+    }
 }

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -37,8 +37,18 @@ pub enum SchemaError {
 
 impl std::fmt::Debug for SchemaError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            SchemaError::InvalidSchema(_) => write!(f, "InvalidSchema"),
+            SchemaError::InvalidCBOR => write!(f, "InvalidCBOR"),
+            SchemaError::NoSchema => write!(f, "NoSchema"),
+            SchemaError::ParsingError(_) => write!(f, "ParsingError"),
+            SchemaError::ValidationError(_) => write!(f, "ValidationError"),
+            SchemaError::OperationFieldsError(_) => write!(f, "OperationFieldsError"),
+            SchemaError::OperationError(_) => write!(f, "OperationError"),
+        }?;
+
         // We want to format based on `Display` ("{}") instead of `Debug` ("{:?}") to respect line
         // breaks from the displayed error messages.
-        f.write_str(format!("{}", self).as_ref())
+        f.write_str(format!("({})", self).as_ref())
     }
 }

--- a/p2panda-rs/src/schema/mod.rs
+++ b/p2panda-rs/src/schema/mod.rs
@@ -28,9 +28,8 @@ pub fn validate_schema(cddl_schema: &str, bytes: Vec<u8>) -> Result<(), SchemaEr
         Err(cbor::Error::Validation(err)) => {
             let err_str = err
                 .iter()
-                .map(|fe| format!("{}: \"{}\"", fe.cbor_location, fe.reason))
-                .collect::<Vec<String>>()
-                .join(", ");
+                .map(|fe| format!("{}", fe).replace("\"", "'"))
+                .collect::<Vec<String>>();
 
             Err(error::SchemaError::InvalidSchema(err_str))
         }

--- a/p2panda-rs/src/schema/mod.rs
+++ b/p2panda-rs/src/schema/mod.rs
@@ -28,7 +28,14 @@ pub fn validate_schema(cddl_schema: &str, bytes: Vec<u8>) -> Result<(), SchemaEr
         Err(cbor::Error::Validation(err)) => {
             let err_str = err
                 .iter()
-                .map(|fe| format!("{}", fe).replace("\"", "'"))
+                .map(|fe| {
+                    format!("{}", fe)
+                        // Quotes escaped in error messages from `cddl` crate are actually not unescaped by
+                        // format macro.
+                        //
+                        // See: https://github.com/anweiss/cddl/blob/main/src/validator/cbor.rs#L100
+                        .replace("\"", "'")
+                })
                 .collect::<Vec<String>>();
 
             Err(error::SchemaError::InvalidSchema(err_str))

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -187,7 +187,7 @@ impl Schema {
 
         let schema_hash = match Hash::new(schema_hash.as_str()) {
             Ok(hash) => Ok(hash),
-            Err(err) => Err(SchemaError::InvalidSchema(err.to_string())),
+            Err(err) => Err(SchemaError::InvalidSchema(vec![err.to_string()])),
         }?;
 
         Ok(Self {
@@ -239,7 +239,7 @@ impl Schema {
         for (key, value) in key_values {
             match fields.add(key, value) {
                 Ok(_) => Ok(()),
-                Err(err) => Err(SchemaError::InvalidSchema(err.to_string())),
+                Err(err) => Err(SchemaError::InvalidSchema(vec![err.to_string()])),
             }?;
         }
 
@@ -250,7 +250,7 @@ impl Schema {
 
         match Operation::new_update(self.schema_hash(), previous_operations, fields) {
             Ok(hash) => Ok(hash),
-            Err(err) => Err(SchemaError::InvalidSchema(err.to_string())),
+            Err(err) => Err(SchemaError::InvalidSchema(vec![err.to_string()])),
         }
     }
 
@@ -298,7 +298,7 @@ where
                     .collect::<Vec<String>>()
                     .join(", ");
 
-                Err(SchemaError::InvalidSchema(err))
+                Err(SchemaError::InvalidSchema(vec![err]))
             }
             Err(cbor::Error::CBORParsing(_err)) => Err(SchemaError::InvalidCBOR),
             Err(cbor::Error::CDDLParsing(err)) => {


### PR DESCRIPTION
Before:

```
thread 'test_utils::mocks::logs::tests::log_entry' panicked at 'called `Result::unwrap()` on an `Err` value: OperationEncodedError(SchemaError(InvalidSchema("/\"fields\": \"unexpected key Text(\"type\")\"\n/\"action\": \"expected value \"update\" got \"create\"\"\n/\"fields\": \"unexpected key Text(\"type\")\"\n: \"object missing key: \"\"previousOperations\"\"\"\n/\"action\": \"expected value \"delete\" got \"create\"\"\n: \"object missing key: \"\"previousOperations\"\"\"\n: \"unexpected key Text(\"schema\")\"")))', src/test_utils/fixtures/param_fixtures.rs:143:40
```

After:

```
thread 'test_utils::mocks::node::tests::concurrent_updates' panicked at 'called `Result::unwrap()` on an `Err` value: OperationEncodedError(SchemaError(InvalidSchema(invalid operation schema: [
    "error validating group choice at cddl location '' and cbor location /'fields': unexpected key Text('type')",
    "error validating group choice at cddl location '' and cbor location /'fields': unexpected key Text('type')",
    "error validating group choice group entry associated with rule 'operation-body' at cddl location '' and cbor location /'action': expected value 'update' got 'create'",
    "error validating group choice at cddl location '' and cbor location /'fields': unexpected key Text('type')",
    "error validating group choice at cddl location '' and cbor location /'fields': unexpected key Text('type')",
    "error validating group choice group entry associated with rule 'operation-body' at cddl location '' and cbor location : object missing key: ''previousOperations''",
    "error validating group choice group entry associated with rule 'operation-body' at cddl location '' and cbor location /'action': expected value 'delete' got 'create'",
    "error validating group choice group entry associated with rule 'operation-body' at cddl location '' and cbor location : object missing key: ''previousOperations''",
    "error validating group choice at cddl location '' and cbor location : unexpected key Text('schema')",
])))', src/test_utils/mocks/client.rs:111:49
```

Closes: #206 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
