### PR TITLE
Generic graph and other bits and pieces for proper graphing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Highlights are marked with a pancake 🥞
 - Impl `IntoIter` trait for `PinnedRelation`, `RelationList` and `DocumentViewId` [#266](https://github.com/p2panda/p2panda/pull/266) `rs`
 - Improve error reporting when adding operation fields [#262](https://github.com/p2panda/p2panda/issues/262)] `rs` `js`
 - Update mock node API [#286](https://github.com/p2panda/p2panda/issues/286) `rs`
+- Refactored graph module to be generic over graph node keys and other graph improvements [#289](https://github.com/p2panda/p2panda/issues/289) `rs`
 
 ## Fixed
 

--- a/p2panda-rs/benches/graph.rs
+++ b/p2panda-rs/benches/graph.rs
@@ -13,7 +13,7 @@ use p2panda_rs::graph::Graph;
 const DEFAULT_DENSITY: f32 = 0.1;
 const DEFAULT_SIZE: u64 = 100;
 
-fn generate_random_p2panda_dag(size: u64, density: f32) -> Graph<u64> {
+fn generate_random_p2panda_dag(size: u64, density: f32) -> Graph<String, u64> {
     use rand::distributions::{Bernoulli, Distribution};
     assert!(0.0 < density && density <= 1.0);
     let mut rng = rand::thread_rng();

--- a/p2panda-rs/benches/graph_comparison.rs
+++ b/p2panda-rs/benches/graph_comparison.rs
@@ -14,7 +14,7 @@ use p2panda_rs::graph::Graph;
 const DEFAULT_DENSITY: f32 = 0.1;
 const DEFAULT_SIZE: u64 = 100;
 
-fn generate_random_p2panda_dag(size: u64, density: f32) -> Graph<u64> {
+fn generate_random_p2panda_dag(size: u64, density: f32) -> Graph<String, u64> {
     use rand::distributions::{Bernoulli, Distribution};
     assert!(0.0 < density && density <= 1.0);
     let mut rng = rand::thread_rng();

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -11,22 +11,22 @@ use crate::schema::SchemaId;
 /// Construct a graph from a list of operations.
 pub(super) fn build_graph(
     operations: &[OperationWithMeta],
-) -> Result<Graph<OperationWithMeta>, DocumentBuilderError> {
+) -> Result<Graph<OperationId, OperationWithMeta>, DocumentBuilderError> {
     let mut graph = Graph::new();
 
     // Add all operations to the graph.
     for operation in operations {
-        graph.add_node(operation.operation_id().as_str(), operation.clone());
+        graph.add_node(operation.operation_id(), operation.clone());
     }
 
     // Add links between operations in the graph.
     for operation in operations {
         if let Some(previous_operations) = operation.previous_operations() {
             for previous in previous_operations {
-                let success = graph.add_link(previous.as_str(), operation.operation_id().as_str());
+                let success = graph.add_link(&previous, operation.operation_id());
                 if !success {
                     return Err(DocumentBuilderError::InvalidOperationLink(
-                        operation.operation_id().as_str().into(),
+                        operation.operation_id().as_hash().as_str().into(),
                     ));
                 }
             }

--- a/p2panda-rs/src/graph/graph.rs
+++ b/p2panda-rs/src/graph/graph.rs
@@ -1,6 +1,7 @@
 use log::debug;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::hash::Hash;
 
 use super::GraphError;
 
@@ -22,17 +23,17 @@ use super::GraphError;
 ///
 /// // Add some nodes to the graph.
 ///
-/// graph.add_node("a", "A");
-/// graph.add_node("b", "B");
-/// graph.add_node("c", "C");
+/// graph.add_node(&'a', 'A');
+/// graph.add_node(&'b', 'B');
+/// graph.add_node(&'c', 'C');
 ///
-/// assert!(graph.get_node("a").is_some());
-/// assert!(graph.get_node("x").is_none());
+/// assert!(graph.get_node(&'a').is_some());
+/// assert!(graph.get_node(&'x').is_none());
 ///
 /// // Add some links between the nodes.
 ///
-/// graph.add_link("a", "b");
-/// graph.add_link("a", "c");
+/// graph.add_link(&'a', &'b');
+/// graph.add_link(&'a', &'c');
 ///
 /// // The graph looks like this:
 /// //
@@ -43,11 +44,11 @@ use super::GraphError;
 ///
 /// let nodes = graph.sort()?;
 ///
-/// assert_eq!(nodes.sorted(), vec!["A", "B", "C"]);
+/// assert_eq!(nodes.sorted(), vec!['A', 'B', 'C']);
 ///
 /// // Add another link which creates a cycle (oh dear!).
 ///
-/// graph.add_link("b", "a");
+/// graph.add_link(&'b', &'a');
 ///
 /// assert!(graph.sort().is_err());
 ///
@@ -55,15 +56,21 @@ use super::GraphError;
 /// # }
 /// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct Graph<T: PartialEq + Clone + Debug>(HashMap<String, Node<T>>);
+pub struct Graph<K, T>(HashMap<K, Node<K, T>>)
+where
+    K: Hash + Ord + PartialOrd + Eq + PartialEq + Clone + Debug,
+    T: PartialEq + Clone + Debug;
 
 /// An internal struct which represents a node in the graph and contains generic data.
 #[derive(Debug, PartialEq, Clone)]
-pub struct Node<T: PartialEq + Clone + Debug> {
-    key: String,
-    data: T,
-    previous: Vec<String>,
-    next: Vec<String>,
+pub struct Node<
+    K: Hash + Ord + PartialOrd + Eq + PartialEq + Clone + Debug,
+    D: PartialEq + Clone + Debug,
+> {
+    key: K,
+    data: D,
+    previous: Vec<K>,
+    next: Vec<K>,
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -84,7 +91,12 @@ impl<T: PartialEq + Clone + Debug> GraphData<T> {
     }
 }
 
-impl<'a, T: PartialEq + Clone + Debug> Node<T> {
+impl<
+        'a,
+        K: Hash + Ord + PartialOrd + Eq + PartialEq + Clone + Debug,
+        T: PartialEq + Clone + Debug,
+    > Node<K, T>
+{
     /// Returns true if this node is the root of this graph.
     fn is_root(&self) -> bool {
         self.previous.is_empty()
@@ -106,17 +118,17 @@ impl<'a, T: PartialEq + Clone + Debug> Node<T> {
     }
 
     /// Returns the key for this node.
-    fn key(&self) -> &String {
+    fn key(&self) -> &K {
         &self.key
     }
 
     /// Returns a vector of keys for the nodes preceding this node in the graph.
-    fn previous(&self) -> &Vec<String> {
+    fn previous(&self) -> &Vec<K> {
         &self.previous
     }
 
     /// Returns a vector of keys for the nodes following this node in the graph.
-    fn next(&self) -> &Vec<String> {
+    fn next(&self) -> &Vec<K> {
         &self.next
     }
 
@@ -125,28 +137,33 @@ impl<'a, T: PartialEq + Clone + Debug> Node<T> {
     }
 }
 
-impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
+impl<
+        'a,
+        K: Hash + Ord + PartialOrd + Eq + PartialEq + Clone + Debug,
+        T: PartialEq + Clone + Debug,
+    > Graph<K, T>
+{
     /// Instantiate a new empty graph.
     pub fn new() -> Self {
         Self(HashMap::new())
     }
 
     /// Add a node to the graph. This node will be detached until it is linked to another node.
-    pub fn add_node(&mut self, key: &str, data: T) {
+    pub fn add_node(&mut self, key: &K, data: T) {
         let new_node = Node {
-            key: key.to_string(),
+            key: key.clone(),
             next: Vec::new(),
             previous: Vec::new(),
             data,
         };
 
-        self.0.insert(key.to_string(), new_node);
+        self.0.insert(key.clone(), new_node);
     }
 
     /// Add a link between existing nodes to the graph. Returns true if the link was added.
     /// Returns false if the link was unable to be added. This happens if either of the nodes were not
     /// present in the graph, or if the link creates a single node loop.
-    pub fn add_link(&mut self, from: &str, to: &str) -> bool {
+    pub fn add_link(&mut self, from: &K, to: &K) -> bool {
         if from == to {
             return false;
         }
@@ -167,17 +184,17 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
     }
 
     /// Get node from the graph by key, returns `None` if it wasn't found.
-    pub fn get_node(&'a self, key: &str) -> Option<&Node<T>> {
+    pub fn get_node(&'a self, key: &K) -> Option<&Node<K, T>> {
         self.0.get(key)
     }
 
     /// Get the data payload from this node.
-    pub fn get_node_data(&self, id: &str) -> Option<&T> {
+    pub fn get_node_data(&self, id: &K) -> Option<&T> {
         self.0.get(id).map(|node| &node.data)
     }
 
     /// Returns true if this node key is connected to the graph.
-    pub fn is_connected(&self, key: &str) -> bool {
+    pub fn is_connected(&self, key: &K) -> bool {
         if let Some(node) = self.get_node(key) {
             !node.previous().is_empty() || !node.next().is_empty()
         } else {
@@ -186,17 +203,17 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
     }
 
     /// Returns the keys for nodes which follows this node key.
-    pub fn get_next(&'a self, key: &str) -> Option<&Vec<String>> {
+    pub fn get_next(&'a self, key: &K) -> Option<&Vec<K>> {
         self.get_node(key).map(|node| node.next())
     }
 
     /// Returns the keys for nodes which precede this node key.
-    pub fn get_previous(&'a self, key: &str) -> Option<&Vec<String>> {
+    pub fn get_previous(&'a self, key: &K) -> Option<&Vec<K>> {
         self.get_node(key).map(|node| node.previous())
     }
 
     /// Returns true if this node key is a merge node.
-    pub fn is_merge_node(&self, key: &str) -> bool {
+    pub fn is_merge_node(&self, key: &K) -> bool {
         match self.get_node(key) {
             Some(node) => node.is_merge(),
             None => false,
@@ -204,7 +221,7 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
     }
 
     /// Returns true if this node key is a branch node.
-    pub fn is_branch_node(&self, key: &str) -> bool {
+    pub fn is_branch_node(&self, key: &K) -> bool {
         match self.get_node(key) {
             Some(node) => node.is_branch(),
             None => false,
@@ -212,7 +229,7 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
     }
 
     /// Returns true if this node key is a graph tip.
-    pub fn is_tip_node(&self, key: &str) -> bool {
+    pub fn is_tip_node(&self, key: &K) -> bool {
         match self.get_node(key) {
             Some(node) => node.is_tip(),
             None => false,
@@ -220,8 +237,8 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
     }
 
     /// Returns a reference to the root node of this graph.
-    pub fn root_node(&self) -> Result<&Node<T>, GraphError> {
-        let root: Vec<&Node<T>> = self.0.values().filter(|node| node.is_root()).collect();
+    pub fn root_node(&self) -> Result<&Node<K, T>, GraphError> {
+        let root: Vec<&Node<K, T>> = self.0.values().filter(|node| node.is_root()).collect();
         match root.len() {
             0 => Err(GraphError::NoRootNode),
             1 => Ok(root[0]),
@@ -230,7 +247,7 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
     }
 
     /// Returns the root node key.
-    pub fn root_node_key(&self) -> Result<&String, GraphError> {
+    pub fn root_node_key(&self) -> Result<&K, GraphError> {
         match self.root_node() {
             Ok(root) => Ok(root.key()),
             Err(e) => Err(e),
@@ -238,7 +255,7 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
     }
 
     /// Check if all a nodes dependencies have been visited.
-    fn dependencies_visited(&self, sorted: &[&Node<T>], node: &Node<T>) -> bool {
+    fn dependencies_visited(&self, sorted: &[&Node<K, T>], node: &Node<K, T>) -> bool {
         let mut has_dependencies = true;
         let previous_nodes = node.previous();
 
@@ -253,8 +270,8 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
     }
 
     /// Returns the next un-visited node following the passed node.
-    fn next(&'a self, sorted: &[&Node<T>], node: &Node<T>) -> Option<Vec<&'a Node<T>>> {
-        let mut next_nodes: Vec<&'a Node<T>> = Vec::new();
+    fn next(&'a self, sorted: &[&Node<K, T>], node: &Node<K, T>) -> Option<Vec<&'a Node<K, T>>> {
+        let mut next_nodes: Vec<&'a Node<K, T>> = Vec::new();
 
         for node_key in node.next() {
             // Unwrap here as we are sure the node is in the graph.
@@ -273,7 +290,7 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
     }
 
     /// Sorts the graph topologically and returns the sorted
-    pub fn walk_from(&'a self, key: &str) -> Result<GraphData<T>, GraphError> {
+    pub fn walk_from(&'a self, key: &K) -> Result<GraphData<T>, GraphError> {
         let root_node = match self.get_node(key) {
             Some(node) => Ok(node),
             None => Err(GraphError::NodeNotFound),
@@ -298,7 +315,7 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
                 graph_data.graph_tips.push(current_node.data())
             }
             debug!(
-                "{}: sorted to position {}",
+                "{:?}: sorted to position {}",
                 current_node.key(),
                 sorted_nodes.len()
             );
@@ -307,22 +324,25 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
             while let Some(mut next_nodes) = self.next(&sorted_nodes, current_node) {
                 // Pop off the next node we will visit.
                 let next_node = next_nodes.pop().expect("Node not in graph");
-                debug!("visiting: {}", next_node.key());
+                debug!("visiting: {:?}", next_node.key());
 
                 // Push all other nodes connected to this one to the queue, we will visit these later.
                 while let Some(node_to_be_queued) = next_nodes.pop() {
                     queue.push(node_to_be_queued);
-                    debug!("{}: pushed to queue", node_to_be_queued.key());
+                    debug!("{:?}: pushed to queue", node_to_be_queued.key());
                 }
 
                 // If it's a merge node, check it's dependencies have all been visited.
                 if next_node.is_merge() {
                     if self.dependencies_visited(&sorted_nodes, next_node) {
                         // If they have been, push this node to the queue and exit this loop.
-                        debug!("{}: is merge and has all dependencies met", next_node.key());
+                        debug!(
+                            "{:?}: is merge and has all dependencies met",
+                            next_node.key()
+                        );
                         queue.push(next_node);
 
-                        debug!("{}: pushed to queue", next_node.key(),);
+                        debug!("{:?}: pushed to queue", next_node.key(),);
 
                         break;
                     } else if queue.is_empty() {
@@ -332,7 +352,7 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
                     }
 
                     debug!(
-                        "{}: is merge and does not have dependencies met",
+                        "{:?}: is merge and does not have dependencies met",
                         next_node.key()
                     );
                     break;
@@ -347,7 +367,7 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
                 }
 
                 debug!(
-                    "{}: sorted to position {}",
+                    "{:?}: sorted to position {}",
                     next_node.key(),
                     sorted_nodes.len()
                 );
@@ -357,6 +377,10 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
         Ok(graph_data)
     }
 
+    // pub fn walk_to(&self) -> Result<GraphData<T>, GraphError> {
+
+    // }
+
     /// Sort the entire graph, starting from the root node.
     pub fn sort(&'a self) -> Result<GraphData<T>, GraphError> {
         let root_node = self.root_node_key()?;
@@ -364,7 +388,12 @@ impl<'a, T: PartialEq + Clone + Debug> Graph<T> {
     }
 }
 
-impl<'a, T: PartialEq + Clone + Debug> Default for Graph<T> {
+impl<
+        'a,
+        K: Hash + Ord + PartialOrd + Eq + PartialEq + Clone + Debug,
+        T: PartialEq + Clone + Debug,
+    > Default for Graph<K, T>
+{
     fn default() -> Self {
         Self::new()
     }
@@ -378,35 +407,35 @@ mod test {
 
     #[test]
     fn basics() {
-        let mut graph = Graph::new();
-        graph.add_node("a", "A");
-        graph.add_node("b", "B");
-        graph.add_node("c", "C");
-        graph.add_node("d", "D");
-        graph.add_node("e", "E");
-        graph.add_node("f", "F");
-        graph.add_node("g", "G");
-        graph.add_node("h", "H");
-        graph.add_node("i", "I");
-        graph.add_node("j", "J");
-        graph.add_node("k", "K");
+        let mut graph: Graph<char, char> = Graph::new();
+        graph.add_node(&'a', 'A');
+        graph.add_node(&'b', 'B');
+        graph.add_node(&'c', 'C');
+        graph.add_node(&'d', 'D');
+        graph.add_node(&'e', 'E');
+        graph.add_node(&'f', 'F');
+        graph.add_node(&'g', 'G');
+        graph.add_node(&'h', 'H');
+        graph.add_node(&'i', 'I');
+        graph.add_node(&'j', 'J');
+        graph.add_node(&'k', 'K');
 
         // NB: unlinked nodes are simply not visited and do not exist in the sorted result.
 
-        graph.add_link("a", "b");
-        graph.add_link("b", "c");
-        graph.add_link("c", "d");
-        graph.add_link("d", "e");
-        graph.add_link("e", "f");
+        graph.add_link(&'a', &'b');
+        graph.add_link(&'b', &'c');
+        graph.add_link(&'c', &'d');
+        graph.add_link(&'d', &'e');
+        graph.add_link(&'e', &'f');
 
         // [A]<--[B]<--[C]<--[D]<--[E]<--[F]
 
         let expected = GraphData {
-            sorted: vec!["A", "B", "C", "D", "E", "F"],
-            graph_tips: vec!["F"],
+            sorted: vec!['A', 'B', 'C', 'D', 'E', 'F'],
+            graph_tips: vec!['F'],
         };
 
-        let graph_data = graph.walk_from("a").unwrap();
+        let graph_data = graph.walk_from(&'a').unwrap();
 
         assert_eq!(graph_data.sorted(), expected.sorted());
         assert_eq!(
@@ -414,19 +443,19 @@ mod test {
             expected.current_graph_tips()
         );
 
-        graph.add_link("a", "g");
-        graph.add_link("g", "h");
-        graph.add_link("h", "d");
+        graph.add_link(&'a', &'g');
+        graph.add_link(&'g', &'h');
+        graph.add_link(&'h', &'d');
 
         //  /--[B]<--[C]--\
         // [A]<--[G]<-----[H]<--[D]<--[E]<---[F]
 
         let expected = GraphData {
-            sorted: vec!["A", "B", "C", "G", "H", "D", "E", "F"],
-            graph_tips: vec!["F"],
+            sorted: vec!['A', 'B', 'C', 'G', 'H', 'D', 'E', 'F'],
+            graph_tips: vec!['F'],
         };
 
-        let graph_data = graph.walk_from("a").unwrap();
+        let graph_data = graph.walk_from(&'a').unwrap();
 
         assert_eq!(graph_data.sorted(), expected.sorted());
         assert_eq!(
@@ -434,10 +463,10 @@ mod test {
             expected.current_graph_tips()
         );
 
-        graph.add_link("c", "i");
-        graph.add_link("i", "j");
-        graph.add_link("j", "k");
-        graph.add_link("k", "f");
+        graph.add_link(&'c', &'i');
+        graph.add_link(&'i', &'j');
+        graph.add_link(&'j', &'k');
+        graph.add_link(&'k', &'f');
 
         //             /--[I]<--[J]<--[K]<--\
         //  /--[B]<--[C]--\                  \
@@ -445,11 +474,11 @@ mod test {
         //
 
         let expected = GraphData {
-            sorted: vec!["A", "B", "C", "I", "J", "K", "G", "H", "D", "E", "F"],
-            graph_tips: vec!["F"],
+            sorted: vec!['A', 'B', 'C', 'I', 'J', 'K', 'G', 'H', 'D', 'E', 'F'],
+            graph_tips: vec!['F'],
         };
 
-        let graph_data = graph.walk_from("a").unwrap();
+        let graph_data = graph.walk_from(&'a').unwrap();
 
         assert_eq!(graph_data.sorted(), expected.sorted());
         assert_eq!(
@@ -461,80 +490,80 @@ mod test {
     #[test]
     fn has_cycle() {
         let mut graph = Graph::new();
-        graph.add_node("a", 1);
-        graph.add_node("b", 2);
-        graph.add_node("c", 3);
-        graph.add_node("d", 4);
+        graph.add_node(&'a', 1);
+        graph.add_node(&'b', 2);
+        graph.add_node(&'c', 3);
+        graph.add_node(&'d', 4);
 
-        graph.add_link("a", "b");
-        graph.add_link("b", "c");
-        graph.add_link("c", "d");
-        graph.add_link("d", "b");
+        graph.add_link(&'a', &'b');
+        graph.add_link(&'b', &'c');
+        graph.add_link(&'c', &'d');
+        graph.add_link(&'d', &'b');
 
-        assert!(graph.walk_from("a").is_err())
+        assert!(graph.walk_from(&'a').is_err())
     }
 
     #[test]
     fn missing_dependencies() {
         let mut graph = Graph::new();
-        graph.add_node("a", 1);
-        graph.add_node("b", 2);
-        graph.add_node("c", 3);
-        graph.add_node("d", 4);
+        graph.add_node(&'a', 1);
+        graph.add_node(&'b', 2);
+        graph.add_node(&'c', 3);
+        graph.add_node(&'d', 4);
 
-        graph.add_link("a", "b");
-        graph.add_link("b", "c");
-        graph.add_link("c", "d");
-        graph.add_link("d", "b");
-        graph.add_link("e", "b"); // "e" doesn't exist in the graph.
+        graph.add_link(&'a', &'b');
+        graph.add_link(&'b', &'c');
+        graph.add_link(&'c', &'d');
+        graph.add_link(&'d', &'b');
+        graph.add_link(&'e', &'b'); // 'e' doesn't exist in the graph.
 
-        assert!(graph.walk_from("a").is_err())
+        assert!(graph.walk_from(&'a').is_err())
     }
 
     #[test]
     fn poetic_graph() {
         let mut graph = Graph::new();
-        graph.add_node("a", "Wake Up");
-        graph.add_node("b", "Make Coffee");
-        graph.add_node("c", "Drink Coffee");
-        graph.add_node("d", "Stroke Cat");
-        graph.add_node("e", "Look Out The Window");
-        graph.add_node("f", "Start The Day");
-        graph.add_node("g", "Cat Jumps Off Bed");
-        graph.add_node("h", "Cat Meows");
-        graph.add_node("i", "Brain Receives Caffeine");
-        graph.add_node("j", "Brain Starts Engine");
-        graph.add_node("k", "Brain Starts Thinking");
+        graph.add_node(&'a', "Wake Up".to_string());
+        graph.add_node(&'b', "Make Coffee".to_string());
+        graph.add_node(&'c', "Drink Coffee".to_string());
+        graph.add_node(&'d', "Stroke Cat".to_string());
+        graph.add_node(&'e', "Look Out The Window".to_string());
+        graph.add_node(&'f', "Start The Day".to_string());
+        graph.add_node(&'g', "Cat Jumps Off Bed".to_string());
+        graph.add_node(&'h', "Cat Meows".to_string());
+        graph.add_node(&'i', "Brain Receives Caffeine".to_string());
+        graph.add_node(&'j', "Brain Starts Engine".to_string());
+        graph.add_node(&'k', "Brain Starts Thinking".to_string());
 
-        graph.add_link("a", "b");
-        graph.add_link("b", "c");
-        graph.add_link("c", "d");
-        graph.add_link("d", "e");
-        graph.add_link("e", "f");
+        graph.add_link(&'a', &'b');
+        graph.add_link(&'b', &'c');
+        graph.add_link(&'c', &'d');
+        graph.add_link(&'d', &'e');
+        graph.add_link(&'e', &'f');
 
-        graph.add_link("a", "g");
-        graph.add_link("g", "h");
-        graph.add_link("h", "d");
+        graph.add_link(&'a', &'g');
+        graph.add_link(&'g', &'h');
+        graph.add_link(&'h', &'d');
 
-        graph.add_link("c", "i");
-        graph.add_link("i", "j");
-        graph.add_link("j", "k");
-        graph.add_link("k", "f");
+        graph.add_link(&'c', &'i');
+        graph.add_link(&'i', &'j');
+        graph.add_link(&'j', &'k');
+        graph.add_link(&'k', &'f');
 
         assert_eq!(
-            graph.walk_from("a").unwrap().sorted(),
+            graph.walk_from(&'a').unwrap().sorted(),
             [
-                "Wake Up",
-                "Make Coffee",
-                "Drink Coffee",
-                "Brain Receives Caffeine",
-                "Brain Starts Engine",
-                "Brain Starts Thinking",
-                "Cat Jumps Off Bed",
-                "Cat Meows",
-                "Stroke Cat",
-                "Look Out The Window",
-                "Start The Day"
+                "Wake Up".to_string(),
+                "Make Coffee".to_string(),
+                "Drink Coffee".to_string(),
+                "Brain Receives Caffeine".to_string(),
+                "Brain Starts Engine".to_string(),
+                "Brain Starts Thinking".to_string(),
+                "Cat Jumps Off Bed".to_string(),
+                "Cat Meows".to_string(),
+                "Stroke Cat".to_string(),
+                "Look Out The Window".to_string(),
+                "Start The Day".to_string()
             ]
         )
     }

--- a/p2panda-rs/src/graph/graph.rs
+++ b/p2panda-rs/src/graph/graph.rs
@@ -329,10 +329,6 @@ impl<
         Ok(graph_data)
     }
 
-    // pub fn walk_to(&self) -> Result<GraphData<T>, GraphError> {
-
-    // }
-
     /// Sort the entire graph, starting from the root node.
     pub fn sort(&'a self) -> Result<GraphData<V>, GraphError> {
         let root_node = self.root_node_key()?;

--- a/p2panda-rs/src/graph/graph.rs
+++ b/p2panda-rs/src/graph/graph.rs
@@ -108,11 +108,6 @@ impl<
         self.previous.len() > 1
     }
 
-    /// Returns true if this is a branch node.
-    fn is_branch(&self) -> bool {
-        self.next.len() > 1
-    }
-
     /// Returns true if this is a graph tip.
     fn is_tip(&self) -> bool {
         self.next.is_empty()
@@ -187,54 +182,6 @@ impl<
     /// Get node from the graph by key, returns `None` if it wasn't found.
     pub fn get_node(&'a self, key: &K) -> Option<&Node<K, V>> {
         self.0.get(key)
-    }
-
-    /// Get the data payload from this node.
-    pub fn get_node_data(&self, id: &K) -> Option<&V> {
-        self.0.get(id).map(|node| &node.data)
-    }
-
-    /// Returns true if this node key is connected to the graph.
-    pub fn is_connected(&self, key: &K) -> bool {
-        if let Some(node) = self.get_node(key) {
-            !node.previous().is_empty() || !node.next().is_empty()
-        } else {
-            false
-        }
-    }
-
-    /// Returns the keys for nodes which follows this node key.
-    pub fn get_next(&'a self, key: &K) -> Option<&Vec<K>> {
-        self.get_node(key).map(|node| node.next())
-    }
-
-    /// Returns the keys for nodes which precede this node key.
-    pub fn get_previous(&'a self, key: &K) -> Option<&Vec<K>> {
-        self.get_node(key).map(|node| node.previous())
-    }
-
-    /// Returns true if this node key is a merge node.
-    pub fn is_merge_node(&self, key: &K) -> bool {
-        match self.get_node(key) {
-            Some(node) => node.is_merge(),
-            None => false,
-        }
-    }
-
-    /// Returns true if this node key is a branch node.
-    pub fn is_branch_node(&self, key: &K) -> bool {
-        match self.get_node(key) {
-            Some(node) => node.is_branch(),
-            None => false,
-        }
-    }
-
-    /// Returns true if this node key is a graph tip.
-    pub fn is_tip_node(&self, key: &K) -> bool {
-        match self.get_node(key) {
-            Some(node) => node.is_tip(),
-            None => false,
-        }
     }
 
     /// Returns a reference to the root node of this graph.
@@ -425,19 +372,13 @@ mod test {
         graph.add_node(&'j', 'J');
         graph.add_node(&'k', 'K');
 
-        assert_eq!(graph.get_node_data(&'a'), Some(&'A'));
-
         // NB: unlinked nodes are simply not visited and do not exist in the sorted result.
-
-        assert!(!graph.is_connected(&'a'));
 
         graph.add_link(&'a', &'b');
         graph.add_link(&'b', &'c');
         graph.add_link(&'c', &'d');
         graph.add_link(&'d', &'e');
         graph.add_link(&'e', &'f');
-
-        assert!(graph.is_connected(&'a'));
 
         // [A]<--[B]<--[C]<--[D]<--[E]<--[F]
 

--- a/p2panda-rs/src/graph/graph.rs
+++ b/p2panda-rs/src/graph/graph.rs
@@ -165,21 +165,21 @@ impl<
     /// Returns false if the link was unable to be added. This happens if either of the nodes were
     /// not present in the graph, or if the link creates a single node loop.
     pub fn add_link(&mut self, from: &K, to: &K) -> bool {
+        // Check for self-referential links
         if from == to {
             return false;
         }
 
-        if let Some(from_node_mut) = self.0.get_mut(from) {
-            from_node_mut.next.push(to.to_owned());
-        } else {
+        // Check that both nodes exist
+        if self.get_node(from).is_none() || self.get_node(to).is_none() {
             return false;
         }
 
-        if let Some(to_node_mut) = self.0.get_mut(to) {
-            to_node_mut.previous.push(from.to_owned());
-        } else {
-            return false;
-        }
+        // Add the outgoing link on the source
+        self.0.get_mut(from).unwrap().next.push(to.to_owned());
+
+        // Add the incoming link on the target
+        self.0.get_mut(to).unwrap().previous.push(from.to_owned());
 
         true
     }

--- a/p2panda-rs/src/graph/graph.rs
+++ b/p2panda-rs/src/graph/graph.rs
@@ -5,10 +5,11 @@ use std::hash::Hash;
 
 use super::GraphError;
 
-/// This struct contains all functionality implemented in this module. It is can be used for building and sorting a graph of
-/// causally connected nodes.
+/// This struct contains all functionality implemented in this module. It is can be used for
+/// building and sorting a graph of causally connected nodes.
 ///
-/// Sorting is deterministic with > comparison of contained node data being the deciding factor on which paths to walk first.
+/// Sorting is deterministic with > comparison of contained node data being the deciding factor on
+/// which paths to walk first.
 ///
 /// ## Example
 ///
@@ -161,8 +162,8 @@ impl<
     }
 
     /// Add a link between existing nodes to the graph. Returns true if the link was added.
-    /// Returns false if the link was unable to be added. This happens if either of the nodes were not
-    /// present in the graph, or if the link creates a single node loop.
+    /// Returns false if the link was unable to be added. This happens if either of the nodes were
+    /// not present in the graph, or if the link creates a single node loop.
     pub fn add_link(&mut self, from: &K, to: &K) -> bool {
         if from == to {
             return false;

--- a/p2panda-rs/src/graph/graph.rs
+++ b/p2panda-rs/src/graph/graph.rs
@@ -271,23 +271,24 @@ impl<
     }
 
     /// Returns the next un-visited node following the passed node.
-    fn next(&'a self, sorted: &[&Node<K, V>], node: &Node<K, V>) -> Result<Option<Vec<&'a Node<K, V>>>, GraphError> {
+    fn next(&'a self, sorted: &[&Node<K, V>], node: &Node<K, V>) -> Option<Vec<&'a Node<K, V>>> {
         let mut next_nodes: Vec<&'a Node<K, V>> = Vec::new();
 
         for node_key in node.next() {
-            // Unwrap here as we are sure the node is in the graph.
-            let node = self.get_node(node_key).ok_or(GraphError::NodeNotFound)?;
+            // Nodes returned by `next()` have always been added by `add_link()`, which ensures
+            // that these keys all have corresponding nodes in the graph so we can unwrap here.
+            let node = self.get_node(node_key).unwrap();
             if !sorted.contains(&node) {
                 next_nodes.push(node)
             }
         }
 
         if next_nodes.is_empty() {
-            return Ok(None);
+            return None;
         };
         next_nodes.sort_by_key(|node_a| node_a.key());
         next_nodes.reverse();
-        Ok(Some(next_nodes))
+        Some(next_nodes)
     }
 
     /// Sorts the graph topologically and returns the sorted
@@ -322,9 +323,12 @@ impl<
             );
 
             // ...and then walk the graph starting from this node.
-            while let Some(mut next_nodes) = self.next(&sorted_nodes, current_node)? {
+            while let Some(mut next_nodes) = self.next(&sorted_nodes, current_node) {
                 // Pop off the next node we will visit.
-                let next_node = next_nodes.pop().ok_or(GraphError::NodeNotFound)?;
+                //
+                // Nodes returned by `next()` have always been added by `add_link()`, which ensures
+                // that these keys all have corresponding nodes in the graph so we can unwrap.
+                let next_node = next_nodes.pop().unwrap();
                 debug!("visiting: {:?}", next_node.key());
 
                 // Push all other nodes connected to this one to the queue, we will visit these later.

--- a/p2panda-rs/src/graph/graph.rs
+++ b/p2panda-rs/src/graph/graph.rs
@@ -57,37 +57,37 @@ use super::GraphError;
 /// # }
 /// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct Graph<K, T>(HashMap<K, Node<K, T>>)
+pub struct Graph<K, V>(HashMap<K, Node<K, V>>)
 where
     K: Hash + Ord + PartialOrd + Eq + PartialEq + Clone + Debug,
-    T: PartialEq + Clone + Debug;
+    V: PartialEq + Clone + Debug;
 
 /// An internal struct which represents a node in the graph and contains generic data.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Node<
     K: Hash + Ord + PartialOrd + Eq + PartialEq + Clone + Debug,
-    D: PartialEq + Clone + Debug,
+    V: PartialEq + Clone + Debug,
 > {
     key: K,
-    data: D,
+    data: V,
     previous: Vec<K>,
     next: Vec<K>,
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]
-pub struct GraphData<T: PartialEq + Clone + Debug> {
-    sorted: Vec<T>,
-    graph_tips: Vec<T>,
+pub struct GraphData<V: PartialEq + Clone + Debug> {
+    sorted: Vec<V>,
+    graph_tips: Vec<V>,
 }
 
-impl<T: PartialEq + Clone + Debug> GraphData<T> {
+impl<V: PartialEq + Clone + Debug> GraphData<V> {
     /// Returns the data from sorted graph nodes.
-    pub fn sorted(&self) -> Vec<T> {
+    pub fn sorted(&self) -> Vec<V> {
         self.sorted.clone()
     }
 
     /// Returns the current tips of this graph.
-    pub fn current_graph_tips(&self) -> Vec<T> {
+    pub fn current_graph_tips(&self) -> Vec<V> {
         self.graph_tips.clone()
     }
 }
@@ -95,8 +95,8 @@ impl<T: PartialEq + Clone + Debug> GraphData<T> {
 impl<
         'a,
         K: Hash + Ord + PartialOrd + Eq + PartialEq + Clone + Debug,
-        T: PartialEq + Clone + Debug,
-    > Node<K, T>
+        V: PartialEq + Clone + Debug,
+    > Node<K, V>
 {
     /// Returns true if this node is the root of this graph.
     fn is_root(&self) -> bool {
@@ -133,7 +133,7 @@ impl<
         &self.next
     }
 
-    fn data(&self) -> T {
+    fn data(&self) -> V {
         self.data.clone()
     }
 }
@@ -141,8 +141,8 @@ impl<
 impl<
         'a,
         K: Hash + Ord + PartialOrd + Eq + PartialEq + Clone + Debug,
-        T: PartialEq + Clone + Debug,
-    > Graph<K, T>
+        V: PartialEq + Clone + Debug,
+    > Graph<K, V>
 {
     /// Instantiate a new empty graph.
     pub fn new() -> Self {
@@ -150,7 +150,7 @@ impl<
     }
 
     /// Add a node to the graph. This node will be detached until it is linked to another node.
-    pub fn add_node(&mut self, key: &K, data: T) {
+    pub fn add_node(&mut self, key: &K, data: V) {
         let new_node = Node {
             key: key.clone(),
             next: Vec::new(),
@@ -185,12 +185,12 @@ impl<
     }
 
     /// Get node from the graph by key, returns `None` if it wasn't found.
-    pub fn get_node(&'a self, key: &K) -> Option<&Node<K, T>> {
+    pub fn get_node(&'a self, key: &K) -> Option<&Node<K, V>> {
         self.0.get(key)
     }
 
     /// Get the data payload from this node.
-    pub fn get_node_data(&self, id: &K) -> Option<&T> {
+    pub fn get_node_data(&self, id: &K) -> Option<&V> {
         self.0.get(id).map(|node| &node.data)
     }
 
@@ -238,8 +238,8 @@ impl<
     }
 
     /// Returns a reference to the root node of this graph.
-    pub fn root_node(&self) -> Result<&Node<K, T>, GraphError> {
-        let root: Vec<&Node<K, T>> = self.0.values().filter(|node| node.is_root()).collect();
+    pub fn root_node(&self) -> Result<&Node<K, V>, GraphError> {
+        let root: Vec<&Node<K, V>> = self.0.values().filter(|node| node.is_root()).collect();
         match root.len() {
             0 => Err(GraphError::NoRootNode),
             1 => Ok(root[0]),
@@ -256,7 +256,7 @@ impl<
     }
 
     /// Check if all a nodes dependencies have been visited.
-    fn dependencies_visited(&self, sorted: &[&Node<K, T>], node: &Node<K, T>) -> bool {
+    fn dependencies_visited(&self, sorted: &[&Node<K, V>], node: &Node<K, V>) -> bool {
         let mut has_dependencies = true;
         let previous_nodes = node.previous();
 
@@ -271,8 +271,8 @@ impl<
     }
 
     /// Returns the next un-visited node following the passed node.
-    fn next(&'a self, sorted: &[&Node<K, T>], node: &Node<K, T>) -> Result<Option<Vec<&'a Node<K, T>>>, GraphError> {
-        let mut next_nodes: Vec<&'a Node<K, T>> = Vec::new();
+    fn next(&'a self, sorted: &[&Node<K, V>], node: &Node<K, V>) -> Result<Option<Vec<&'a Node<K, V>>>, GraphError> {
+        let mut next_nodes: Vec<&'a Node<K, V>> = Vec::new();
 
         for node_key in node.next() {
             // Unwrap here as we are sure the node is in the graph.
@@ -291,7 +291,7 @@ impl<
     }
 
     /// Sorts the graph topologically and returns the sorted
-    pub fn walk_from(&'a self, key: &K) -> Result<GraphData<T>, GraphError> {
+    pub fn walk_from(&'a self, key: &K) -> Result<GraphData<V>, GraphError> {
         let root_node = match self.get_node(key) {
             Some(node) => Ok(node),
             None => Err(GraphError::NodeNotFound),
@@ -383,7 +383,7 @@ impl<
     // }
 
     /// Sort the entire graph, starting from the root node.
-    pub fn sort(&'a self) -> Result<GraphData<T>, GraphError> {
+    pub fn sort(&'a self) -> Result<GraphData<V>, GraphError> {
         let root_node = self.root_node_key()?;
         self.walk_from(root_node)
     }
@@ -392,8 +392,8 @@ impl<
 impl<
         'a,
         K: Hash + Ord + PartialOrd + Eq + PartialEq + Clone + Debug,
-        T: PartialEq + Clone + Debug,
-    > Default for Graph<K, T>
+        V: PartialEq + Clone + Debug,
+    > Default for Graph<K, V>
 {
     fn default() -> Self {
         Self::new()

--- a/p2panda-rs/src/graph/graph.rs
+++ b/p2panda-rs/src/graph/graph.rs
@@ -408,7 +408,7 @@ mod test {
 
     #[test]
     fn basics() {
-        let mut graph: Graph<char, char> = Graph::new();
+        let mut graph: Graph<char, char> = Graph::default();
         graph.add_node(&'a', 'A');
         graph.add_node(&'b', 'B');
         graph.add_node(&'c', 'C');
@@ -421,13 +421,19 @@ mod test {
         graph.add_node(&'j', 'J');
         graph.add_node(&'k', 'K');
 
+        assert_eq!(graph.get_node_data(&'a'), Some(&'A'));
+
         // NB: unlinked nodes are simply not visited and do not exist in the sorted result.
+
+        assert!(!graph.is_connected(&'a'));
 
         graph.add_link(&'a', &'b');
         graph.add_link(&'b', &'c');
         graph.add_link(&'c', &'d');
         graph.add_link(&'d', &'e');
         graph.add_link(&'e', &'f');
+
+        assert!(graph.is_connected(&'a'));
 
         // [A]<--[B]<--[C]<--[D]<--[E]<--[F]
 
@@ -491,10 +497,17 @@ mod test {
     #[test]
     fn has_cycle() {
         let mut graph = Graph::new();
+
         graph.add_node(&'a', 1);
         graph.add_node(&'b', 2);
         graph.add_node(&'c', 3);
         graph.add_node(&'d', 4);
+
+        // Can't add self-referential links
+        assert!(!graph.add_link(&'a', &'a'));
+
+        // Can't add links to non-existing nodes
+        assert!(!graph.add_link(&'a', &'x'));
 
         graph.add_link(&'a', &'b');
         graph.add_link(&'b', &'c');

--- a/p2panda-rs/src/graph/mod.rs
+++ b/p2panda-rs/src/graph/mod.rs
@@ -23,25 +23,25 @@
 //!
 //! // Add some nodes to the graph.
 //!
-//! graph.add_node("a", "A");
-//! graph.add_node("b", "B");
-//! graph.add_node("c", "C");
-//! graph.add_node("d", "D");
-//! graph.add_node("e", "E");
-//! graph.add_node("f", "F");
-//! graph.add_node("g", "G");
-//! graph.add_node("h", "H");
+//! graph.add_node(&'a', 'A');
+//! graph.add_node(&'b', 'B');
+//! graph.add_node(&'c', 'C');
+//! graph.add_node(&'d', 'D');
+//! graph.add_node(&'e', 'E');
+//! graph.add_node(&'f', 'F');
+//! graph.add_node(&'g', 'G');
+//! graph.add_node(&'h', 'H');
 //!
 //! // Add some links between the nodes.
 //!
-//! graph.add_link("a", "b");
-//! graph.add_link("b", "c");
-//! graph.add_link("c", "d");
-//! graph.add_link("d", "e");
-//! graph.add_link("e", "f");
-//! graph.add_link("a", "g");
-//! graph.add_link("g", "h");
-//! graph.add_link("h", "d");
+//! graph.add_link(&'a', &'b');
+//! graph.add_link(&'b', &'c');
+//! graph.add_link(&'c', &'d');
+//! graph.add_link(&'d', &'e');
+//! graph.add_link(&'e', &'f');
+//! graph.add_link(&'a', &'g');
+//! graph.add_link(&'g', &'h');
+//! graph.add_link(&'h', &'d');
 //!
 //! // The graph looks like this:
 //! //
@@ -52,41 +52,39 @@
 //!
 //! let sorted = graph.sort()?.sorted();
 //!
-//! assert_eq!(sorted, vec!["A", "B", "C", "G", "H", "D", "E", "F"]);
+//! assert_eq!(sorted, vec!['A', 'B', 'C', 'G', 'H', 'D', 'E', 'F']);
 //!
 //! // Or done more poetically:
 //! let mut graph = Graph::new();
-//! graph.add_node("a", "Wake Up");
-//! graph.add_node("b", "Make Coffee");
-//! graph.add_node("c", "Drink Coffee");
-//! graph.add_node("d", "Stroke Cat");
-//! graph.add_node("e", "Look Out The Window");
-//! graph.add_node("f", "Start The Day");
-//! graph.add_node("g", "Cat Jumps Off Bed");
-//! graph.add_node("h", "Cat Meows");
-//! graph.add_node("i", "Brain Receives Caffeine");
-//! graph.add_node("j", "Brain Starts Engine");
-//! graph.add_node("k", "Brain Starts Thinking");
+//! graph.add_node(&'a', "Wake Up".to_string());
+//! graph.add_node(&'b', "Make Coffee".to_string());
+//! graph.add_node(&'c', "Drink Coffee".to_string());
+//! graph.add_node(&'d', "Stroke Cat".to_string());
+//! graph.add_node(&'e', "Look Out The Window".to_string());
+//! graph.add_node(&'f', "Start The Day".to_string());
+//! graph.add_node(&'g', "Cat Jumps Off Bed".to_string());
+//! graph.add_node(&'h', "Cat Meows".to_string());
+//! graph.add_node(&'i', "Brain Receives Caffeine".to_string());
+//! graph.add_node(&'j', "Brain Starts Engine".to_string());
+//! graph.add_node(&'k', "Brain Starts Thinking".to_string());
+//! graph.add_link(&'a', &'b');
+//! graph.add_link(&'b', &'c');
+//! graph.add_link(&'c', &'d');
+//! graph.add_link(&'d', &'e');
+//! graph.add_link(&'e', &'f');
 //!
-//! graph.add_link("a", "b");
-//! graph.add_link("b", "c");
-//! graph.add_link("c", "d");
-//! graph.add_link("d", "e");
-//! graph.add_link("e", "f");
-//!
-//! graph.add_link("a", "g");
-//! graph.add_link("g", "h");
-//! graph.add_link("h", "d");
-//!
-//! graph.add_link("c", "i");
-//! graph.add_link("i", "j");
-//! graph.add_link("j", "k");
-//! graph.add_link("k", "f");
+//! graph.add_link(&'a', &'g');
+//! graph.add_link(&'g', &'h');
+//! graph.add_link(&'h', &'d');
+//! graph.add_link(&'c', &'i');
+//! graph.add_link(&'i', &'j');
+//! graph.add_link(&'j', &'k');
+//! graph.add_link(&'k', &'f');
 //!
 //! // The graph looks like this:
 //! //
 //! // ["Cat Jumps Off Bed"]-->["Wake Up"]
-//! //   ^                       ^                
+//! //   ^                       ^
 //! //   |                     ["Make Coffee"]
 //! //   |                       ^
 //! //   |                     ["Drink Coffee"]<-------["Brain Receives Caffeine"]
@@ -96,22 +94,22 @@
 //! //                         ["Look Out The Window"]   |
 //! //                           ^                       |
 //! //                         ["Start The Day"]------>["Brain Starts Thinking"]
-//! //                         
+//! //
 //!
 //! assert_eq!(
-//!     graph.walk_from("a")?.sorted(),
+//!     graph.walk_from(&'a')?.sorted(),
 //!     [
-//!         "Wake Up",
-//!         "Make Coffee",
-//!         "Drink Coffee",
-//!         "Brain Receives Caffeine",
-//!         "Brain Starts Engine",
-//!         "Brain Starts Thinking",
-//!         "Cat Jumps Off Bed",
-//!         "Cat Meows",
-//!         "Stroke Cat",
-//!         "Look Out The Window",
-//!         "Start The Day"
+//!         "Wake Up".to_string(),
+//!         "Make Coffee".to_string(),
+//!         "Drink Coffee".to_string(),
+//!         "Brain Receives Caffeine".to_string(),
+//!         "Brain Starts Engine".to_string(),
+//!         "Brain Starts Thinking".to_string(),
+//!         "Cat Jumps Off Bed".to_string(),
+//!         "Cat Meows".to_string(),
+//!         "Stroke Cat".to_string(),
+//!         "Look Out The Window".to_string(),
+//!         "Start The Day".to_string()
 //!     ]
 //! );
 //!

--- a/p2panda-rs/src/graph/mod.rs
+++ b/p2panda-rs/src/graph/mod.rs
@@ -3,12 +3,13 @@
 //! Generic structs which can be used for building a graph structure and sorting it's nodes in
 //! a topological depth-first manner.
 //!
-//! Graph building API based on [tangle-graph](https://gitlab.com/tangle-js/tangle-graph) and graph sorting inspired
-//! by [incremental-topo](https://github.com/declanvk/incremental-topo).
+//! Graph building API based on [tangle-graph](https://gitlab.com/tangle-js/tangle-graph) and graph
+//! sorting inspired by [incremental-topo](https://github.com/declanvk/incremental-topo).
 //!
-//! The unique character in this implementation is that the graph sorting is deterministic, with the paths chosen to walk first
-//! being decided by a > comparison between the data contained in each node. If two graphs contain the same nodes and links,
-//! regardless to the order they were added, the final sorting will be the same.
+//! The unique character in this implementation is that the graph sorting is deterministic, with
+//! the paths chosen to walk first being decided by a > comparison between the data contained in
+//! each node. If two graphs contain the same nodes and links, regardless to the order they were
+//! added, the final sorting will be the same.
 //!
 //! ## Example
 //!


### PR DESCRIPTION
Refactor for `Graph` to make it generic over both key and value of the graph nodes.

Other improvements included here:

- Docstrings formatted to max line length 100
- Fixed `add_link` implementation to prevent adding links to non-existing nodes + tests for this.
- Removed all methods that are never used.
  - They were included because they are part of the tangle api which `Graph` was implementing but as we neither use nor test them they are prone to becoming broken and non-maintained in our codebase over time. Their implementation is preserved in the branch [`graph-with-tangle-api`](https://github.com/p2panda/p2panda/tree/graph-with-tangle-api).

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
