### PR TITLE
Migrate across storage traits for operations from `aquadoggo`

### DIFF
--- a/p2panda-rs/src/storage_provider/errors.rs
+++ b/p2panda-rs/src/storage_provider/errors.rs
@@ -114,3 +114,19 @@ pub enum PublishEntryError {
     #[error("Invalid Entry and Operation pair with id {0}")]
     InvalidEntryWithOperation(Hash),
 }
+
+/// `OperationStore` errors.
+#[derive(thiserror::Error, Debug)]
+pub enum OperationStorageError {
+    /// Catch all error which implementers can use for passing their own errors up the chain.
+    #[error("Error occured in OperationStore: {0}")]
+    Custom(String),
+
+    /// A fatal error occured when performing a storage query.
+    #[error("A fatal error occured in OperationStore: {0}")]
+    FatalStorageError(String),
+
+    /// Error which originates in `insert_operation()` when the insertion fails.
+    #[error("Error occured when inserting an operation with id {0:?} into storage")]
+    InsertionError(OperationId),
+}

--- a/p2panda-rs/src/storage_provider/traits/mod.rs
+++ b/p2panda-rs/src/storage_provider/traits/mod.rs
@@ -4,6 +4,7 @@
 mod entry_store;
 mod log_store;
 mod models;
+mod operation_store;
 mod requests;
 mod responses;
 mod storage_provider;

--- a/p2panda-rs/src/storage_provider/traits/operation_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/operation_store.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use async_trait::async_trait;
+
+use crate::document::DocumentId;
+use crate::identity::Author;
+use crate::operation::{OperationAction, OperationFields, OperationId};
+use crate::schema::SchemaId;
+use crate::storage_provider::errors::OperationStorageError;
+
+pub type PreviousOperations = Vec<OperationId>;
+
+pub trait AsStorageOperation: Sized + Clone + Send + Sync {
+    /// The error type returned by this traits' methods.
+    type AsStorageOperationError: 'static + std::error::Error;
+
+    fn action(&self) -> OperationAction;
+
+    fn author(&self) -> Author;
+
+    fn document_id(&self) -> DocumentId;
+
+    fn fields(&self) -> Option<OperationFields>;
+
+    fn id(&self) -> OperationId;
+
+    fn previous_operations(&self) -> PreviousOperations;
+
+    fn schema_id(&self) -> SchemaId;
+}
+
+#[async_trait]
+pub trait OperationStore<StorageOperation: AsStorageOperation> {
+    /// Insert an operation into the db.
+    ///
+    /// The passed operation must implement the `AsStorageOperation` trait. Errors when
+    /// a fatal DB error occurs.
+    async fn insert_operation(
+        &self,
+        operation: &StorageOperation,
+    ) -> Result<(), OperationStorageError>;
+
+    /// Get an operation identified by it's OperationId.
+    ///
+    /// Returns a type implementing `AsStorageOperation` which includes `Author`, `DocumentId` and
+    /// `OperationId` metadata.
+    async fn get_operation_by_id(
+        &self,
+        id: OperationId,
+    ) -> Result<Option<StorageOperation>, OperationStorageError>;
+
+    /// Get the id of the document an operation is contained within.
+    ///
+    /// If no document was found, then this method returns a result wrapping
+    /// a None variant.
+    async fn get_document_by_operation_id(
+        &self,
+        id: OperationId,
+    ) -> Result<Option<DocumentId>, OperationStorageError>;
+
+    /// Get all operations which are part of a specific document.
+    ///
+    /// Returns a result containing a vector of operations. If no document
+    /// was found then an empty vecotr is returned. Errors if a fatal storage
+    /// error occured.
+    async fn get_operations_by_document_id(
+        &self,
+        id: &DocumentId,
+    ) -> Result<Vec<StorageOperation>, OperationStorageError>;
+}


### PR DESCRIPTION
- bring storage traits for operation into `p2panda-rs` (implemented in `aquadoggo` here:https://github.com/p2panda/aquadoggo/pull/103)  
 
## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
- [ ] Check if descriptions and terminology match `handbook` content (and visa-versa) 
