### PR TITLE
Test `debug` macro calls in Github CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           command: test
           args: --manifest-path ${{ env.cargo_manifest }}
+        # Ensure debug output is also tested
+        env:
+          RUST_LOG: debug
 
   rust-check:
     runs-on: ubuntu-latest
@@ -141,6 +144,9 @@ jobs:
         with:
           # Force cleaning via `--force-clean` flag to prevent buggy code coverage
           args: --manifest-path ${{ env.cargo_manifest }} --locked --force-clean
+        # Ensure debug output is also tested
+        env:
+          RUST_LOG: debug
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Highlights are marked with a pancake 🥞
 - Split up overly long `operation.rs` file [#232](https://github.com/p2panda/p2panda/pull/232) `rs`
 - Extend test coverage for `OperationFields` [#236](https://github.com/p2panda/p2panda/pull/236) `rs`
 - Further develop our best practices for writing documentation [#240](https://github.com/p2panda/p2panda/pull/240) `rs`
+- Test `debug` macro calls in Github CI [#288](https://github.com/p2panda/p2panda/pull/288) `rs`
 
 ## [0.3.0]
 


### PR DESCRIPTION
Calls to the debug macro `debug!("hey! it's a debug")` are only run when `RUST_LOG=debug` is set in the environment. In order to test that we don't introduce bugs in those calls the CI is updated here to also run them.

The effect of that is of course an enormous amount of output in the test logs. Does this bother you? I feel that it could even be useful because you would probably only log at those logs if you are trying to see what kind of error occurred and for what reason - but a shorter log is also nice.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
