### PR TITLE
Require thread-safe error types in storage provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Highlights are marked with a pancake 🥞
 - Update `Schema` implementation to make use of new `SchemaId` [#296](https://github.com/p2panda/p2panda/pull/296) `rs`
 - Require schema field definitions to specify a specific schema [#269](https://github.com/p2panda/p2panda/pull/269) `rs` 🥞
 - Methods for getting string representations of `OperationValue` field type and `OperationAction` [#303](https://github.com/p2panda/p2panda/pull/303) `rs`
+- Require storage provider errors to be thread-safe [#324](https://github.com/p2panda/p2panda/pull/324)
 
 ## Fixed
 

--- a/p2panda-rs/src/lib.rs
+++ b/p2panda-rs/src/lib.rs
@@ -82,7 +82,7 @@ pub mod wasm;
 /// Trait used by p2panda structs to validate arguments.
 pub trait Validate {
     /// Validation error type.
-    type Error: std::fmt::Debug + std::error::Error + 'static;
+    type Error: std::fmt::Debug + std::error::Error + Send + Sync + 'static;
 
     /// Validates p2panda data type instance.
     fn validate(&self) -> Result<(), Self::Error>;

--- a/p2panda-rs/src/storage_provider/traits/models.rs
+++ b/p2panda-rs/src/storage_provider/traits/models.rs
@@ -17,7 +17,7 @@ pub trait AsStorageEntry:
     Sized + Clone + Send + Sync + Validate + PartialEq + std::fmt::Debug
 {
     /// The error type returned by this traits' methods.
-    type AsStorageEntryError: 'static + std::error::Error;
+    type AsStorageEntryError: 'static + std::error::Error + Send + Sync;
 
     /// Construct an instance of the struct implementing `AsStorageEntry`
     fn new(

--- a/p2panda-rs/src/storage_provider/traits/storage_provider.rs
+++ b/p2panda-rs/src/storage_provider/traits/storage_provider.rs
@@ -59,14 +59,14 @@ pub trait StorageProvider<StorageEntry: AsStorageEntry, StorageLog: AsStorageLog
     async fn get_document_by_entry(
         &self,
         entry_hash: &Hash,
-    ) -> Result<Option<DocumentId>, Box<dyn std::error::Error>>;
+    ) -> Result<Option<DocumentId>, Box<dyn std::error::Error + Send + Sync>>;
 
     /// Returns required data (backlink and skiplink entry hashes, last sequence number and the
     /// document's log_id) to encode a new bamboo entry.
     async fn get_entry_args(
         &self,
         params: &Self::EntryArgsRequest,
-    ) -> Result<Self::EntryArgsResponse, Box<dyn std::error::Error>> {
+    ) -> Result<Self::EntryArgsResponse, Box<dyn std::error::Error + Send + Sync>> {
         // Validate the entry args request parameters.
         params.validate()?;
 
@@ -109,7 +109,7 @@ pub trait StorageProvider<StorageEntry: AsStorageEntry, StorageLog: AsStorageLog
     async fn publish_entry(
         &self,
         params: &Self::PublishEntryRequest,
-    ) -> Result<Self::PublishEntryResponse, Box<dyn std::error::Error>> {
+    ) -> Result<Self::PublishEntryResponse, Box<dyn std::error::Error + Send + Sync>> {
         // Create a storage entry.
         let entry = StorageEntry::new(params.entry_signed(), params.operation_encoded())?;
         // Validate the entry (this also maybe happened in the above constructor)
@@ -248,7 +248,7 @@ pub mod tests {
         async fn get_document_by_entry(
             &self,
             entry_hash: &Hash,
-        ) -> Result<Option<DocumentId>, Box<dyn std::error::Error>> {
+        ) -> Result<Option<DocumentId>, Box<dyn std::error::Error + Sync + Send>> {
             let entries = self.entries.lock().unwrap();
 
             let entry = entries.iter().find(|entry| entry.hash() == *entry_hash);


### PR DESCRIPTION
In order for GraphQL request handlers to process storage provider errors they must implement `Send` + `Sync`.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
