### PR TITLE
Additions for aquadoggo dev

### DIFF
--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -207,13 +207,20 @@ impl From<Hash> for DocumentViewId {
 
 /// Convenience method converting a hash string into a document view id.
 ///
-/// Converts a hash string into a `DocumentViewId`, assuming that this document view only consists
-/// of one graph tip hash.
+/// Converts a string formatted document view id into a `DocumentViewId`. Expects
+/// multi-hash ids to be hash strings seperated by an `_` character.
 impl FromStr for DocumentViewId {
     type Err = HashError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::new(&[Hash::new(s)?.into()]))
+        let mut operations: Vec<OperationId> = Vec::new();
+        s.rsplit('_')
+            .try_for_each::<_, Result<(), Self::Err>>(|hash_str| {
+                let hash = Hash::new(hash_str)?;
+                operations.push(hash.into());
+                Ok(())
+            })?;
+        Ok(Self::new(&operations))
     }
 }
 
@@ -291,6 +298,7 @@ mod tests {
             .unwrap();
         let document_view_id = DocumentViewId::new(&[operation_1, operation_2]);
         assert_eq!(document_view_id.as_str(), "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543_0020d3235c8fe6f58608200851b83cd8482808eb81e4c6b4b17805bba57da9f16e79");
+        assert_eq!("0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543_0020d3235c8fe6f58608200851b83cd8482808eb81e4c6b4b17805bba57da9f16e79".parse::<DocumentViewId>().unwrap(), document_view_id);
     }
 
     #[rstest]

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -56,6 +56,16 @@ impl DocumentViewId {
         graph_tips
     }
 
+    /// Get a string representation of all graph tips in this view id.
+    pub fn as_str(&self) -> String {
+        let mut id_str = "".to_string();
+        for (i, operation_id) in self.sorted().iter().enumerate() {
+            let separator = if i == 0 { "" } else { "_" };
+            id_str += format!("{}{}", separator, operation_id.as_hash().as_str()).as_str();
+        }
+        id_str
+    }
+
     /// Returns a hash over the sorted graph tips constituting this view id.
     ///
     /// Use this as a unique identifier for a document if you need a value with a limited size. The
@@ -249,7 +259,7 @@ mod tests {
     }
 
     #[test]
-    fn string_representation() {
+    fn debug_representation() {
         let document_view_id = DEFAULT_HASH.parse::<DocumentViewId>().unwrap();
 
         assert_eq!(format!("{}", document_view_id), "496543");
@@ -262,6 +272,25 @@ mod tests {
             .unwrap();
         let view_id_unmerged = DocumentViewId::new(&[operation_1, operation_2]);
         assert_eq!(format!("{}", view_id_unmerged), "496543_f16e79");
+    }
+
+    #[test]
+    fn string_representation() {
+        let document_view_id = DEFAULT_HASH.parse::<DocumentViewId>().unwrap();
+
+        assert_eq!(
+            document_view_id.as_str(),
+            "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
+        );
+
+        let operation_1 = "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
+            .parse::<OperationId>()
+            .unwrap();
+        let operation_2 = "0020d3235c8fe6f58608200851b83cd8482808eb81e4c6b4b17805bba57da9f16e79"
+            .parse::<OperationId>()
+            .unwrap();
+        let document_view_id = DocumentViewId::new(&[operation_1, operation_2]);
+        assert_eq!(document_view_id.as_str(), "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543_0020d3235c8fe6f58608200851b83cd8482808eb81e4c6b4b17805bba57da9f16e79");
     }
 
     #[rstest]

--- a/p2panda-rs/src/operation/operation.rs
+++ b/p2panda-rs/src/operation/operation.rs
@@ -43,7 +43,7 @@ pub enum OperationAction {
 impl OperationAction {
     /// Returns the operation action as a string.
     #[allow(unused)]
-    fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match self {
             OperationAction::Create => "create",
             OperationAction::Update => "update",

--- a/p2panda-rs/src/operation/relation.rs
+++ b/p2panda-rs/src/operation/relation.rs
@@ -120,6 +120,9 @@ pub struct RelationList(Vec<DocumentId>);
 impl RelationList {
     /// Returns a new list of relations.
     pub fn new(relations: Vec<DocumentId>) -> Self {
+        let mut relations = relations;
+        relations.sort_by_key(|a| a.as_str().to_string());
+
         Self(relations)
     }
 
@@ -158,6 +161,9 @@ pub struct PinnedRelationList(Vec<DocumentViewId>);
 impl PinnedRelationList {
     /// Returns a new list of pinned relations.
     pub fn new(relations: Vec<DocumentViewId>) -> Self {
+        let mut relations = relations;
+        relations.sort_by_key(|a| a.as_str());
+
         Self(relations)
     }
 


### PR DESCRIPTION
- Implement `as_str()` method for `DocumentViewId`
- Handle multi-hash strings in `FromStr` conversion into `DocumentViewId`
- Sort hashes in `RelationList` and `PinnedRelationList` constructor
- Make `as_str()` method public in `OperationAction`

closes #305 #302

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
