### PR TITLE
Remove document id from views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Highlights are marked with a pancake 🥞
 - `SchemaId` enum for identifying different schema types [#221](https://github.com/p2panda/p2panda/pull/221) `rs`
 - CDDL for _schema_v1_ and _schema_field_v1_, use `cddl-cat` instead of `cddl` [#248](https://github.com/p2panda/p2panda/pull/248) `rs`
 - `Schema` for representing application schema [#250](https://github.com/p2panda/p2panda/pull/250) `rs`
+- Move `DocumentId` from `DocmentView` into `Document` [#255](https://github.com/p2panda/p2panda/pull/255) `rs`
 
 ## Changed
 

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -90,7 +90,7 @@ pub struct Document {
 impl Document {
     /// Get the document id.
     pub fn id(&self) -> &DocumentId {
-        self.view.document_id()
+        &self.id
     }
 
     /// Get the document view id.
@@ -238,9 +238,10 @@ impl DocumentBuilder {
         let document_view_id = DocumentViewId::new(graph_tips);
 
         // Construct the document view, from the reduced values and the document view id
-        let document_view = DocumentView::new(document_view_id, document_id, view);
+        let document_view = DocumentView::new(document_view_id, view);
 
         Ok(Document {
+            id: document_id,
             schema,
             author,
             view: document_view,

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -79,7 +79,7 @@ pub struct DocumentMeta {
 /// to the specific document instance. These can be accessed through getter methods. To create
 /// documents you should use `DocumentBuilder`.
 #[derive(Debug, Clone)]
-pub struct Document {
+struct Document {
     author: Author,
     schema: SchemaId,
     view: DocumentView,

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -79,7 +79,8 @@ pub struct DocumentMeta {
 /// to the specific document instance. These can be accessed through getter methods. To create
 /// documents you should use `DocumentBuilder`.
 #[derive(Debug, Clone)]
-struct Document {
+pub struct Document {
+    id: DocumentId,
     author: Author,
     schema: SchemaId,
     view: DocumentView,

--- a/p2panda-rs/src/document/document_view.rs
+++ b/p2panda-rs/src/document/document_view.rs
@@ -25,7 +25,7 @@ pub struct DocumentView {
 impl DocumentView {
     /// Construct a document view.
     ///
-    /// Requires the DocumentId, DocumentViewId and field values to be calculated seperately and
+    /// Requires the DocumentViewId and field values to be calculated seperately and
     /// then passed in during construction.
     pub fn new(id: DocumentViewId, view: BTreeMap<FieldKey, OperationValue>) -> Self {
         Self { id, view }
@@ -63,32 +63,24 @@ impl DocumentView {
 }
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
+    use rstest::{fixture, rstest};
 
     use crate::document::{reduce, DocumentId};
     use crate::hash::Hash;
-    use crate::operation::{OperationValue, OperationValueRelation, Relation};
+    use crate::operation::{Operation, OperationValue, OperationValueRelation, Relation};
     use crate::schema::SchemaId;
     use crate::test_utils::fixtures::{
-        create_operation, delete_operation, fields, random_document_id, random_hash, schema,
-        update_operation,
+        create_operation, document_id, fields, random_hash, schema, update_operation,
     };
 
     use super::{DocumentView, DocumentViewId};
 
-    #[rstest]
-    fn gets_the_right_values(
-        schema: SchemaId,
-        #[from(random_hash)] prev_op_hash: Hash,
-        #[from(random_document_id)] profile_picture_id: DocumentId,
-        #[from(random_hash)] view_id: Hash,
-    ) {
-        let document_view_id = DocumentViewId::new(vec![view_id]);
+    #[fixture]
+    fn test_create_operation(schema: SchemaId, document_id: DocumentId) -> Operation {
+        let relation = Relation::new(document_id);
 
-        let relation = Relation::new(profile_picture_id);
-
-        let create_operation = create_operation(
-            schema.clone(),
+        create_operation(
+            schema,
             fields(vec![
                 ("username", OperationValue::Text("bubu".to_owned())),
                 ("height", OperationValue::Float(3.5)),
@@ -96,15 +88,40 @@ mod tests {
                 ("is_admin", OperationValue::Boolean(false)),
                 (
                     "profile_picture",
-                    OperationValue::Relation(OperationValueRelation::Unpinned(relation.clone())),
+                    OperationValue::Relation(OperationValueRelation::Unpinned(relation)),
                 ),
             ]),
-        );
+        )
+    }
+
+    #[fixture]
+    fn test_update_operation(
+        schema: SchemaId,
+        #[from(random_hash)] prev_op_hash: Hash,
+    ) -> Operation {
+        update_operation(
+            schema,
+            vec![prev_op_hash],
+            fields(vec![
+                ("age", OperationValue::Integer(29)),
+                ("is_admin", OperationValue::Boolean(true)),
+            ]),
+        )
+    }
+
+    #[rstest]
+    fn from_single_create_op(
+        test_create_operation: Operation,
+        #[from(random_hash)] view_id: Hash,
+        #[from(document_id)] relation_id: DocumentId,
+    ) {
+        let document_view_id = DocumentViewId::new(vec![view_id]);
+        let expected_relation = Relation::new(relation_id);
 
         // Reduce a single CREATE `Operation`
-        let (view, is_edited, is_deleted) = reduce(&[create_operation.clone()]);
+        let (view, is_edited, is_deleted) = reduce(&[test_create_operation]);
 
-        let document_view = DocumentView::new(document_view_id.clone(), view);
+        let document_view = DocumentView::new(document_view_id, view);
 
         assert_eq!(
             document_view.keys(),
@@ -130,23 +147,21 @@ mod tests {
         );
         assert_eq!(
             document_view.get("profile_picture").unwrap(),
-            &OperationValue::Relation(OperationValueRelation::Unpinned(relation))
+            &OperationValue::Relation(OperationValueRelation::Unpinned(expected_relation))
         );
         assert!(!is_edited);
         assert!(!is_deleted);
+    }
 
-        let update_operation = update_operation(
-            schema.clone(),
-            vec![prev_op_hash.clone()],
-            fields(vec![
-                ("age", OperationValue::Integer(29)),
-                ("is_admin", OperationValue::Boolean(true)),
-            ]),
-        );
+    #[rstest]
+    fn with_update_op(
+        test_create_operation: Operation,
+        test_update_operation: Operation,
+        #[from(random_hash)] view_id: Hash,
+    ) {
+        let document_view_id = DocumentViewId::new(vec![view_id]);
 
-        // Reduce again now with an UPDATE operation as well
-        let (view, is_edited, is_deleted) =
-            reduce(&[create_operation.clone(), update_operation.clone()]);
+        let (view, is_edited, is_deleted) = reduce(&[test_create_operation, test_update_operation]);
 
         let document_view = DocumentView::new(document_view_id, view);
 
@@ -160,14 +175,5 @@ mod tests {
         );
         assert!(is_edited);
         assert!(!is_deleted);
-
-        let delete_operation = delete_operation(schema, vec![prev_op_hash]);
-
-        // Reduce again now with a DELETE operation as well
-        let (_document_view, is_edited, is_deleted) =
-            reduce(&[create_operation, update_operation, delete_operation]);
-
-        assert!(is_edited);
-        assert!(is_deleted);
     }
 }

--- a/p2panda-rs/src/document/document_view.rs
+++ b/p2panda-rs/src/document/document_view.rs
@@ -4,7 +4,7 @@
 use std::collections::btree_map::Iter as BTreeMapIter;
 use std::collections::BTreeMap;
 
-use crate::document::{DocumentId, DocumentViewId};
+use crate::document::DocumentViewId;
 use crate::operation::OperationValue;
 
 type FieldKey = String;
@@ -18,9 +18,6 @@ pub struct DocumentView {
     /// Identifier of this document view.
     pub(crate) id: DocumentViewId,
 
-    /// Identifier of the document this view is derived from.
-    pub(crate) document_id: DocumentId,
-
     /// Materialized data held by this document view.
     pub(crate) view: BTreeMap<FieldKey, OperationValue>,
 }
@@ -30,26 +27,13 @@ impl DocumentView {
     ///
     /// Requires the DocumentId, DocumentViewId and field values to be calculated seperately and
     /// then passed in during construction.
-    pub fn new(
-        id: DocumentViewId,
-        document_id: DocumentId,
-        view: BTreeMap<FieldKey, OperationValue>,
-    ) -> Self {
-        Self {
-            id,
-            document_id,
-            view,
-        }
+    pub fn new(id: DocumentViewId, view: BTreeMap<FieldKey, OperationValue>) -> Self {
+        Self { id, view }
     }
 
     /// Get the id of this document view.
     pub fn id(&self) -> &DocumentViewId {
         &self.id
-    }
-
-    /// Get the id of this document.
-    pub fn document_id(&self) -> &DocumentId {
-        &self.document_id
     }
 
     /// Get a single value from this instance by it's key.
@@ -96,7 +80,6 @@ mod tests {
     fn gets_the_right_values(
         schema: SchemaId,
         #[from(random_hash)] prev_op_hash: Hash,
-        #[from(random_document_id)] document_id: DocumentId,
         #[from(random_document_id)] profile_picture_id: DocumentId,
         #[from(random_hash)] view_id: Hash,
     ) {
@@ -121,7 +104,7 @@ mod tests {
         // Reduce a single CREATE `Operation`
         let (view, is_edited, is_deleted) = reduce(&[create_operation.clone()]);
 
-        let document_view = DocumentView::new(document_view_id.clone(), document_id.clone(), view);
+        let document_view = DocumentView::new(document_view_id.clone(), view);
 
         assert_eq!(
             document_view.keys(),
@@ -165,7 +148,7 @@ mod tests {
         let (view, is_edited, is_deleted) =
             reduce(&[create_operation.clone(), update_operation.clone()]);
 
-        let document_view = DocumentView::new(document_view_id, document_id, view);
+        let document_view = DocumentView::new(document_view_id, view);
 
         assert_eq!(
             document_view.get("age").unwrap(),

--- a/p2panda-rs/src/document/mod.rs
+++ b/p2panda-rs/src/document/mod.rs
@@ -262,9 +262,9 @@ mod document_view;
 mod document_view_id;
 mod error;
 
+pub use document::DocumentBuilder;
 #[allow(unused_imports)]
 use document::{build_graph, reduce};
-pub use document::{Document, DocumentBuilder};
 pub use document_id::DocumentId;
 pub use document_view::DocumentView;
 pub use document_view_id::DocumentViewId;

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -69,18 +69,14 @@ mod tests {
 
     use rstest::rstest;
 
-    use crate::document::{DocumentId, DocumentView, DocumentViewId};
+    use crate::document::{DocumentView, DocumentViewId};
     use crate::hash::Hash;
     use crate::operation::{OperationValue, OperationValueRelationList, PinnedRelationList};
     use crate::schema::schema::Schema;
     use crate::schema::system::{SchemaFieldView, SchemaView};
-    use crate::test_utils::fixtures::{random_document_id, random_hash};
+    use crate::test_utils::fixtures::random_hash;
 
-    fn create_schema(
-        fields: PinnedRelationList,
-        view_id: DocumentViewId,
-        document_id: DocumentId,
-    ) -> SchemaView {
+    fn create_schema(fields: PinnedRelationList, view_id: DocumentViewId) -> SchemaView {
         let mut schema = BTreeMap::new();
         schema.insert(
             "name".to_string(),
@@ -94,18 +90,11 @@ mod tests {
             "fields".to_string(),
             OperationValue::RelationList(OperationValueRelationList::Pinned(fields)),
         );
-        let schema_view: SchemaView = DocumentView::new(view_id, document_id, schema)
-            .try_into()
-            .unwrap();
+        let schema_view: SchemaView = DocumentView::new(view_id, schema).try_into().unwrap();
         schema_view
     }
 
-    fn create_field(
-        name: &str,
-        field_type: &str,
-        view_id: DocumentViewId,
-        document_id: DocumentId,
-    ) -> SchemaFieldView {
+    fn create_field(name: &str, field_type: &str, view_id: DocumentViewId) -> SchemaFieldView {
         let mut capacity_field = BTreeMap::new();
         capacity_field.insert("name".to_string(), OperationValue::Text(name.to_string()));
         capacity_field.insert(
@@ -113,10 +102,9 @@ mod tests {
             OperationValue::Text(field_type.to_string()),
         );
 
-        let capacity_field_view: SchemaFieldView =
-            DocumentView::new(view_id, document_id, capacity_field)
-                .try_into()
-                .unwrap();
+        let capacity_field_view: SchemaFieldView = DocumentView::new(view_id, capacity_field)
+            .try_into()
+            .unwrap();
         capacity_field_view
     }
 
@@ -126,9 +114,6 @@ mod tests {
         #[from(random_hash)] relation_operation_id_2: Hash,
         #[from(random_hash)] relation_operation_id_3: Hash,
         #[from(random_hash)] schema_view_id: Hash,
-        #[from(random_document_id)] schema_id: DocumentId,
-        #[from(random_document_id)] bool_field_id: DocumentId,
-        #[from(random_document_id)] capacity_field_id: DocumentId,
     ) {
         // Create schema definition for "venue"
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -142,7 +127,7 @@ mod tests {
             ]),
         ]);
 
-        let schema_view = create_schema(fields, schema_view_id, schema_id);
+        let schema_view = create_schema(fields, schema_view_id);
 
         // Create first schema field "is_accessible"
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -151,7 +136,6 @@ mod tests {
             "is_accessible",
             "bool",
             DocumentViewId::new(vec![relation_operation_id_1]),
-            bool_field_id,
         );
 
         // Create second schema field "capacity"
@@ -161,7 +145,6 @@ mod tests {
             "capacity",
             "int",
             DocumentViewId::new(vec![relation_operation_id_2, relation_operation_id_3]),
-            capacity_field_id,
         );
 
         // Create venue schema from schema and field views
@@ -187,9 +170,6 @@ mod tests {
         #[from(random_hash)] relation_operation_id_2: Hash,
         #[from(random_hash)] invalid_relation_hash: Hash,
         #[from(random_hash)] schema_view_id: Hash,
-        #[from(random_document_id)] schema_id: DocumentId,
-        #[from(random_document_id)] bool_field_id: DocumentId,
-        #[from(random_document_id)] capacity_field_id: DocumentId,
     ) {
         // Create schema definition for "venue"
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -200,40 +180,26 @@ mod tests {
             DocumentViewId::new(vec![relation_operation_id_2.clone()]),
         ]);
 
-        let schema_view = create_schema(fields, schema_view_id, schema_id);
+        let schema_view = create_schema(fields, schema_view_id);
 
         // Create first valid schema field "is_accessible"
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         let bool_field_document_view_id = DocumentViewId::new(vec![relation_operation_id_1]);
-        let bool_field_view = create_field(
-            "is_accessible",
-            "bool",
-            bool_field_document_view_id,
-            bool_field_id,
-        );
+        let bool_field_view = create_field("is_accessible", "bool", bool_field_document_view_id);
 
         // Create second valid schema field "capacity"
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         let capacity_field_document_view_id = DocumentViewId::new(vec![relation_operation_id_2]);
-        let capacity_field_view = create_field(
-            "capacity",
-            "int",
-            capacity_field_document_view_id,
-            capacity_field_id.clone(),
-        );
+        let capacity_field_view = create_field("capacity", "int", capacity_field_document_view_id);
 
         // Create field with invalid DocumentViewId
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         let invalid_document_view_id = DocumentViewId::new(vec![invalid_relation_hash]);
-        let field_with_invalid_document_view_id = create_field(
-            "capacity",
-            "int",
-            invalid_document_view_id,
-            capacity_field_id,
-        );
+        let field_with_invalid_document_view_id =
+            create_field("capacity", "int", invalid_document_view_id);
 
         // Passing field with invalid DocumentViewId should fail
         assert!(Schema::new(

--- a/p2panda-rs/src/test_utils/fixtures/params.rs
+++ b/p2panda-rs/src/test_utils/fixtures/params.rs
@@ -61,6 +61,13 @@ pub fn hash(#[default(DEFAULT_HASH)] hash_str: &str) -> Hash {
     utils::hash(hash_str)
 }
 
+/// Fixture which injects the default DocumentId into a test method. Default value can be overridden at
+/// testing time by passing in a custom hash string.
+#[fixture]
+pub fn document_id(#[default(DEFAULT_HASH)] hash_str: &str) -> DocumentId {
+    DocumentId::new(hash(hash_str))
+}
+
 /// Fixture which injects a random hash into a test method.
 #[fixture]
 pub fn random_hash() -> Hash {


### PR DESCRIPTION
- Move `DocumentId` from the `DocumentView` to the `Document`
  - This means changes in `SchemaView` and `SchemaFieldView` too.
- Don't export `Document` at crate level.
- Refactor `DocumentView` tests,

closes #252 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
