### PR TITLE
Implement support for all `Relation` types in `cddl` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Highlights are marked with a pancake 🥞
 - Split `Relation` into pinned and unpinned type [#235](https://github.com/p2panda/p2panda/pull/235) `rs`
 - Separate `cddl` from `schema` more clearly [#239](https://github.com/p2panda/p2panda/pull/239) `rs`
 - Turn schema field in operations into a pinned relation [#256](https://github.com/p2panda/p2panda/pull/256) `rs`
+- Support all `Relation` flavours in `cddl` module [#259](https://github.com/p2panda/p2panda/pull/259) `rs`
 
 ## Fixed
 

--- a/p2panda-rs/src/cddl/definitions.rs
+++ b/p2panda-rs/src/cddl/definitions.rs
@@ -69,12 +69,22 @@ value_boolean = (
 
 value_relation = (
     type: "relation",
-    value: relation / pinned_relation,
+    value: relation,
 )
 
 value_relation_list = (
     type: "relation_list",
-    value: relation_list / pinned_relation_list,
+    value: relation_list,
+)
+
+value_pinned_relation = (
+    type: "pinned_relation",
+    value: pinned_relation,
+)
+
+value_pinned_relation_list = (
+    type: "pinned_relation_list",
+    value: pinned_relation_list,
 )
 "#;
 
@@ -100,7 +110,9 @@ fields = {
         value_float //
         value_boolean //
         value_relation //
-        value_relation-list
+        value_relation_list //
+        value_pinned_relation //
+        value_pinned_relation_list
     }
 }
 "#;
@@ -162,7 +174,7 @@ description = (
 field_type = (
     field_type: {
         type: "str",
-        value: "str" / "int" / "float" / "bool" / "relation" / "relation_list",
+        value: "str" / "int" / "float" / "bool" / "relation" / "relation_list" / "pinned_relation" / "pinned_relation_list",
     }
 )
 "#;
@@ -612,7 +624,19 @@ mod tests {
                     ],
                     "fields" => {
                         "field_type" => {
+                            "value" => "relation",
+                            "type" => "str"
+                        },
+                        "field_type" => {
                             "value" => "relation_list",
+                            "type" => "str"
+                        },
+                        "field_type" => {
+                            "value" => "pinned_relation",
+                            "type" => "str"
+                        },
+                        "field_type" => {
+                            "value" => "pinned_relation_list",
                             "type" => "str"
                         },
                     },

--- a/p2panda-rs/src/cddl/definitions.rs
+++ b/p2panda-rs/src/cddl/definitions.rs
@@ -174,7 +174,8 @@ description = (
 field_type = (
     field_type: {
         type: "str",
-        value: "str" / "int" / "float" / "bool" / "relation" / "relation_list" / "pinned_relation" / "pinned_relation_list",
+        value: "str" / "int" / "float" / "bool" / "relation" /
+            "relation_list" / "pinned_relation" / "pinned_relation_list",
     }
 )
 "#;

--- a/p2panda-rs/src/cddl/generator.rs
+++ b/p2panda-rs/src/cddl/generator.rs
@@ -144,14 +144,14 @@ mod tests {
 
     #[test]
     pub fn generate_cddl_fields() {
-        let expected_fields_cddl = "age = { type: \"int\", value: int, }\n".to_string()
-        + "favorite_food = { type: \"relation\", value: tstr .regexp \"[0-9a-f]{68}\", }\n"
-        + "height = { type: \"float\", value: float, }\n"
-        + "is_cool = { type: \"bool\", value: bool, }\n"
-        + "name = { type: \"str\", value: tstr, }\n"
-        + "one_specific_meal = { type: \"pinned_relation\", value: [+ tstr .regexp \"[0-9a-f]{68}\"], }\n"
-        + "top_ten_foods = { type: \"relation_list\", value: [* tstr .regexp \"[0-9a-f]{68}\"], }\n"
-        + "top_ten_specific_meals = { type: \"pinned_relation_list\", value: [* [+ tstr .regexp \"[0-9a-f]{68}\"]], }";
+        let expected_fields_cddl = "age = { type: \"int\", value: int, }\n\
+           favorite_food = { type: \"relation\", value: tstr .regexp \"[0-9a-f]{68}\", }\n\
+           height = { type: \"float\", value: float, }\n\
+           is_cool = { type: \"bool\", value: bool, }\n\
+           name = { type: \"str\", value: tstr, }\n\
+           one_specific_meal = { type: \"pinned_relation\", value: [+ tstr .regexp \"[0-9a-f]{68}\"], }\n\
+           top_ten_foods = { type: \"relation_list\", value: [* tstr .regexp \"[0-9a-f]{68}\"], }\n\
+           top_ten_specific_meals = { type: \"pinned_relation_list\", value: [* [+ tstr .regexp \"[0-9a-f]{68}\"]], }";
 
         let fields_cddl = generate_fields(&person());
 
@@ -160,8 +160,9 @@ mod tests {
 
     #[test]
     pub fn generate_cddl_create_fields() {
-        let expected_create_fields_cddl: &str =
-        "create-fields = { age, favorite_food, height, is_cool, name, one_specific_meal, top_ten_foods, top_ten_specific_meals }";
+        let expected_create_fields_cddl = "create-fields = { age, \
+            favorite_food, height, is_cool, name, one_specific_meal, \
+            top_ten_foods, top_ten_specific_meals }";
 
         let person = person();
         let field_names: Vec<&String> = person.keys().collect();
@@ -172,8 +173,10 @@ mod tests {
 
     #[test]
     pub fn generate_cddl_update_fields() {
-        let expected_update_fields_cddl: &str =
-        "update-fields = { + ( age // favorite_food // height // is_cool // name // one_specific_meal // top_ten_foods // top_ten_specific_meals ) }";
+        let expected_update_fields_cddl = "update-fields = { + ( \
+            age // favorite_food // height // is_cool // name // \
+            one_specific_meal // top_ten_foods // \
+            top_ten_specific_meals ) }";
 
         let person = person();
         let field_names: Vec<&String> = person.keys().collect();
@@ -184,16 +187,16 @@ mod tests {
 
     #[test]
     pub fn generates_cddl_definition() {
-        let expected_cddl = "age = { type: \"int\", value: int, }\n".to_string()
-        + "favorite_food = { type: \"relation\", value: tstr .regexp \"[0-9a-f]{68}\", }\n"
-        + "height = { type: \"float\", value: float, }\n"
-        + "is_cool = { type: \"bool\", value: bool, }\n"
-        + "name = { type: \"str\", value: tstr, }\n"
-        + "one_specific_meal = { type: \"pinned_relation\", value: [+ tstr .regexp \"[0-9a-f]{68}\"], }\n"
-        + "top_ten_foods = { type: \"relation_list\", value: [* tstr .regexp \"[0-9a-f]{68}\"], }\n"
-        + "top_ten_specific_meals = { type: \"pinned_relation_list\", value: [* [+ tstr .regexp \"[0-9a-f]{68}\"]], }\n"
-        + "create-fields = { age, favorite_food, height, is_cool, name, one_specific_meal, top_ten_foods, top_ten_specific_meals }\n"
-        + "update-fields = { + ( age // favorite_food // height // is_cool // name // one_specific_meal // top_ten_foods // top_ten_specific_meals ) }";
+        let expected_cddl = "age = { type: \"int\", value: int, }\n\
+           favorite_food = { type: \"relation\", value: tstr .regexp \"[0-9a-f]{68}\", }\n\
+           height = { type: \"float\", value: float, }\n\
+           is_cool = { type: \"bool\", value: bool, }\n\
+           name = { type: \"str\", value: tstr, }\n\
+           one_specific_meal = { type: \"pinned_relation\", value: [+ tstr .regexp \"[0-9a-f]{68}\"], }\n\
+           top_ten_foods = { type: \"relation_list\", value: [* tstr .regexp \"[0-9a-f]{68}\"], }\n\
+           top_ten_specific_meals = { type: \"pinned_relation_list\", value: [* [+ tstr .regexp \"[0-9a-f]{68}\"]], }\n\
+           create-fields = { age, favorite_food, height, is_cool, name, one_specific_meal, top_ten_foods, top_ten_specific_meals }\n\
+           update-fields = { + ( age // favorite_food // height // is_cool // name // one_specific_meal // top_ten_foods // top_ten_specific_meals ) }";
 
         let person = person();
         let generated_cddl = generate_cddl_definition(&person);

--- a/p2panda-rs/src/cddl/generator.rs
+++ b/p2panda-rs/src/cddl/generator.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::schema::system::FieldType;
+use crate::schema::FieldType;
 
 /// CDDL types.
 #[derive(Clone, Debug)]
@@ -121,7 +121,7 @@ mod tests {
             generate_cddl_definition,
             generator::{generate_create_fields, generate_fields, generate_update_fields},
         },
-        schema::system::FieldType,
+        schema::FieldType,
     };
 
     fn person() -> BTreeMap<String, FieldType> {

--- a/p2panda-rs/src/cddl/generator.rs
+++ b/p2panda-rs/src/cddl/generator.rs
@@ -132,6 +132,12 @@ mod tests {
         person.insert("height".to_string(), FieldType::Float);
         person.insert("is_cool".to_string(), FieldType::Bool);
         person.insert("favorite_food".to_string(), FieldType::Relation);
+        person.insert("top_ten_foods".to_string(), FieldType::RelationList);
+        person.insert("one_specific_meal".to_string(), FieldType::PinnedRelation);
+        person.insert(
+            "top_ten_specific_meals".to_string(),
+            FieldType::PinnedRelationList,
+        );
 
         person
     }
@@ -139,10 +145,13 @@ mod tests {
     #[test]
     pub fn generate_cddl_fields() {
         let expected_fields_cddl = "age = { type: \"int\", value: int, }\n".to_string()
-            + "favorite_food = { type: \"relation\", value: tstr .regexp \"[0-9a-f]{68}\", }\n"
-            + "height = { type: \"float\", value: float, }\n"
-            + "is_cool = { type: \"bool\", value: bool, }\n"
-            + "name = { type: \"str\", value: tstr, }";
+        + "favorite_food = { type: \"relation\", value: tstr .regexp \"[0-9a-f]{68}\", }\n"
+        + "height = { type: \"float\", value: float, }\n"
+        + "is_cool = { type: \"bool\", value: bool, }\n"
+        + "name = { type: \"str\", value: tstr, }\n"
+        + "one_specific_meal = { type: \"pinned_relation\", value: [+ tstr .regexp \"[0-9a-f]{68}\"], }\n"
+        + "top_ten_foods = { type: \"relation_list\", value: [* tstr .regexp \"[0-9a-f]{68}\"], }\n"
+        + "top_ten_specific_meals = { type: \"pinned_relation_list\", value: [* [+ tstr .regexp \"[0-9a-f]{68}\"]], }";
 
         let fields_cddl = generate_fields(&person());
 
@@ -152,7 +161,7 @@ mod tests {
     #[test]
     pub fn generate_cddl_create_fields() {
         let expected_create_fields_cddl: &str =
-            "create-fields = { age, favorite_food, height, is_cool, name }";
+        "create-fields = { age, favorite_food, height, is_cool, name, one_specific_meal, top_ten_foods, top_ten_specific_meals }";
 
         let person = person();
         let field_names: Vec<&String> = person.keys().collect();
@@ -164,7 +173,7 @@ mod tests {
     #[test]
     pub fn generate_cddl_update_fields() {
         let expected_update_fields_cddl: &str =
-            "update-fields = { + ( age // favorite_food // height // is_cool // name ) }";
+        "update-fields = { + ( age // favorite_food // height // is_cool // name // one_specific_meal // top_ten_foods // top_ten_specific_meals ) }";
 
         let person = person();
         let field_names: Vec<&String> = person.keys().collect();
@@ -176,12 +185,15 @@ mod tests {
     #[test]
     pub fn generates_cddl_definition() {
         let expected_cddl = "age = { type: \"int\", value: int, }\n".to_string()
-            + "favorite_food = { type: \"relation\", value: tstr .regexp \"[0-9a-f]{68}\", }\n"
-            + "height = { type: \"float\", value: float, }\n"
-            + "is_cool = { type: \"bool\", value: bool, }\n"
-            + "name = { type: \"str\", value: tstr, }\n"
-            + "create-fields = { age, favorite_food, height, is_cool, name }\n"
-            + "update-fields = { + ( age // favorite_food // height // is_cool // name ) }";
+        + "favorite_food = { type: \"relation\", value: tstr .regexp \"[0-9a-f]{68}\", }\n"
+        + "height = { type: \"float\", value: float, }\n"
+        + "is_cool = { type: \"bool\", value: bool, }\n"
+        + "name = { type: \"str\", value: tstr, }\n"
+        + "one_specific_meal = { type: \"pinned_relation\", value: [+ tstr .regexp \"[0-9a-f]{68}\"], }\n"
+        + "top_ten_foods = { type: \"relation_list\", value: [* tstr .regexp \"[0-9a-f]{68}\"], }\n"
+        + "top_ten_specific_meals = { type: \"pinned_relation_list\", value: [* [+ tstr .regexp \"[0-9a-f]{68}\"]], }\n"
+        + "create-fields = { age, favorite_food, height, is_cool, name, one_specific_meal, top_ten_foods, top_ten_specific_meals }\n"
+        + "update-fields = { + ( age // favorite_food // height // is_cool // name // one_specific_meal // top_ten_foods // top_ten_specific_meals ) }";
 
         let person = person();
         let generated_cddl = generate_cddl_definition(&person);

--- a/p2panda-rs/src/cddl/generator.rs
+++ b/p2panda-rs/src/cddl/generator.rs
@@ -12,6 +12,9 @@ pub enum CddlType {
     Float,
     Tstr,
     Relation,
+    RelationList,
+    PinnedRelation,
+    PinnedRelationList,
 }
 
 /// CDDL types to string representation.
@@ -24,6 +27,9 @@ impl CddlType {
             CddlType::Float => "float",
             CddlType::Tstr => "tstr",
             CddlType::Relation => "tstr .regexp \"[0-9a-f]{68}\"",
+            CddlType::RelationList => "[* tstr .regexp \"[0-9a-f]{68}\"]",
+            CddlType::PinnedRelation => "[+ tstr .regexp \"[0-9a-f]{68}\"]",
+            CddlType::PinnedRelationList => "[* [+ tstr .regexp \"[0-9a-f]{68}\"]]",
         }
     }
 }
@@ -36,6 +42,9 @@ impl From<FieldType> for CddlType {
             FieldType::Float => CddlType::Float,
             FieldType::String => CddlType::Tstr,
             FieldType::Relation => CddlType::Relation,
+            FieldType::RelationList => CddlType::RelationList,
+            FieldType::PinnedRelation => CddlType::PinnedRelation,
+            FieldType::PinnedRelationList => CddlType::PinnedRelationList,
         }
     }
 }

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -17,3 +17,11 @@ pub enum SchemaError {
     #[error("invalid fields found for this schema")]
     InvalidFields,
 }
+
+/// Custom error types for field types.
+#[derive(Error, Debug)]
+pub enum FieldTypeError {
+    /// Invalid field type found.
+    #[error("invalid field type '{0}'")]
+    InvalidFieldType(String),
+}

--- a/p2panda-rs/src/schema/field_types.rs
+++ b/p2panda-rs/src/schema/field_types.rs
@@ -32,6 +32,22 @@ pub enum FieldType {
     PinnedRelationList,
 }
 
+impl FieldType {
+    /// Returns the string representation of this type.
+    pub fn as_str(&self) -> &str {
+        match self {
+            FieldType::Bool => "bool",
+            FieldType::Int => "int",
+            FieldType::Float => "float",
+            FieldType::String => "str",
+            FieldType::Relation => "relation",
+            FieldType::RelationList => "relation_list",
+            FieldType::PinnedRelation => "pinned_relation",
+            FieldType::PinnedRelationList => "pinned_relation_list",
+        }
+    }
+}
+
 impl FromStr for FieldType {
     type Err = FieldTypeError;
 
@@ -52,32 +68,7 @@ impl FromStr for FieldType {
 
 impl From<FieldType> for String {
     fn from(field_type: FieldType) -> Self {
-        match field_type {
-            FieldType::Bool => "bool".to_string(),
-            FieldType::Int => "int".to_string(),
-            FieldType::Float => "float".to_string(),
-            FieldType::String => "str".to_string(),
-            FieldType::Relation => "relation".to_string(),
-            FieldType::RelationList => "relation_list".to_string(),
-            FieldType::PinnedRelation => "pinned_relation".to_string(),
-            FieldType::PinnedRelationList => "pinned_relation_list".to_string(),
-        }
-    }
-}
-
-impl FieldType {
-    /// Returns the string representation of this type.
-    pub fn as_str(&self) -> &str {
-        match self {
-            FieldType::Bool => "bool",
-            FieldType::Int => "int",
-            FieldType::Float => "float",
-            FieldType::String => "str",
-            FieldType::Relation => "relation",
-            FieldType::RelationList => "relation_list",
-            FieldType::PinnedRelation => "pinned_relation",
-            FieldType::PinnedRelationList => "pinned_relation_list",
-        }
+        field_type.as_str().to_string()
     }
 }
 
@@ -117,6 +108,29 @@ mod tests {
             "pinned_relation_list".parse().unwrap()
         );
     }
+    #[test]
+    fn into_string() {
+        let bool_type: String = FieldType::Bool.into();
+        assert_eq!(bool_type, "bool".to_string());
+        let int_type: String = FieldType::Int.into();
+        assert_eq!(int_type, "int".to_string());
+        let type_float: String = FieldType::Float.into();
+        assert_eq!(type_float, "float".to_string());
+        let type_string: String = FieldType::String.into();
+        assert_eq!(type_string, "str".to_string());
+        let type_relation: String = FieldType::Relation.into();
+        assert_eq!(type_relation, "relation".to_string());
+        let type_relation_list: String = FieldType::RelationList.into();
+        assert_eq!(type_relation_list, "relation_list".to_string());
+        let type_pinned_relation: String = FieldType::PinnedRelation.into();
+        assert_eq!(type_pinned_relation, "pinned_relation".to_string());
+        let type_pinned_relation_list: String = FieldType::PinnedRelationList.into();
+        assert_eq!(
+            type_pinned_relation_list,
+            "pinned_relation_list".to_string()
+        );
+    }
+
     #[test]
     fn invalid_type_string() {
         assert!("poopy".parse::<FieldType>().is_err());

--- a/p2panda-rs/src/schema/field_types.rs
+++ b/p2panda-rs/src/schema/field_types.rs
@@ -50,6 +50,21 @@ impl FromStr for FieldType {
     }
 }
 
+impl From<FieldType> for String {
+    fn from(field_type: FieldType) -> Self {
+        match field_type {
+            FieldType::Bool => "bool".to_string(),
+            FieldType::Int => "int".to_string(),
+            FieldType::Float => "float".to_string(),
+            FieldType::String => "str".to_string(),
+            FieldType::Relation => "relation".to_string(),
+            FieldType::RelationList => "relation_list".to_string(),
+            FieldType::PinnedRelation => "pinned_relation".to_string(),
+            FieldType::PinnedRelationList => "pinned_relation_list".to_string(),
+        }
+    }
+}
+
 impl FieldType {
     /// Returns the string representation of this type.
     pub fn as_str(&self) -> &str {

--- a/p2panda-rs/src/schema/field_types.rs
+++ b/p2panda-rs/src/schema/field_types.rs
@@ -65,3 +65,45 @@ impl FieldType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use crate::schema::FieldType;
+
+    #[test]
+    fn serialises() {
+        assert_eq!(FieldType::Bool.as_str(), "bool");
+        assert_eq!(FieldType::Int.as_str(), "int");
+        assert_eq!(FieldType::Float.as_str(), "float");
+        assert_eq!(FieldType::String.as_str(), "str");
+        assert_eq!(FieldType::Relation.as_str(), "relation");
+        assert_eq!(FieldType::RelationList.as_str(), "relation_list");
+        assert_eq!(FieldType::PinnedRelation.as_str(), "pinned_relation");
+        assert_eq!(
+            FieldType::PinnedRelationList.as_str(),
+            "pinned_relation_list"
+        );
+    }
+    #[test]
+    fn deserialises() {
+        assert_eq!(FieldType::Bool, "bool".parse().unwrap());
+        assert_eq!(FieldType::Int, "int".parse().unwrap());
+        assert_eq!(FieldType::Float, "float".parse().unwrap());
+        assert_eq!(FieldType::String, "str".parse().unwrap());
+        assert_eq!(FieldType::Relation, "relation".parse().unwrap());
+        assert_eq!(FieldType::RelationList, "relation_list".parse().unwrap());
+        assert_eq!(
+            FieldType::PinnedRelation,
+            "pinned_relation".parse().unwrap()
+        );
+        assert_eq!(
+            FieldType::PinnedRelationList,
+            "pinned_relation_list".parse().unwrap()
+        );
+    }
+    #[test]
+    fn invalid_type_string() {
+        assert!("poopy".parse::<FieldType>().is_err());
+    }
+}

--- a/p2panda-rs/src/schema/field_types.rs
+++ b/p2panda-rs/src/schema/field_types.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::str::FromStr;
+
+use super::FieldTypeError;
+
+/// Valid field types for publishing an application schema.
+#[derive(Clone, Debug, Copy, PartialEq)]
+pub enum FieldType {
+    /// Defines a boolean field.
+    Bool,
+
+    /// Defines an integer number field.
+    Int,
+
+    /// Defines a floating point number field.
+    Float,
+
+    /// Defines a text string field.
+    String,
+
+    /// Defines a [`Relation`][`crate::operation::Relation`] field.
+    Relation,
+
+    /// Defines a [`RelationList`][`crate::operation::RelationList`] field.
+    RelationList,
+
+    /// Defines a [`PinnedRelation`][`crate::operation::PinnedRelation`] field.
+    PinnedRelation,
+
+    /// Defines a [`PinnedRelationList`][`crate::operation::PinnedRelationList`] field.
+    PinnedRelationList,
+}
+
+impl FromStr for FieldType {
+    type Err = FieldTypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bool" => Ok(FieldType::Bool),
+            "int" => Ok(FieldType::Int),
+            "float" => Ok(FieldType::Float),
+            "str" => Ok(FieldType::String),
+            "relation" => Ok(FieldType::Relation),
+            "relation_list" => Ok(FieldType::RelationList),
+            "pinned_relation" => Ok(FieldType::PinnedRelation),
+            "pinned_relation_list" => Ok(FieldType::PinnedRelationList),
+            type_str => Err(FieldTypeError::InvalidFieldType(type_str.into())),
+        }
+    }
+}
+
+impl FieldType {
+    /// Returns the string representation of this type.
+    pub fn as_str(&self) -> &str {
+        match self {
+            FieldType::Bool => "bool",
+            FieldType::Int => "int",
+            FieldType::Float => "float",
+            FieldType::String => "str",
+            FieldType::Relation => "relation",
+            FieldType::RelationList => "relation_list",
+            FieldType::PinnedRelation => "pinned_relation",
+            FieldType::PinnedRelationList => "pinned_relation_list",
+        }
+    }
+}

--- a/p2panda-rs/src/schema/mod.rs
+++ b/p2panda-rs/src/schema/mod.rs
@@ -2,10 +2,12 @@
 
 //! Schemas describe the format of data used in operation fields.
 mod error;
+mod field_types;
 #[allow(clippy::module_inception)]
 mod schema;
 mod schema_id;
 pub mod system;
 
-pub use error::{SchemaError, SchemaIdError};
+pub use error::{FieldTypeError, SchemaError, SchemaIdError};
+pub use field_types::FieldType;
 pub use schema_id::SchemaId;

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -4,8 +4,8 @@ use std::collections::BTreeMap;
 
 use crate::cddl::generate_cddl_definition;
 use crate::document::DocumentViewId;
-use crate::schema::system::{FieldType, SchemaFieldView, SchemaView};
-use crate::schema::SchemaError;
+use crate::schema::system::{SchemaFieldView, SchemaView};
+use crate::schema::{FieldType, SchemaError};
 
 /// The key of a schema field
 type FieldKey = String;

--- a/p2panda-rs/src/schema/system/error.rs
+++ b/p2panda-rs/src/schema/system/error.rs
@@ -16,6 +16,6 @@ pub enum SystemSchemaError {
     MissingField(String),
 
     /// Invalid field type found.
-    #[error("invalid field type '{0}'")]
-    InvalidFieldType(String),
+    #[error("invalid field type")]
+    InvalidFieldType(#[from] crate::schema::FieldTypeError),
 }

--- a/p2panda-rs/src/schema/system/mod.rs
+++ b/p2panda-rs/src/schema/system/mod.rs
@@ -8,4 +8,4 @@ mod error;
 mod schema_views;
 
 pub use error::SystemSchemaError;
-pub use schema_views::{FieldType, SchemaFieldView, SchemaView};
+pub use schema_views::{SchemaFieldView, SchemaView};

--- a/p2panda-rs/src/schema/system/schema_views.rs
+++ b/p2panda-rs/src/schema/system/schema_views.rs
@@ -212,7 +212,10 @@ mod tests {
             "name".to_string(),
             OperationValue::Text("is_accessible".to_string()),
         );
-        bool_field.insert("type".to_string(), OperationValue::Text("bool".to_string()));
+        bool_field.insert(
+            "type".to_string(),
+            OperationValue::Text(FieldType::Bool.into()),
+        );
 
         let document_view = DocumentView::new(document_view_id.clone(), bool_field);
         let field_view = SchemaFieldView::try_from(document_view);
@@ -230,7 +233,10 @@ mod tests {
             "name".to_string(),
             OperationValue::Text("capacity".to_string()),
         );
-        capacity_field.insert("type".to_string(), OperationValue::Text("int".to_string()));
+        capacity_field.insert(
+            "type".to_string(),
+            OperationValue::Text(FieldType::Int.into()),
+        );
 
         let document_view = DocumentView::new(document_view_id.clone(), capacity_field);
         let field_view = SchemaFieldView::try_from(document_view);
@@ -247,7 +253,7 @@ mod tests {
         );
         float_field.insert(
             "type".to_string(),
-            OperationValue::Text("float".to_string()),
+            OperationValue::Text(FieldType::Float.into()),
         );
 
         let document_view = DocumentView::new(document_view_id.clone(), float_field);
@@ -263,7 +269,10 @@ mod tests {
             "name".to_string(),
             OperationValue::Text("venue_name".to_string()),
         );
-        str_field.insert("type".to_string(), OperationValue::Text("str".to_string()));
+        str_field.insert(
+            "type".to_string(),
+            OperationValue::Text(FieldType::String.into()),
+        );
 
         let document_view = DocumentView::new(document_view_id.clone(), str_field);
         let field_view = SchemaFieldView::try_from(document_view);
@@ -280,7 +289,7 @@ mod tests {
         );
         relation_field.insert(
             "type".to_string(),
-            OperationValue::Text("relation".to_string()),
+            OperationValue::Text(FieldType::Relation.into()),
         );
 
         let document_view = DocumentView::new(document_view_id, relation_field);

--- a/p2panda-rs/src/schema/system/schema_views.rs
+++ b/p2panda-rs/src/schema/system/schema_views.rs
@@ -25,6 +25,15 @@ pub enum FieldType {
 
     /// Defines a [`Relation`][`crate::operation::Relation`] field.
     Relation,
+
+    /// Defines a [`RelationList`][`crate::operation::RelationList`] field.
+    RelationList,
+
+    /// Defines a [`PinnedRelation`][`crate::operation::PinnedRelation`] field.
+    PinnedRelation,
+
+    /// Defines a [`PinnedRelationList`][`crate::operation::PinnedRelationList`] field.
+    PinnedRelationList,
 }
 
 impl FromStr for FieldType {
@@ -37,6 +46,9 @@ impl FromStr for FieldType {
             "float" => Ok(FieldType::Float),
             "str" => Ok(FieldType::String),
             "relation" => Ok(FieldType::Relation),
+            "relation_list" => Ok(FieldType::RelationList),
+            "pinned_relation" => Ok(FieldType::PinnedRelation),
+            "pinned_relation_list" => Ok(FieldType::PinnedRelationList),
             type_str => Err(SystemSchemaError::InvalidFieldType(type_str.into())),
         }
     }
@@ -51,6 +63,9 @@ impl FieldType {
             FieldType::Float => "float",
             FieldType::String => "str",
             FieldType::Relation => "relation",
+            FieldType::RelationList => "relation_list",
+            FieldType::PinnedRelation => "pinned_relation",
+            FieldType::PinnedRelationList => "pinned_relation_list",
         }
     }
 }


### PR DESCRIPTION
Implement support for all `Relation` types in CDDL module.

- [x] CDDL generator
- [x] ~~`p2panda-js`~~ <- do this in another PR
- [x] ~~anywhere else?~~ <- think this is it

BONUS:
- [x] Implement `From<FieldType> for String` and use when defining SchemaField operations 

closes: #258

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
