### PR TITLE
Introduce schema hash id as a unique string representation for schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Highlights are marked with a pancake 🥞
 - `Schema` for representing application schema [#250](https://github.com/p2panda/p2panda/pull/250) `rs`
 - Performance benchmarks for entry and operation encoding/decoding [#254](https://github.com/p2panda/p2panda/pull/254) `rs`
 - Move `DocumentId` from `DocmentView` into `Document` [#255](https://github.com/p2panda/p2panda/pull/255) `rs`
+- Implement `Display` for `SchemaId` [#268](https://github.com/p2panda/p2panda/pull/268) `rs`
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Highlights are marked with a pancake 🥞
 - `Schema` for representing application schema [#250](https://github.com/p2panda/p2panda/pull/250) `rs`
 - Performance benchmarks for entry and operation encoding/decoding [#254](https://github.com/p2panda/p2panda/pull/254) `rs`
 - Move `DocumentId` from `DocmentView` into `Document` [#255](https://github.com/p2panda/p2panda/pull/255) `rs`
-- Implement `Display` for `SchemaId` [#268](https://github.com/p2panda/p2panda/pull/268) `rs`
+- Introduce the schema hash id as a unique string identifier for schemas [#268](https://github.com/p2panda/p2panda/pull/268) `rs`
 
 ## Changed
 

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -55,8 +55,16 @@ impl DocumentViewId {
 }
 
 impl Display for DocumentViewId {
+    /// Document view ids are displayed by concatenating their hashes with an underscore separator.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.hash().as_str())
+        let mut is_first = true;
+        for hash in self.0.clone().into_iter() {
+            write!(f, "{}{}", if is_first { "" } else { "_" }, hash)?;
+            if is_first {
+                is_first = false;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -148,7 +156,20 @@ mod tests {
 
         assert_eq!(
             format!("{}", document_view_id),
-            "0020fc76e3a452648023d5e169369116be1526f6d3fc2b7742ed1af2b55f11bca7fb"
+            "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
+        );
+
+        let hash_1 = "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
+            .parse::<Hash>()
+            .unwrap();
+        let hash_2 = "0020d3235c8fe6f58608200851b83cd8482808eb81e4c6b4b17805bba57da9f16e79"
+            .parse::<Hash>()
+            .unwrap();
+        let view_id_unmerged = DocumentViewId::new(vec![hash_1, hash_2]);
+
+        assert_eq!(
+            format!("{}", view_id_unmerged),
+            "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543_0020d3235c8fe6f58608200851b83cd8482808eb81e4c6b4b17805bba57da9f16e79"
         );
     }
 }

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -143,7 +143,7 @@ mod tests {
     }
 
     #[test]
-    fn hashes() {
+    fn string_representation() {
         let document_view_id = DEFAULT_HASH.parse::<DocumentViewId>().unwrap();
 
         assert_eq!(

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -109,6 +109,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::hash::Hash;
+    use crate::test_utils::constants::DEFAULT_HASH;
     use crate::test_utils::fixtures::random_hash;
     use crate::Validate;
 
@@ -141,13 +142,13 @@ mod tests {
         }
     }
 
-    #[rstest]
-    fn hashes(#[from(random_hash)] hash_1: Hash, #[from(random_hash)] hash_2: Hash) {
-        let document_view_id = DocumentViewId::new(vec![hash_1, hash_2]);
+    #[test]
+    fn hashes() {
+        let document_view_id = DEFAULT_HASH.parse::<DocumentViewId>().unwrap();
 
         assert_eq!(
             document_view_id.hash().as_str(),
-            "002078559f175cd145855326705975a62440d4ebf31b835da646161485ea5cdb781c"
+            "0020fc76e3a452648023d5e169369116be1526f6d3fc2b7742ed1af2b55f11bca7fb"
         );
     }
 }

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -145,6 +145,9 @@ mod tests {
     fn hashes(#[from(random_hash)] hash_1: Hash, #[from(random_hash)] hash_2: Hash) {
         let document_view_id = DocumentViewId::new(vec![hash_1, hash_2]);
 
-        assert_eq!(document_view_id.hash().as_str(), "");
+        assert_eq!(
+            document_view_id.hash().as_str(),
+            "002078559f175cd145855326705975a62440d4ebf31b835da646161485ea5cdb781c"
+        );
     }
 }

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -147,7 +147,7 @@ mod tests {
         let document_view_id = DEFAULT_HASH.parse::<DocumentViewId>().unwrap();
 
         assert_eq!(
-            document_view_id.hash().as_str(),
+            format!("{}", document_view_id),
             "0020fc76e3a452648023d5e169369116be1526f6d3fc2b7742ed1af2b55f11bca7fb"
         );
     }

--- a/p2panda-rs/src/hash/hash.rs
+++ b/p2panda-rs/src/hash/hash.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::convert::TryFrom;
+use std::fmt;
 use std::hash::Hash as StdHash;
 use std::str::FromStr;
 
@@ -59,6 +60,12 @@ impl Hash {
     /// Returns hash as hex string.
     pub fn as_str(&self) -> &str {
         self.0.as_str()
+    }
+}
+
+impl fmt::Display for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/p2panda-rs/src/operation/relation.rs
+++ b/p2panda-rs/src/operation/relation.rs
@@ -86,6 +86,11 @@ impl PinnedRelation {
     pub fn new(document_view_id: DocumentViewId) -> Self {
         Self(document_view_id)
     }
+
+    /// Access the contained view id.
+    pub fn view_id(&self) -> &DocumentViewId {
+        &self.0
+    }
 }
 
 impl Validate for PinnedRelation {

--- a/p2panda-rs/src/operation/relation.rs
+++ b/p2panda-rs/src/operation/relation.rs
@@ -86,6 +86,11 @@ impl PinnedRelation {
     pub fn new(document_view_id: DocumentViewId) -> Self {
         Self(document_view_id)
     }
+
+    /// Returns the pinned relation's document view id.
+    pub fn view_id(&self) -> &DocumentViewId {
+        &self.0
+    }
 }
 
 impl Validate for PinnedRelation {

--- a/p2panda-rs/src/operation/relation.rs
+++ b/p2panda-rs/src/operation/relation.rs
@@ -86,11 +86,6 @@ impl PinnedRelation {
     pub fn new(document_view_id: DocumentViewId) -> Self {
         Self(document_view_id)
     }
-
-    /// Access the contained view id.
-    pub fn view_id(&self) -> &DocumentViewId {
-        &self.0
-    }
 }
 
 impl Validate for PinnedRelation {

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -64,15 +64,16 @@ impl Schema {
 
     /// Returns a unique string identifier for this schema
     ///
-    /// This has the format "<schema name>_<hashed schema document view graph tips>".
+    /// This has the format "<schema name>-<hashed schema document view graph tips>".
+    #[allow(unused)]
     pub fn hash_id(&self) -> String {
-        format!("{}_{}", self.name, self.id.hash().as_str())
+        format!("{}-{}", self.name, self.id.hash().as_str())
     }
 }
 
 impl Display for Schema {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.hash_id())
+        write!(f, "{}_{}", self.name, self.id)
     }
 }
 
@@ -82,7 +83,6 @@ mod tests {
     use std::convert::TryInto;
 
     use rstest::rstest;
-    use yasmf_hash::MAX_YAMF_HASH_SIZE;
 
     use crate::document::{DocumentView, DocumentViewId};
     use crate::hash::Hash;
@@ -180,11 +180,11 @@ mod tests {
         // Schema should return correct cddl string
         assert_eq!(expected_cddl, schema.as_cddl());
 
+        // Schema should have a string representation
+        assert!(format!("{}", schema).starts_with("venue_name_0020"));
+
         // Schema should have a hash id
-        assert_eq!(
-            format!("{}", schema).len(),
-            "venue_name_".len() + MAX_YAMF_HASH_SIZE * 2
-        )
+        assert!(schema.hash_id().starts_with("venue_name-0020"));
     }
 
     #[rstest]

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -13,7 +13,7 @@ type FieldKey = String;
 
 /// A struct representing a materialised schema.
 ///
-/// It is constructed from a `SchemaView` and all related `SchemaFieldView`s.
+/// It is constructed from a [`SchemaView`] and all related [`SchemaFieldView`]s.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Schema {
     id: DocumentViewId,

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -62,12 +62,15 @@ impl Schema {
         generate_cddl_definition(&self.fields)
     }
 
-    /// Returns a unique string identifier for this schema
+    /// Returns a unique string identifier for this schema.
     ///
-    /// This has the format "<schema name>-<hashed schema document view graph tips>".
+    /// This identifier can only be used when it is not necessary to reconstruct this schema's
+    /// document from it.
+    ///
+    /// It has the format "<schema name>__<hashed schema document view graph tips>".
     #[allow(unused)]
     pub fn hash_id(&self) -> String {
-        format!("{}-{}", self.name, self.id.hash().as_str())
+        format!("{}__{}", self.name, self.id.hash().as_str())
     }
 }
 
@@ -184,7 +187,7 @@ mod tests {
         assert!(format!("{}", schema).starts_with("venue_name_0020"));
 
         // Schema should have a hash id
-        assert!(schema.hash_id().starts_with("venue_name-0020"));
+        assert!(schema.hash_id().starts_with("venue_name__0020"));
     }
 
     #[rstest]

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -188,6 +188,17 @@ mod test {
     }
 
     #[test]
+    fn string_representation() {
+        let app_schema = SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap();
+        assert_eq!(
+            format!("{}", app_schema),
+            "0020505ecc036ed0fbac12acbc5cabe0efb985e53a7e36a71fc67fe0f50f631cd3ec"
+        );
+        assert_eq!(format!("{}", SchemaId::Schema), "schema_v1");
+        assert_eq!(format!("{}", SchemaId::SchemaField), "schema_field_v1");
+    }
+
+    #[test]
     fn invalid_deserialization() {
         assert!(serde_json::from_str::<SchemaId>("[\"This is not a hash\"]").is_err());
         assert!(serde_json::from_str::<SchemaId>(

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::fmt::{self, Display};
+use std::fmt;
 use std::str::FromStr;
 
 use serde::de::{SeqAccess, Visitor};
@@ -36,17 +36,6 @@ impl SchemaId {
             "schema_field_v1" => Ok(SchemaId::SchemaField),
             hash_str => Ok(SchemaId::from(Hash::new(hash_str)?)),
         }
-    }
-}
-
-impl Display for SchemaId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let repr = match &self {
-            SchemaId::Application(relation) => relation.view_id().hash().as_str().into(),
-            SchemaId::Schema => "schema_v1".to_string(),
-            SchemaId::SchemaField => "schema_field_v1".to_string(),
-        };
-        write!(f, "{}", repr)
     }
 }
 
@@ -185,17 +174,6 @@ mod test {
             serde_json::from_str::<SchemaId>("\"schema_field_v1\"").unwrap(),
             schema_field
         );
-    }
-
-    #[test]
-    fn string_representation() {
-        let app_schema = SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap();
-        assert_eq!(
-            format!("{}", app_schema),
-            "0020505ecc036ed0fbac12acbc5cabe0efb985e53a7e36a71fc67fe0f50f631cd3ec"
-        );
-        assert_eq!(format!("{}", SchemaId::Schema), "schema_v1");
-        assert_eq!(format!("{}", SchemaId::SchemaField), "schema_field_v1");
     }
 
     #[test]

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -39,6 +39,16 @@ impl SchemaId {
     }
 }
 
+impl fmt::Display for SchemaId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SchemaId::Application(relation) => write!(f, "{}", relation.view_id()),
+            SchemaId::Schema => write!(f, "schema_v1"),
+            SchemaId::SchemaField => write!(f, "schema_field_v1"),
+        }
+    }
+}
+
 impl From<Hash> for SchemaId {
     fn from(hash: Hash) -> Self {
         Self::Application(PinnedRelation::new(DocumentViewId::new(vec![hash])))
@@ -197,11 +207,18 @@ mod test {
                 .unwrap()
         );
 
+        assert_eq!(
+            format!("{}", appl_schema),
+            "0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
+        );
+
         let schema = SchemaId::new("schema_v1").unwrap();
         assert_eq!(schema, SchemaId::Schema);
+        assert_eq!(format!("{}", schema), "schema_v1");
 
         let schema_field = SchemaId::new("schema_field_v1").unwrap();
         assert_eq!(schema_field, SchemaId::SchemaField);
+        assert_eq!(format!("{}", schema_field), "schema_field_v1");
     }
 
     #[test]

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::fmt;
+use std::fmt::{self, Display};
 use std::str::FromStr;
 
 use serde::de::{SeqAccess, Visitor};
@@ -36,6 +36,17 @@ impl SchemaId {
             "schema_field_v1" => Ok(SchemaId::SchemaField),
             hash_str => Ok(SchemaId::from(Hash::new(hash_str)?)),
         }
+    }
+}
+
+impl Display for SchemaId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let repr = match &self {
+            SchemaId::Application(relation) => relation.view_id().hash().as_str().into(),
+            SchemaId::Schema => "schema_v1".to_string(),
+            SchemaId::SchemaField => "schema_field_v1".to_string(),
+        };
+        write!(f, "{}", repr)
     }
 }
 


### PR DESCRIPTION
The schema hash id consists of the schema name and its hashed document view graph tips, concatenated with an underscore. 

Implements `Display` for `SchemaId`.

I'll be waiting with a handbook update until I hear from you aboot what ye think.

Closes #267 and #243

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [ ] Check if descriptions and terminology match `handbook` content (and visa-versa) 
