### PR TITLE
Document store traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Highlights are marked with a pancake 🥞
 - Storage traits for `Operation` [#326](https://github.com/p2panda/p2panda/pull/326) `rs`
 - Implement schema hash id as a unique identifier for schemas `rs` [#282](https://github.com/p2panda/p2panda/pull/282) `rs`
 - `Graph` method for selecting sub-section of graph [#335](https://github.com/p2panda/p2panda/pull/335) `rs`
+- Storage traits for documents [#343](https://github.com/p2panda/p2panda/pull/343) `rs`
 
 ## Changed
 

--- a/p2panda-rs/src/storage_provider/errors.rs
+++ b/p2panda-rs/src/storage_provider/errors.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! Errors for `Storage` provider and associated traits.
+use crate::document::{DocumentId, DocumentViewId};
 use crate::entry::{EntryError, EntrySignedError, LogIdError, SeqNumError};
 use crate::hash::{Hash, HashError};
 use crate::identity::AuthorError;
@@ -129,4 +130,25 @@ pub enum OperationStorageError {
     /// Error returned when insertion of an operation is not possible due to database constraints.
     #[error("Error occured when inserting an operation with id {0:?} into storage")]
     InsertionError(OperationId),
+}
+
+/// `DocumentStore` errors.
+#[derive(thiserror::Error, Debug)]
+pub enum DocumentStorageError {
+    /// Catch all error which implementers can use for passing their own errors up the chain.
+    #[allow(dead_code)]
+    #[error("Error occured in DocumentStore: {0}")]
+    Custom(String),
+
+    /// A fatal error occured when performing a storage query.
+    #[error("A fatal error occured in DocumentStore: {0}")]
+    FatalStorageError(String),
+
+    /// Error which originates in `insert_document_view()` when the insertion fails.
+    #[error("Error occured when inserting a document view with id {0:?} into storage")]
+    DocumentViewInsertionError(DocumentViewId),
+
+    /// Error which originates in `insert_document()` when the insertion fails.
+    #[error("Error occured when inserting a document with id {0:?} into storage")]
+    DocumentInsertionError(DocumentId),
 }

--- a/p2panda-rs/src/storage_provider/traits/document_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/document_store.rs
@@ -7,6 +7,9 @@ use crate::schema::SchemaId;
 use crate::storage_provider::errors::DocumentStorageError;
 
 /// Storage traits for documents and document views.
+///
+/// This trait should be implemented on the root storage provider struct. It's definitions make up
+/// the required methods for inserting into and querying documents and document views from storage.
 #[async_trait]
 pub trait DocumentStore {
     /// Insert document view into storage.

--- a/p2panda-rs/src/storage_provider/traits/document_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/document_store.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use async_trait::async_trait;
+
+use crate::document::{Document, DocumentId, DocumentView, DocumentViewId};
+use crate::schema::SchemaId;
+use crate::storage_provider::errors::DocumentStorageError;
+
+/// Storage traits for documents and document views.
+#[async_trait]
+pub trait DocumentStore {
+    /// Insert document view into storage.
+    ///
+    /// returns an error when a fatal storage error occurs.
+    async fn insert_document_view(
+        &self,
+        document_view: &DocumentView,
+        schema_id: &SchemaId,
+    ) -> Result<(), DocumentStorageError>;
+
+    /// Get a document view from storage by it's `DocumentViewId`.
+    ///
+    /// Returns a DocumentView or `None` if no view was found with this id. Returns
+    /// an error if a fatal storage error occured.
+    async fn get_document_view_by_id(
+        &self,
+        id: &DocumentViewId,
+    ) -> Result<Option<DocumentView>, DocumentStorageError>;
+
+    /// Insert a document into storage.
+    ///
+    /// Inserts a document into storage and should retain a pointer to it's most recent
+    /// document view. Returns an error if a fatal storage error occured.
+    async fn insert_document(&self, document: &Document) -> Result<(), DocumentStorageError>;
+
+    /// Get the lates document view for a document identified by it's `DocumentId`.
+    ///
+    /// Returns a type implementing `AsDocumentView` wrapped in an `Option`, returns
+    /// `None` if no view was found with this document. Returns an error if a fatal storage error
+    /// occured.
+    ///
+    /// Note: if no view for this document was found, it might have been deleted.
+    async fn get_document_by_id(
+        &self,
+        id: &DocumentId,
+    ) -> Result<Option<DocumentView>, DocumentStorageError>;
+
+    /// Get the most recent view for all documents which follow the passed schema.
+    ///
+    /// Returns a vector of `DocumentView`, or an empty vector if none were found. Returns
+    /// an error when a fatal storage error occured.  
+    async fn get_documents_by_schema(
+        &self,
+        schema_id: &SchemaId,
+    ) -> Result<Vec<DocumentView>, DocumentStorageError>;
+}

--- a/p2panda-rs/src/storage_provider/traits/mod.rs
+++ b/p2panda-rs/src/storage_provider/traits/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! Traits used when implementing a custom storage provider for a p2panda client or node.
+mod document_store;
 mod entry_store;
 mod log_store;
 mod models;
@@ -11,6 +12,7 @@ mod storage_provider;
 #[cfg(test)]
 mod test_utils;
 
+pub use document_store::DocumentStore;
 pub use entry_store::EntryStore;
 pub use log_store::LogStore;
 pub use models::{AsStorageEntry, AsStorageLog, AsStorageOperation};


### PR DESCRIPTION
Adds storage provider traits for document store ([previously living in `aquadoggo`](https://github.com/p2panda/aquadoggo/pull/133)).

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
