### PR TITLE
Pin dependency versions in `Cargo.toml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Highlights are marked with a pancake 🥞
 
 - Fix determination of field types in p2panda-js [#202](https://github.com/p2panda/p2panda/pull/202) `js`
 - Fix equality of document view ids by sorting before comparison [#284](https://github.com/p2panda/p2panda/pull/284) `js`
+- Pin all versions in `Cargo.toml` to avoid unexpected crate updates [#299](https://github.com/p2panda/p2panda/pull/299)
 
 ## Everything burrito
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Highlights are marked with a pancake 🥞
 
 - Fix determination of field types in p2panda-js [#202](https://github.com/p2panda/p2panda/pull/202) `js`
 - Fix equality of document view ids by sorting before comparison [#284](https://github.com/p2panda/p2panda/pull/284) `js`
-- Pin all versions in `Cargo.toml` to avoid unexpected crate updates [#299](https://github.com/p2panda/p2panda/pull/299)
+- Pin all versions in `Cargo.toml` to avoid unexpected crate updates [#299](https://github.com/p2panda/p2panda/pull/299) `rs`
 
 ## Everything burrito
 

--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -28,27 +28,24 @@ path = "src/test_utils/generate_test_data.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-aquamarine = "0.1.11"
-arrayvec = "0.5.2"
-bamboo-rs-core-ed25519-yasmf = "0.1.1"
-ciborium = "0.2.0"
-cddl-cat = { version = "0.6.0", default-features = false, features = ["serde_cbor"] }
-ed25519 = "1.3.0"
-ed25519-dalek = "1.0.1"
-hex = "0.4.3"
-lazy_static = "1.4.0"
-log = "0.4"
-serde = { version = "1.0.132", features = ["derive"] }
-serde-wasm-bindgen = "0.4.1"
-serde_json = "1.0.73"
-serde_repr = "0.1.7"
-thiserror = "1.0.30"
-tls_codec = { version = "0.2.0-pre.3", features = [
-  "derive",
-  "serde_serialize",
-] }
-regex = "1.5.5"
-yasmf-hash = "0.1.1"
+aquamarine = "^0.1.11"
+arrayvec = "^0.5.2"
+bamboo-rs-core-ed25519-yasmf = "^0.1.1"
+cddl-cat = { version = "^0.6.0", default-features = false, features = ["serde_cbor"] }
+ciborium = "^0.2.0"
+ed25519 = "^1.3.0"
+ed25519-dalek = "^1.0.1"
+hex = "^0.4.3"
+lazy_static = "^1.4.0"
+log = "^0.4"
+regex = "^1.5.5"
+serde = { version = "^1.0.132", features = ["derive"] }
+serde-wasm-bindgen = "^0.4.1"
+serde_json = "^1.0.73"
+serde_repr = "^0.1.7"
+thiserror = "^1.0.30"
+tls_codec = { version = "^0.2.0-pre.3", features = [ "derive", "serde_serialize", ] }
+yasmf-hash = "^0.1.1"
 
 # @TODO: Use `openmls` crate as soon as changes got merged into `main` in
 # upstream and released as version `0.4.0`.
@@ -71,13 +68,13 @@ git = "https://github.com/adzialocha/openmls"
 branch = "p2panda"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rand = "0.7.3"
+rand = "^0.7.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = "0.1.7"
-js-sys = "0.3.55"
-rand = { version = "0.7.3", features = ["wasm-bindgen"] }
-wasm-bindgen = "0.2.78"
+console_error_panic_hook = "^0.1.7"
+js-sys = "^0.3.55"
+rand = { version = "^0.7.3", features = ["wasm-bindgen"] }
+wasm-bindgen = "^0.2.78"
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -31,7 +31,7 @@ crate-type = ["cdylib", "rlib"]
 aquamarine = "^0.1.11"
 arrayvec = "^0.5.2"
 bamboo-rs-core-ed25519-yasmf = "^0.1.1"
-cddl-cat = { version = "^0.6.0", default-features = false, features = ["serde_cbor"] }
+cddl-cat = { version = "^0.6.1", default-features = false, features = ["serde_cbor"] }
 ciborium = "^0.2.0"
 ed25519 = "^1.3.0"
 ed25519-dalek = "^1.0.1"
@@ -39,9 +39,9 @@ hex = "^0.4.3"
 lazy_static = "^1.4.0"
 log = "^0.4"
 regex = "^1.5.5"
-serde = { version = "^1.0.132", features = ["derive"] }
-serde-wasm-bindgen = "^0.4.1"
-serde_json = "^1.0.73"
+serde = { version = "^1.0.136", features = ["derive"] }
+serde-wasm-bindgen = "^0.4.2"
+serde_json = "^1.0.79"
 serde_repr = "^0.1.7"
 thiserror = "^1.0.30"
 tls_codec = { version = "^0.2.0-pre.3", features = [ "derive", "serde_serialize", ] }
@@ -72,7 +72,7 @@ rand = "^0.7.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "^0.1.7"
-js-sys = "^0.3.55"
+js-sys = "^0.3.57"
 rand = { version = "^0.7.3", features = ["wasm-bindgen"] }
 wasm-bindgen = "^0.2.78"
 
@@ -83,7 +83,7 @@ incremental-topo = "0.1.2"
 pretty_env_logger = "0.4"
 rstest = "0.12.0"
 rstest_reuse = "0.1.3"
-wasm-bindgen-test = "0.3.28"
+wasm-bindgen-test = "0.3.30"
 
 [[bench]]
 name = "graph"


### PR DESCRIPTION
Pins all versions in `Cargo.toml` to avoid breaking the CI with silent and breaking dependency updates. Updates some dependencies, including `cddl-cat` with an security update.

Closes: #273 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
