### PR TITLE
Introduce pinned and unpinned relation field type

### DIFF
--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -234,7 +234,8 @@ impl DocumentBuilder {
         let document_view_id = DocumentViewId::new(graph_tips);
 
         // Construct the document view, from the reduced values and the document view id
-        let document_view = DocumentView::new(document_id, document_view_id, view);
+        // @TODO
+        let document_view = DocumentView::new(document_id.clone(), document_view_id, view);
 
         Ok(Document {
             id: document_id,
@@ -252,8 +253,9 @@ mod tests {
 
     use rstest::rstest;
 
+    use crate::hash::Hash;
     use crate::identity::KeyPair;
-    use crate::operation::{Operation, OperationValue, OperationWithMeta};
+    use crate::operation::{Operation, OperationValue, OperationWithMeta, PinnedRelation};
     use crate::schema::SchemaId;
     use crate::test_utils::constants::DEFAULT_SCHEMA_HASH;
     use crate::test_utils::fixtures::{
@@ -524,7 +526,9 @@ mod tests {
             )
             .unwrap(),
         );
-        let schema = SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap();
+        // @TODO
+        let pinned_relation = PinnedRelation::new(vec![Hash::new(DEFAULT_SCHEMA_HASH).unwrap()]);
+        let schema = SchemaId::new_application_schema(pinned_relation).unwrap();
         let mut node = Node::new();
         let (polar_entry_1_hash, _) = send_to_node(
             &mut node,

--- a/p2panda-rs/src/document/document_view.rs
+++ b/p2panda-rs/src/document/document_view.rs
@@ -4,34 +4,29 @@
 use std::collections::btree_map::Iter as BTreeMapIter;
 use std::collections::BTreeMap;
 
+use crate::document::DocumentId;
 use crate::hash::Hash;
 use crate::operation::OperationValue;
 
 /// The ID of a document view. Contains the hash id of the document, and the hash ids of the
 /// current document graph tips.
 #[derive(Debug, PartialEq, Clone)]
-pub struct DocumentViewId {
-    document_id: Hash,
-    view_id: Vec<Hash>,
-}
+pub struct DocumentViewId(Vec<Hash>);
 
 impl DocumentViewId {
     /// Create a new document view id.
-    pub fn new(document_id: Hash, view_id: Vec<Hash>) -> Self {
-        Self {
-            document_id,
-            view_id,
-        }
+    pub fn new(view_id: Vec<Hash>) -> Self {
+        Self(view_id)
     }
 
-    /// Get just the document id.
-    pub fn document_id(&self) -> &Hash {
-        &self.document_id
+    /// Generate a document view hash from operation ids.
+    pub fn hash(&self) -> Hash {
+        unimplemented!()
     }
 
-    /// Get just the view id.
-    pub fn view_id(&self) -> &[Hash] {
-        self.view_id.as_slice()
+    /// Get the operation ids.
+    pub fn operation_ids(&self) -> &[Hash] {
+        self.0.as_slice()
     }
 }
 
@@ -43,7 +38,8 @@ type FieldKey = String;
 /// or DELETE operations.
 #[derive(Debug, PartialEq, Clone)]
 pub struct DocumentView {
-    pub(crate) id: DocumentViewId,
+    pub(crate) id: DocumentId,
+    pub(crate) view_id: DocumentViewId,
     pub(crate) view: BTreeMap<FieldKey, OperationValue>,
 }
 
@@ -52,23 +48,22 @@ impl DocumentView {
     ///
     /// Requires the DocumentViewId and field values to be calculated seperately and then passed in
     /// during construction.
-    pub fn new(id: DocumentViewId, view: BTreeMap<FieldKey, OperationValue>) -> Self {
-        Self { id, view }
-    }
-
-    /// Get the id of this document view.
-    pub fn id(&self) -> &[Hash] {
-        self.id.view_id()
+    pub fn new(
+        id: DocumentId,
+        view_id: DocumentViewId,
+        view: BTreeMap<FieldKey, OperationValue>,
+    ) -> Self {
+        Self { id, view_id, view }
     }
 
     /// Get the id of this document.
-    pub fn document_id(&self) -> &Hash {
-        self.id.document_id()
+    pub fn document_id(&self) -> &DocumentId {
+        &self.id
     }
 
     /// Get the document view id.
     pub fn document_view_id(&self) -> &DocumentViewId {
-        &self.id
+        &self.view_id
     }
 
     /// Get a single value from this instance by it's key.

--- a/p2panda-rs/src/document/mod.rs
+++ b/p2panda-rs/src/document/mod.rs
@@ -262,6 +262,6 @@ mod error;
 
 #[allow(unused_imports)]
 use document::{build_graph, reduce};
-pub use document::{Document, DocumentBuilder};
+pub use document::{Document, DocumentBuilder, DocumentId};
 pub use document_view::{DocumentView, DocumentViewId};
 pub use error::{DocumentBuilderError, DocumentError, DocumentViewError};

--- a/p2panda-rs/src/operation/mod.rs
+++ b/p2panda-rs/src/operation/mod.rs
@@ -10,11 +10,13 @@ mod operation;
 mod operation_encoded;
 mod operation_fields;
 mod operation_meta;
+mod relation;
 
 pub use error::{
     OperationEncodedError, OperationError, OperationFieldsError, OperationWithMetaError,
 };
 pub use operation::{AsOperation, Operation, OperationAction, OperationVersion};
 pub use operation_encoded::OperationEncoded;
-pub use operation_fields::{OperationFields, OperationValue, Relation};
+pub use operation_fields::{OperationFields, OperationValue};
 pub use operation_meta::OperationWithMeta;
+pub use relation::{Relation, RelationList};

--- a/p2panda-rs/src/operation/mod.rs
+++ b/p2panda-rs/src/operation/mod.rs
@@ -19,4 +19,4 @@ pub use operation::{AsOperation, Operation, OperationAction, OperationVersion};
 pub use operation_encoded::OperationEncoded;
 pub use operation_fields::{OperationFields, OperationValue};
 pub use operation_meta::OperationWithMeta;
-pub use relation::{Relation, RelationList};
+pub use relation::{PinnedRelation, PinnedRelationList, Relation, RelationList};

--- a/p2panda-rs/src/operation/relation.rs
+++ b/p2panda-rs/src/operation/relation.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use serde::{Deserialize, Serialize};
+
+use crate::hash::Hash;
+use crate::operation::OperationError;
+use crate::Validate;
+
+// @TODO: Replace this with DocumentViewId
+type GraphTips = Vec<Hash>;
+
+/// Field type representing references to other documents.
+///
+/// The "relation" field type references a document id and the historical state which it had at the
+/// point this relation was created.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Relation {
+    /// Document id this relation is referring to.
+    // @TODO: Replace inner value with DocumentId
+    Unpinned(Hash),
+
+    /// Reference to the exact version of the document.
+    ///
+    /// This field is `None` when there is no more than one operation (when the document only
+    /// consists of one CREATE operation).
+    Pinned(GraphTips),
+}
+
+impl Validate for Relation {
+    type Error = OperationError;
+
+    fn validate(&self) -> Result<(), Self::Error> {
+        match &self {
+            Relation::Unpinned(hash) => {
+                hash.validate()?;
+            }
+            Relation::Pinned(document_view) => {
+                for operation_id in document_view {
+                    operation_id.validate()?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RelationList {
+    Unpinned(Vec<Hash>),
+    Pinned(Vec<GraphTips>),
+}
+
+impl Validate for RelationList {
+    type Error = OperationError;
+
+    fn validate(&self) -> Result<(), Self::Error> {
+        match &self {
+            RelationList::Unpinned(documents) => {
+                for document in documents {
+                    document.validate()?;
+                }
+            }
+            RelationList::Pinned(document_view) => {
+                for view in document_view {
+                    for operation_id in view {
+                        operation_id.validate()?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/p2panda-rs/src/operation/relation.rs
+++ b/p2panda-rs/src/operation/relation.rs
@@ -10,10 +10,86 @@ use crate::Validate;
 type GraphTips = Vec<Hash>;
 
 /// Field type representing references to other documents.
-///
-/// The "relation" field type references a document id and the historical state which it had at the
-/// point this relation was created.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Relation(Hash);
+
+impl Relation {
+    pub fn new(hash: Hash) -> Self {
+        Self(hash)
+    }
+}
+
+impl Validate for Relation {
+    type Error = OperationError;
+
+    fn validate(&self) -> Result<(), Self::Error> {
+        self.0.validate()?;
+        Ok(())
+    }
+}
+
+/// Field type representing references to other documents at a certain point in history.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PinnedRelation(GraphTips);
+
+impl PinnedRelation {
+    pub fn new(graph_tips: GraphTips) -> Self {
+        Self(graph_tips)
+    }
+}
+
+impl Validate for PinnedRelation {
+    type Error = OperationError;
+
+    fn validate(&self) -> Result<(), Self::Error> {
+        for hash in &self.0 {
+            hash.validate()?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RelationList(Vec<Hash>);
+
+impl RelationList {
+    pub fn new(hashes: Vec<Hash>) -> Self {
+        Self(hashes)
+    }
+}
+
+impl Validate for RelationList {
+    type Error = OperationError;
+
+    fn validate(&self) -> Result<(), Self::Error> {
+        for hash in &self.0 {
+            hash.validate()?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PinnedRelationList(Vec<GraphTips>);
+
+impl PinnedRelationList {
+    pub fn new(graph_tips_vec: Vec<GraphTips>) -> Self {
+        Self(graph_tips_vec)
+    }
+}
+
+impl Validate for PinnedRelationList {
+    type Error = OperationError;
+
+    fn validate(&self) -> Result<(), Self::Error> {
+        // @TODO
+        Ok(())
+    }
+}
+
+/* #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Relation {
     /// Document id this relation is referring to.
@@ -74,4 +150,4 @@ impl Validate for RelationList {
 
         Ok(())
     }
-}
+} */

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -43,6 +43,9 @@ pub enum SchemaIdError {
     /// `OperationFields` error.
     #[error("invalid hash string")]
     HashError(#[from] crate::hash::HashError),
+
+    #[error("Unknown system schema name {0}")]
+    UnknownSystemSchema(String),
 }
 
 /// Custom error types for system schema views.

--- a/p2panda-rs/src/schema/system_schema.rs
+++ b/p2panda-rs/src/schema/system_schema.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 use std::str::FromStr;
 
 use crate::document::{DocumentView, DocumentViewId};
-use crate::operation::{OperationValue, Relation};
+use crate::operation::{OperationValue, RelationList};
 
 use super::SystemSchemaError;
 
@@ -47,8 +47,6 @@ pub struct SchemaView {
     /// The fields in this schema.
     fields: RelationList,
 }
-
-type RelationList = Vec<Relation>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SchemaFieldView {

--- a/p2panda-rs/src/test_utils/generate_test_data.rs
+++ b/p2panda-rs/src/test_utils/generate_test_data.rs
@@ -3,7 +3,8 @@
 /// Generate JSON formatted test data. This is run with the `cargo run --bin json-test-data`
 /// command. The output data can be used for testing a p2panda implementation. It is currently used
 /// in `p2panda-js`.
-use p2panda_rs::operation::OperationValue;
+use p2panda_rs::hash::Hash;
+use p2panda_rs::operation::{OperationValue, PinnedRelation};
 use p2panda_rs::schema::SchemaId;
 use p2panda_rs::test_utils::constants::DEFAULT_SCHEMA_HASH;
 use p2panda_rs::test_utils::mocks::Client;
@@ -20,12 +21,19 @@ fn main() {
     // Instantiate one client called "panda"
     let panda = Client::new("panda".to_string(), new_key_pair());
 
+    // @TODO
+    let schema_id =
+        SchemaId::new_application_schema(PinnedRelation::new(vec![
+            Hash::new(DEFAULT_SCHEMA_HASH).unwrap()
+        ]))
+        .unwrap();
+
     // Publish a CREATE operation
     let (entry1_hash, _) = send_to_node(
         &mut node,
         &panda,
         &create_operation(
-            SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap(),
+            schema_id.clone(),
             operation_fields(vec![(
                 "message",
                 OperationValue::Text("Ohh, my first message!".to_string()),
@@ -39,7 +47,7 @@ fn main() {
         &mut node,
         &panda,
         &update_operation(
-            SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap(),
+            schema_id.clone(),
             vec![entry1_hash],
             operation_fields(vec![(
                 "message",
@@ -54,7 +62,7 @@ fn main() {
         &mut node,
         &panda,
         &update_operation(
-            SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap(),
+            schema_id.clone(),
             vec![entry2_hash],
             operation_fields(vec![(
                 "message",
@@ -68,10 +76,7 @@ fn main() {
     send_to_node(
         &mut node,
         &panda,
-        &delete_operation(
-            SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap(),
-            vec![entry3_hash],
-        ),
+        &delete_operation(schema_id, vec![entry3_hash]),
     )
     .unwrap();
 
@@ -84,11 +89,11 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use p2panda_rs::schema::SchemaId;
-    // Generate json formatted test data
     use serde_json::Value;
 
-    use p2panda_rs::operation::OperationValue;
+    use p2panda_rs::hash::Hash;
+    use p2panda_rs::operation::{OperationValue, PinnedRelation};
+    use p2panda_rs::schema::SchemaId;
     use p2panda_rs::test_utils::constants::{DEFAULT_PRIVATE_KEY, DEFAULT_SCHEMA_HASH};
     use p2panda_rs::test_utils::mocks::Client;
     use p2panda_rs::test_utils::mocks::{send_to_node, Node};
@@ -106,12 +111,19 @@ mod tests {
             keypair_from_private(DEFAULT_PRIVATE_KEY.into()),
         );
 
+        // @TODO
+        let schema_id = SchemaId::new_application_schema(PinnedRelation::new(vec![Hash::new(
+            DEFAULT_SCHEMA_HASH,
+        )
+        .unwrap()]))
+        .unwrap();
+
         // Publish a CREATE operation
         send_to_node(
             &mut node,
             &panda,
             &create_operation(
-                SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap(),
+                schema_id,
                 operation_fields(vec![(
                     "message",
                     OperationValue::Text("Ohh, my first message!".to_string()),


### PR DESCRIPTION
Splits `Relation` type into `Pinned` and `Unpinned`.

Closes: https://github.com/p2panda/p2panda/issues/229

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
- [ ] Check if descriptions and terminology match `handbook` content (and visa-versa) 
