### PR TITLE
Automock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
+- Add `mockall` crate and create mocks for `EntryStore` and `LogStore` [#314](https://github.com/p2panda/p2panda/pull/314).
+
 ## Added
 
 - `Document` for sorting and reducing a graph of `Operations` [#169](https://github.com/p2panda/p2panda/pull/169) `rs` 🥞

--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -40,6 +40,7 @@ ed25519-dalek = "^1.0.1"
 hex = "^0.4.3"
 lazy_static = "^1.4.0"
 log = "^0.4"
+mockall = "0.11.0"
 regex = "^1.5.5"
 serde = { version = "^1.0.136", features = ["derive"] }
 serde-wasm-bindgen = "^0.4.2"

--- a/p2panda-rs/src/storage_provider/traits/entry_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/entry_store.rs
@@ -8,11 +8,13 @@ use crate::identity::Author;
 use crate::schema::SchemaId;
 use crate::storage_provider::errors::EntryStorageError;
 use crate::storage_provider::traits::AsStorageEntry;
+use mockall::automock;
 
 /// Trait which handles all storage actions relating to `Entry`.
 ///
 /// This trait should be implemented on the root storage provider struct. It's definitions make up
 /// the required methods for inserting and querying entries from storage.
+#[automock]
 #[async_trait]
 pub trait EntryStore<StorageEntry: AsStorageEntry> {
     /// Insert an entry into storage.

--- a/p2panda-rs/src/storage_provider/traits/entry_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/entry_store.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use bamboo_rs_core_ed25519_yasmf::entry::is_lipmaa_required;
+use mockall::automock;
 
 use crate::entry::LogId;
 use crate::entry::SeqNum;
@@ -8,7 +9,6 @@ use crate::identity::Author;
 use crate::schema::SchemaId;
 use crate::storage_provider::errors::EntryStorageError;
 use crate::storage_provider::traits::AsStorageEntry;
-use mockall::automock;
 
 /// Trait which handles all storage actions relating to `Entry`.
 ///

--- a/p2panda-rs/src/storage_provider/traits/log_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/log_store.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use async_trait::async_trait;
+use mockall::automock;
 
 use crate::document::DocumentId;
 use crate::entry::LogId;
@@ -12,6 +13,7 @@ use crate::storage_provider::traits::AsStorageLog;
 ///
 /// This trait should be implemented on the root storage provider struct. It's definitions
 /// make up the required methods for inserting and querying logs from storage.
+#[automock]
 #[async_trait]
 pub trait LogStore<StorageLog: AsStorageLog> {
     /// Insert a log into storage.
@@ -31,10 +33,10 @@ pub trait LogStore<StorageLog: AsStorageLog> {
     ///
     /// If no log has been previously registered for this document it
     /// automatically returns the next unused log_id.
-    async fn find_document_log_id(
+    async fn find_document_log_id<'a>(
         &self,
         author: &Author,
-        document_id: Option<&DocumentId>,
+        document_id: Option<&'a DocumentId>,
     ) -> Result<LogId, LogStorageError> {
         // Determine log_id for this document when a hash was given
         let document_log_id = match document_id {

--- a/p2panda-rs/src/storage_provider/traits/storage_provider.rs
+++ b/p2panda-rs/src/storage_provider/traits/storage_provider.rs
@@ -32,7 +32,6 @@ use crate::Validate;
 /// most of it's methods (`get_entry_args` and `publish_entry` are defined below). The only one
 /// which needs defining is `get_document_by_entry`. It is also possible to over-ride the default
 /// definitions for any of the trait methods.
-#[automock]
 #[async_trait]
 pub trait StorageProvider<StorageEntry: AsStorageEntry, StorageLog: AsStorageLog>:
     EntryStore<StorageEntry> + LogStore<StorageLog>

--- a/p2panda-rs/src/storage_provider/traits/storage_provider.rs
+++ b/p2panda-rs/src/storage_provider/traits/storage_provider.rs
@@ -32,6 +32,7 @@ use crate::Validate;
 /// most of it's methods (`get_entry_args` and `publish_entry` are defined below). The only one
 /// which needs defining is `get_document_by_entry`. It is also possible to over-ride the default
 /// definitions for any of the trait methods.
+#[automock]
 #[async_trait]
 pub trait StorageProvider<StorageEntry: AsStorageEntry, StorageLog: AsStorageLog>:
     EntryStore<StorageEntry> + LogStore<StorageLog>


### PR DESCRIPTION
I'd really like to be able to write tests that mock the `EntryStore` trait so that my tests don't have to hit a db.
How would you feel about this?

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
