### PR TITLE
Update schema definition and schema field definition id strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Highlights are marked with a pancake 🥞
 - Refactored graph module to be generic over graph node keys and other graph improvements [#289](https://github.com/p2panda/p2panda/issues/289) `rs`
 - Require sorted serialisation of document view ids [#284](https://github.com/p2panda/p2panda/pull/284) `rs`
 - Introduce new application schema id format [#292](https://github.com/p2panda/p2panda/pull/292) `rs`
+- Update spelling of system schema ids [#294](https://github.com/p2panda/p2panda/pull/294) `rs`
 
 ## Fixed
 

--- a/p2panda-js/openrpc.json
+++ b/p2panda-js/openrpc.json
@@ -84,10 +84,10 @@
                 "schema": {
                     "oneOf": [
                         {
-                            "const": "schema_v1"
+                            "const": "schema_definition_v1"
                         },
                         {
-                            "const": "schema_field_v1"
+                            "const": "schema_field_definition_v1"
                         },
                         {
                             "type": "string",
@@ -167,10 +167,10 @@
             "SchemaId": {
                 "oneOf": [
                     {
-                        "const": "schema_v1"
+                        "const": "schema_definition_v1"
                     },
                     {
-                        "const": "schema_field_v1"
+                        "const": "schema_field_definition_v1"
                     },
                     {
                         "type": "string",
@@ -564,10 +564,10 @@
                     "schema": {
                         "oneOf": [
                             {
-                                "const": "schema_v1"
+                                "const": "schema_definition_v1"
                             },
                             {
-                                "const": "schema_field_v1"
+                                "const": "schema_field_definition_v1"
                             },
                             {
                                 "type": "string",

--- a/p2panda-js/src/types.ts
+++ b/p2panda-js/src/types.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-export type SchemaId = 'schema_v1' | 'schema_field_v1' | string;
+export type SchemaId =
+  | 'schema_definition_v1'
+  | 'schema_field_definition_v1'
+  | string;
 
 /**
  * Arguments for publishing the next entry.

--- a/p2panda-js/test/openrpc-template.json
+++ b/p2panda-js/test/openrpc-template.json
@@ -81,10 +81,10 @@
             "SchemaId": {
                 "oneOf": [
                     {
-                        "const": "schema_v1"
+                        "const": "schema_definition_v1"
                     },
                     {
-                        "const": "schema_field_v1"
+                        "const": "schema_field_definition_v1"
                     },
                     {
                         "type": "string",

--- a/p2panda-rs/src/cddl/definitions.rs
+++ b/p2panda-rs/src/cddl/definitions.rs
@@ -97,11 +97,11 @@ const CDDL_ANY_OPERATION: &str = r#"
 ; The first section is the name, which has 1-64 characters, must start
 ; with a letter and must contain only alphanumeric characters and
 ; underscores. The remaining sections are the document view id of the
-; schema's `schema_v1` document, represented as alphabetically sorted
-; hex-encoded operation ids, separated by underscores.
+; schema's `schema_definition_v1` document, represented as alphabetically
+; sorted hex-encoded operation ids, separated by underscores.
 application_schema_id = tstr .regexp "[A-Za-z]{1}[A-Za-z0-9_]{0,63}_([0-9A-Za-z]{68})(_[0-9A-Za-z]{68})*"
 
-system_schema_id = "schema_v1" / "schema_field_v1"
+system_schema_id = "schema_definition_v1" / "schema_field_definition_v1"
 
 schema_id =  system_schema_id / application_schema_id
 
@@ -132,7 +132,7 @@ const CDDL_SCHEMA_V1: &str = r#"
 ; System Schema "Schema" v1
 ; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-schema_id = "schema_v1"
+schema_id = "schema_definition_v1"
 
 create_fields = { name, description, fields }
 
@@ -163,7 +163,7 @@ const CDDL_SCHEMA_FIELD_V1: &str = r#"
 ; System Schema "Schema field" v1
 ; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-schema_id = "schema_field_v1"
+schema_id = "schema_field_definition_v1"
 
 create_fields = { name, description, field_type }
 
@@ -199,12 +199,12 @@ lazy_static! {
         format!("{}{}", CDDL_HEADER, CDDL_ANY_OPERATION)
     };
 
-    /// CDDL definition of "schema_v1" system operations.
+    /// CDDL definition of "schema_definition_v1" system operations.
     pub static ref SCHEMA_V1_FORMAT: String = {
         format!("{}{}", CDDL_HEADER, CDDL_SCHEMA_V1)
     };
 
-    /// CDDL definition of "schema_field_v1" system operations.
+    /// CDDL definition of "schema_field_definition_v1" system operations.
     pub static ref SCHEMA_FIELD_V1_FORMAT: String = {
         format!("{}{}", CDDL_HEADER, CDDL_SCHEMA_FIELD_V1)
     };
@@ -434,13 +434,13 @@ mod tests {
     }
 
     #[test]
-    fn valid_schema_v1() {
+    fn valid_schema_definition_v1() {
         assert!(validate_cbor(
             &SCHEMA_V1_FORMAT,
             &to_cbor(
                 cbor!({
                     "action" => "create",
-                    "schema" => "schema_v1",
+                    "schema" => "schema_definition_v1",
                     "version" => 1,
                     "fields" => {
                         "name" => {
@@ -474,7 +474,7 @@ mod tests {
             &to_cbor(
                 cbor!({
                     "action" => "update",
-                    "schema" => "schema_v1",
+                    "schema" => "schema_definition_v1",
                     "version" => 1,
                     "previous_operations" => [
                         "00207134365ce71dca6bd7c31d04bfb3244b29897ab538906216fc8ff3d6189410ad",
@@ -496,7 +496,7 @@ mod tests {
             &to_cbor(
                 cbor!({
                     "action" => "delete",
-                    "schema" => "schema_v1",
+                    "schema" => "schema_definition_v1",
                     "version" => 1,
                     "previous_operations" => [
                         "00203ea9940af9e5a191a81a49a118ee049283c3f62e879b33f879e154abad3e682f",
@@ -509,13 +509,13 @@ mod tests {
     }
 
     #[test]
-    fn invalid_schema_v1() {
+    fn invalid_schema_definition_v1() {
         assert!(validate_cbor(
             &SCHEMA_V1_FORMAT,
             &to_cbor(
                 cbor!({
                     "action" => "create",
-                    "schema" => "schema_v1",
+                    "schema" => "schema_definition_v1",
                     "version" => 1,
                     "fields" => {
                         "name" => {
@@ -539,7 +539,7 @@ mod tests {
             &to_cbor(
                 cbor!({
                     "action" => "create",
-                    "schema" => "schema_v1",
+                    "schema" => "schema_definition_v1",
                     "version" => 1,
                     "fields" => {
                         "name" => {
@@ -574,7 +574,7 @@ mod tests {
             &to_cbor(
                 cbor!({
                     "action" => "update",
-                    "schema" => "schema_v1",
+                    "schema" => "schema_definition_v1",
                     "version" => 1,
                     "previous_operations" => [
                         "00207134365ce71dca6bd7c31d04bfb3244b29897ab538906216fc8ff3d6189410ad",
@@ -594,13 +594,13 @@ mod tests {
     }
 
     #[test]
-    fn valid_schema_field_v1() {
+    fn valid_schema_field_definition_v1() {
         assert!(validate_cbor(
             &SCHEMA_FIELD_V1_FORMAT,
             &to_cbor(
                 cbor!({
                     "action" => "create",
-                    "schema" => "schema_field_v1",
+                    "schema" => "schema_field_definition_v1",
                     "version" => 1,
                     "fields" => {
                         "name" => {
@@ -627,7 +627,7 @@ mod tests {
             &to_cbor(
                 cbor!({
                     "action" => "update",
-                    "schema" => "schema_field_v1",
+                    "schema" => "schema_field_definition_v1",
                     "version" => 1,
                     "previous_operations" => [
                         "00208a5cbba0facc96f22fe3c283e05706c74801282bb7ba315fb5c77caa44689846",
@@ -662,7 +662,7 @@ mod tests {
             &to_cbor(
                 cbor!({
                     "action" => "delete",
-                    "schema" => "schema_field_v1",
+                    "schema" => "schema_field_definition_v1",
                     "version" => 1,
                     "previous_operations" => [
                         "002066f3cec300b76993da433f80c0c32104678e483fa24d59625d0e3994c09115e2",
@@ -675,13 +675,13 @@ mod tests {
     }
 
     #[test]
-    fn invalid_schema_field_v1() {
+    fn invalid_schema_field_definition_v1() {
         assert!(validate_cbor(
             &SCHEMA_FIELD_V1_FORMAT,
             &to_cbor(
                 cbor!({
                     "action" => "create",
-                    "schema" => "schema_field_v1",
+                    "schema" => "schema_field_definition_v1",
                     "version" => 1,
                     "fields" => {
                         "name" => {
@@ -705,7 +705,7 @@ mod tests {
             &to_cbor(
                 cbor!({
                     "action" => "update",
-                    "schema" => "schema_field_v1",
+                    "schema" => "schema_field_definition_v1",
                     "version" => 1,
                     "previous_operations" => [
                         "00209caa5f232debd2835e35a673d5eb148ea803a272c6ca004cd86cbe4a834718d5",

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -11,6 +11,12 @@ use crate::document::DocumentViewId;
 use crate::operation::OperationId;
 use crate::schema::error::SchemaIdError;
 
+/// Schema id for _schema definition_ schema
+pub(super) const SCHEMA_DEFINITION_ID_STR: &str = "schema_definition_v1";
+
+/// Schema id for _schema field definition_ schema
+pub(super) const SCHEMA_FIELD_DEFINITION_ID_STR: &str = "schema_field_definition_v1";
+
 /// Identifies the schema of an [`crate::operation::Operation`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SchemaId {
@@ -31,8 +37,8 @@ impl SchemaId {
     /// inside.
     pub fn new(id: &str) -> Result<Self, SchemaIdError> {
         match id {
-            "schema_v1" => Ok(SchemaId::Schema),
-            "schema_field_v1" => Ok(SchemaId::SchemaField),
+            SCHEMA_DEFINITION_ID_STR => Ok(SchemaId::Schema),
+            SCHEMA_FIELD_DEFINITION_ID_STR => Ok(SchemaId::SchemaField),
             application_schema_id => Self::parse_application_schema_str(application_schema_id),
         }
     }
@@ -91,8 +97,8 @@ impl SchemaId {
     /// Returns schema id as string slice.
     pub fn as_str(&self) -> String {
         match self {
-            SchemaId::Schema => "schema_v1".to_string(),
-            SchemaId::SchemaField => "schema_field_v1".to_string(),
+            SchemaId::Schema => SCHEMA_DEFINITION_ID_STR.to_string(),
+            SchemaId::SchemaField => SCHEMA_FIELD_DEFINITION_ID_STR.to_string(),
             SchemaId::Application(name, view_id) => {
                 let mut schema_id = name.clone();
                 for op_id in view_id.sorted().into_iter() {
@@ -158,7 +164,7 @@ mod test {
     use crate::test_utils::constants::TEST_SCHEMA_ID;
     use crate::test_utils::fixtures::random_operation_id;
 
-    use super::SchemaId;
+    use super::{SchemaId, SCHEMA_DEFINITION_ID_STR, SCHEMA_FIELD_DEFINITION_ID_STR};
 
     #[test]
     fn serialize() {
@@ -169,12 +175,15 @@ mod test {
         );
 
         let schema = SchemaId::Schema;
-        assert_eq!(serde_json::to_string(&schema).unwrap(), "\"schema_v1\"");
+        assert_eq!(
+            serde_json::to_string(&schema).unwrap(),
+            "\"schema_definition_v1\""
+        );
 
         let schema_field = SchemaId::SchemaField;
         assert_eq!(
             serde_json::to_string(&schema_field).unwrap(),
-            "\"schema_field_v1\""
+            "\"schema_field_definition_v1\""
         );
     }
 
@@ -198,12 +207,12 @@ mod test {
         );
         let schema = SchemaId::Schema;
         assert_eq!(
-            serde_json::from_str::<SchemaId>("\"schema_v1\"").unwrap(),
+            serde_json::from_str::<SchemaId>("\"schema_definition_v1\"").unwrap(),
             schema
         );
         let schema_field = SchemaId::SchemaField;
         assert_eq!(
-            serde_json::from_str::<SchemaId>("\"schema_field_v1\"").unwrap(),
+            serde_json::from_str::<SchemaId>("\"schema_field_definition_v1\"").unwrap(),
             schema_field
         );
     }
@@ -274,16 +283,16 @@ mod test {
             .unwrap()
         );
 
-        let schema = SchemaId::new("schema_v1").unwrap();
+        let schema = SchemaId::new(SCHEMA_DEFINITION_ID_STR).unwrap();
         assert_eq!(schema, SchemaId::Schema);
 
-        let schema_field = SchemaId::new("schema_field_v1").unwrap();
+        let schema_field = SchemaId::new(SCHEMA_FIELD_DEFINITION_ID_STR).unwrap();
         assert_eq!(schema_field, SchemaId::SchemaField);
     }
 
     #[test]
     fn parse_schema_type() {
-        let schema: SchemaId = "schema_v1".parse().unwrap();
+        let schema: SchemaId = SCHEMA_DEFINITION_ID_STR.parse().unwrap();
         assert_eq!(schema, SchemaId::Schema);
     }
 }


### PR DESCRIPTION
Aligns the spelling with [handbook](https://p2panda.org/handbook/docs/writing-data/schemas#system-schemas).

Also creates constants for their exact spelling to be used in the schema module.

Follow-up to #292 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
