### PR TITLE
Update `DocumentBuilder` docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Highlights are marked with a pancake 🥞
 - Force cache cleanup to fix code coverage report [#231](https://github.com/p2panda/p2panda/pull/231)
 - Split up overly long `operation.rs` file [#232](https://github.com/p2panda/p2panda/pull/232) `rs`
 - Extend test coverage for `OperationFields` [#236](https://github.com/p2panda/p2panda/pull/236) `rs`
+- Further develop our best practices for writing documentation [#240](https://github.com/p2panda/p2panda/pull/240) `rs`
 
 ## [0.3.0]
 

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -147,9 +147,9 @@ impl Document {
 /// # use p2panda_rs::test_utils::meta_operation;
 /// #
 /// # #[rstest]
-/// # fn main(meta_operation: OperationWithMeta) -> () {
+/// # fn main(#[from(meta_operation)] operation: OperationWithMeta) -> () {
 /// // You need a `Vec<OperationWithMeta>` that includes the `CREATE` operation
-/// let operations: Vec<OperationWithMeta> = vec![meta_operation];
+/// let operations: Vec<OperationWithMeta> = vec![operation];
 ///
 /// // Then you can make a `Document` from it
 /// let document = DocumentBuilder::new(operations).build();

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -145,6 +145,7 @@ impl Document {
 /// # use p2panda_rs::document::DocumentBuilder;
 /// # use p2panda_rs::operation::OperationWithMeta;
 /// # use p2panda_rs::test_utils::meta_operation;
+/// #
 /// # #[rstest]
 /// # fn main(meta_operation: OperationWithMeta) -> () {
 /// // You need a `Vec<OperationWithMeta>` that includes the `CREATE` operation

--- a/p2panda-rs/src/test_utils/fixtures/mod.rs
+++ b/p2panda-rs/src/test_utils/fixtures/mod.rs
@@ -21,13 +21,13 @@
 //! # use std::convert::TryFrom;
 //! # use rstest::rstest;
 //! # use rstest_reuse::apply;
-//! # use crate::entry::{sign_and_encode, Entry};
-//! # use crate::identity::KeyPair;
-//! # use crate::operation::{Operation, OperationEncoded};
+//! # use p2panda_rs::entry::{sign_and_encode, Entry};
+//! # use p2panda_rs::identity::KeyPair;
+//! # use p2panda_rs::operation::{Operation, OperationEncoded};
 //! // These are the fixtures we will be using below
-//! use crate::test_utils::fixtures::{create_operation, defaults, entry, key_pair, Fixture};
+//! use p2panda_rs::test_utils::fixtures::{create_operation, defaults, entry, key_pair, Fixture};
 //! // And these are the templates we can run tests against
-//! use crate::test_utils::fixtures::templates::{
+//! use p2panda_rs::test_utils::fixtures::templates::{
 //!     many_valid_entries, non_default_operation_values_panic, version_fixtures,
 //! };
 //!


### PR DESCRIPTION
This is a showcase for using doctests more to document how we want library consumers to use all of this stuff (we already did this early on for `Entry` for example). Here I am using `test_utils` to generate some example values behind the scenes and then in the actual example only use the `DocumentBuilder` API.

I also did some language updates to the docstrings and moved some duplicate validation into `DocumentBuilder::build` that previously existed on both the struct itself as well as that method (but in different variations).

LMKWYT (let me know what you think)

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
