### PR TITLE
Use DocumentViewId for previous_operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Highlights are marked with a pancake 🥞
 - Additional constructor method for `OperationWithMeta` [322](https://github.com/p2panda/p2panda/pull/322) `rs`
 - Minor method renaming in `EntryStore` [323](https://github.com/p2panda/p2panda/pull/323) `rs`
 - Require storage provider errors to be thread-safe [#340](https://github.com/p2panda/p2panda/pull/340)
+- Make previous_operations a `DocumentViewId` [#342](https://github.com/p2panda/p2panda/pull/342) `rs`
 
 ## Fixed
 

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -280,13 +280,13 @@ mod tests {
     use rstest::rstest;
 
     use crate::document::document_view_fields::{DocumentViewFields, DocumentViewValue};
-    use crate::document::DocumentId;
+    use crate::document::{DocumentId, DocumentViewId};
     use crate::identity::KeyPair;
     use crate::operation::{OperationEncoded, OperationId, OperationValue, OperationWithMeta};
     use crate::schema::SchemaId;
     use crate::test_utils::fixtures::{
         create_operation, create_operation_with_meta, delete_operation, delete_operation_with_meta,
-        fields, random_key_pair, random_operation_id, schema, update_operation,
+        fields, random_document_view_id, random_key_pair, schema, update_operation,
         update_operation_with_meta,
     };
     use crate::test_utils::mocks::{send_to_node, Client, Node};
@@ -377,7 +377,7 @@ mod tests {
             &panda,
             &update_operation(
                 schema.clone(),
-                vec![panda_entry_1_hash.clone().into()],
+                panda_entry_1_hash.clone().into(),
                 fields(vec![(
                     "name",
                     OperationValue::Text("Panda Cafe!".to_string()),
@@ -396,7 +396,7 @@ mod tests {
             &penguin,
             &update_operation(
                 schema.clone(),
-                vec![panda_entry_1_hash.clone().into()],
+                panda_entry_1_hash.clone().into(),
                 fields(vec![(
                     "name",
                     OperationValue::Text("Penguin Cafe".to_string()),
@@ -415,10 +415,10 @@ mod tests {
             &penguin,
             &update_operation(
                 schema.clone(),
-                vec![
+                DocumentViewId::new(&[
                     penguin_entry_1_hash.clone().into(),
                     panda_entry_2_hash.clone().into(),
-                ],
+                ]),
                 fields(vec![(
                     "name",
                     OperationValue::Text("Polar Bear Cafe".to_string()),
@@ -436,7 +436,7 @@ mod tests {
             &penguin,
             &update_operation(
                 schema.clone(),
-                vec![penguin_entry_2_hash.clone().into()],
+                penguin_entry_2_hash.clone().into(),
                 fields(vec![(
                     "name",
                     OperationValue::Text("Polar Bear Cafe!!!!!!!!!!".to_string()),
@@ -605,7 +605,7 @@ mod tests {
             &panda,
             &update_operation(
                 schema,
-                vec![panda_entry_1_hash.into()],
+                panda_entry_1_hash.into(),
                 fields(vec![(
                     "name",
                     OperationValue::Text("Panda Cafe!".to_string()),
@@ -636,7 +636,7 @@ mod tests {
     fn incorrect_previous_operations(
         schema: SchemaId,
         #[from(random_key_pair)] key_pair_1: KeyPair,
-        #[from(random_operation_id)] incorrect_previous_operation: OperationId,
+        #[from(random_document_view_id)] incorrect_previous_operation: DocumentViewId,
     ) {
         let panda = Client::new("panda".to_string(), key_pair_1);
         let mut node = Node::new();
@@ -659,7 +659,7 @@ mod tests {
         // Construct an update operation with non-existant previous operations
         let operation_with_wrong_prev_ops = update_operation(
             schema,
-            vec![incorrect_previous_operation],
+            incorrect_previous_operation,
             fields(vec![(
                 "name",
                 OperationValue::Text("Panda Cafe!".to_string()),
@@ -724,7 +724,7 @@ mod tests {
             &panda,
             &update_operation(
                 SchemaId::new("schema_definition_v1").unwrap(),
-                vec![panda_entry_1_hash.into()],
+                panda_entry_1_hash.into(),
                 fields(vec![(
                     "name",
                     OperationValue::Text("Panda Cafe!".to_string()),
@@ -779,7 +779,7 @@ mod tests {
         send_to_node(
             &mut node,
             &panda,
-            &delete_operation(schema, vec![panda_entry_1_hash.into()]),
+            &delete_operation(schema, panda_entry_1_hash.into()),
         )
         .unwrap();
 
@@ -875,7 +875,7 @@ mod tests {
             &polar,
             &update_operation(
                 schema.clone(),
-                vec![polar_entry_1_hash.clone().into()],
+                polar_entry_1_hash.clone().into(),
                 operation_fields(vec![
                     ("name", OperationValue::Text("ʕ •ᴥ•ʔ Cafe!".to_string())),
                     ("owner", OperationValue::Text("しろくま".to_string())),
@@ -888,7 +888,7 @@ mod tests {
             &panda,
             &update_operation(
                 schema.clone(),
-                vec![polar_entry_1_hash.clone().into()],
+                polar_entry_1_hash.clone().into(),
                 operation_fields(vec![(
                     "name",
                     OperationValue::Text("🐼 Cafe!!".to_string()),
@@ -901,10 +901,10 @@ mod tests {
             &polar,
             &update_operation(
                 schema.clone(),
-                vec![
+                DocumentViewId::new(&[
                     panda_entry_1_hash.clone().into(),
                     polar_entry_2_hash.clone().into(),
-                ],
+                ]),
                 operation_fields(vec![("house-number", OperationValue::Integer(102))]),
             ),
         )
@@ -912,7 +912,7 @@ mod tests {
         let (polar_entry_4_hash, _) = send_to_node(
             &mut node,
             &polar,
-            &delete_operation(schema, vec![polar_entry_3_hash.clone().into()]),
+            &delete_operation(schema, polar_entry_3_hash.clone().into()),
         )
         .unwrap();
         let entry_1 = node.get_entry(&polar_entry_1_hash);

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -252,7 +252,7 @@ impl DocumentBuilder {
         };
 
         // Construct the document view id
-        let document_view_id = DocumentViewId::new(&graph_tips);
+        let document_view_id = DocumentViewId::new(&graph_tips).unwrap();
 
         // Construct the document view, from the reduced values and the document view id
         let document_view = if is_deleted {
@@ -418,7 +418,8 @@ mod tests {
                 DocumentViewId::new(&[
                     penguin_entry_1_hash.clone().into(),
                     panda_entry_2_hash.clone().into(),
-                ]),
+                ])
+                .unwrap(),
                 fields(vec![(
                     "name",
                     OperationValue::Text("Polar Bear Cafe".to_string()),
@@ -904,7 +905,8 @@ mod tests {
                 DocumentViewId::new(&[
                     panda_entry_1_hash.clone().into(),
                     polar_entry_2_hash.clone().into(),
-                ]),
+                ])
+                .unwrap(),
                 operation_fields(vec![("house-number", OperationValue::Integer(102))]),
             ),
         )

--- a/p2panda-rs/src/document/document_view.rs
+++ b/p2panda-rs/src/document/document_view.rs
@@ -86,8 +86,8 @@ mod tests {
     use crate::operation::{OperationId, OperationValue, OperationWithMeta, Relation};
     use crate::schema::SchemaId;
     use crate::test_utils::fixtures::{
-        create_operation, document_id, document_view_id, fields, public_key, random_operation_id,
-        schema, update_operation,
+        create_operation, document_id, document_view_id, fields, public_key,
+        random_document_view_id, random_operation_id, schema, update_operation,
     };
 
     use super::{DocumentView, DocumentViewId};
@@ -118,13 +118,13 @@ mod tests {
     #[fixture]
     fn test_update_operation(
         #[from(random_operation_id)] operation_id: OperationId,
-        #[from(random_operation_id)] prev_op_id: OperationId,
+        #[from(random_document_view_id)] prev_operations: DocumentViewId,
         schema: SchemaId,
         public_key: Author,
     ) -> OperationWithMeta {
         let operation = update_operation(
             schema,
-            vec![prev_op_id],
+            prev_operations,
             fields(vec![
                 ("age", OperationValue::Integer(29)),
                 ("is_admin", OperationValue::Boolean(true)),

--- a/p2panda-rs/src/document/document_view_hash.rs
+++ b/p2panda-rs/src/document/document_view_hash.rs
@@ -61,9 +61,10 @@ mod tests {
         #[from(random_operation_id)] operation_id_1: OperationId,
         #[from(random_operation_id)] operation_id_2: OperationId,
     ) {
-        let view_id_1 = DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]);
+        let view_id_1 =
+            DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]).unwrap();
         let view_hash_1 = DocumentViewHash::from(&view_id_1);
-        let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]);
+        let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]).unwrap();
         let view_hash_2 = DocumentViewHash::from(&view_id_2);
         assert_eq!(view_hash_1, view_hash_2);
     }

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -42,8 +42,10 @@ pub struct DocumentViewId(Vec<OperationId>);
 
 impl DocumentViewId {
     /// Create a new document view id.
-    pub fn new(graph_tips: &[OperationId]) -> Self {
-        Self(graph_tips.to_vec())
+    pub fn new(graph_tips: &[OperationId]) -> Result<Self, DocumentViewIdError> {
+        let document_view_id = Self(graph_tips.to_vec());
+        document_view_id.validate()?;
+        Ok(document_view_id)
     }
 
     /// Get the graph tip ids of this view id.
@@ -96,6 +98,10 @@ impl Validate for DocumentViewId {
 
     /// Checks that constituting operation ids are sorted and represent valid hashes.
     fn validate(&self) -> Result<(), Self::Error> {
+        if self.0.is_empty() {
+            return Err(DocumentViewIdError::ZeroOperationIds);
+        };
+
         for hash in &self.0 {
             hash.validate()?;
         }
@@ -153,7 +159,12 @@ impl<'de> Visitor<'de> for DocumentViewIdVisitor {
             prev_id = Some(operation_id);
         }
 
-        Ok(DocumentViewId::new(&op_ids))
+        let document_view_id = DocumentViewId::new(&op_ids);
+
+        match document_view_id {
+            Ok(id) => Ok(id),
+            Err(err) => Err(serde::de::Error::custom(err.to_string())),
+        }
     }
 }
 
@@ -182,7 +193,7 @@ impl IntoIterator for DocumentViewId {
 /// only consists of one graph tip hash.
 impl From<OperationId> for DocumentViewId {
     fn from(operation_id: OperationId) -> Self {
-        Self::new(&[operation_id])
+        Self::new(&[operation_id]).unwrap()
     }
 }
 
@@ -192,7 +203,7 @@ impl From<OperationId> for DocumentViewId {
 /// consists of one graph tip hash.
 impl From<Hash> for DocumentViewId {
     fn from(hash: Hash) -> Self {
-        Self::new(&[hash.into()])
+        Self::new(&[hash.into()]).unwrap()
     }
 }
 
@@ -211,7 +222,7 @@ impl FromStr for DocumentViewId {
                 operations.push(hash.into());
                 Ok(())
             })?;
-        Ok(Self::new(&operations))
+        Ok(Self::new(&operations).unwrap())
     }
 }
 
@@ -237,16 +248,19 @@ mod tests {
         let document_id: DocumentViewId = hash_str.parse().unwrap();
         assert_eq!(
             document_id,
-            DocumentViewId::new(&[hash_str.parse::<OperationId>().unwrap()])
+            DocumentViewId::new(&[hash_str.parse::<OperationId>().unwrap()]).unwrap()
         );
 
         // Converts a `Hash` to `DocumentViewId`
         let document_id: DocumentViewId = hash.clone().into();
-        assert_eq!(document_id, DocumentViewId::new(&[hash.clone().into()]));
+        assert_eq!(
+            document_id,
+            DocumentViewId::new(&[hash.clone().into()]).unwrap()
+        );
 
         // Converts an `OperationId` to `DocumentViewId`
         let document_id: DocumentViewId = OperationId::new(hash.clone()).into();
-        assert_eq!(document_id, DocumentViewId::new(&[hash.into()]));
+        assert_eq!(document_id, DocumentViewId::new(&[hash.into()]).unwrap());
 
         // Fails when string is not a hash
         assert!("This is not a hash".parse::<DocumentViewId>().is_err());
@@ -270,7 +284,7 @@ mod tests {
         let operation_2 = "0020d3235c8fe6f58608200851b83cd8482808eb81e4c6b4b17805bba57da9f16e79"
             .parse::<OperationId>()
             .unwrap();
-        let view_id_unmerged = DocumentViewId::new(&[operation_1, operation_2]);
+        let view_id_unmerged = DocumentViewId::new(&[operation_1, operation_2]).unwrap();
         assert_eq!(format!("{}", view_id_unmerged), "496543_f16e79");
     }
 
@@ -289,7 +303,7 @@ mod tests {
         let operation_2 = "0020d3235c8fe6f58608200851b83cd8482808eb81e4c6b4b17805bba57da9f16e79"
             .parse::<OperationId>()
             .unwrap();
-        let document_view_id = DocumentViewId::new(&[operation_1, operation_2]);
+        let document_view_id = DocumentViewId::new(&[operation_1, operation_2]).unwrap();
         assert_eq!(document_view_id.as_str(), "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543_0020d3235c8fe6f58608200851b83cd8482808eb81e4c6b4b17805bba57da9f16e79");
         assert_eq!("0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543_0020d3235c8fe6f58608200851b83cd8482808eb81e4c6b4b17805bba57da9f16e79".parse::<DocumentViewId>().unwrap(), document_view_id);
     }
@@ -299,8 +313,9 @@ mod tests {
         #[from(random_operation_id)] operation_id_1: OperationId,
         #[from(random_operation_id)] operation_id_2: OperationId,
     ) {
-        let view_id_1 = DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]);
-        let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]);
+        let view_id_1 =
+            DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]).unwrap();
+        let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]).unwrap();
         assert_eq!(view_id_1, view_id_2);
     }
 
@@ -311,8 +326,9 @@ mod tests {
     ) {
         let mut hasher_1 = DefaultHasher::default();
         let mut hasher_2 = DefaultHasher::default();
-        let view_id_1 = DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]);
-        let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]);
+        let view_id_1 =
+            DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]).unwrap();
+        let view_id_2 = DocumentViewId::new(&[operation_id_2, operation_id_1]).unwrap();
         view_id_1.hash(&mut hasher_1);
         view_id_2.hash(&mut hasher_2);
         assert_eq!(hasher_1.finish(), hasher_2.finish());
@@ -347,7 +363,7 @@ mod tests {
         let mut reversed_ids = vec![operation_id_1, operation_id_2];
         reversed_ids.sort();
         reversed_ids.reverse();
-        let view_id_unsorted = DocumentViewId::new(&reversed_ids);
+        let view_id_unsorted = DocumentViewId::new(&reversed_ids).unwrap();
 
         let mut cbor_bytes = Vec::new();
         ciborium::ser::into_writer(&view_id_unsorted, &mut cbor_bytes).unwrap();

--- a/p2panda-rs/src/document/error.rs
+++ b/p2panda-rs/src/document/error.rs
@@ -75,4 +75,8 @@ pub enum DocumentViewIdError {
     /// Handle errors from validating operation id hashes
     #[error(transparent)]
     InvalidOperationId(#[from] HashError),
+
+    /// Document view ids must contain at least one operation ids
+    #[error("Expected one or more operation ids")]
+    ZeroOperationIds,
 }

--- a/p2panda-rs/src/document/mod.rs
+++ b/p2panda-rs/src/document/mod.rs
@@ -20,7 +20,7 @@
 //! # use p2panda_rs::test_utils::utils::{create_operation, delete_operation, update_operation, operation_fields};
 //! # use p2panda_rs::test_utils::constants::TEST_SCHEMA_ID;
 //! # use p2panda_rs::test_utils::mocks::{send_to_node, Client, Node};
-//! use p2panda_rs::document::{DocumentBuilder, DocumentViewValue, DocumentViewFields};
+//! use p2panda_rs::document::{DocumentBuilder, DocumentViewValue, DocumentViewFields, DocumentViewId};
 //! #
 //! # let polar = Client::new(
 //! #     "polar".to_string(),
@@ -59,7 +59,7 @@
 //! #     &polar,
 //! #     &update_operation(
 //! #         schema.clone(),
-//! #         vec![polar_entry_1_hash.clone().into()],
+//! #         polar_entry_1_hash.clone().into(),
 //! #         operation_fields(vec![
 //! #             ("name", OperationValue::Text("ʕ •ᴥ•ʔ Cafe!".to_string())),
 //! #             ("owner", OperationValue::Text("しろくま".to_string())),
@@ -73,7 +73,7 @@
 //! #     &panda,
 //! #     &update_operation(
 //! #         schema.clone(),
-//! #         vec![polar_entry_1_hash.clone().into()],
+//! #         polar_entry_1_hash.clone().into(),
 //! #         operation_fields(vec![("name", OperationValue::Text("🐼 Cafe!!".to_string()))]),
 //! #     ),
 //! # )
@@ -84,7 +84,7 @@
 //! #     &polar,
 //! #     &update_operation(
 //! #         schema.clone(),
-//! #         vec![panda_entry_1_hash.clone().into(), polar_entry_2_hash.clone().into()],
+//! #         DocumentViewId::new(&[panda_entry_1_hash.clone().into(), polar_entry_2_hash.clone().into()]),
 //! #         operation_fields(vec![("house-number", OperationValue::Integer(102))]),
 //! #     ),
 //! # )
@@ -95,7 +95,7 @@
 //! #     &polar,
 //! #     &delete_operation(
 //! #         schema,
-//! #         vec![polar_entry_3_hash.clone().into()]
+//! #         polar_entry_3_hash.clone().into()
 //! #     ),
 //! # )
 //! # .unwrap();

--- a/p2panda-rs/src/document/mod.rs
+++ b/p2panda-rs/src/document/mod.rs
@@ -84,7 +84,7 @@
 //! #     &polar,
 //! #     &update_operation(
 //! #         schema.clone(),
-//! #         DocumentViewId::new(&[panda_entry_1_hash.clone().into(), polar_entry_2_hash.clone().into()]),
+//! #         DocumentViewId::new(&[panda_entry_1_hash.clone().into(), polar_entry_2_hash.clone().into()]).unwrap(),
 //! #         operation_fields(vec![("house-number", OperationValue::Integer(102))]),
 //! #     ),
 //! # )

--- a/p2panda-rs/src/operation/operation.rs
+++ b/p2panda-rs/src/operation/operation.rs
@@ -5,7 +5,8 @@ use std::hash::{Hash as StdHash, Hasher};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::operation::{OperationEncoded, OperationError, OperationFields, OperationId};
+use crate::document::DocumentViewId;
+use crate::operation::{OperationEncoded, OperationError, OperationFields};
 use crate::schema::SchemaId;
 use crate::Validate;
 
@@ -106,9 +107,10 @@ pub struct Operation {
     /// Version schema of this operation.
     version: OperationVersion,
 
-    /// Optional array of operation ids directly preceding this one in the document.
+    /// Optional DocumentViewId containing the operation ids directly preceding this one
+    /// in the document.
     #[serde(skip_serializing_if = "Option::is_none")]
-    previous_operations: Option<Vec<OperationId>>,
+    previous_operations: Option<DocumentViewId>,
 
     /// Optional fields map holding the operation data.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -161,7 +163,7 @@ impl Operation {
     /// Returns new UPDATE operation.
     pub fn new_update(
         schema: SchemaId,
-        previous_operations: Vec<OperationId>,
+        previous_operations: DocumentViewId,
         fields: OperationFields,
     ) -> Result<Self, OperationError> {
         let operation = Self {
@@ -180,7 +182,7 @@ impl Operation {
     /// Returns new DELETE operation.
     pub fn new_delete(
         schema: SchemaId,
-        previous_operations: Vec<OperationId>,
+        previous_operations: DocumentViewId,
     ) -> Result<Self, OperationError> {
         let operation = Self {
             action: OperationAction::Delete,
@@ -219,17 +221,16 @@ pub trait AsOperation {
     fn fields(&self) -> Option<OperationFields>;
 
     /// Returns vector of this operation's previous operation ids
-    fn previous_operations(&self) -> Option<Vec<OperationId>>;
+    fn previous_operations(&self) -> Option<DocumentViewId>;
 
     /// Returns true if operation contains fields.
     fn has_fields(&self) -> bool {
         self.fields().is_some()
     }
 
-    /// Returns true if previous_operations contains an vec which itself contains
-    /// at least one item.
+    /// Returns true if previous_operations contains a document view id.
     fn has_previous_operations(&self) -> bool {
-        self.previous_operations().is_some() && !self.previous_operations().unwrap().is_empty()
+        self.previous_operations().is_some()
     }
 
     /// Returns true when instance is CREATE operation.
@@ -270,7 +271,7 @@ impl AsOperation for Operation {
     }
 
     /// Returns known previous operations vector of this operation.
-    fn previous_operations(&self) -> Option<Vec<OperationId>> {
+    fn previous_operations(&self) -> Option<DocumentViewId> {
         self.previous_operations.clone()
     }
 }
@@ -337,11 +338,13 @@ mod tests {
     use rstest::rstest;
     use rstest_reuse::apply;
 
-    use crate::document::DocumentId;
-    use crate::operation::{OperationEncoded, OperationId, OperationValue, Relation};
+    use crate::document::{DocumentId, DocumentViewId};
+    use crate::operation::{OperationEncoded, OperationValue, Relation};
     use crate::schema::SchemaId;
     use crate::test_utils::fixtures::templates::many_valid_operations;
-    use crate::test_utils::fixtures::{fields, random_document_id, random_operation_id, schema};
+    use crate::test_utils::fixtures::{
+        fields, random_document_id, random_document_view_id, schema,
+    };
     use crate::Validate;
 
     use super::{AsOperation, Operation, OperationAction, OperationFields, OperationVersion};
@@ -357,7 +360,7 @@ mod tests {
     fn operation_validation(
         fields: OperationFields,
         schema: SchemaId,
-        #[from(random_operation_id)] prev_op_id: OperationId,
+        #[from(random_document_view_id)] prev_op_id: DocumentViewId,
     ) {
         let invalid_create_operation_1 = Operation {
             action: OperationAction::Create,
@@ -375,7 +378,7 @@ mod tests {
             version: OperationVersion::Default,
             schema: schema.clone(),
             // CREATE operations must not contain previous_operations
-            previous_operations: Some(vec![prev_op_id.clone()]), // Error
+            previous_operations: Some(prev_op_id.clone()), // Error
             fields: Some(fields.clone()),
         };
 
@@ -396,23 +399,12 @@ mod tests {
             action: OperationAction::Update,
             version: OperationVersion::Default,
             schema: schema.clone(),
-            previous_operations: Some(vec![prev_op_id.clone()]),
+            previous_operations: Some(prev_op_id.clone()),
             // UPDATE operations must contain fields
             fields: None, // Error
         };
 
         assert!(invalid_update_operation_2.validate().is_err());
-
-        let invalid_update_operation_3 = Operation {
-            action: OperationAction::Update,
-            version: OperationVersion::Default,
-            schema: schema.clone(),
-            // UPDATE operations must contain previous_operations containing at least one operation_id
-            previous_operations: Some(vec![]), // Error
-            fields: None,
-        };
-
-        assert!(invalid_update_operation_3.validate().is_err());
 
         let invalid_delete_operation_1 = Operation {
             action: OperationAction::Delete,
@@ -428,30 +420,19 @@ mod tests {
         let invalid_delete_operation_2 = Operation {
             action: OperationAction::Delete,
             version: OperationVersion::Default,
-            schema: schema.clone(),
-            previous_operations: Some(vec![prev_op_id]),
+            schema,
+            previous_operations: Some(prev_op_id),
             // DELETE operations must not contain fields
             fields: Some(fields), // Error
         };
 
         assert!(invalid_delete_operation_2.validate().is_err());
-
-        let invalid_delete_operation_3 = Operation {
-            action: OperationAction::Update,
-            version: OperationVersion::Default,
-            schema,
-            // DELETE operations must contain previous_operations containing at least one operation_id
-            previous_operations: Some(vec![]), // Error
-            fields: None,
-        };
-
-        assert!(invalid_delete_operation_3.validate().is_err());
     }
 
     #[rstest]
     fn encode_and_decode(
         schema: SchemaId,
-        #[from(random_operation_id)] prev_op_id: OperationId,
+        #[from(random_document_view_id)] prev_op_id: DocumentViewId,
         #[from(random_document_id)] document_id: DocumentId,
     ) {
         // Create test operation
@@ -477,7 +458,7 @@ mod tests {
             )
             .unwrap();
 
-        let operation = Operation::new_update(schema, vec![prev_op_id], fields).unwrap();
+        let operation = Operation::new_update(schema, prev_op_id, fields).unwrap();
 
         assert!(operation.is_update());
 

--- a/p2panda-rs/src/operation/operation_encoded.rs
+++ b/p2panda-rs/src/operation/operation_encoded.rs
@@ -78,7 +78,7 @@ mod tests {
     use crate::test_utils::fixtures::templates::version_fixtures;
     use crate::test_utils::fixtures::{
         encoded_create_string, fields, operation_encoded_invalid_relation_fields,
-        random_document_id, random_operation_id, schema, update_operation, Fixture,
+        random_document_id, random_document_view_id, schema, update_operation, Fixture,
     };
     use crate::Validate;
 
@@ -126,7 +126,7 @@ mod tests {
             // Schema hash
             schema.clone(),
             // Previous operations
-            vec![random_operation_id()],
+            random_document_view_id(),
             // Operation fields
             fields(vec![
               ("username", OperationValue::Text("bubu".to_owned())),

--- a/p2panda-rs/src/operation/operation_fields.rs
+++ b/p2panda-rs/src/operation/operation_fields.rs
@@ -170,10 +170,10 @@ mod tests {
         #[from(random_operation_id)] operation_id_5: OperationId,
         #[from(random_operation_id)] operation_id_6: OperationId,
     ) {
-        let document_view_id_1 = DocumentViewId::new(&[operation_id_1, operation_id_2]);
-        let document_view_id_2 = DocumentViewId::new(&[operation_id_3]);
+        let document_view_id_1 = DocumentViewId::new(&[operation_id_1, operation_id_2]).unwrap();
+        let document_view_id_2 = DocumentViewId::new(&[operation_id_3]).unwrap();
         let document_view_id_3 =
-            DocumentViewId::new(&[operation_id_4, operation_id_5, operation_id_6]);
+            DocumentViewId::new(&[operation_id_4, operation_id_5, operation_id_6]).unwrap();
 
         let relations = PinnedRelationList::new(vec![
             document_view_id_1,

--- a/p2panda-rs/src/operation/operation_meta.rs
+++ b/p2panda-rs/src/operation/operation_meta.rs
@@ -2,6 +2,7 @@
 
 use std::hash::Hash as StdHash;
 
+use crate::document::DocumentViewId;
 use crate::entry::{decode_entry, EntrySigned};
 use crate::identity::Author;
 use crate::operation::{
@@ -123,8 +124,8 @@ impl AsOperation for OperationWithMeta {
         self.operation.fields()
     }
 
-    /// Returns vector of previous operations.
-    fn previous_operations(&self) -> Option<Vec<OperationId>> {
+    /// Returns this operations previous_operations as a `DocumentViewId`.
+    fn previous_operations(&self) -> Option<DocumentViewId> {
         self.operation.previous_operations()
     }
 }

--- a/p2panda-rs/src/operation/operation_value.rs
+++ b/p2panda-rs/src/operation/operation_value.rs
@@ -117,10 +117,9 @@ mod tests {
             OperationValue::Relation(Relation::new(DocumentId::new(operation_id.clone())));
         assert_eq!(relation.field_type(), "relation");
 
-        let pinned_relation =
-            OperationValue::PinnedRelation(PinnedRelation::new(DocumentViewId::new(&[
-                operation_id.clone(),
-            ])));
+        let pinned_relation = OperationValue::PinnedRelation(PinnedRelation::new(
+            DocumentViewId::new(&[operation_id.clone()]).unwrap(),
+        ));
         assert_eq!(pinned_relation.field_type(), "pinned_relation");
 
         let relation_list = OperationValue::RelationList(RelationList::new(vec![DocumentId::new(
@@ -129,7 +128,7 @@ mod tests {
         assert_eq!(relation_list.field_type(), "relation_list");
 
         let pinned_relation_list = OperationValue::PinnedRelationList(PinnedRelationList::new(
-            vec![DocumentViewId::new(&[operation_id])],
+            vec![DocumentViewId::new(&[operation_id]).unwrap()],
         ));
         assert_eq!(pinned_relation_list.field_type(), "pinned_relation_list");
     }
@@ -154,11 +153,9 @@ mod tests {
         );
 
         // 2. Pinned relation
-        let pinned_relation =
-            OperationValue::PinnedRelation(PinnedRelation::new(DocumentViewId::new(&[
-                operation_2,
-                operation_3,
-            ])));
+        let pinned_relation = OperationValue::PinnedRelation(PinnedRelation::new(
+            DocumentViewId::new(&[operation_2, operation_3]).unwrap(),
+        ));
         assert_eq!(
             pinned_relation,
             OperationValue::deserialize_str(&pinned_relation.serialize())
@@ -177,8 +174,8 @@ mod tests {
         // 4. Pinned relation list
         let pinned_relation_list =
             OperationValue::PinnedRelationList(PinnedRelationList::new(vec![
-                DocumentViewId::new(&[operation_6, operation_7]),
-                DocumentViewId::new(&[operation_8]),
+                DocumentViewId::new(&[operation_6, operation_7]).unwrap(),
+                DocumentViewId::new(&[operation_8]).unwrap(),
             ]));
         assert_eq!(
             pinned_relation_list,
@@ -197,10 +194,9 @@ mod tests {
         let value = OperationValue::Relation(relation);
         assert!(value.validate().is_ok());
 
-        let pinned_relation = PinnedRelation::new(DocumentViewId::new(&[
-            operation_id_1.clone(),
-            operation_id_2.clone(),
-        ]));
+        let pinned_relation = PinnedRelation::new(
+            DocumentViewId::new(&[operation_id_1.clone(), operation_id_2.clone()]).unwrap(),
+        );
         let value = OperationValue::PinnedRelation(pinned_relation);
         assert!(value.validate().is_ok());
 

--- a/p2panda-rs/src/operation/relation.rs
+++ b/p2panda-rs/src/operation/relation.rs
@@ -229,10 +229,9 @@ mod tests {
 
     #[rstest]
     fn iterates(#[from(random_hash)] hash_1: Hash, #[from(random_hash)] hash_2: Hash) {
-        let pinned_relation = PinnedRelation::new(DocumentViewId::new(&[
-            hash_1.clone().into(),
-            hash_2.clone().into(),
-        ]));
+        let pinned_relation = PinnedRelation::new(
+            DocumentViewId::new(&[hash_1.clone().into(), hash_2.clone().into()]).unwrap(),
+        );
 
         for hash in pinned_relation {
             assert!(hash.validate().is_ok());

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -204,11 +204,12 @@ mod tests {
         // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         let fields = PinnedRelationList::new(vec![
-            DocumentViewId::new(&[relation_operation_id_1.clone()]),
+            DocumentViewId::new(&[relation_operation_id_1.clone()]).unwrap(),
             DocumentViewId::new(&[
                 relation_operation_id_2.clone(),
                 relation_operation_id_3.clone(),
-            ]),
+            ])
+            .unwrap(),
         ]);
 
         let schema_view = create_schema_view(&fields, &schema_view_id, &field_operation_id);
@@ -229,7 +230,7 @@ mod tests {
         let capacity_field_view = create_field(
             "capacity",
             "int",
-            &DocumentViewId::new(&[relation_operation_id_2, relation_operation_id_3]),
+            &DocumentViewId::new(&[relation_operation_id_2, relation_operation_id_3]).unwrap(),
             &field_operation_id,
         );
 

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -121,7 +121,7 @@ impl SchemaId {
 
         Ok(SchemaId::Application(
             remainder.to_string(),
-            DocumentViewId::new(&operation_ids),
+            DocumentViewId::new(&operation_ids).unwrap(),
         ))
     }
 

--- a/p2panda-rs/src/schema/system/schema_views.rs
+++ b/p2panda-rs/src/schema/system/schema_views.rs
@@ -218,7 +218,7 @@ mod tests {
             DocumentViewValue::new(
                 &operation_id,
                 &OperationValue::PinnedRelationList(PinnedRelationList::new(vec![
-                    DocumentViewId::new(&[relation]),
+                    DocumentViewId::new(&[relation]).unwrap(),
                 ])),
             ),
         );

--- a/p2panda-rs/src/storage_provider/traits/models.rs
+++ b/p2panda-rs/src/storage_provider/traits/models.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use crate::document::DocumentId;
+use crate::document::{DocumentId, DocumentViewId};
 use crate::entry::{EntrySigned, LogId, SeqNum};
 use crate::hash::Hash;
 use crate::identity::Author;
@@ -102,7 +102,7 @@ pub trait AsStorageOperation: Sized + Clone + Send + Sync {
     fn id(&self) -> OperationId;
 
     /// The previous operations for this operation.
-    fn previous_operations(&self) -> Vec<OperationId>;
+    fn previous_operations(&self) -> Option<DocumentViewId>;
 
     /// The id of the schema this operation follows.
     fn schema_id(&self) -> SchemaId;

--- a/p2panda-rs/src/storage_provider/traits/test_utils.rs
+++ b/p2panda-rs/src/storage_provider/traits/test_utils.rs
@@ -334,11 +334,11 @@ pub fn test_db(
 
         let update_operation = update_operation(
             schema.clone(),
-            vec![db_entries
+            db_entries
                 .get(seq_num.as_u64() as usize - 2)
                 .unwrap()
                 .hash()
-                .into()],
+                .into(),
             fields.clone(),
         );
 

--- a/p2panda-rs/src/test_utils/README.md
+++ b/p2panda-rs/src/test_utils/README.md
@@ -89,7 +89,7 @@ let (panda_entry_2_hash, next_entry_args) = send_to_node(
     &panda,
     &update_operation(
         SchemaId::new(TEST_SCHEMA_ID).unwrap(),
-        vec![panda_entry_1_hash.clone()], // The previous tip of this document graph
+        panda_entry_1_hash.clone().into(), // The previous tip of this document graph
         operation_fields(vec![(
             "cafe_name",
             OperationValue::Text("Panda Cafe!!".to_string()),
@@ -109,7 +109,7 @@ let (penguin_entry_1_hash, next_entry_args) = send_to_node(
     &penguin,
     &update_operation(
         SchemaId::new(TEST_SCHEMA_ID).unwrap(),
-        vec![panda_entry_2_hash],
+        panda_entry_2_hash.into(),
         operation_fields(vec![(
             "message",
             OperationValue::Text("Penguin Cafe".to_string()),

--- a/p2panda-rs/src/test_utils/fixtures/defaults.rs
+++ b/p2panda-rs/src/test_utils/fixtures/defaults.rs
@@ -43,7 +43,7 @@ pub fn create_operation() -> Operation {
 pub fn update_operation() -> Operation {
     fixtures::update_operation(
         fixtures::schema(TEST_SCHEMA_ID),
-        vec![fixtures::operation_id(DEFAULT_HASH)],
+        fixtures::document_view_id(vec![DEFAULT_HASH]),
         fields(),
     )
 }
@@ -52,7 +52,7 @@ pub fn update_operation() -> Operation {
 pub fn delete_operation() -> Operation {
     fixtures::delete_operation(
         fixtures::schema(TEST_SCHEMA_ID),
-        vec![fixtures::operation_id(DEFAULT_HASH)],
+        fixtures::document_view_id(vec![DEFAULT_HASH]),
     )
 }
 

--- a/p2panda-rs/src/test_utils/fixtures/params.rs
+++ b/p2panda-rs/src/test_utils/fixtures/params.rs
@@ -83,7 +83,7 @@ pub fn document_view_id(#[default(vec![DEFAULT_HASH])] hash_str_vec: Vec<&str>) 
         .into_iter()
         .map(|hash| hash.parse::<OperationId>().unwrap())
         .collect();
-    DocumentViewId::new(&hashes)
+    DocumentViewId::new(&hashes).unwrap()
 }
 
 /// Fixture which injects the default `OperationId` into a test method. Default value can be
@@ -115,7 +115,7 @@ pub fn random_document_id() -> DocumentId {
 /// Fixture which injects a random document view id into a test method.
 #[fixture]
 pub fn random_document_view_id() -> DocumentViewId {
-    DocumentViewId::new(&[random_hash().into(), random_hash().into()])
+    DocumentViewId::new(&[random_hash().into(), random_hash().into()]).unwrap()
 }
 
 /// Fixture which injects the default OperationFields value into a test method.

--- a/p2panda-rs/src/test_utils/fixtures/params.rs
+++ b/p2panda-rs/src/test_utils/fixtures/params.rs
@@ -112,6 +112,12 @@ pub fn random_document_id() -> DocumentId {
     DocumentId::new(random_hash().into())
 }
 
+/// Fixture which injects a random document view id into a test method.
+#[fixture]
+pub fn random_document_view_id() -> DocumentViewId {
+    DocumentViewId::new(&[random_hash().into(), random_hash().into()])
+}
+
 /// Fixture which injects the default OperationFields value into a test method.
 ///
 /// Default value can be overridden at testing time by passing in a custom vector of key-value
@@ -161,7 +167,7 @@ pub fn entry(
 #[fixture]
 pub fn operation(
     #[from(some_fields)] fields: Option<OperationFields>,
-    #[default(None)] previous_operations: Option<Vec<OperationId>>,
+    #[default(None)] previous_operations: Option<DocumentViewId>,
 ) -> Operation {
     utils::any_operation(fields, previous_operations)
 }
@@ -201,7 +207,7 @@ pub fn create_operation(schema: SchemaId, fields: OperationFields) -> Operation 
 #[fixture]
 pub fn update_operation(
     schema: SchemaId,
-    #[default(vec![operation_id(DEFAULT_HASH)])] previous_operations: Vec<OperationId>,
+    #[default(document_view_id(vec![DEFAULT_HASH]))] previous_operations: DocumentViewId,
     #[default(fields(vec![("message", OperationValue::Text("Updated, hello!".to_string()))]))]
     fields: OperationFields,
 ) -> Operation {
@@ -215,7 +221,7 @@ pub fn update_operation(
 #[fixture]
 pub fn delete_operation(
     schema: SchemaId,
-    #[default(vec![operation_id(DEFAULT_HASH)])] previous_operations: Vec<OperationId>,
+    #[default(document_view_id(vec![DEFAULT_HASH]))] previous_operations: DocumentViewId,
 ) -> Operation {
     utils::delete_operation(schema, previous_operations)
 }

--- a/p2panda-rs/src/test_utils/fixtures/templates.rs
+++ b/p2panda-rs/src/test_utils/fixtures/templates.rs
@@ -63,21 +63,21 @@ fn many_valid_entries(#[case] entry: Entry) {}
 #[allow(unused_qualifications)]
 #[case::update_operation_many_previous(crate::test_utils::utils::any_operation(
     Some(crate::test_utils::fixtures::defaults::fields()),
-    Some(vec![
+    Some(DocumentViewId::new(&[
         crate::test_utils::fixtures::random_operation_id(),
         crate::test_utils::fixtures::random_operation_id(),
         crate::test_utils::fixtures::random_operation_id()
-        ])
+        ]))
     )
 )]
 #[case::delete_operation_many_previous(crate::test_utils::utils::any_operation(
     None,
     #[allow(unused_qualifications)]
-    Some(vec![
+    Some(DocumentViewId::new(&[
         crate::test_utils::fixtures::random_operation_id(),
         crate::test_utils::fixtures::random_operation_id(),
         crate::test_utils::fixtures::random_operation_id()
-        ])
+        ]))
     )
 )]
 fn many_valid_operations(#[case] operation: Operation) {}

--- a/p2panda-rs/src/test_utils/fixtures/templates.rs
+++ b/p2panda-rs/src/test_utils/fixtures/templates.rs
@@ -67,7 +67,7 @@ fn many_valid_entries(#[case] entry: Entry) {}
         crate::test_utils::fixtures::random_operation_id(),
         crate::test_utils::fixtures::random_operation_id(),
         crate::test_utils::fixtures::random_operation_id()
-        ]))
+        ]).unwrap())
     )
 )]
 #[case::delete_operation_many_previous(crate::test_utils::utils::any_operation(
@@ -77,7 +77,7 @@ fn many_valid_entries(#[case] entry: Entry) {}
         crate::test_utils::fixtures::random_operation_id(),
         crate::test_utils::fixtures::random_operation_id(),
         crate::test_utils::fixtures::random_operation_id()
-        ]))
+        ]).unwrap())
     )
 )]
 fn many_valid_operations(#[case] operation: Operation) {}

--- a/p2panda-rs/src/test_utils/generate_test_data.rs
+++ b/p2panda-rs/src/test_utils/generate_test_data.rs
@@ -43,7 +43,7 @@ fn main() {
         &panda,
         &update_operation(
             schema_id.clone(),
-            vec![entry1_hash.into()],
+            entry1_hash.into(),
             operation_fields(vec![(
                 "message",
                 OperationValue::Text("Which I now update.".to_string()),
@@ -58,7 +58,7 @@ fn main() {
         &panda,
         &update_operation(
             schema_id.clone(),
-            vec![entry2_hash.into()],
+            entry2_hash.into(),
             operation_fields(vec![(
                 "message",
                 OperationValue::Text("And then update again.".to_string()),
@@ -71,7 +71,7 @@ fn main() {
     send_to_node(
         &mut node,
         &panda,
-        &delete_operation(schema_id, vec![entry3_hash.into()]),
+        &delete_operation(schema_id, entry3_hash.into()),
     )
     .unwrap();
 

--- a/p2panda-rs/src/test_utils/mocks/logs.rs
+++ b/p2panda-rs/src/test_utils/mocks/logs.rs
@@ -8,10 +8,11 @@
 use std::convert::TryFrom;
 use std::slice::Iter;
 
+use crate::document::DocumentViewId;
 use crate::entry::{decode_entry, EntrySigned, LogId, SeqNum};
 use crate::hash::Hash;
 use crate::identity::Author;
-use crate::operation::{AsOperation, Operation, OperationEncoded, OperationId};
+use crate::operation::{AsOperation, Operation, OperationEncoded};
 use crate::schema::SchemaId;
 
 /// Entry of an append-only which contains an encoded entry and operation.
@@ -64,7 +65,7 @@ impl LogEntry {
     }
 
     /// Get the previous operation hash for this entry.
-    pub fn previous_operations(&self) -> Option<Vec<OperationId>> {
+    pub fn previous_operations(&self) -> Option<DocumentViewId> {
         self.operation().previous_operations()
     }
 }

--- a/p2panda-rs/src/test_utils/mocks/node.rs
+++ b/p2panda-rs/src/test_utils/mocks/node.rs
@@ -905,7 +905,8 @@ mod tests {
             &penguin,
             &update_operation(
                 schema,
-                DocumentViewId::new(&[penguin_entry_1_hash.into(), panda_entry_2_hash.into()]),
+                DocumentViewId::new(&[penguin_entry_1_hash.into(), panda_entry_2_hash.into()])
+                    .unwrap(),
                 operation_fields(vec![(
                     "cafe_name",
                     OperationValue::Text("Polar Bear Café".to_string()),

--- a/p2panda-rs/src/test_utils/mocks/node.rs
+++ b/p2panda-rs/src/test_utils/mocks/node.rs
@@ -42,7 +42,7 @@
 //!     &panda,
 //!     &update_operation(
 //!         schema(TEST_SCHEMA_ID),
-//!         vec![document1_hash_id.clone().into()],
+//!         document1_hash_id.clone().into(),
 //!         operation_fields(vec![(
 //!             "message",
 //!             OperationValue::Text("Which I now update.".to_string()),
@@ -57,7 +57,7 @@
 //!     &panda,
 //!     &delete_operation(
 //!         schema(TEST_SCHEMA_ID),
-//!         vec![entry2_hash.into()]
+//!         entry2_hash.into()
 //!     )
 //! )
 //! .unwrap();
@@ -117,17 +117,10 @@ pub fn send_to_node(
             .previous_operations()
             .expect("UPDATE / DELETE operations must contain previous_operations");
 
-        // If it's an empty collection we have a problem as all UPDATE and DELETE operations
-        // must be pointing at other existing operations.
-        if previous_operations.is_empty() {
-            return Err(
-                "UPDATE / DELETE operations must have more than 1 previous operation".into(),
-            );
-        };
-
         // Using the first previous operation in the list we retrieve the associated document
         // id from the database.
-        let document_id = node.get_document_id_by_entry(previous_operations[0].as_hash());
+        let document_id = node
+            .get_document_id_by_entry(previous_operations.into_iter().next().unwrap().as_hash());
 
         Some(document_id.expect("This node does not contain the required document"))
     };
@@ -397,7 +390,7 @@ impl Node {
                 )
             });
             let document_id = self
-                .get_document_id_by_entry(previous_operations[0].as_hash())
+                .get_document_id_by_entry(previous_operations.into_iter().next().unwrap().as_hash())
                 .unwrap_or_else(|| {
                     panic!(
                         "Document log for entry {} not found on node",
@@ -515,6 +508,7 @@ impl Node {
 mod tests {
     use rstest::rstest;
 
+    use crate::document::DocumentViewId;
     use crate::entry::{LogId, SeqNum};
     use crate::identity::KeyPair;
     use crate::operation::OperationValue;
@@ -594,7 +588,7 @@ mod tests {
             &panda,
             &update_operation(
                 schema.clone(),
-                vec![panda_entry_1_hash.clone().into()],
+                panda_entry_1_hash.clone().into(),
                 operation_fields(vec![(
                     "message",
                     OperationValue::Text("Which I now update. [Panda]".to_string()),
@@ -646,7 +640,7 @@ mod tests {
             &penguin,
             &update_operation(
                 schema.clone(),
-                vec![panda_entry_2_hash.into()],
+                panda_entry_2_hash.into(),
                 operation_fields(vec![(
                     "message",
                     OperationValue::Text("My turn to update. [Penguin]".to_string()),
@@ -680,7 +674,7 @@ mod tests {
             &penguin,
             &update_operation(
                 schema.clone(),
-                vec![penguin_entry_1_hash.into()],
+                penguin_entry_1_hash.into(),
                 operation_fields(vec![(
                     "message",
                     OperationValue::Text("And again. [Penguin]".to_string()),
@@ -777,7 +771,7 @@ mod tests {
             &panda,
             &update_operation(
                 schema,
-                vec![entry1_hash.clone().into()],
+                entry1_hash.clone().into(),
                 operation_fields(vec![(
                     "message",
                     OperationValue::Text("Which I now update.".to_string()),
@@ -857,7 +851,7 @@ mod tests {
             &panda,
             &update_operation(
                 schema.clone(),
-                vec![panda_entry_1_hash.clone().into()],
+                panda_entry_1_hash.clone().into(),
                 operation_fields(vec![(
                     "cafe_name",
                     OperationValue::Text("Polar Bear Cafe".to_string()),
@@ -884,7 +878,7 @@ mod tests {
             &penguin,
             &update_operation(
                 schema.clone(),
-                vec![panda_entry_1_hash.clone().into()],
+                panda_entry_1_hash.clone().into(),
                 operation_fields(vec![(
                     "address",
                     OperationValue::Text("1, Polar Bear rd, Panda Town".to_string()),
@@ -911,7 +905,7 @@ mod tests {
             &penguin,
             &update_operation(
                 schema,
-                vec![penguin_entry_1_hash.into(), panda_entry_2_hash.into()],
+                DocumentViewId::new(&[penguin_entry_1_hash.into(), panda_entry_2_hash.into()]),
                 operation_fields(vec![(
                     "cafe_name",
                     OperationValue::Text("Polar Bear Café".to_string()),

--- a/p2panda-rs/src/test_utils/utils.rs
+++ b/p2panda-rs/src/test_utils/utils.rs
@@ -9,11 +9,12 @@
 //! into `rstest` defined methods.
 use serde::Serialize;
 
+use crate::document::DocumentViewId;
 use crate::entry::{Entry, EntrySigned, LogId, SeqNum};
 use crate::hash::Hash;
 use crate::identity::KeyPair;
 use crate::operation::{
-    Operation, OperationEncoded, OperationFields, OperationId, OperationValue, OperationWithMeta,
+    Operation, OperationEncoded, OperationFields, OperationValue, OperationWithMeta,
 };
 use crate::schema::SchemaId;
 use crate::test_utils::constants::TEST_SCHEMA_ID;
@@ -44,7 +45,7 @@ pub struct NextEntryArgs {
 /// provided, this is a DELETE operation.
 pub fn any_operation(
     fields: Option<OperationFields>,
-    previous_operations: Option<Vec<OperationId>>,
+    previous_operations: Option<DocumentViewId>,
 ) -> Operation {
     let schema_id = SchemaId::new(TEST_SCHEMA_ID).unwrap();
     match fields {
@@ -121,14 +122,14 @@ pub fn create_operation(schema: SchemaId, fields: OperationFields) -> Operation 
 /// Generate an UPDATE operation based on passed schema id, document id and operation fields.
 pub fn update_operation(
     schema: SchemaId,
-    previous_operations: Vec<OperationId>,
+    previous_operations: DocumentViewId,
     fields: OperationFields,
 ) -> Operation {
     Operation::new_update(schema, previous_operations, fields).unwrap()
 }
 
 /// Generate a DELETE operation based on passed schema id and document id.
-pub fn delete_operation(schema: SchemaId, previous_operations: Vec<OperationId>) -> Operation {
+pub fn delete_operation(schema: SchemaId, previous_operations: DocumentViewId) -> Operation {
     Operation::new_delete(schema, previous_operations).unwrap()
 }
 

--- a/p2panda-rs/src/wasm/operation.rs
+++ b/p2panda-rs/src/wasm/operation.rs
@@ -5,6 +5,7 @@ use std::convert::TryFrom;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
+use crate::document::DocumentViewId;
 use crate::operation::{
     Operation, OperationEncoded, OperationFields as OperationFieldsNonWasm, OperationId,
     OperationValue, PinnedRelation, PinnedRelationList, Relation, RelationList,
@@ -204,7 +205,8 @@ pub fn encode_update_operation(
         .map(|prev_op| prev_op.parse())
         .collect();
 
-    let previous = jserr!(prev_op_result);
+    let previous_ops = jserr!(prev_op_result);
+    let previous = jserr!(DocumentViewId::new(&previous_ops));
     let operation = jserr!(Operation::new_update(schema, previous, fields.0));
     let operation_encoded = jserr!(OperationEncoded::try_from(&operation));
     Ok(operation_encoded.as_str().to_owned())
@@ -230,7 +232,8 @@ pub fn encode_delete_operation(
         .map(|prev_op| prev_op.parse())
         .collect();
 
-    let previous = jserr!(prev_op_result);
+    let previous_ops = jserr!(prev_op_result);
+    let previous = jserr!(DocumentViewId::new(&previous_ops));
     let operation = jserr!(Operation::new_delete(schema, previous));
     let operation_encoded = jserr!(OperationEncoded::try_from(&operation));
     Ok(operation_encoded.as_str().to_owned())


### PR DESCRIPTION
- [x] make previous_operations a `DocumentViewId`
- [x] add validation  to `DocumentViewId` asserting it contains at least one operation id
- [x] make changes in `js` / `wasm` land

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
