### PR TITLE
Rename EntryStore methods to match other store naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Highlights are marked with a pancake 🥞
 - Update `Schema` implementation to make use of new `SchemaId` [#296](https://github.com/p2panda/p2panda/pull/296) `rs`
 - Require schema field definitions to specify a specific schema [#269](https://github.com/p2panda/p2panda/pull/269) `rs` 🥞
 - Methods for getting string representations of `OperationValue` field type and `OperationAction` [#303](https://github.com/p2panda/p2panda/pull/303) `rs`
+- Minor method renaming in `EntryStore` [323](https://github.com/p2panda/p2panda/pull/323) `rs`
 
 ## Fixed
 

--- a/p2panda-rs/src/storage_provider/traits/storage_provider.rs
+++ b/p2panda-rs/src/storage_provider/traits/storage_provider.rs
@@ -78,7 +78,7 @@ pub trait StorageProvider<StorageEntry: AsStorageEntry, StorageLog: AsStorageLog
 
         // Determine backlink and skiplink hashes for the next entry. To do this we need the latest
         // entry in this log
-        let entry_latest = self.latest_entry(params.author(), &log).await?;
+        let entry_latest = self.get_latest_entry(params.author(), &log).await?;
 
         match entry_latest.clone() {
             // An entry was found which serves as the backlink for the upcoming entry
@@ -191,7 +191,7 @@ pub trait StorageProvider<StorageEntry: AsStorageEntry, StorageLog: AsStorageLog
 
         // Already return arguments for next entry creation
         let entry_latest: StorageEntry = self
-            .latest_entry(&entry.author(), &entry.log_id())
+            .get_latest_entry(&entry.author(), &entry.log_id())
             .await?
             .unwrap();
         let entry_hash_skiplink = self.determine_next_skiplink(&entry_latest).await?;


### PR DESCRIPTION
Minor renaming so conventions match across stores `get_{x}_by_{y}()` etc...

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
