### PR TITLE
Introduce `DocumentViewHash`, implement `Hash` for `DocumentViewId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Highlights are marked with a pancake 🥞
 - `StorageProvider` and associated traits for implementing storage solutions [#274](https://github.com/p2panda/p2panda/pull/274) `rs` 🥞
 - Implement `Display` trait for various structs [#281](https://github.com/p2panda/p2panda/pull/281) `rs`
 - Implement document view id hash as a limited-size identifier for document views [#277](https://github.com/p2panda/p2panda/pull/277) `rs`
+- Introduce `DocumentViewHash`, implement `Hash` for `DocumentViewId` [#313](https://github.com/p2panda/p2panda/pull/313) `rs`
 
 ## Changed
 

--- a/p2panda-rs/src/document/document_view_hash.rs
+++ b/p2panda-rs/src/document/document_view_hash.rs
@@ -14,8 +14,8 @@ use crate::hash::Hash;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DocumentViewHash(Hash);
 
-impl From<DocumentViewId> for DocumentViewHash {
-    fn from(document_view_id: DocumentViewId) -> Self {
+impl From<&DocumentViewId> for DocumentViewHash {
+    fn from(document_view_id: &DocumentViewId) -> Self {
         let graph_tip_bytes = document_view_id
             .sorted()
             .into_iter()
@@ -43,9 +43,9 @@ mod tests {
         #[from(random_operation_id)] operation_id_2: OperationId,
     ) {
         let view_id_1 = DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]);
-        let view_hash_1 = DocumentViewHash::from(view_id_1);
+        let view_hash_1 = DocumentViewHash::from(&view_id_1);
         let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]);
-        let view_hash_2 = DocumentViewHash::from(view_id_2);
+        let view_hash_2 = DocumentViewHash::from(&view_id_2);
         assert_eq!(view_hash_1, view_hash_2);
     }
 }

--- a/p2panda-rs/src/document/document_view_hash.rs
+++ b/p2panda-rs/src/document/document_view_hash.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use crate::document::DocumentViewId;
+use crate::hash::Hash;
+
+/// Contains a hash over the sorted graph tips constituting this view id.
+///
+/// Use this as a unique identifier for a document if you need a value with a limited size. The
+/// document view id itself grows with the number of graph tips that the document has, which may
+/// not be desirable for an identifier.
+///
+/// Keep in mind that when you refer to document views with this hash value it will not be possible
+/// to recover the document view id from it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DocumentViewHash(Hash);
+
+impl From<DocumentViewId> for DocumentViewHash {
+    fn from(document_view_id: DocumentViewId) -> Self {
+        let graph_tip_bytes = document_view_id
+            .sorted()
+            .into_iter()
+            .flat_map(|graph_tip| graph_tip.as_hash().to_bytes())
+            .collect();
+
+        // Unwrap here as the content should be validated at this point
+        Self(Hash::new_from_bytes(graph_tip_bytes).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use crate::document::DocumentViewId;
+    use crate::operation::OperationId;
+    use crate::test_utils::fixtures::random_operation_id;
+
+    use super::DocumentViewHash;
+
+    #[rstest]
+    fn document_view_hash(
+        #[from(random_operation_id)] operation_id_1: OperationId,
+        #[from(random_operation_id)] operation_id_2: OperationId,
+    ) {
+        let view_id_1 = DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]);
+        let view_hash_1 = DocumentViewHash::from(view_id_1);
+        let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]);
+        let view_hash_2 = DocumentViewHash::from(view_id_2);
+        assert_eq!(view_hash_1, view_hash_2);
+    }
+}

--- a/p2panda-rs/src/document/document_view_hash.rs
+++ b/p2panda-rs/src/document/document_view_hash.rs
@@ -14,6 +14,24 @@ use crate::hash::Hash;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DocumentViewHash(Hash);
 
+impl DocumentViewHash {
+    /// Creates a new instance of `DocumentViewHash`.
+    pub fn new(hash: Hash) -> Self {
+        Self(hash)
+    }
+
+    /// Returns the string representation of the document view hash.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<Hash> for DocumentViewHash {
+    fn from(hash: Hash) -> Self {
+        Self::new(hash)
+    }
+}
+
 impl From<&DocumentViewId> for DocumentViewHash {
     fn from(document_view_id: &DocumentViewId) -> Self {
         let graph_tip_bytes = document_view_id
@@ -23,7 +41,7 @@ impl From<&DocumentViewId> for DocumentViewHash {
             .collect();
 
         // Unwrap here as the content should be validated at this point
-        Self(Hash::new_from_bytes(graph_tip_bytes).unwrap())
+        Self::new(Hash::new_from_bytes(graph_tip_bytes).unwrap())
     }
 }
 
@@ -32,13 +50,14 @@ mod tests {
     use rstest::rstest;
 
     use crate::document::DocumentViewId;
+    use crate::hash::Hash;
     use crate::operation::OperationId;
-    use crate::test_utils::fixtures::random_operation_id;
+    use crate::test_utils::fixtures::{random_hash, random_operation_id};
 
     use super::DocumentViewHash;
 
     #[rstest]
-    fn document_view_hash(
+    fn equality_after_conversion(
         #[from(random_operation_id)] operation_id_1: OperationId,
         #[from(random_operation_id)] operation_id_2: OperationId,
     ) {
@@ -47,5 +66,11 @@ mod tests {
         let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]);
         let view_hash_2 = DocumentViewHash::from(&view_id_2);
         assert_eq!(view_hash_1, view_hash_2);
+    }
+
+    #[rstest]
+    fn str_representation(#[from(random_hash)] hash: Hash) {
+        let document_view_hash = DocumentViewHash::new(hash.clone());
+        assert_eq!(hash.as_str(), document_view_hash.as_str());
     }
 }

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -215,6 +215,9 @@ impl FromStr for DocumentViewId {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hash as StdHash;
+
     use rstest::rstest;
 
     use crate::hash::Hash;
@@ -297,6 +300,17 @@ mod tests {
         let view_id_1 = DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]);
         let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]);
         assert_eq!(view_id_1, view_id_2);
+    }
+
+    #[rstest]
+    fn hash_equality(
+        #[from(random_operation_id)] operation_id_1: OperationId,
+        #[from(random_operation_id)] operation_id_2: OperationId,
+    ) {
+        let mut hasher = DefaultHasher::default();
+        let view_id_1 = DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]);
+        let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]);
+        assert_eq!(view_id_1.hash(&mut hasher), view_id_2.hash(&mut hasher));
     }
 
     #[rstest]

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -65,23 +65,6 @@ impl DocumentViewId {
         }
         id_str
     }
-
-    /// Returns a hash over the sorted graph tips constituting this view id.
-    ///
-    /// Use this as a unique identifier for a document if you need a value with a limited size. The
-    /// document view id itself grows with the number of graph tips that the document has, which
-    /// may not be desirable for an identifier.
-    ///
-    /// Keep in mind that when you refer to document views with this hash value it will not be
-    /// possible to recover the document view id from it.
-    pub fn hash(&self) -> Hash {
-        let graph_tip_bytes = self
-            .sorted()
-            .into_iter()
-            .flat_map(|graph_tip| graph_tip.as_hash().to_bytes())
-            .collect();
-        Hash::new_from_bytes(graph_tip_bytes).unwrap()
-    }
 }
 
 impl fmt::Display for DocumentViewId {
@@ -91,6 +74,12 @@ impl fmt::Display for DocumentViewId {
             write!(f, "{}{}", separator, operation_id.as_hash().short_str())?;
         }
         Ok(())
+    }
+}
+
+impl std::hash::Hash for DocumentViewId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.sorted().hash(state);
     }
 }
 
@@ -207,8 +196,8 @@ impl From<Hash> for DocumentViewId {
 
 /// Convenience method converting a hash string into a document view id.
 ///
-/// Converts a string formatted document view id into a `DocumentViewId`. Expects
-/// multi-hash ids to be hash strings seperated by an `_` character.
+/// Converts a string formatted document view id into a `DocumentViewId`. Expects multi-hash ids to
+/// be hash strings seperated by an `_` character.
 impl FromStr for DocumentViewId {
     type Err = HashError;
 
@@ -268,7 +257,6 @@ mod tests {
     #[test]
     fn debug_representation() {
         let document_view_id = DEFAULT_HASH.parse::<DocumentViewId>().unwrap();
-
         assert_eq!(format!("{}", document_view_id), "496543");
 
         let operation_1 = "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
@@ -372,17 +360,5 @@ mod tests {
         );
 
         assert_eq!(result.unwrap_err().to_string(), expected_result.to_string());
-    }
-
-    #[rstest]
-    fn document_view_hash(
-        #[from(random_operation_id)] operation_id_1: OperationId,
-        #[from(random_operation_id)] operation_id_2: OperationId,
-    ) {
-        let view_id_1 = DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]);
-        assert!(view_id_1.hash().validate().is_ok());
-
-        let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]);
-        assert_eq!(view_id_1.hash(), view_id_2.hash());
     }
 }

--- a/p2panda-rs/src/document/mod.rs
+++ b/p2panda-rs/src/document/mod.rs
@@ -259,6 +259,7 @@
 mod document;
 mod document_id;
 mod document_view;
+mod document_view_hash;
 mod document_view_id;
 mod error;
 
@@ -267,5 +268,6 @@ use document::{build_graph, reduce};
 pub use document::{Document, DocumentBuilder};
 pub use document_id::DocumentId;
 pub use document_view::DocumentView;
+pub use document_view_hash::DocumentViewHash;
 pub use document_view_id::DocumentViewId;
 pub use error::{DocumentBuilderError, DocumentError, DocumentViewError};


### PR DESCRIPTION
Introduces new `DocumentViewHash` struct which contains hash representation of document view id. This lives better there as it is a) wrapping the `Hash` type, making clear what we're dealing with b) removes the `hash` method from `DocumentViewId` which collides with implementing the `std::hash::Hash` trait.

For our `std::hash::Hash` trait implementation we sort the array before in `DocumentViewId`, to make sure we respect our rules of data equality.

Closes: #312

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
