### PR TITLE
Introduce `OperationId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Highlights are marked with a pancake 🥞
 - `Schema` for representing application schema [#250](https://github.com/p2panda/p2panda/pull/250) `rs`
 - Performance benchmarks for entry and operation encoding/decoding [#254](https://github.com/p2panda/p2panda/pull/254) `rs`
 - Move `DocumentId` from `DocmentView` into `Document` [#255](https://github.com/p2panda/p2panda/pull/255) `rs`
+- Introduce `OperationId` to increase type safety around uses of `Hash` [#272](https://github.com/p2panda/p2panda/pull/272) `rs`
 
 ## Changed
 

--- a/p2panda-js/src/session/session.ts
+++ b/p2panda-js/src/session/session.ts
@@ -303,15 +303,17 @@ export class Session {
 
   /**
    * Signs and publishes an UPDATE operation for the given application data and
-   * matching schema. An UPDATE operation references the entry hash of the
-   * CREATE operation which is the root of this document.
+   * matching schema.
+   *
+   * The document to be updated is referenced by its document id, which is the
+   * operation id of that document's initial `CREATE` operation.
    *
    * Caches arguments for creating the next entry of this schema in the given
    * session.
    *
-   * @param documentId id of the document we update, this is the hash of the root `create` entry
+   * @param documentId id of the document we update, this is the id of the root `create` operation
    * @param fields application data to publish with the new entry, needs to match schema
-   * @param previousOperations array of operation hash ids identifying the tips of all currently un-merged branches in the document graph
+   * @param previousOperations array of operation ids identifying the tips of all currently un-merged branches in the document graph
    * @param options optional config object:
    * @param options.keyPair will be used to sign the new entry
    * @param options.schema hex-encoded schema id
@@ -354,13 +356,15 @@ export class Session {
   }
 
   /**
-   * Signs and publishes a DELETE operation for the given schema. References
-   * the entry hash of the CREATE operation which is the id of this document.
+   * Signs and publishes a DELETE operation for the given schema.
+   *
+   * The document to be deleted is referenced by its document id, which is the
+   * operation id of that document's initial `CREATE` operation.
    *
    * Caches arguments for creating the next entry of this schema in the given session.
    *
    * @param documentId id of the document we delete, this is the hash of the root `create` entry
-   * @param previousOperations array of operation hash ids identifying the tips of all currently un-merged branches in the document graph
+   * @param previousOperations array of operation ids identifying the tips of all currently un-merged branches in the document graph
    * @param options optional config object:
    * @param options.keyPair will be used to sign the new entry
    * @param options.schema hex-encoded schema id

--- a/p2panda-js/src/wasm.test.ts
+++ b/p2panda-js/src/wasm.test.ts
@@ -100,21 +100,21 @@ describe('WebAssembly interface', () => {
       );
 
       expect(() => fields.add('contact', 'relation', [TEST_HASH])).toThrow(
-        'Expected a hash value for field of type relation',
+        'Expected an operation id value for field of type relation',
       );
 
       expect(() => fields.add('contact', 'relation_list', TEST_HASH)).toThrow(
-        'Exptected an array of hashes for field of type relation list',
+        'Exptected an array of operation ids for field of type relation list',
       );
 
       expect(() => fields.add('contact', 'pinned_relation', TEST_HASH)).toThrow(
-        'Expected an array of hashes for field of type relation list',
+        'Expected an array of operation ids for field of type relation list',
       );
 
       expect(() =>
         fields.add('contact', 'pinned_relation_list', [TEST_HASH]),
       ).toThrow(
-        'Expected a nested array of hashes for field of type pinned relation list',
+        'Expected a nested array of operation ids for field of type pinned relation list',
       );
 
       // Throw when relation is an invalid hash

--- a/p2panda-js/src/wasm.test.ts
+++ b/p2panda-js/src/wasm.test.ts
@@ -104,11 +104,11 @@ describe('WebAssembly interface', () => {
       );
 
       expect(() => fields.add('contact', 'relation_list', TEST_HASH)).toThrow(
-        'Exptected an array of operation ids for field of type relation list',
+        'Expected an array of operation ids for field of type relation list',
       );
 
       expect(() => fields.add('contact', 'pinned_relation', TEST_HASH)).toThrow(
-        'Expected an array of operation ids for field of type relation list',
+        'Expected an array of operation ids for field of type pinned relation list',
       );
 
       expect(() =>

--- a/p2panda-rs/.gitignore
+++ b/p2panda-rs/.gitignore
@@ -2,3 +2,6 @@
 Cargo.lock
 pkg
 target
+
+# Used to configure system-specific paths to browser binaries for headless testing with wasm-pack
+/webdriver.json

--- a/p2panda-rs/benches/encode_decode.rs
+++ b/p2panda-rs/benches/encode_decode.rs
@@ -27,10 +27,10 @@ fn run_encode(payload: &str, key_pair: &KeyPair) -> (EntrySigned, OperationEncod
         .unwrap();
 
     // This is a random schema id that doesn't correspond to an actually published schema.
-    let hash =
+    let schema_id =
         SchemaId::new("0020d3ce4e85222017ffcb4e5ee032716e2e391478379a29e25bc35d74dd614e4132")
             .unwrap();
-    let operation = Operation::new_create(hash, fields).unwrap();
+    let operation = Operation::new_create(schema_id, fields).unwrap();
 
     let entry = Entry::new(
         &LogId::default(),

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -6,7 +6,7 @@ use crate::document::{DocumentBuilderError, DocumentId, DocumentView, DocumentVi
 use crate::graph::Graph;
 use crate::hash::Hash;
 use crate::identity::Author;
-use crate::operation::{AsOperation, OperationValue, OperationWithMeta};
+use crate::operation::{AsOperation, OperationValue, OperationWithMeta, OperationId};
 use crate::schema::SchemaId;
 
 /// Construct a graph from a list of operations.
@@ -218,7 +218,7 @@ impl DocumentBuilder {
         let sorted_graph_data = graph.sort()?;
 
         // These are the current graph tips, to be added to the document view id
-        let graph_tips: Vec<Hash> = sorted_graph_data
+        let graph_tips: Vec<OperationId> = sorted_graph_data
             .current_graph_tips()
             .iter()
             .map(|operation| operation.operation_id().to_owned())

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -339,7 +339,7 @@ mod tests {
         .unwrap();
 
         // Panda publishes an update operation.
-        // It contains the hash of the previous operation in it's `previous_operations` array
+        // It contains the id of the previous operation in it's `previous_operations` array
         //
         // DOCUMENT: [panda_1]<--[panda_2]
         //
@@ -377,7 +377,7 @@ mod tests {
         .unwrap();
 
         // Penguin publishes a new operation while now being aware of the previous branching situation.
-        // Their `previous_operations` field now contains 2 operation hash id's.
+        // Their `previous_operations` field now contains 2 operation id's.
         //
         // DOCUMENT: [panda_1]<--[penguin_1]<---[penguin_2]
         //                    \----[panda_2]<--/
@@ -767,7 +767,7 @@ mod tests {
         .unwrap();
 
         // Panda publishes an update operation.
-        // It contains the hash of the previous operation in it's `previous_operations` array
+        // It contains the id of the previous operation in it's `previous_operations` array
         send_to_node(
             &mut node,
             &panda,
@@ -815,7 +815,7 @@ mod tests {
         .unwrap();
 
         // Panda publishes an delete operation.
-        // It contains the hash of the previous operation in it's `previous_operations` array.
+        // It contains the id of the previous operation in it's `previous_operations` array.
         send_to_node(
             &mut node,
             &panda,

--- a/p2panda-rs/src/document/document_id.rs
+++ b/p2panda-rs/src/document/document_id.rs
@@ -73,7 +73,10 @@ mod tests {
         // Converts any string to `DocumentId`
         let hash_str = "0020cfb0fa37f36d082faad3886a9ffbcc2813b7afe90f0609a556d425f1a76ec805";
         let document_id: DocumentId = hash_str.parse().unwrap();
-        assert_eq!(document_id, DocumentId::new(hash_str.parse::<OperationId>().unwrap()));
+        assert_eq!(
+            document_id,
+            DocumentId::new(hash_str.parse::<OperationId>().unwrap())
+        );
         assert_eq!(document_id.as_str(), hash_str);
 
         // Converts any `Hash` to `DocumentId`

--- a/p2panda-rs/src/document/document_id.rs
+++ b/p2panda-rs/src/document/document_id.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use crate::hash::{Hash, HashError};
+use crate::operation::OperationId;
 use crate::Validate;
 
 /// Identifier of a document.
@@ -20,12 +21,12 @@ use crate::Validate;
 ///                         \
 ///                          \__ [UPDATE] (Hash: "eff..")
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct DocumentId(Hash);
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct DocumentId(OperationId);
 
 impl DocumentId {
     /// Creates a new instance of `DocumentId`.
-    pub fn new(id: Hash) -> Self {
+    pub fn new(id: OperationId) -> Self {
         Self(id)
     }
 
@@ -45,7 +46,7 @@ impl Validate for DocumentId {
 
 impl From<Hash> for DocumentId {
     fn from(hash: Hash) -> Self {
-        Self::new(hash)
+        Self::new(hash.into())
     }
 }
 
@@ -53,7 +54,7 @@ impl FromStr for DocumentId {
     type Err = HashError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::new(Hash::new(s)?))
+        Ok(Self::new(s.parse::<OperationId>()?))
     }
 }
 
@@ -62,6 +63,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::hash::Hash;
+    use crate::operation::OperationId;
     use crate::test_utils::fixtures::random_hash;
 
     use super::DocumentId;
@@ -71,12 +73,12 @@ mod tests {
         // Converts any string to `DocumentId`
         let hash_str = "0020cfb0fa37f36d082faad3886a9ffbcc2813b7afe90f0609a556d425f1a76ec805";
         let document_id: DocumentId = hash_str.parse().unwrap();
-        assert_eq!(document_id, DocumentId::new(Hash::new(hash_str).unwrap()));
+        assert_eq!(document_id, DocumentId::new(hash_str.parse::<OperationId>().unwrap()));
         assert_eq!(document_id.as_str(), hash_str);
 
         // Converts any `Hash` to `DocumentId`
         let document_id = DocumentId::from(hash.clone());
-        assert_eq!(document_id, DocumentId::new(hash));
+        assert_eq!(document_id, DocumentId::new(hash.into()));
 
         // Fails when string is not a hash
         assert!("This is not a hash".parse::<DocumentId>().is_err());

--- a/p2panda-rs/src/document/document_id.rs
+++ b/p2panda-rs/src/document/document_id.rs
@@ -11,8 +11,9 @@ use crate::Validate;
 /// Identifier of a document.
 ///
 /// Documents are formed by one or many operations which create, update or delete the regarding
-/// document. The hash of the entry containing the CREATE operation is automatically also the
-/// identifier of the whole document.
+/// document. The whole document is always identified by the [`OperationId`] of its initial `CREATE`
+/// operation. This operation id is equivalent to the [`Hash`] of the entry with which that
+/// operation was published.
 ///
 /// ```text
 /// The document with the following operation graph has the id "2fa..":

--- a/p2panda-rs/src/document/document_view.rs
+++ b/p2panda-rs/src/document/document_view.rs
@@ -66,11 +66,11 @@ mod tests {
     use rstest::{fixture, rstest};
 
     use crate::document::{reduce, DocumentId};
-    use crate::hash::Hash;
-    use crate::operation::{Operation, OperationValue, Relation};
+    use crate::operation::{Operation, OperationId, OperationValue, Relation};
     use crate::schema::SchemaId;
     use crate::test_utils::fixtures::{
-        create_operation, document_id, fields, random_hash, schema, update_operation,
+        create_operation, document_id, document_view_id, fields, random_operation_id, schema,
+        update_operation,
     };
 
     use super::{DocumentView, DocumentViewId};
@@ -94,11 +94,11 @@ mod tests {
     #[fixture]
     fn test_update_operation(
         schema: SchemaId,
-        #[from(random_hash)] prev_op_hash: Hash,
+        #[from(random_operation_id)] prev_op_id: OperationId,
     ) -> Operation {
         update_operation(
             schema,
-            vec![prev_op_hash],
+            vec![prev_op_id],
             fields(vec![
                 ("age", OperationValue::Integer(29)),
                 ("is_admin", OperationValue::Boolean(true)),
@@ -109,10 +109,9 @@ mod tests {
     #[rstest]
     fn from_single_create_op(
         test_create_operation: Operation,
-        #[from(random_hash)] view_id: Hash,
+        document_view_id: DocumentViewId,
         #[from(document_id)] relation_id: DocumentId,
     ) {
-        let document_view_id = DocumentViewId::new(vec![view_id]);
         let expected_relation = Relation::new(relation_id);
 
         // Reduce a single CREATE `Operation`
@@ -154,10 +153,8 @@ mod tests {
     fn with_update_op(
         test_create_operation: Operation,
         test_update_operation: Operation,
-        #[from(random_hash)] view_id: Hash,
+        document_view_id: DocumentViewId,
     ) {
-        let document_view_id = DocumentViewId::new(vec![view_id]);
-
         let (view, is_edited, is_deleted) = reduce(&[test_create_operation, test_update_operation]);
 
         let document_view = DocumentView::new(document_view_id, view);

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -10,8 +10,8 @@ use crate::Validate;
 
 /// The identifier of a document view.
 ///
-/// Contains the hashes of the document graph tips which is all the information we need to reliably
-/// reconstruct a specific version of a document.
+/// Contains the operation ids of the document graph tips, which is all the information we need
+/// to reliably reconstruct a specific version of a document.
 ///
 /// ```text
 /// The document with the following operation graph has the id "2fa.." and six different document
@@ -37,7 +37,7 @@ impl DocumentViewId {
         Self(graph_tips)
     }
 
-    /// Get the graph tip hashes of this view id.
+    /// Get the graph tip ids of this view id.
     pub fn graph_tips(&self) -> &[OperationId] {
         self.0.as_slice()
     }

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -28,16 +28,16 @@ use crate::Validate;
 ///                          \__ [UPDATE] (Hash: "eff..")
 /// ```
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub struct DocumentViewId(Vec<Hash>);
+pub struct DocumentViewId(Vec<OperationId>);
 
 impl DocumentViewId {
     /// Create a new document view id.
-    pub fn new(graph_tips: Vec<Hash>) -> Self {
+    pub fn new(graph_tips: Vec<OperationId>) -> Self {
         Self(graph_tips)
     }
 
     /// Get the graph tip hashes of this view id.
-    pub fn graph_tips(&self) -> &[Hash] {
+    pub fn graph_tips(&self) -> &[OperationId] {
         self.0.as_slice()
     }
 }

--- a/p2panda-rs/src/document/mod.rs
+++ b/p2panda-rs/src/document/mod.rs
@@ -59,7 +59,7 @@
 //! #     &polar,
 //! #     &update_operation(
 //! #         schema.clone(),
-//! #         vec![polar_entry_1_hash.clone()],
+//! #         vec![polar_entry_1_hash.clone().into()],
 //! #         operation_fields(vec![
 //! #             ("name", OperationValue::Text("ʕ •ᴥ•ʔ Cafe!".to_string())),
 //! #             ("owner", OperationValue::Text("しろくま".to_string())),
@@ -73,7 +73,7 @@
 //! #     &panda,
 //! #     &update_operation(
 //! #         schema.clone(),
-//! #         vec![polar_entry_1_hash.clone()],
+//! #         vec![polar_entry_1_hash.clone().into()],
 //! #         operation_fields(vec![("name", OperationValue::Text("🐼 Cafe!".to_string()))]),
 //! #     ),
 //! # )
@@ -84,7 +84,7 @@
 //! #     &polar,
 //! #     &update_operation(
 //! #         schema.clone(),
-//! #         vec![panda_entry_1_hash.clone(), polar_entry_2_hash.clone()],
+//! #         vec![panda_entry_1_hash.clone().into(), polar_entry_2_hash.clone().into()],
 //! #         operation_fields(vec![("house-number", OperationValue::Integer(102))]),
 //! #     ),
 //! # )
@@ -95,7 +95,7 @@
 //! #     &polar,
 //! #     &delete_operation(
 //! #         schema,
-//! #         vec![polar_entry_3_hash.clone()]
+//! #         vec![polar_entry_3_hash.clone().into()]
 //! #     ),
 //! # )
 //! # .unwrap();
@@ -116,7 +116,7 @@
 //! # let operation_5 =
 //! #     OperationWithMeta::new(&entry_5.entry_encoded(), &entry_5.operation_encoded()).unwrap();
 //! #
-//! //== Operation creation it hidden for brevity, see the operation module docs for details ==//
+//! //== Operation creation is hidden for brevity, see the operation module docs for details ==//
 //!
 //! // Here we have a collection of 2 operations
 //! let mut operations = vec![

--- a/p2panda-rs/src/entry/encode.rs
+++ b/p2panda-rs/src/entry/encode.rs
@@ -28,11 +28,11 @@ use crate::operation::OperationEncoded;
 /// let key_pair = KeyPair::new();
 ///
 /// // Create operation
-/// let schema_hash =
+/// let schema_id =
 ///     SchemaId::new("0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b")?;
 /// let mut fields = OperationFields::new();
 /// fields.add("title", OperationValue::Text("Hello, Panda!".to_owned()))?;
-/// let operation = Operation::new_create(schema_hash, fields)?;
+/// let operation = Operation::new_create(schema_id, fields)?;
 ///
 /// // Create entry
 /// let entry = Entry::new(

--- a/p2panda-rs/src/entry/entry.rs
+++ b/p2panda-rs/src/entry/entry.rs
@@ -35,15 +35,15 @@ use crate::Validate;
 ///
 /// // == FIRST ENTRY IN NEW LOG ==
 ///
-/// // Create schema hash
-/// let schema_hash = SchemaId::new(schema_hash_str)?;
+/// // Create schema id
+/// let schema_id = SchemaId::new(schema_hash_str)?;
 ///
 /// // Create a OperationFields instance and add a text field string with the key "title"
 /// let mut fields = OperationFields::new();
 /// fields.add("title", OperationValue::Text("Hello, Panda!".to_owned()))?;
 ///
 /// // Create an operation containing the above fields
-/// let operation = Operation::new_create(schema_hash, fields)?;
+/// let operation = Operation::new_create(schema_id, fields)?;
 ///
 /// // Create the first Entry in a log
 /// let entry = Entry::new(
@@ -70,14 +70,14 @@ use crate::Validate;
 /// # let schema_hash_string = "0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b";
 ///
 /// // Create schema
-/// let schema = SchemaId::new(schema_hash_string)?;
+/// let schema_id = SchemaId::new(schema_hash_string)?;
 ///
 /// // Create a OperationFields instance and add a text field string with the key "title"
 /// let mut fields = OperationFields::new();
 /// fields.add("title", OperationValue::Text("Hello, Panda!".to_owned()))?;
 ///
 /// // Create an operation containing the above fields
-/// let operation = Operation::new_create(schema, fields)?;
+/// let operation = Operation::new_create(schema_id, fields)?;
 ///
 /// // Create log ID from u64
 /// let log_id = LogId::new(1);

--- a/p2panda-rs/src/entry/entry.rs
+++ b/p2panda-rs/src/entry/entry.rs
@@ -212,14 +212,14 @@ mod tests {
 
     use crate::entry::{LogId, SeqNum};
     use crate::hash::Hash;
-    use crate::operation::{Operation, OperationFields, OperationValue};
+    use crate::operation::{Operation, OperationFields, OperationId, OperationValue};
     use crate::schema::SchemaId;
-    use crate::test_utils::fixtures::random_hash;
+    use crate::test_utils::fixtures::random_operation_id;
 
     use super::Entry;
 
     #[rstest]
-    fn validation(#[from(random_hash)] operation_id: Hash) {
+    fn validation(#[from(random_operation_id)] operation_id: OperationId) {
         // Prepare sample values
         let mut fields = OperationFields::new();
         fields

--- a/p2panda-rs/src/lib.rs
+++ b/p2panda-rs/src/lib.rs
@@ -19,10 +19,13 @@
 //! # use p2panda_rs::entry::{sign_and_encode, Entry, EntrySigned, LogId, SeqNum};
 //! # use p2panda_rs::hash::Hash;
 //! # use p2panda_rs::identity::KeyPair;
-//! # use p2panda_rs::operation::{Operation, OperationFields, OperationValue, Relation};
+//! # use p2panda_rs::operation::{Operation, OperationFields, OperationValue, OperationId, Relation};
 //! # use p2panda_rs::schema::SchemaId;
-//! # use p2panda_rs::document::DocumentId;
-//! # let profile_schema: SchemaId = Hash::new_from_bytes(vec![1, 2, 3])?.into();
+//! # use p2panda_rs::document::{DocumentId, DocumentViewId};
+//! # let profile_schema_view_id = OperationId::from(
+//! #     Hash::new_from_bytes(vec![1, 2, 3])?
+//! # );
+//! # let profile_schema: SchemaId = profile_schema_view_id.into();
 //! // Generate new Ed25519 key pair
 //! let key_pair = KeyPair::new();
 //!

--- a/p2panda-rs/src/operation/mod.rs
+++ b/p2panda-rs/src/operation/mod.rs
@@ -9,6 +9,7 @@ mod error;
 mod operation;
 mod operation_encoded;
 mod operation_fields;
+mod operation_id;
 mod operation_meta;
 mod relation;
 
@@ -18,5 +19,6 @@ pub use error::{
 pub use operation::{AsOperation, Operation, OperationAction, OperationVersion};
 pub use operation_encoded::OperationEncoded;
 pub use operation_fields::{OperationFields, OperationValue};
+pub use operation_id::OperationId;
 pub use operation_meta::OperationWithMeta;
 pub use relation::{PinnedRelation, PinnedRelationList, Relation, RelationList};

--- a/p2panda-rs/src/operation/operation.rs
+++ b/p2panda-rs/src/operation/operation.rs
@@ -81,7 +81,7 @@ impl<'de> Deserialize<'de> for OperationAction {
 /// entire graph and no more UPDATE operations should be published.
 ///
 /// All UPDATE and DELETE operations have a `previous_operations` field which contains a vector of
-/// operation hash ids which identify the known branch tips at the time of publication. These allow
+/// operation ids which identify the known branch tips at the time of publication. These allow
 /// us to build the graph and retain knowledge of the graph state at the time the specific
 /// operation was published.
 ///

--- a/p2panda-rs/src/operation/operation.rs
+++ b/p2panda-rs/src/operation/operation.rs
@@ -5,8 +5,7 @@ use std::hash::{Hash as StdHash, Hasher};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::hash::Hash;
-use crate::operation::{OperationEncoded, OperationError, OperationFields};
+use crate::operation::{OperationEncoded, OperationError, OperationFields, OperationId};
 use crate::schema::SchemaId;
 use crate::Validate;
 
@@ -131,10 +130,9 @@ pub struct Operation {
     /// Version schema of this operation.
     version: OperationVersion,
 
-    /// Optional array of hashes referring to operations directly preceding this one in the
-    /// document.
+    /// Optional array of operation ids directly preceding this one in the document.
     #[serde(skip_serializing_if = "Option::is_none")]
-    previous_operations: Option<Vec<Hash>>,
+    previous_operations: Option<Vec<OperationId>>,
 
     /// Optional fields map holding the operation data.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -187,7 +185,7 @@ impl Operation {
     /// Returns new UPDATE operation.
     pub fn new_update(
         schema: SchemaId,
-        previous_operations: Vec<Hash>,
+        previous_operations: Vec<OperationId>,
         fields: OperationFields,
     ) -> Result<Self, OperationError> {
         let operation = Self {
@@ -206,7 +204,7 @@ impl Operation {
     /// Returns new DELETE operation.
     pub fn new_delete(
         schema: SchemaId,
-        previous_operations: Vec<Hash>,
+        previous_operations: Vec<OperationId>,
     ) -> Result<Self, OperationError> {
         let operation = Self {
             action: OperationAction::Delete,
@@ -244,8 +242,8 @@ pub trait AsOperation {
     /// Returns application data fields of operation.
     fn fields(&self) -> Option<OperationFields>;
 
-    /// Returns vector of known previous operation hashes of this operation.
-    fn previous_operations(&self) -> Option<Vec<Hash>>;
+    /// Returns vector of this operation's previous operation ids
+    fn previous_operations(&self) -> Option<Vec<OperationId>>;
 
     /// Returns true if operation contains fields.
     fn has_fields(&self) -> bool {
@@ -295,7 +293,7 @@ impl AsOperation for Operation {
     }
 
     /// Returns known previous operations vector of this operation.
-    fn previous_operations(&self) -> Option<Vec<Hash>> {
+    fn previous_operations(&self) -> Option<Vec<OperationId>> {
         self.previous_operations.clone()
     }
 }
@@ -363,11 +361,12 @@ mod tests {
     use rstest_reuse::apply;
 
     use crate::document::DocumentId;
-    use crate::hash::Hash;
-    use crate::operation::{OperationEncoded, OperationValue, Relation};
+    use crate::operation::{OperationEncoded, OperationId, OperationValue, Relation};
     use crate::schema::SchemaId;
     use crate::test_utils::fixtures::templates::many_valid_operations;
-    use crate::test_utils::fixtures::{fields, random_document_id, random_hash, schema};
+    use crate::test_utils::fixtures::{
+        fields, random_document_id, random_operation_id, schema,
+    };
     use crate::Validate;
 
     use super::{AsOperation, Operation, OperationAction, OperationFields, OperationVersion};
@@ -376,7 +375,7 @@ mod tests {
     fn operation_validation(
         fields: OperationFields,
         schema: SchemaId,
-        #[from(random_hash)] prev_op_id: Hash,
+        #[from(random_operation_id)] prev_op_id: OperationId,
     ) {
         let invalid_create_operation_1 = Operation {
             action: OperationAction::Create,
@@ -448,7 +447,7 @@ mod tests {
     #[rstest]
     fn encode_and_decode(
         schema: SchemaId,
-        #[from(random_hash)] prev_op_id: Hash,
+        #[from(random_operation_id)] prev_op_id: OperationId,
         #[from(random_document_id)] document_id: DocumentId,
     ) {
         // Create test operation

--- a/p2panda-rs/src/operation/operation.rs
+++ b/p2panda-rs/src/operation/operation.rs
@@ -364,9 +364,7 @@ mod tests {
     use crate::operation::{OperationEncoded, OperationId, OperationValue, Relation};
     use crate::schema::SchemaId;
     use crate::test_utils::fixtures::templates::many_valid_operations;
-    use crate::test_utils::fixtures::{
-        fields, random_document_id, random_operation_id, schema,
-    };
+    use crate::test_utils::fixtures::{fields, random_document_id, random_operation_id, schema};
     use crate::Validate;
 
     use super::{AsOperation, Operation, OperationAction, OperationFields, OperationVersion};

--- a/p2panda-rs/src/operation/operation_encoded.rs
+++ b/p2panda-rs/src/operation/operation_encoded.rs
@@ -78,7 +78,7 @@ mod tests {
     use crate::test_utils::fixtures::templates::version_fixtures;
     use crate::test_utils::fixtures::{
         encoded_create_string, fields, operation_encoded_invalid_relation_fields,
-        random_document_id, random_hash, schema, update_operation, Fixture,
+        random_document_id, random_operation_id, schema, update_operation, Fixture,
     };
     use crate::Validate;
 
@@ -126,7 +126,7 @@ mod tests {
             // Schema hash
             schema.clone(),
             // Previous operations
-            vec![random_hash()],
+            vec![random_operation_id()],
             // Operation fields
             fields(vec![
               ("username", OperationValue::Text("bubu".to_owned())),

--- a/p2panda-rs/src/operation/operation_fields.rs
+++ b/p2panda-rs/src/operation/operation_fields.rs
@@ -195,9 +195,11 @@ mod tests {
     use rstest::rstest;
 
     use crate::document::{DocumentId, DocumentViewId};
-    use crate::hash::Hash;
-    use crate::operation::{PinnedRelation, PinnedRelationList, Relation, RelationList};
-    use crate::test_utils::fixtures::{random_document_id, random_hash};
+
+    use crate::operation::{
+        OperationId, PinnedRelation, PinnedRelationList, Relation, RelationList,
+    };
+    use crate::test_utils::fixtures::{random_document_id, random_operation_id};
     use crate::Validate;
 
     use super::{OperationFields, OperationValue};
@@ -235,17 +237,17 @@ mod tests {
     #[rstest]
     #[allow(clippy::too_many_arguments)]
     fn encode_decode_relations(
-        #[from(random_hash)] hash_1: Hash,
-        #[from(random_hash)] hash_2: Hash,
-        #[from(random_hash)] hash_3: Hash,
-        #[from(random_hash)] hash_4: Hash,
-        #[from(random_hash)] hash_5: Hash,
-        #[from(random_hash)] hash_6: Hash,
-        #[from(random_hash)] hash_7: Hash,
-        #[from(random_hash)] hash_8: Hash,
+        #[from(random_operation_id)] operation_1: OperationId,
+        #[from(random_operation_id)] operation_2: OperationId,
+        #[from(random_operation_id)] operation_3: OperationId,
+        #[from(random_operation_id)] operation_4: OperationId,
+        #[from(random_operation_id)] operation_5: OperationId,
+        #[from(random_operation_id)] operation_6: OperationId,
+        #[from(random_operation_id)] operation_7: OperationId,
+        #[from(random_operation_id)] operation_8: OperationId,
     ) {
         // 1. Unpinned relation
-        let relation = OperationValue::Relation(Relation::new(DocumentId::new(hash_1)));
+        let relation = OperationValue::Relation(Relation::new(DocumentId::new(operation_1)));
         assert_eq!(
             relation,
             OperationValue::deserialize_str(&relation.serialize())
@@ -254,7 +256,8 @@ mod tests {
         // 2. Pinned relation
         let pinned_relation =
             OperationValue::PinnedRelation(PinnedRelation::new(DocumentViewId::new(vec![
-                hash_2, hash_3,
+                operation_2,
+                operation_3,
             ])));
         assert_eq!(
             pinned_relation,
@@ -263,8 +266,8 @@ mod tests {
 
         // 3. Unpinned relation list
         let relation_list = OperationValue::RelationList(RelationList::new(vec![
-            DocumentId::new(hash_4),
-            DocumentId::new(hash_5),
+            DocumentId::new(operation_4),
+            DocumentId::new(operation_5),
         ]));
         assert_eq!(
             relation_list,
@@ -274,8 +277,8 @@ mod tests {
         // 4. Pinned relation list
         let pinned_relation_list =
             OperationValue::PinnedRelationList(PinnedRelationList::new(vec![
-                DocumentViewId::new(vec![hash_6, hash_7]),
-                DocumentViewId::new(vec![hash_8]),
+                DocumentViewId::new(vec![operation_6, operation_7]),
+                DocumentViewId::new(vec![operation_8]),
             ]));
         assert_eq!(
             pinned_relation_list,
@@ -287,8 +290,8 @@ mod tests {
     fn validation_ok(
         #[from(random_document_id)] document_1: DocumentId,
         #[from(random_document_id)] document_2: DocumentId,
-        #[from(random_hash)] operation_id_1: Hash,
-        #[from(random_hash)] operation_id_2: Hash,
+        #[from(random_operation_id)] operation_id_1: OperationId,
+        #[from(random_operation_id)] operation_id_2: OperationId,
     ) {
         let relation = Relation::new(document_1.clone());
         let value = OperationValue::Relation(relation);
@@ -306,8 +309,8 @@ mod tests {
         assert!(value.validate().is_ok());
 
         let pinned_relation_list = PinnedRelationList::new(vec![
-            DocumentViewId::new(vec![operation_id_1]),
-            DocumentViewId::new(vec![operation_id_2]),
+            DocumentViewId::from(operation_id_1),
+            DocumentViewId::from(operation_id_2),
         ]);
         let value = OperationValue::PinnedRelationList(pinned_relation_list);
         assert!(value.validate().is_ok());
@@ -361,12 +364,12 @@ mod tests {
 
     #[rstest]
     fn pinned_relation_lists(
-        #[from(random_hash)] operation_id_1: Hash,
-        #[from(random_hash)] operation_id_2: Hash,
-        #[from(random_hash)] operation_id_3: Hash,
-        #[from(random_hash)] operation_id_4: Hash,
-        #[from(random_hash)] operation_id_5: Hash,
-        #[from(random_hash)] operation_id_6: Hash,
+        #[from(random_operation_id)] operation_id_1: OperationId,
+        #[from(random_operation_id)] operation_id_2: OperationId,
+        #[from(random_operation_id)] operation_id_3: OperationId,
+        #[from(random_operation_id)] operation_id_4: OperationId,
+        #[from(random_operation_id)] operation_id_5: OperationId,
+        #[from(random_operation_id)] operation_id_6: OperationId,
     ) {
         let document_view_id_1 = DocumentViewId::new(vec![operation_id_1, operation_id_2]);
         let document_view_id_2 = DocumentViewId::new(vec![operation_id_3]);

--- a/p2panda-rs/src/operation/operation_id.rs
+++ b/p2panda-rs/src/operation/operation_id.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::hash::{Hash, HashError};
+use crate::Validate;
+
+/// Uniquely identifies an [`Operation`].
+///
+/// An `OperationId` is the hash of the [`Entry`] with which an operation was published.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct OperationId(Hash);
+
+impl OperationId {
+    /// Returns an `OperationId` given an entry's hash.
+    pub fn new(entry_hash: Hash) -> Self {
+        Self(entry_hash)
+    }
+
+    /// Extracts a string slice from the operation id's hash.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Validate for OperationId {
+    type Error = HashError;
+
+    fn validate(&self) -> Result<(), Self::Error> {
+        self.0.validate()
+    }
+}
+
+impl From<Hash> for OperationId {
+    fn from(hash: Hash) -> Self {
+        Self::new(hash)
+    }
+}
+
+impl FromStr for OperationId {
+    type Err = HashError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::new(Hash::new(s)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::hash::Hash;
+    use crate::test_utils::fixtures::random_hash;
+
+    use super::OperationId;
+
+    #[rstest]
+    fn conversion(#[from(random_hash)] hash: Hash) {
+        // Converts any string to `OperationId`
+        let hash_str = "0020cfb0fa37f36d082faad3886a9ffbcc2813b7afe90f0609a556d425f1a76ec805";
+        let operation_id: OperationId = hash_str.parse().unwrap();
+        assert_eq!(operation_id, OperationId::new(Hash::new(hash_str).unwrap()));
+        assert_eq!(operation_id.as_str(), hash_str);
+
+        // Converts any `Hash` to `OperationId`
+        let operation_id = OperationId::from(hash.clone());
+        assert_eq!(operation_id, OperationId::new(hash));
+
+        // Fails when string is not a hash
+        assert!("This is not a hash".parse::<OperationId>().is_err());
+    }
+}

--- a/p2panda-rs/src/operation/operation_id.rs
+++ b/p2panda-rs/src/operation/operation_id.rs
@@ -23,6 +23,11 @@ impl OperationId {
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }
+
+    /// Access the inner [`Hash`] value of this operation id.
+    pub fn as_hash(&self) -> &Hash {
+        &self.0
+    }
 }
 
 impl Validate for OperationId {

--- a/p2panda-rs/src/operation/operation_meta.rs
+++ b/p2panda-rs/src/operation/operation_meta.rs
@@ -3,7 +3,6 @@
 use std::hash::Hash as StdHash;
 
 use crate::entry::{decode_entry, EntrySigned};
-use crate::hash::Hash;
 use crate::identity::Author;
 use crate::operation::{
     AsOperation, Operation, OperationAction, OperationEncoded, OperationFields, OperationVersion,
@@ -88,7 +87,7 @@ impl AsOperation for OperationWithMeta {
     }
 
     /// Returns vector of previous operations.
-    fn previous_operations(&self) -> Option<Vec<Hash>> {
+    fn previous_operations(&self) -> Option<Vec<OperationId>> {
         self.operation.previous_operations()
     }
 }

--- a/p2panda-rs/src/operation/operation_meta.rs
+++ b/p2panda-rs/src/operation/operation_meta.rs
@@ -13,11 +13,11 @@ use crate::Validate;
 
 use super::OperationId;
 
-/// Wrapper struct containing an operation, the hash of its entry, and the public key of its
+/// Wrapper struct containing an operation, its operation id, and the public key of its
 /// author.
 #[derive(Debug, Clone, Eq, PartialEq, StdHash)]
 pub struct OperationWithMeta {
-    /// The hash of this operations entry.
+    /// The hash of this operation's entry.
     operation_id: OperationId,
 
     /// The public key of the author who published this operation.

--- a/p2panda-rs/src/operation/operation_meta.rs
+++ b/p2panda-rs/src/operation/operation_meta.rs
@@ -12,12 +12,14 @@ use crate::operation::{
 use crate::schema::SchemaId;
 use crate::Validate;
 
+use super::OperationId;
+
 /// Wrapper struct containing an operation, the hash of its entry, and the public key of its
 /// author.
 #[derive(Debug, Clone, Eq, PartialEq, StdHash)]
 pub struct OperationWithMeta {
     /// The hash of this operations entry.
-    operation_id: Hash,
+    operation_id: OperationId,
 
     /// The public key of the author who published this operation.
     public_key: Author,
@@ -38,7 +40,7 @@ impl OperationWithMeta {
         decode_entry(entry_encoded, Some(operation_encoded))?;
 
         let operation_with_meta = Self {
-            operation_id: entry_encoded.hash(),
+            operation_id: entry_encoded.hash().into(),
             public_key: entry_encoded.author(),
             operation,
         };
@@ -49,7 +51,7 @@ impl OperationWithMeta {
     }
 
     /// Returns the identifier for this operation.
-    pub fn operation_id(&self) -> &Hash {
+    pub fn operation_id(&self) -> &OperationId {
         &self.operation_id
     }
 

--- a/p2panda-rs/src/operation/relation.rs
+++ b/p2panda-rs/src/operation/relation.rs
@@ -41,8 +41,8 @@
 //! Document: [Comment "This was great!"]
 //! ```
 //!
-//! Document view ids contain the hashes of the document graph tips, which is all the information
-//! we need to reliably recreate the document at this certain point in time.
+//! Document view ids contain the operation ids of the document graph tips, which is all the
+//! information we need to reliably recreate the document at this certain point in time.
 //!
 //! Pinned relations give us immutability and the option to restore a historical state across
 //! documents. However, most cases will probably only need unpinned relations: For example when

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -70,11 +70,10 @@ mod tests {
     use rstest::rstest;
 
     use crate::document::{DocumentView, DocumentViewId};
-    use crate::hash::Hash;
-    use crate::operation::{OperationValue, PinnedRelationList};
+    use crate::operation::{OperationId, OperationValue, PinnedRelationList};
     use crate::schema::schema::Schema;
     use crate::schema::system::{SchemaFieldView, SchemaView};
-    use crate::test_utils::fixtures::random_hash;
+    use crate::test_utils::fixtures::{document_view_id, random_operation_id};
 
     fn create_schema(fields: PinnedRelationList, view_id: DocumentViewId) -> SchemaView {
         let mut schema = BTreeMap::new();
@@ -110,15 +109,14 @@ mod tests {
 
     #[rstest]
     fn construct_schema(
-        #[from(random_hash)] relation_operation_id_1: Hash,
-        #[from(random_hash)] relation_operation_id_2: Hash,
-        #[from(random_hash)] relation_operation_id_3: Hash,
-        #[from(random_hash)] schema_view_id: Hash,
+        #[from(random_operation_id)] relation_operation_id_1: OperationId,
+        #[from(random_operation_id)] relation_operation_id_2: OperationId,
+        #[from(random_operation_id)] relation_operation_id_3: OperationId,
+        #[from(document_view_id)] schema_view_id: DocumentViewId,
     ) {
         // Create schema definition for "venue"
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-        let schema_view_id = DocumentViewId::new(vec![schema_view_id]);
         let fields = PinnedRelationList::new(vec![
             DocumentViewId::new(vec![relation_operation_id_1.clone()]),
             DocumentViewId::new(vec![
@@ -135,7 +133,7 @@ mod tests {
         let bool_field_view = create_field(
             "is_accessible",
             "bool",
-            DocumentViewId::new(vec![relation_operation_id_1]),
+            DocumentViewId::from(relation_operation_id_1),
         );
 
         // Create second schema field "capacity"
@@ -166,18 +164,17 @@ mod tests {
 
     #[rstest]
     fn invalid_fields_fail(
-        #[from(random_hash)] relation_operation_id_1: Hash,
-        #[from(random_hash)] relation_operation_id_2: Hash,
-        #[from(random_hash)] invalid_relation_hash: Hash,
-        #[from(random_hash)] schema_view_id: Hash,
+        #[from(random_operation_id)] relation_operation_id_1: OperationId,
+        #[from(random_operation_id)] relation_operation_id_2: OperationId,
+        #[from(random_operation_id)] invalid_relation_hash: OperationId,
+        #[from(document_view_id)] schema_view_id: DocumentViewId,
     ) {
         // Create schema definition for "venue"
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-        let schema_view_id = DocumentViewId::new(vec![schema_view_id]);
         let fields = PinnedRelationList::new(vec![
-            DocumentViewId::new(vec![relation_operation_id_1.clone()]),
-            DocumentViewId::new(vec![relation_operation_id_2.clone()]),
+            DocumentViewId::from(relation_operation_id_1.clone()),
+            DocumentViewId::from(relation_operation_id_2.clone()),
         ]);
 
         let schema_view = create_schema(fields, schema_view_id);
@@ -185,19 +182,19 @@ mod tests {
         // Create first valid schema field "is_accessible"
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-        let bool_field_document_view_id = DocumentViewId::new(vec![relation_operation_id_1]);
+        let bool_field_document_view_id = DocumentViewId::from(relation_operation_id_1);
         let bool_field_view = create_field("is_accessible", "bool", bool_field_document_view_id);
 
         // Create second valid schema field "capacity"
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-        let capacity_field_document_view_id = DocumentViewId::new(vec![relation_operation_id_2]);
+        let capacity_field_document_view_id = DocumentViewId::from(relation_operation_id_2);
         let capacity_field_view = create_field("capacity", "int", capacity_field_document_view_id);
 
         // Create field with invalid DocumentViewId
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-        let invalid_document_view_id = DocumentViewId::new(vec![invalid_relation_hash]);
+        let invalid_document_view_id = DocumentViewId::from(invalid_relation_hash);
         let field_with_invalid_document_view_id =
             create_field("capacity", "int", invalid_document_view_id);
 

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -166,7 +166,7 @@ mod tests {
     fn invalid_fields_fail(
         #[from(random_operation_id)] relation_operation_id_1: OperationId,
         #[from(random_operation_id)] relation_operation_id_2: OperationId,
-        #[from(random_operation_id)] invalid_relation_hash: OperationId,
+        #[from(random_operation_id)] invalid_relation_id: OperationId,
         #[from(document_view_id)] schema_view_id: DocumentViewId,
     ) {
         // Create schema definition for "venue"
@@ -194,7 +194,7 @@ mod tests {
         // Create field with invalid DocumentViewId
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-        let invalid_document_view_id = DocumentViewId::from(invalid_relation_hash);
+        let invalid_document_view_id = DocumentViewId::from(invalid_relation_id);
         let field_with_invalid_document_view_id =
             create_field("capacity", "int", invalid_document_view_id);
 

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::document::DocumentViewId;
 use crate::operation::{OperationId, PinnedRelation};
 use crate::schema::error::SchemaIdError;
-use crate::Validate;
 
 /// Identifies the schema of an [`crate::operation::Operation`].
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -33,7 +33,7 @@ impl SchemaId {
         match id {
             "schema_v1" => Ok(SchemaId::Schema),
             "schema_field_v1" => Ok(SchemaId::SchemaField),
-            hash_str => Ok(hash_str.parse::<OperationId>()?.into()),
+            hash_str => Ok(hash_str.parse::<DocumentViewId>()?.into()),
         }
     }
 }

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -177,6 +177,7 @@ mod test {
     #[test]
     fn invalid_deserialization() {
         assert!(serde_json::from_str::<SchemaId>("[\"This is not a hash\"]").is_err());
+        assert!(serde_json::from_str::<SchemaId>("5").is_err());
         assert!(serde_json::from_str::<SchemaId>(
             "0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
         )

--- a/p2panda-rs/src/schema/system/schema_views.rs
+++ b/p2panda-rs/src/schema/system/schema_views.rs
@@ -166,7 +166,7 @@ mod tests {
     use crate::hash::Hash;
     use crate::operation::{OperationValue, PinnedRelationList};
     use crate::schema::system::SchemaFieldView;
-    use crate::test_utils::fixtures::random_hash;
+    use crate::test_utils::fixtures::{document_view_id, random_hash};
 
     use super::{FieldType, SchemaView};
 
@@ -186,22 +186,19 @@ mod tests {
         );
         bool_field.insert(
             "fields".to_string(),
-            OperationValue::PinnedRelationList(PinnedRelationList::new(vec![DocumentViewId::new(
-                vec![relation_operation_id],
-            )])),
+            OperationValue::PinnedRelationList(PinnedRelationList::new(vec![
+                relation_operation_id.into(),
+            ])),
         );
 
-        let document_view_id = DocumentViewId::new(vec![view_id]);
+        let document_view_id = DocumentViewId::from(view_id);
         let document_view = DocumentView::new(document_view_id, bool_field);
 
         assert!(SchemaView::try_from(document_view).is_ok());
     }
 
     #[rstest]
-    fn field_type_from_document_view(#[from(random_hash)] view_id: Hash) {
-        // Prepare common document view id
-        let document_view_id = DocumentViewId::new(vec![view_id]);
-
+    fn field_type_from_document_view(document_view_id: DocumentViewId) {
         // Create first schema field "is_accessible"
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -297,9 +294,7 @@ mod tests {
     }
 
     #[rstest]
-    fn invalid_schema_field(#[from(random_hash)] view_id: Hash) {
-        let document_view_id = DocumentViewId::new(vec![view_id]);
-
+    fn invalid_schema_field(document_view_id: DocumentViewId) {
         let mut invalid_field = BTreeMap::new();
         invalid_field.insert(
             "name".to_string(),

--- a/p2panda-rs/src/test_utils/README.md
+++ b/p2panda-rs/src/test_utils/README.md
@@ -80,7 +80,7 @@ let (panda_entry_1_hash, next_entry_args) = send_to_node(
 .unwrap();
 
 // Panda publishes an update operation. This appends a new entry to the document log, the operation also refers to the previous
-// tip of the graph by it's hash id.
+// tip of the graph by it's operation id.
 //
 // PANDA  : [1] <--[2]
 // PENGUIN:

--- a/p2panda-rs/src/test_utils/fixtures/defaults.rs
+++ b/p2panda-rs/src/test_utils/fixtures/defaults.rs
@@ -43,7 +43,7 @@ pub fn create_operation() -> Operation {
 pub fn update_operation() -> Operation {
     fixtures::update_operation(
         fixtures::schema(DEFAULT_SCHEMA_HASH),
-        vec![fixtures::hash(DEFAULT_HASH)],
+        vec![fixtures::operation_id(DEFAULT_HASH)],
         fields(),
     )
 }
@@ -52,7 +52,7 @@ pub fn update_operation() -> Operation {
 pub fn delete_operation() -> Operation {
     fixtures::delete_operation(
         fixtures::schema(DEFAULT_SCHEMA_HASH),
-        vec![fixtures::hash(DEFAULT_HASH)],
+        vec![fixtures::operation_id(DEFAULT_HASH)],
     )
 }
 

--- a/p2panda-rs/src/test_utils/fixtures/templates.rs
+++ b/p2panda-rs/src/test_utils/fixtures/templates.rs
@@ -64,9 +64,9 @@ fn many_valid_entries(#[case] entry: Entry) {}
 #[case::update_operation_many_previous(crate::test_utils::utils::any_operation(
     Some(crate::test_utils::fixtures::defaults::fields()),
     Some(vec![
-        crate::test_utils::fixtures::random_hash(),
-        crate::test_utils::fixtures::random_hash(),
-        crate::test_utils::fixtures::random_hash()
+        crate::test_utils::fixtures::random_operation_id(),
+        crate::test_utils::fixtures::random_operation_id(),
+        crate::test_utils::fixtures::random_operation_id()
         ])
     )
 )]
@@ -74,9 +74,9 @@ fn many_valid_entries(#[case] entry: Entry) {}
     None,
     #[allow(unused_qualifications)]
     Some(vec![
-        crate::test_utils::fixtures::random_hash(),
-        crate::test_utils::fixtures::random_hash(),
-        crate::test_utils::fixtures::random_hash()
+        crate::test_utils::fixtures::random_operation_id(),
+        crate::test_utils::fixtures::random_operation_id(),
+        crate::test_utils::fixtures::random_operation_id()
         ])
     )
 )]

--- a/p2panda-rs/src/test_utils/generate_test_data.rs
+++ b/p2panda-rs/src/test_utils/generate_test_data.rs
@@ -40,7 +40,7 @@ fn main() {
         &panda,
         &update_operation(
             SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap(),
-            vec![entry1_hash],
+            vec![entry1_hash.into()],
             operation_fields(vec![(
                 "message",
                 OperationValue::Text("Which I now update.".to_string()),
@@ -55,7 +55,7 @@ fn main() {
         &panda,
         &update_operation(
             SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap(),
-            vec![entry2_hash],
+            vec![entry2_hash.into()],
             operation_fields(vec![(
                 "message",
                 OperationValue::Text("And then update again.".to_string()),
@@ -70,7 +70,7 @@ fn main() {
         &panda,
         &delete_operation(
             SchemaId::new(DEFAULT_SCHEMA_HASH).unwrap(),
-            vec![entry3_hash],
+            vec![entry3_hash.into()],
         ),
     )
     .unwrap();

--- a/p2panda-rs/src/test_utils/mocks/logs.rs
+++ b/p2panda-rs/src/test_utils/mocks/logs.rs
@@ -11,7 +11,7 @@ use std::slice::Iter;
 use crate::entry::{decode_entry, EntrySigned, LogId, SeqNum};
 use crate::hash::Hash;
 use crate::identity::Author;
-use crate::operation::{AsOperation, Operation, OperationEncoded};
+use crate::operation::{AsOperation, Operation, OperationEncoded, OperationId};
 use crate::schema::SchemaId;
 
 /// Entry of an append-only which contains an encoded entry and operation.
@@ -64,7 +64,7 @@ impl LogEntry {
     }
 
     /// Get the previous operation hash for this entry.
-    pub fn previous_operations(&self) -> Option<Vec<Hash>> {
+    pub fn previous_operations(&self) -> Option<Vec<OperationId>> {
         self.operation().previous_operations()
     }
 }

--- a/p2panda-rs/src/test_utils/mocks/node.rs
+++ b/p2panda-rs/src/test_utils/mocks/node.rs
@@ -44,7 +44,7 @@
 //!     &panda,
 //!     &update_operation(
 //!         schema(DEFAULT_SCHEMA_HASH),
-//!         vec![document1_hash_id.clone()],
+//!         vec![document1_hash_id.clone().into()],
 //!         operation_fields(vec![(
 //!             "message",
 //!             OperationValue::Text("Which I now update.".to_string()),
@@ -59,7 +59,7 @@
 //!     &panda,
 //!     &delete_operation(
 //!         schema(DEFAULT_SCHEMA_HASH),
-//!         vec![entry2_hash]
+//!         vec![entry2_hash.into()]
 //!     )
 //! )
 //! .unwrap();
@@ -129,7 +129,7 @@ pub fn send_to_node(
 
         // Using the first previous operation in the list we retrieve the associated document
         // id from the database.
-        let document_id = node.get_document_by_entry(&previous_operations[0]);
+        let document_id = node.get_document_by_entry(previous_operations[0].as_hash());
 
         Some(document_id.expect("This node does not contain the required document"))
     };
@@ -399,7 +399,7 @@ impl Node {
                 )
             });
             let document_id = self
-                .get_document_by_entry(&previous_operations[0])
+                .get_document_by_entry(previous_operations[0].as_hash())
                 .unwrap_or_else(|| {
                     panic!(
                         "Document log for entry {} not found on node",
@@ -593,7 +593,7 @@ mod tests {
             &panda,
             &update_operation(
                 schema.clone(),
-                vec![panda_entry_1_hash.clone()],
+                vec![panda_entry_1_hash.clone().into()],
                 operation_fields(vec![(
                     "message",
                     OperationValue::Text("Which I now update. [Panda]".to_string()),
@@ -645,7 +645,7 @@ mod tests {
             &penguin,
             &update_operation(
                 schema.clone(),
-                vec![panda_entry_2_hash],
+                vec![panda_entry_2_hash.into()],
                 operation_fields(vec![(
                     "message",
                     OperationValue::Text("My turn to update. [Penguin]".to_string()),
@@ -679,7 +679,7 @@ mod tests {
             &penguin,
             &update_operation(
                 schema.clone(),
-                vec![penguin_entry_1_hash],
+                vec![penguin_entry_1_hash.into()],
                 operation_fields(vec![(
                     "message",
                     OperationValue::Text("And again. [Penguin]".to_string()),
@@ -776,7 +776,7 @@ mod tests {
             &panda,
             &update_operation(
                 schema,
-                vec![entry1_hash.clone()],
+                vec![entry1_hash.clone().into()],
                 operation_fields(vec![(
                     "message",
                     OperationValue::Text("Which I now update.".to_string()),
@@ -855,7 +855,7 @@ mod tests {
             &panda,
             &update_operation(
                 schema.clone(),
-                vec![panda_entry_1_hash.clone()],
+                vec![panda_entry_1_hash.clone().into()],
                 operation_fields(vec![(
                     "cafe_name",
                     OperationValue::Text("Polar Bear Cafe".to_string()),
@@ -881,7 +881,7 @@ mod tests {
             &penguin,
             &update_operation(
                 schema.clone(),
-                vec![panda_entry_1_hash.clone()],
+                vec![panda_entry_1_hash.clone().into()],
                 operation_fields(vec![(
                     "address",
                     OperationValue::Text("1, Polar Bear rd, Panda Town".to_string()),
@@ -907,7 +907,7 @@ mod tests {
             &penguin,
             &update_operation(
                 schema,
-                vec![penguin_entry_1_hash, panda_entry_2_hash],
+                vec![penguin_entry_1_hash.into(), panda_entry_2_hash.into()],
                 operation_fields(vec![(
                     "cafe_name",
                     OperationValue::Text("Polar Bear Café".to_string()),

--- a/p2panda-rs/src/test_utils/utils.rs
+++ b/p2panda-rs/src/test_utils/utils.rs
@@ -119,12 +119,12 @@ pub fn entry(
     .unwrap()
 }
 
-/// Generate a CREATE operation based on passed schema hash and operation fields.
+/// Generate a CREATE operation based on passed schema id and operation fields.
 pub fn create_operation(schema: SchemaId, fields: OperationFields) -> Operation {
     Operation::new_create(schema, fields).unwrap()
 }
 
-/// Generate an UPDATE operation based on passed schema hash, document id and operation fields.
+/// Generate an UPDATE operation based on passed schema id, document id and operation fields.
 pub fn update_operation(
     schema: SchemaId,
     previous_operations: Vec<OperationId>,
@@ -133,7 +133,7 @@ pub fn update_operation(
     Operation::new_update(schema, previous_operations, fields).unwrap()
 }
 
-/// Generate a DELETE operation based on passed schema hash and document id.
+/// Generate a DELETE operation based on passed schema id and document id.
 pub fn delete_operation(schema: SchemaId, previous_operations: Vec<OperationId>) -> Operation {
     Operation::new_delete(schema, previous_operations).unwrap()
 }

--- a/p2panda-rs/src/test_utils/utils.rs
+++ b/p2panda-rs/src/test_utils/utils.rs
@@ -13,7 +13,7 @@ use crate::entry::{Entry, EntrySigned, LogId, SeqNum};
 use crate::hash::Hash;
 use crate::identity::KeyPair;
 use crate::operation::{
-    Operation, OperationEncoded, OperationFields, OperationValue, OperationWithMeta,
+    Operation, OperationEncoded, OperationFields, OperationId, OperationValue, OperationWithMeta,
 };
 use crate::schema::SchemaId;
 use crate::test_utils::constants::DEFAULT_SCHEMA_HASH;
@@ -44,7 +44,7 @@ pub struct NextEntryArgs {
 /// provided, this is a DELETE operation.
 pub fn any_operation(
     fields: Option<OperationFields>,
-    previous_operations: Option<Vec<Hash>>,
+    previous_operations: Option<Vec<OperationId>>,
 ) -> Operation {
     match fields {
         // It's a CREATE operation
@@ -127,14 +127,14 @@ pub fn create_operation(schema: SchemaId, fields: OperationFields) -> Operation 
 /// Generate an UPDATE operation based on passed schema hash, document id and operation fields.
 pub fn update_operation(
     schema: SchemaId,
-    previous_operations: Vec<Hash>,
+    previous_operations: Vec<OperationId>,
     fields: OperationFields,
 ) -> Operation {
     Operation::new_update(schema, previous_operations, fields).unwrap()
 }
 
 /// Generate a DELETE operation based on passed schema hash and document id.
-pub fn delete_operation(schema: SchemaId, previous_operations: Vec<Hash>) -> Operation {
+pub fn delete_operation(schema: SchemaId, previous_operations: Vec<OperationId>) -> Operation {
     Operation::new_delete(schema, previous_operations).unwrap()
 }
 

--- a/p2panda-rs/src/wasm/operation.rs
+++ b/p2panda-rs/src/wasm/operation.rs
@@ -5,10 +5,9 @@ use std::convert::TryFrom;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
-use crate::hash::Hash;
 use crate::operation::{
-    Operation, OperationEncoded, OperationFields as OperationFieldsNonWasm, OperationValue,
-    PinnedRelation, PinnedRelationList, Relation, RelationList,
+    Operation, OperationEncoded, OperationFields as OperationFieldsNonWasm, OperationId,
+    OperationValue, PinnedRelation, PinnedRelationList, Relation, RelationList,
 };
 use crate::schema::SchemaId;
 use crate::wasm::error::jserr;
@@ -188,10 +187,10 @@ pub fn encode_update_operation(
         "Can not deserialize array"
     );
 
-    // Create hashes from strings and collect wrapped in a result
-    let prev_op_result: Result<Vec<Hash>, _> = prev_op_strings
+    // Create operation ids from strings and collect wrapped in a result
+    let prev_op_result: Result<Vec<OperationId>, _> = prev_op_strings
         .iter()
-        .map(|prev_op| Hash::new(prev_op))
+        .map(|prev_op| prev_op.parse())
         .collect();
 
     let previous = jserr!(prev_op_result);
@@ -214,10 +213,10 @@ pub fn encode_delete_operation(
         "Can not deserialize array"
     );
 
-    // Create hashes from strings and collect wrapped in a result
-    let prev_op_result: Result<Vec<Hash>, _> = prev_op_strings
+    // Create operation ids from strings and collect wrapped in a result
+    let prev_op_result: Result<Vec<OperationId>, _> = prev_op_strings
         .iter()
-        .map(|prev_op| Hash::new(prev_op))
+        .map(|prev_op| prev_op.parse())
         .collect();
 
     let previous = jserr!(prev_op_result);

--- a/p2panda-rs/src/wasm/operation.rs
+++ b/p2panda-rs/src/wasm/operation.rs
@@ -87,7 +87,7 @@ impl OperationFields {
             "relation_list" => {
                 let relations: RelationList = jserr!(
                     deserialize_from_js(value),
-                    "Exptected an array of operation ids for field of type relation list"
+                    "Expected an array of operation ids for field of type relation list"
                 );
                 jserr!(relations.validate());
                 jserr!(self.0.add(name, OperationValue::RelationList(relations)));
@@ -96,7 +96,7 @@ impl OperationFields {
             "pinned_relation" => {
                 let relation: PinnedRelation = jserr!(
                     deserialize_from_js(value),
-                    "Expected an array of operation ids for field of type relation list"
+                    "Expected an array of operation ids for field of type pinned relation list"
                 );
                 jserr!(relation.validate());
                 jserr!(self.0.add(name, OperationValue::PinnedRelation(relation)));

--- a/p2panda-rs/src/wasm/operation.rs
+++ b/p2panda-rs/src/wasm/operation.rs
@@ -31,10 +31,18 @@ impl OperationFields {
 
     /// Adds a field with a value and a given value type.
     ///
-    /// The type is defined by a simple string, similar to an enum. Since Rust enums can not (yet)
-    /// be exported via wasm-bindgen we have to do it like this. Possible type values are "str"
-    /// (String), "bool" (Boolean), "float" (Number), "relation" (String representing a hex-encoded
-    /// hash) and "int" (Number).
+    /// The type is defined by a simple string, similar to an enum. Possible type values are:
+    ///
+    /// - "bool" (Boolean)
+    /// - "float" (Number)
+    /// - "int" (Number)
+    /// - "str" (String)
+    /// - "relation" (hex-encoded document id)
+    /// - "relation_list" (array of hex-encoded document ids)
+    /// - "pinned_relation" (document view id, represented as an array
+    ///     of hex-encoded operation ids)
+    /// - "pinned_relation_list" (array of document view ids, represented as an array
+    ///     of arrays of hex-encoded operation ids)
     ///
     /// This method will throw an error when the field was already set, an invalid type value got
     /// passed or when the value does not reflect the given type.
@@ -70,7 +78,7 @@ impl OperationFields {
             "relation" => {
                 let relation: Relation = jserr!(
                     deserialize_from_js(value),
-                    "Expected a hash value for field of type relation"
+                    "Expected an operation id value for field of type relation"
                 );
                 jserr!(relation.validate());
                 jserr!(self.0.add(name, OperationValue::Relation(relation)));
@@ -79,7 +87,7 @@ impl OperationFields {
             "relation_list" => {
                 let relations: RelationList = jserr!(
                     deserialize_from_js(value),
-                    "Exptected an array of hashes for field of type relation list"
+                    "Exptected an array of operation ids for field of type relation list"
                 );
                 jserr!(relations.validate());
                 jserr!(self.0.add(name, OperationValue::RelationList(relations)));
@@ -88,7 +96,7 @@ impl OperationFields {
             "pinned_relation" => {
                 let relation: PinnedRelation = jserr!(
                     deserialize_from_js(value),
-                    "Expected an array of hashes for field of type relation list"
+                    "Expected an array of operation ids for field of type relation list"
                 );
                 jserr!(relation.validate());
                 jserr!(self.0.add(name, OperationValue::PinnedRelation(relation)));
@@ -97,7 +105,7 @@ impl OperationFields {
             "pinned_relation_list" => {
                 let relations: PinnedRelationList = jserr!(
                     deserialize_from_js(value),
-                    "Expected a nested array of hashes for field of type pinned relation list"
+                    "Expected a nested array of operation ids for field of type pinned relation list"
                 );
                 jserr!(relations.validate());
                 jserr!(self

--- a/p2panda-rs/src/wasm/tests/entry.rs
+++ b/p2panda-rs/src/wasm/tests/entry.rs
@@ -4,7 +4,6 @@ use std::convert::TryFrom;
 
 use wasm_bindgen_test::*;
 
-use crate::document::DocumentViewId;
 use crate::hash::Hash;
 use crate::operation::{OperationEncoded, OperationFields, OperationValue, PinnedRelation};
 use crate::schema::SchemaId;
@@ -16,9 +15,9 @@ wasm_bindgen_test_configure!(run_in_browser);
 #[wasm_bindgen_test]
 fn encodes_decodes_entries() {
     let key_pair = KeyPair::new();
-    let schema = SchemaId::Application(PinnedRelation::new(DocumentViewId::new(vec![
-        Hash::new_from_bytes(vec![1, 2, 3]).unwrap(),
-    ])));
+    let schema = SchemaId::Application(PinnedRelation::new(
+        Hash::new_from_bytes(vec![1, 2, 3]).unwrap().into(),
+    ));
 
     let mut fields = OperationFields::new();
     fields


### PR DESCRIPTION
`OperationId` is a wrapper type around `Hash` and replaces `Hash` as the argument of all methods where the hash represents an operation. This increases type safety and developer experience.

Closes #241 

- [x] Implement `OperationId`
- [x] Replace uses of `Hash` with `OperationId`
- [x] Update js and wasm tests
- [x] Update docstrings
- [x] Check handbook (should be fine)

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
