### PR TITLE
Update schema impl to use new schema id functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Highlights are marked with a pancake 🥞
 - Refactored graph module to be generic over graph node keys and other graph improvements [#289](https://github.com/p2panda/p2panda/issues/289) `rs`
 - Require sorted serialisation of document view ids [#284](https://github.com/p2panda/p2panda/pull/284) `rs`
 - Introduce new application schema id format [#292](https://github.com/p2panda/p2panda/pull/292) `rs`
+- Update `Schema` implementation to make use of new `SchemaId` [#296](https://github.com/p2panda/p2panda/pull/296) `rs`
 
 ## Fixed
 

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -10,8 +10,8 @@ pub enum SchemaIdError {
     HashError(#[from] crate::hash::HashError),
 
     /// Encountered a malformed schema id.
-    #[error("malformed application schema id: {0}")]
-    MalformedApplicationSchemaId(String),
+    #[error("malformed schema id: {0}")]
+    MalformedSchemaId(String),
 
     /// Application schema ids must start with the schema's name.
     #[error("application schema id is missing a name: {0}")]

--- a/p2panda-rs/src/schema/mod.rs
+++ b/p2panda-rs/src/schema/mod.rs
@@ -10,4 +10,5 @@ pub mod system;
 
 pub use error::{FieldTypeError, SchemaError, SchemaIdError};
 pub use field_types::FieldType;
-pub use schema_id::SchemaId;
+pub use schema::Schema;
+pub use schema_id::{SchemaId, SchemaVersion};

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -18,7 +18,7 @@ pub struct Schema {
     /// The application schema id for this schema.
     id: SchemaId,
 
-    /// Describes the schemas indented use.
+    /// Describes the schema's intended use.
     description: String,
 
     /// This schema's field definitions.

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -72,24 +72,26 @@ impl Schema {
 
     /// Access the schema view id.
     #[allow(unused)]
-    pub fn view_id(&self) -> &DocumentViewId {
-        if let SchemaId::Application(_, view_id) = &self.id {
-            return view_id;
-        }
-        // This statement is unreachable because it's not possible to construct a `Schema`
-        // that doesn't contain an application schema id.
-        panic!()
+    pub fn view_id(&self) -> DocumentViewId {
+        let view_id = match self.id.clone() {
+            SchemaId::Application(_, view_id) => Some(view_id),
+            _ => None,
+        };
+        // Unwrap because it's not possible to construct a `Schema` that doesn't contain an
+        // application schema id.
+        view_id.unwrap()
     }
 
     /// Access the schema name.
     #[allow(unused)]
-    pub fn name(&self) -> &str {
-        if let SchemaId::Application(name, _) = &self.id {
-            return name;
-        }
-        // This statement is unreachable because it's not possible to construct a `Schema`
-        // that doesn't contain an application schema id.
-        panic!()
+    pub fn name(&self) -> String {
+        let name = match self.id.clone() {
+            SchemaId::Application(name, _) => Some(name),
+            _ => None,
+        };
+        // Unwrap because it's not possible to construct a `Schema` that doesn't contain an
+        // application schema id.
+        name.unwrap()
     }
 
     /// Access the schema description.
@@ -209,7 +211,7 @@ mod tests {
             &SchemaId::new_application("venue_name", expected_view_id)
         );
         assert_eq!(schema.name(), "venue_name");
-        assert_eq!(schema.view_id(), expected_view_id);
+        assert_eq!(&schema.view_id(), expected_view_id);
         assert_eq!(schema.description(), "Describes a venue");
         assert_eq!(schema.fields().len(), 2);
 

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -64,7 +64,7 @@ impl Schema {
         generate_cddl_definition(&self.fields)
     }
 
-    /// Access the schema id.
+    /// Access the schema's [`SchemaId`].
     #[allow(unused)]
     pub fn id(&self) -> &SchemaId {
         &self.id

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -3,9 +3,10 @@
 use std::collections::BTreeMap;
 
 use crate::cddl::generate_cddl_definition;
-use crate::document::DocumentViewId;
 use crate::schema::system::{SchemaFieldView, SchemaView};
 use crate::schema::{FieldType, SchemaError, SchemaId};
+
+use super::schema_id::SchemaVersion;
 
 /// The key of a schema field
 type FieldKey = String;
@@ -70,28 +71,16 @@ impl Schema {
         &self.id
     }
 
-    /// Access the schema view id.
+    /// Access the schema version.
     #[allow(unused)]
-    pub fn view_id(&self) -> DocumentViewId {
-        let view_id = match self.id.clone() {
-            SchemaId::Application(_, view_id) => Some(view_id),
-            _ => None,
-        };
-        // Unwrap because it's not possible to construct a `Schema` that doesn't contain an
-        // application schema id.
-        view_id.unwrap()
+    pub fn version(&self) -> SchemaVersion {
+        self.id.version()
     }
 
     /// Access the schema name.
     #[allow(unused)]
-    pub fn name(&self) -> String {
-        let name = match self.id.clone() {
-            SchemaId::Application(name, _) => Some(name),
-            _ => None,
-        };
-        // Unwrap because it's not possible to construct a `Schema` that doesn't contain an
-        // application schema id.
-        name.unwrap()
+    pub fn name(&self) -> &str {
+        self.id.name()
     }
 
     /// Access the schema description.
@@ -116,9 +105,8 @@ mod tests {
 
     use crate::document::{DocumentView, DocumentViewId};
     use crate::operation::{OperationId, OperationValue, PinnedRelationList};
-    use crate::schema::schema::Schema;
     use crate::schema::system::{SchemaFieldView, SchemaView};
-    use crate::schema::SchemaId;
+    use crate::schema::{Schema, SchemaId, SchemaVersion};
     use crate::test_utils::fixtures::{document_view_id, random_operation_id};
 
     fn create_schema_view(fields: PinnedRelationList, view_id: DocumentViewId) -> SchemaView {
@@ -211,7 +199,10 @@ mod tests {
             &SchemaId::new_application("venue_name", &expected_view_id)
         );
         assert_eq!(schema.name(), "venue_name");
-        assert_eq!(schema.view_id(), expected_view_id);
+        assert_eq!(
+            schema.version(),
+            SchemaVersion::Application(expected_view_id)
+        );
         assert_eq!(schema.description(), "Describes a venue");
         assert_eq!(schema.fields().len(), 2);
 

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -92,13 +92,13 @@ impl Schema {
         panic!()
     }
 
-    /// Access the schema's description.
+    /// Access the schema description.
     #[allow(unused)]
     pub fn description(&self) -> &str {
         &self.description
     }
 
-    /// Access the schema's fields.
+    /// Access the schema fields.
     #[allow(unused)]
     pub fn fields(&self) -> &BTreeMap<FieldKey, FieldType> {
         &self.fields

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -21,7 +21,7 @@ pub struct Schema {
     /// Describes the schema's intended use.
     description: String,
 
-    /// This schema's field definitions.
+    /// Maps all of the schema's field names to their respective types.
     fields: BTreeMap<FieldKey, FieldType>,
 }
 
@@ -203,15 +203,15 @@ mod tests {
 
         // Test getters
         let expected_view_id =
-            &"0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
+            "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                 .parse::<DocumentViewId>()
                 .unwrap();
         assert_eq!(
             schema.id(),
-            &SchemaId::new_application("venue_name", expected_view_id)
+            &SchemaId::new_application("venue_name", &expected_view_id)
         );
         assert_eq!(schema.name(), "venue_name");
-        assert_eq!(&schema.view_id(), expected_view_id);
+        assert_eq!(schema.view_id(), expected_view_id);
         assert_eq!(schema.description(), "Describes a venue");
         assert_eq!(schema.fields().len(), 2);
 

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -119,19 +119,10 @@ impl SchemaId {
             ));
         }
 
-        Ok(Self::Application(
+        Ok(SchemaId::Application(
             remainder.to_string(),
             DocumentViewId::new(&operation_ids),
         ))
-    }
-
-    /// Access the schema name.
-    pub fn name(&self) -> &str {
-        match self {
-            SchemaId::Application(name, _) => name,
-            SchemaId::SchemaDefinition(_) => SCHEMA_DEFINITION_NAME,
-            SchemaId::SchemaFieldDefinition(_) => SCHEMA_FIELD_DEFINITION_NAME,
-        }
     }
 
     /// Returns schema id as string slice.
@@ -151,6 +142,15 @@ impl SchemaId {
             SchemaId::SchemaFieldDefinition(version) => {
                 format!("{}_v{}", SCHEMA_FIELD_DEFINITION_NAME, version)
             }
+        }
+    }
+
+    /// Access the schema name.
+    pub fn name(&self) -> &str {
+        match self {
+            SchemaId::Application(name, _) => name,
+            SchemaId::SchemaDefinition(_) => SCHEMA_DEFINITION_NAME,
+            SchemaId::SchemaFieldDefinition(_) => SCHEMA_FIELD_DEFINITION_NAME,
         }
     }
 

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -11,41 +11,87 @@ use crate::document::DocumentViewId;
 use crate::operation::OperationId;
 use crate::schema::error::SchemaIdError;
 
-/// Schema id for _schema definition_ schema
-pub(super) const SCHEMA_DEFINITION_ID_STR: &str = "schema_definition_v1";
+/// Spelling of _schema definition_ schema
+pub(super) const SCHEMA_DEFINITION_NAME: &str = "schema_definition";
 
-/// Schema id for _schema field definition_ schema
-pub(super) const SCHEMA_FIELD_DEFINITION_ID_STR: &str = "schema_field_definition_v1";
+/// Spelling of _schema field definition_ schema
+pub(super) const SCHEMA_FIELD_DEFINITION_NAME: &str = "schema_field_definition";
 
-/// Identifies the schema of an [`crate::operation::Operation`].
+/// Represent a schema's version.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SchemaVersion {
+    /// An application schema's version contains its document view id.
+    Application(DocumentViewId),
+
+    /// A system schema's version contains an integer version number.
+    System(u8),
+}
+
+/// Identifies the schema of an [`Operation`][`crate::operation::Operation`] or
+/// [`Document`][`crate::document::Document`].
+///
+/// Every schema id has a name and version.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SchemaId {
     /// An application schema.
     Application(String, DocumentViewId),
 
     /// A schema definition.
-    SchemaDefinition,
+    SchemaDefinition(u8),
 
     /// A schema definition field.
-    SchemaFieldDefinition,
+    SchemaFieldDefinition(u8),
 }
 
 impl SchemaId {
-    /// Instantiate a new `SchemaId` from a hash string or system schema name.
+    /// Instantiate a new `SchemaId`.
     ///
-    /// If a hash string is passed, it will be converted into a document view id with only one hash
-    /// inside.
+    /// ```
+    /// # use p2panda_rs::schema::SchemaId;
+    /// let system_schema = SchemaId::new("schema_definition_v1");
+    /// assert!(system_schema.is_ok());
+    ///
+    /// let application_schema = SchemaId::new(
+    ///     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
+    /// );
+    /// assert!(application_schema.is_ok());
+    /// ```
     pub fn new(id: &str) -> Result<Self, SchemaIdError> {
-        match id {
-            SCHEMA_DEFINITION_ID_STR => Ok(SchemaId::SchemaDefinition),
-            SCHEMA_FIELD_DEFINITION_ID_STR => Ok(SchemaId::SchemaFieldDefinition),
-            application_schema_id => Self::parse_application_schema_str(application_schema_id),
+        // Retrieve the rightmost section separated by an underscore and check whether it follows
+        // the version format of system schemas (e.g. `..._v1`).
+        let rightmost_section = id
+            .rsplit_once('_')
+            .ok_or_else(|| {
+                SchemaIdError::MalformedSchemaId("doesn't contain an underscore".to_string())
+            })?
+            .1;
+        let is_system_schema =
+            rightmost_section.starts_with('v') && rightmost_section.len() < MAX_YAMF_HASH_SIZE * 2;
+
+        match is_system_schema {
+            true => Self::parse_system_schema_str(id),
+            false => Self::parse_application_schema_str(id),
         }
     }
 
     /// Returns a `SchemaId` given an application schema's name and view id.
     pub fn new_application(name: &str, view_id: &DocumentViewId) -> Self {
-        SchemaId::Application(name.to_string(), view_id.clone())
+        Self::Application(name.to_string(), view_id.clone())
+    }
+
+    fn parse_system_schema_str(id_str: &str) -> Result<Self, SchemaIdError> {
+        let (name, version_str) = id_str.rsplit_once('_').unwrap();
+        let version = version_str[1..].parse::<u8>().map_err(|_| {
+            SchemaIdError::MalformedSchemaId(format!(
+                "couldn't parse system schema version from '{}'",
+                id_str
+            ))
+        })?;
+        match name {
+            SCHEMA_DEFINITION_NAME => Ok(Self::SchemaDefinition(version)),
+            SCHEMA_FIELD_DEFINITION_NAME => Ok(Self::SchemaFieldDefinition(version)),
+            _ => Err(SchemaIdError::UnknownSystemSchema(name.to_string())),
+        }
     }
 
     /// Read an application schema id from a string.
@@ -54,24 +100,9 @@ impl SchemaId {
     /// remainder is shorter than an operation id. Each section is parsed as an operation id
     /// and the last (leftmost) section is parsed as the schema's name.
     fn parse_application_schema_str(id_str: &str) -> Result<Self, SchemaIdError> {
-        if id_str.find('_').is_none() {
-            return Err(SchemaIdError::MalformedApplicationSchemaId(
-                "expecting name and view id hashes separated by underscore".to_string(),
-            ));
-        }
-
         let mut operation_ids = vec![];
         let mut remainder = id_str;
         while let Some((left, right)) = remainder.rsplit_once('_') {
-            // While we're parsing application schema ids here, let's not forget the possibility
-            // that a system schema id is being thrown at this method. If that were to happen, the
-            // version identifier part (e.g. `v1`) would end up in `right` in this loop iteration.
-            // The following check let's us return a more helpful error in that situation than we
-            // we would've gotten if we'd try and parse that as an `OperationId` right below.
-            if right.starts_with('v') && right.len() < MAX_YAMF_HASH_SIZE * 2 {
-                return Err(SchemaIdError::UnknownSystemSchema(id_str.to_string()));
-            }
-
             operation_ids.push(right.parse::<OperationId>()?);
 
             // If the remainder is no longer than an entry hash we assume that it's the schema name.
@@ -88,25 +119,47 @@ impl SchemaId {
             ));
         }
 
-        Ok(SchemaId::Application(
+        Ok(Self::Application(
             remainder.to_string(),
             DocumentViewId::new(&operation_ids),
         ))
     }
 
+    /// Access the schema name.
+    pub fn name(&self) -> &str {
+        match self {
+            SchemaId::Application(name, _) => name,
+            SchemaId::SchemaDefinition(_) => SCHEMA_DEFINITION_NAME,
+            SchemaId::SchemaFieldDefinition(_) => SCHEMA_FIELD_DEFINITION_NAME,
+        }
+    }
+
     /// Returns schema id as string slice.
     pub fn as_str(&self) -> String {
         match self {
-            SchemaId::SchemaDefinition => SCHEMA_DEFINITION_ID_STR.to_string(),
-            SchemaId::SchemaFieldDefinition => SCHEMA_FIELD_DEFINITION_ID_STR.to_string(),
             SchemaId::Application(name, view_id) => {
-                let mut schema_id = name.clone();
+                let mut schema_id = name.to_string();
                 for op_id in view_id.sorted().into_iter() {
                     schema_id.push('_');
                     schema_id.push_str(op_id.as_hash().as_str());
                 }
                 schema_id
             }
+            SchemaId::SchemaDefinition(version) => {
+                format!("{}_v{}", SCHEMA_DEFINITION_NAME, version)
+            }
+            SchemaId::SchemaFieldDefinition(version) => {
+                format!("{}_v{}", SCHEMA_FIELD_DEFINITION_NAME, version)
+            }
+        }
+    }
+
+    /// Access the schema version.
+    pub fn version(&self) -> SchemaVersion {
+        match self {
+            SchemaId::Application(_, view_id) => SchemaVersion::Application(view_id.clone()),
+            SchemaId::SchemaDefinition(version) => SchemaVersion::System(*version),
+            SchemaId::SchemaFieldDefinition(version) => SchemaVersion::System(*version),
         }
     }
 }
@@ -164,7 +217,7 @@ mod test {
     use crate::test_utils::constants::TEST_SCHEMA_ID;
     use crate::test_utils::fixtures::random_operation_id;
 
-    use super::{SchemaId, SCHEMA_DEFINITION_ID_STR, SCHEMA_FIELD_DEFINITION_ID_STR};
+    use super::SchemaId;
 
     #[test]
     fn serialize() {
@@ -174,13 +227,13 @@ mod test {
             "\"venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b\""
         );
 
-        let schema = SchemaId::SchemaDefinition;
+        let schema = SchemaId::SchemaDefinition(1);
         assert_eq!(
             serde_json::to_string(&schema).unwrap(),
             "\"schema_definition_v1\""
         );
 
-        let schema_field = SchemaId::SchemaFieldDefinition;
+        let schema_field = SchemaId::SchemaFieldDefinition(1);
         assert_eq!(
             serde_json::to_string(&schema_field).unwrap(),
             "\"schema_field_definition_v1\""
@@ -205,12 +258,12 @@ mod test {
             .unwrap(),
             app_schema
         );
-        let schema = SchemaId::SchemaDefinition;
+        let schema = SchemaId::SchemaDefinition(1);
         assert_eq!(
             serde_json::from_str::<SchemaId>("\"schema_definition_v1\"").unwrap(),
             schema
         );
-        let schema_field = SchemaId::SchemaFieldDefinition;
+        let schema_field = SchemaId::SchemaFieldDefinition(1);
         assert_eq!(
             serde_json::from_str::<SchemaId>("\"schema_field_definition_v1\"").unwrap(),
             schema_field
@@ -221,8 +274,7 @@ mod test {
     #[rstest]
     #[case(
         "\"This is not a hash\"",
-        "malformed application schema id: expecting name and view id hashes separated by \
-        underscore at line 1 column 20"
+        "malformed schema id: doesn't contain an underscore at line 1 column 20"
     )]
     // An integer
     #[case(
@@ -232,8 +284,7 @@ mod test {
     // Only an operation id, could be interpreted as document view id but still missing the name
     #[case(
         "\"0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b\"",
-        "malformed application schema id: expecting name and view id hashes separated by \
-        underscore at line 1 column 70"
+        "malformed schema id: doesn't contain an underscore at line 1 column 70"
     )]
     // Only the name is missing now
     #[case(
@@ -252,12 +303,18 @@ mod test {
     #[case(
         "\"venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc7\"",
         "encountered invalid hash while parsing application schema id: invalid hash length 33 \
-    bytes, expected 34 bytes at line 1 column 74"
+        bytes, expected 34 bytes at line 1 column 74"
     )]
     // this looks like a system schema, but it is not
     #[case(
         "\"unknown_system_schema_name_v1\"",
-        "not a known system schema: unknown_system_schema_name_v1 at line 1 column 31"
+        "not a known system schema: unknown_system_schema_name at line 1 column 31"
+    )]
+    // malformed system schema version number
+    #[case(
+        "\"schema_definition_v1.5\"",
+        "malformed schema id: couldn't parse system schema version from 'schema_definition_v1.5' \
+        at line 1 column 24"
     )]
     fn invalid_deserialization(#[case] schema_id: &str, #[case] expected_err: &str) {
         assert_eq!(
@@ -283,16 +340,16 @@ mod test {
             .unwrap()
         );
 
-        let schema = SchemaId::new(SCHEMA_DEFINITION_ID_STR).unwrap();
-        assert_eq!(schema, SchemaId::SchemaDefinition);
+        let schema = SchemaId::new("schema_definition_v50").unwrap();
+        assert_eq!(schema, SchemaId::SchemaDefinition(50));
 
-        let schema_field = SchemaId::new(SCHEMA_FIELD_DEFINITION_ID_STR).unwrap();
-        assert_eq!(schema_field, SchemaId::SchemaFieldDefinition);
+        let schema_field = SchemaId::new("schema_field_definition_v1").unwrap();
+        assert_eq!(schema_field, SchemaId::SchemaFieldDefinition(1));
     }
 
     #[test]
     fn parse_schema_type() {
-        let schema: SchemaId = SCHEMA_DEFINITION_ID_STR.parse().unwrap();
-        assert_eq!(schema, SchemaId::SchemaDefinition);
+        let schema: SchemaId = "schema_definition_v1".parse().unwrap();
+        assert_eq!(schema, SchemaId::SchemaDefinition(1));
     }
 }


### PR DESCRIPTION
- add a `SchemaId` to `Schema`
- add getters for schema properties
- update `SchemaId`
  - add getters for name and version
  - add new `SchemaVersion` enum that represents both application and system schema versions

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
