### PR TITLE
Force cache cleanup to fix code coverage report

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -139,8 +139,8 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          # Skip cleaning via `--skip-clean` flag to be able to use cache
-          args: --manifest-path ${{ env.cargo_manifest }} --skip-clean --locked
+          # Force cleaning via `--force-clean` flag to prevent buggy code coverage
+          args: --manifest-path ${{ env.cargo_manifest }} --locked --force-clean
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Highlights are marked with a pancake 🥞
 ## Everything burrito
 
 - Easier to read CDDL schema error strings [#207](https://github.com/p2panda/p2panda/pull/207) `rs`
+- Force cache cleanup to fix code coverage report [#231](https://github.com/p2panda/p2panda/pull/231)
 
 ## [0.3.0]
 


### PR DESCRIPTION
Unfortunately tarpaulin needs to reset the Rust cache to prevent some (unknown) errors resulting in inconsistent code coverage reports.

This PR should fix that issue. Since no cache is used anymore for that CI task it will take more time.

Closes: https://github.com/p2panda/p2panda/issues/228

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
