### PR TITLE
Rename `OperationWithMeta` and related trait refactoring

### DIFF
--- a/p2panda-rs/src/document/document_view.rs
+++ b/p2panda-rs/src/document/document_view.rs
@@ -82,7 +82,7 @@ mod tests {
 
     use crate::document::document_view_fields::DocumentViewValue;
     use crate::document::{reduce, DocumentId};
-    use crate::operation::{OperationValue, OperationWithMeta, Relation};
+    use crate::operation::{AsVerifiedOperation, OperationValue, Relation, VerifiedOperation};
     use crate::test_utils::constants::DEFAULT_HASH;
     use crate::test_utils::fixtures::{
         document_id, document_view_id, operation_fields, operation_with_meta,
@@ -92,7 +92,7 @@ mod tests {
 
     #[rstest]
     fn from_single_create_op(
-        operation_with_meta: OperationWithMeta,
+        operation_with_meta: VerifiedOperation,
         document_view_id: DocumentViewId,
     ) {
         let expected_relation = Relation::new(DEFAULT_HASH.parse().unwrap());
@@ -158,7 +158,7 @@ mod tests {
 
     #[rstest]
     fn with_update_op(
-        #[from(operation_with_meta)] create_operation: OperationWithMeta,
+        #[from(operation_with_meta)] create_operation: VerifiedOperation,
         #[from(operation_with_meta)]
         #[with(Some(operation_fields(vec![
             ("username", OperationValue::Text("yahoo".to_owned())),
@@ -166,7 +166,7 @@ mod tests {
             ("age", OperationValue::Integer(12)),
             ("is_admin", OperationValue::Boolean(true)),
         ])), Some(DEFAULT_HASH.parse().unwrap()))]
-        update_operation: OperationWithMeta,
+        update_operation: VerifiedOperation,
         document_view_id: DocumentViewId,
         #[from(document_id)] relation_id: DocumentId,
     ) {

--- a/p2panda-rs/src/document/document_view_fields.rs
+++ b/p2panda-rs/src/document/document_view_fields.rs
@@ -4,7 +4,8 @@ use std::collections::btree_map::Iter;
 use std::collections::BTreeMap;
 
 use crate::operation::{
-    AsOperation, OperationFields, OperationId, OperationValue, OperationWithMeta,
+    AsOperation, AsVerifiedOperation, OperationFields, OperationId, OperationValue,
+    VerifiedOperation,
 };
 
 /// The current value of a document fiew field as well as the id of the operation it came from.
@@ -96,8 +97,8 @@ impl Default for DocumentViewFields {
     }
 }
 
-impl From<OperationWithMeta> for DocumentViewFields {
-    fn from(operation: OperationWithMeta) -> Self {
+impl From<VerifiedOperation> for DocumentViewFields {
+    fn from(operation: VerifiedOperation) -> Self {
         let mut document_view_fields = DocumentViewFields::new();
 
         if let Some(fields) = operation.fields() {
@@ -118,7 +119,9 @@ mod tests {
     use rstest::rstest;
 
     use crate::document::{DocumentViewFields, DocumentViewValue};
-    use crate::operation::{AsOperation, OperationId, OperationValue, OperationWithMeta};
+    use crate::operation::{
+        AsOperation, AsVerifiedOperation, OperationId, OperationValue, VerifiedOperation,
+    };
     use crate::test_utils::fixtures::{operation_with_meta, random_operation_id};
 
     #[rstest]
@@ -154,14 +157,14 @@ mod tests {
     }
 
     #[rstest]
-    fn from_meta_operation(operation_with_meta: OperationWithMeta) {
+    fn from_meta_operation(operation_with_meta: VerifiedOperation) {
         let document_view_fields = DocumentViewFields::from(operation_with_meta.clone());
         let operation_fields = operation_with_meta.operation().fields().unwrap();
         assert_eq!(document_view_fields.len(), operation_fields.len());
     }
 
     #[rstest]
-    fn new_from_operation_fields(operation_with_meta: OperationWithMeta) {
+    fn new_from_operation_fields(operation_with_meta: VerifiedOperation) {
         let document_view_fields = DocumentViewFields::new_from_operation_fields(
             operation_with_meta.operation_id(),
             &operation_with_meta.operation().fields().unwrap(),

--- a/p2panda-rs/src/document/mod.rs
+++ b/p2panda-rs/src/document/mod.rs
@@ -15,7 +15,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # use p2panda_rs::hash::Hash;
 //! # use p2panda_rs::identity::KeyPair;
-//! # use p2panda_rs::operation::{OperationValue, OperationWithMeta};
+//! # use p2panda_rs::operation::{OperationValue, VerifiedOperation, AsVerifiedOperation};
 //! # use p2panda_rs::schema::SchemaId;
 //! # use p2panda_rs::test_utils::fixtures::{create_operation, delete_operation, update_operation, operation_fields};
 //! # use p2panda_rs::test_utils::constants::TEST_SCHEMA_ID;
@@ -94,19 +94,19 @@
 //! #
 //! # let entry_1 = node.get_entry(&polar_entry_1_hash);
 //! # let operation_1 =
-//! #     OperationWithMeta::new_from_entry(&entry_1.entry_encoded(), &entry_1.operation_encoded()).unwrap();
+//! #     VerifiedOperation::new_from_entry(&entry_1.entry_encoded(), &entry_1.operation_encoded()).unwrap();
 //! # let entry_2 = node.get_entry(&polar_entry_2_hash);
 //! # let operation_2 =
-//! #     OperationWithMeta::new_from_entry(&entry_2.entry_encoded(), &entry_2.operation_encoded()).unwrap();
+//! #     VerifiedOperation::new_from_entry(&entry_2.entry_encoded(), &entry_2.operation_encoded()).unwrap();
 //! # let entry_3 = node.get_entry(&panda_entry_1_hash);
 //! # let operation_3 =
-//! #     OperationWithMeta::new_from_entry(&entry_3.entry_encoded(), &entry_3.operation_encoded()).unwrap();
+//! #     VerifiedOperation::new_from_entry(&entry_3.entry_encoded(), &entry_3.operation_encoded()).unwrap();
 //! # let entry_4 = node.get_entry(&polar_entry_3_hash);
 //! # let operation_4 =
-//! #     OperationWithMeta::new_from_entry(&entry_4.entry_encoded(), &entry_4.operation_encoded()).unwrap();
+//! #     VerifiedOperation::new_from_entry(&entry_4.entry_encoded(), &entry_4.operation_encoded()).unwrap();
 //! # let entry_5 = node.get_entry(&polar_entry_4_hash);
 //! # let operation_5 =
-//! #     OperationWithMeta::new_from_entry(&entry_5.entry_encoded(), &entry_5.operation_encoded()).unwrap();
+//! #     VerifiedOperation::new_from_entry(&entry_5.entry_encoded(), &entry_5.operation_encoded()).unwrap();
 //! #
 //! //== Operation creation is hidden for brevity, see the operation module docs for details ==//
 //!

--- a/p2panda-rs/src/operation/error.rs
+++ b/p2panda-rs/src/operation/error.rs
@@ -49,9 +49,9 @@ pub enum OperationEncodedError {
     InvalidHexEncoding,
 }
 
-/// Error types for methods of `OperationWithMeta` struct.
+/// Error types for methods of `VerifiedOperation` struct.
 #[derive(Error, Debug)]
-pub enum OperationWithMetaError {
+pub enum VerifiedOperationError {
     /// Invalid encoded entry found.
     #[error(transparent)]
     EntrySignedError(#[from] crate::entry::EntrySignedError),

--- a/p2panda-rs/src/operation/mod.rs
+++ b/p2panda-rs/src/operation/mod.rs
@@ -10,17 +10,19 @@ mod operation;
 mod operation_encoded;
 mod operation_fields;
 mod operation_id;
-mod operation_meta;
 mod operation_value;
 mod relation;
+mod traits;
+mod verified_operation;
 
 pub use error::{
-    OperationEncodedError, OperationError, OperationFieldsError, OperationWithMetaError,
+    OperationEncodedError, OperationError, OperationFieldsError, VerifiedOperationError,
 };
-pub use operation::{AsOperation, Operation, OperationAction, OperationVersion};
+pub use operation::{Operation, OperationAction, OperationVersion};
 pub use operation_encoded::OperationEncoded;
 pub use operation_fields::OperationFields;
 pub use operation_id::OperationId;
-pub use operation_meta::OperationWithMeta;
 pub use operation_value::OperationValue;
 pub use relation::{PinnedRelation, PinnedRelationList, Relation, RelationList};
+pub use traits::{AsOperation, AsVerifiedOperation};
+pub use verified_operation::VerifiedOperation;

--- a/p2panda-rs/src/operation/operation.rs
+++ b/p2panda-rs/src/operation/operation.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::document::DocumentViewId;
-use crate::operation::{OperationEncoded, OperationError, OperationFields};
+use crate::operation::{AsOperation, OperationEncoded, OperationError, OperationFields};
 use crate::schema::SchemaId;
 use crate::Validate;
 
@@ -205,50 +205,6 @@ impl Operation {
     }
 }
 
-/// Shared methods for [`Operation`] and
-/// [`OperationWithMeta`][crate::operation::OperationWithMeta].
-pub trait AsOperation {
-    /// Returns action type of operation.
-    fn action(&self) -> OperationAction;
-
-    /// Returns schema of operation.
-    fn schema(&self) -> SchemaId;
-
-    /// Returns version of operation.
-    fn version(&self) -> OperationVersion;
-
-    /// Returns application data fields of operation.
-    fn fields(&self) -> Option<OperationFields>;
-
-    /// Returns vector of this operation's previous operation ids
-    fn previous_operations(&self) -> Option<DocumentViewId>;
-
-    /// Returns true if operation contains fields.
-    fn has_fields(&self) -> bool {
-        self.fields().is_some()
-    }
-
-    /// Returns true if previous_operations contains a document view id.
-    fn has_previous_operations(&self) -> bool {
-        self.previous_operations().is_some()
-    }
-
-    /// Returns true when instance is CREATE operation.
-    fn is_create(&self) -> bool {
-        self.action() == OperationAction::Create
-    }
-
-    /// Returns true when instance is UPDATE operation.
-    fn is_update(&self) -> bool {
-        self.action() == OperationAction::Update
-    }
-
-    /// Returns true when instance is DELETE operation.
-    fn is_delete(&self) -> bool {
-        self.action() == OperationAction::Delete
-    }
-}
-
 impl AsOperation for Operation {
     /// Returns action type of operation.
     fn action(&self) -> OperationAction {
@@ -339,7 +295,7 @@ mod tests {
     use rstest_reuse::apply;
 
     use crate::document::{DocumentId, DocumentViewId};
-    use crate::operation::{OperationEncoded, OperationValue, Relation};
+    use crate::operation::{AsOperation, OperationEncoded, OperationValue, Relation};
     use crate::schema::SchemaId;
     use crate::test_utils::fixtures::{
         operation_fields, random_document_id, random_document_view_id, schema,
@@ -347,7 +303,7 @@ mod tests {
     use crate::test_utils::templates::many_valid_operations;
     use crate::Validate;
 
-    use super::{AsOperation, Operation, OperationAction, OperationFields, OperationVersion};
+    use super::{Operation, OperationAction, OperationFields, OperationVersion};
 
     #[test]
     fn stringify_action() {

--- a/p2panda-rs/src/operation/traits.rs
+++ b/p2panda-rs/src/operation/traits.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use crate::document::DocumentViewId;
+use crate::identity::Author;
+use crate::operation::{
+    Operation, OperationAction, OperationFields, OperationId, OperationVersion,
+};
+use crate::schema::SchemaId;
+
+pub trait AsOperation {
+    /// Returns action type of operation.
+    fn action(&self) -> OperationAction;
+
+    /// Returns schema of operation.
+    fn schema(&self) -> SchemaId;
+
+    /// Returns version of operation.
+    fn version(&self) -> OperationVersion;
+
+    /// Returns application data fields of operation.
+    fn fields(&self) -> Option<OperationFields>;
+
+    /// Returns vector of this operation's previous operation ids
+    fn previous_operations(&self) -> Option<DocumentViewId>;
+
+    /// Returns true if operation contains fields.
+    fn has_fields(&self) -> bool {
+        self.fields().is_some()
+    }
+
+    /// Returns true if previous_operations contains a document view id.
+    fn has_previous_operations(&self) -> bool {
+        self.previous_operations().is_some()
+    }
+
+    /// Returns true when instance is CREATE operation.
+    fn is_create(&self) -> bool {
+        self.action() == OperationAction::Create
+    }
+
+    /// Returns true when instance is UPDATE operation.
+    fn is_update(&self) -> bool {
+        self.action() == OperationAction::Update
+    }
+
+    /// Returns true when instance is DELETE operation.
+    fn is_delete(&self) -> bool {
+        self.action() == OperationAction::Delete
+    }
+}
+
+pub trait AsVerifiedOperation {
+    /// Returns the identifier for this operation.
+    fn operation_id(&self) -> &OperationId;
+
+    /// Returns the public key of the author of this operation.
+    fn public_key(&self) -> &Author;
+
+    /// Returns the wrapped operation.
+    fn operation(&self) -> &Operation;
+}
+
+impl<T: AsVerifiedOperation> AsOperation for T {
+    /// Returns action type of operation.
+    fn action(&self) -> OperationAction {
+        self.operation().action()
+    }
+
+    /// Returns schema of operation.
+    fn schema(&self) -> SchemaId {
+        self.operation().schema()
+    }
+
+    /// Returns version of operation.
+    fn version(&self) -> OperationVersion {
+        self.operation().version()
+    }
+
+    /// Returns application data fields of operation.
+    fn fields(&self) -> Option<OperationFields> {
+        self.operation().fields()
+    }
+
+    /// Returns vector of this operation's previous operation ids
+    fn previous_operations(&self) -> Option<DocumentViewId> {
+        self.operation().previous_operations()
+    }
+}

--- a/p2panda-rs/src/operation/traits.rs
+++ b/p2panda-rs/src/operation/traits.rs
@@ -7,6 +7,7 @@ use crate::operation::{
 };
 use crate::schema::SchemaId;
 
+/// Trait to be implemented on `Operation` and `VerifiedOperation` structs.
 pub trait AsOperation {
     /// Returns action type of operation.
     fn action(&self) -> OperationAction;

--- a/p2panda-rs/src/operation/traits.rs
+++ b/p2panda-rs/src/operation/traits.rs
@@ -49,6 +49,15 @@ pub trait AsOperation {
     }
 }
 
+/// Trait to be implemented on a struct representing an operation which has been encoded and
+/// published on a signed entry.
+///
+/// Contains the values of an operation as well as it's author and id. The reason an unpublished
+/// operation has no id is that the id is derived from the hash of the signed entry an operation is
+/// encoded on.
+///
+/// StorageProvider implementations should implement this for a data structure that represents an
+/// operation as it is stored in the database.
 pub trait AsVerifiedOperation {
     /// Returns the identifier for this operation.
     fn operation_id(&self) -> &OperationId;

--- a/p2panda-rs/src/operation/verified_operation.rs
+++ b/p2panda-rs/src/operation/verified_operation.rs
@@ -9,7 +9,7 @@ use crate::Validate;
 
 use super::OperationId;
 
-/// An operation which has been encoded on a signed entry.
+/// An operation which has been encoded and published on a signed entry.
 ///
 /// Contains the values of an operation as well as it's author and id. The reason an unpublished
 /// operation has no id is that the id is derived from the hash of the signed entry an operation is

--- a/p2panda-rs/src/operation/verified_operation.rs
+++ b/p2panda-rs/src/operation/verified_operation.rs
@@ -9,8 +9,11 @@ use crate::Validate;
 
 use super::OperationId;
 
-/// Wrapper struct containing an operation, its operation id, and the public key of its
-/// author.
+/// An operation which has been encoded on a signed entry.
+///
+/// Contains the values of an operation as well as it's author and id. The reason an unpublished
+/// operation has no id is that the id is derived from the hash of the signed entry an operation is
+/// encoded on.
 #[derive(Debug, Clone, Eq, PartialEq, StdHash)]
 pub struct VerifiedOperation {
     /// The hash of this operation's entry.

--- a/p2panda-rs/src/storage_provider/traits/mod.rs
+++ b/p2panda-rs/src/storage_provider/traits/mod.rs
@@ -15,7 +15,7 @@ mod test_utils;
 pub use document_store::DocumentStore;
 pub use entry_store::EntryStore;
 pub use log_store::LogStore;
-pub use models::{AsStorageEntry, AsStorageLog, AsStorageOperation};
+pub use models::{AsStorageEntry, AsStorageLog};
 pub use operation_store::OperationStore;
 pub use requests::{AsEntryArgsRequest, AsPublishEntryRequest};
 pub use responses::{AsEntryArgsResponse, AsPublishEntryResponse};

--- a/p2panda-rs/src/storage_provider/traits/models.rs
+++ b/p2panda-rs/src/storage_provider/traits/models.rs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use crate::document::{DocumentId, DocumentViewId};
+use crate::document::DocumentId;
 use crate::entry::{EntrySigned, LogId, SeqNum};
 use crate::hash::Hash;
 use crate::identity::Author;
-use crate::operation::{
-    Operation, OperationAction, OperationEncoded, OperationFields, OperationId,
-};
+use crate::operation::{Operation, OperationEncoded};
 use crate::schema::SchemaId;
 use crate::Validate;
 

--- a/p2panda-rs/src/storage_provider/traits/models.rs
+++ b/p2panda-rs/src/storage_provider/traits/models.rs
@@ -74,36 +74,36 @@ pub trait AsStorageLog: Sized + Send + Sync {
     fn schema_id(&self) -> SchemaId;
 }
 
-/// Trait to be implemented on a struct representing a stored operation.
-///
-/// Contains the values of an operation as well as it's author, it's id, and the id of
-/// it's document.
-///
-/// Storage implementations should implement this for a data structure that represents an
-/// operation as it is stored in the database. This trait defines methods for reading
-/// values from the operation and some meta data.
-pub trait AsStorageOperation: Sized + Clone + Send + Sync {
-    /// The error type returned by this traits' methods.
-    type AsStorageOperationError: 'static + std::error::Error;
+// /// Trait to be implemented on a struct representing a stored operation.
+// ///
+// /// Contains the values of an operation as well as it's author, it's id, and the id of
+// /// it's document.
+// ///
+// /// Storage implementations should implement this for a data structure that represents an
+// /// operation as it is stored in the database. This trait defines methods for reading
+// /// values from the operation and some meta data.
+// pub trait AsStorageOperation: Sized + Clone + Send + Sync {
+//     /// The error type returned by this traits' methods.
+//     type AsStorageOperationError: 'static + std::error::Error;
 
-    /// The action this operation performs.
-    fn action(&self) -> OperationAction;
+//     /// The action this operation performs.
+//     fn action(&self) -> OperationAction;
 
-    /// The author who published this operation.
-    fn author(&self) -> Author;
+//     /// The author who published this operation.
+//     fn author(&self) -> Author;
 
-    /// The id of the document this operation is part of.
-    fn document_id(&self) -> DocumentId;
+//     /// The id of the document this operation is part of.
+//     fn document_id(&self) -> DocumentId;
 
-    /// The fields contained in this operation.
-    fn fields(&self) -> Option<OperationFields>;
+//     /// The fields contained in this operation.
+//     fn fields(&self) -> Option<OperationFields>;
 
-    /// The id of this operation.
-    fn id(&self) -> OperationId;
+//     /// The id of this operation.
+//     fn id(&self) -> OperationId;
 
-    /// The previous operations for this operation.
-    fn previous_operations(&self) -> Option<DocumentViewId>;
+//     /// The previous operations for this operation.
+//     fn previous_operations(&self) -> Option<DocumentViewId>;
 
-    /// The id of the schema this operation follows.
-    fn schema_id(&self) -> SchemaId;
-}
+//     /// The id of the schema this operation follows.
+//     fn schema_id(&self) -> SchemaId;
+// }

--- a/p2panda-rs/src/storage_provider/traits/models.rs
+++ b/p2panda-rs/src/storage_provider/traits/models.rs
@@ -73,37 +73,3 @@ pub trait AsStorageLog: Sized + Send + Sync {
     /// Returns the SchemaId of this log.
     fn schema_id(&self) -> SchemaId;
 }
-
-// /// Trait to be implemented on a struct representing a stored operation.
-// ///
-// /// Contains the values of an operation as well as it's author, it's id, and the id of
-// /// it's document.
-// ///
-// /// Storage implementations should implement this for a data structure that represents an
-// /// operation as it is stored in the database. This trait defines methods for reading
-// /// values from the operation and some meta data.
-// pub trait AsStorageOperation: Sized + Clone + Send + Sync {
-//     /// The error type returned by this traits' methods.
-//     type AsStorageOperationError: 'static + std::error::Error;
-
-//     /// The action this operation performs.
-//     fn action(&self) -> OperationAction;
-
-//     /// The author who published this operation.
-//     fn author(&self) -> Author;
-
-//     /// The id of the document this operation is part of.
-//     fn document_id(&self) -> DocumentId;
-
-//     /// The fields contained in this operation.
-//     fn fields(&self) -> Option<OperationFields>;
-
-//     /// The id of this operation.
-//     fn id(&self) -> OperationId;
-
-//     /// The previous operations for this operation.
-//     fn previous_operations(&self) -> Option<DocumentViewId>;
-
-//     /// The id of the schema this operation follows.
-//     fn schema_id(&self) -> SchemaId;
-// }

--- a/p2panda-rs/src/storage_provider/traits/operation_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/operation_store.rs
@@ -3,33 +3,30 @@
 use async_trait::async_trait;
 
 use crate::document::DocumentId;
+use crate::operation::AsVerifiedOperation;
 use crate::operation::OperationId;
 use crate::storage_provider::errors::OperationStorageError;
-use crate::storage_provider::traits::AsStorageOperation;
 
 /// Trait which handles all storage actions relating to `Operation`s.
 ///
 /// This trait should be implemented on the root storage provider struct. It's definitions make up
 /// the required methods for inserting and querying operations from storage.
 #[async_trait]
-pub trait OperationStore<StorageOperation: AsStorageOperation> {
+pub trait OperationStore<Operation: AsVerifiedOperation> {
     /// Insert an operation into the db.
     ///
-    /// The passed operation must implement the `AsStorageOperation` trait. Errors when
+    /// The passed operation must implement the `AsVerifiedOperation` trait. Errors when
     /// a fatal DB error occurs.
-    async fn insert_operation(
-        &self,
-        operation: &StorageOperation,
-    ) -> Result<(), OperationStorageError>;
+    async fn insert_operation(&self, operation: &Operation) -> Result<(), OperationStorageError>;
 
     /// Get an operation identified by it's OperationId.
     ///
-    /// Returns a type implementing `AsStorageOperation` which includes `Author`, `DocumentId` and
+    /// Returns a type implementing `AsVerifiedOperation` which includes `Author`, `DocumentId` and
     /// `OperationId` metadata.
     async fn get_operation_by_id(
         &self,
         id: OperationId,
-    ) -> Result<Option<StorageOperation>, OperationStorageError>;
+    ) -> Result<Option<Operation>, OperationStorageError>;
 
     /// Get the id of the document an operation is contained within.
     ///
@@ -48,5 +45,5 @@ pub trait OperationStore<StorageOperation: AsStorageOperation> {
     async fn get_operations_by_document_id(
         &self,
         id: &DocumentId,
-    ) -> Result<Vec<StorageOperation>, OperationStorageError>;
+    ) -> Result<Vec<Operation>, OperationStorageError>;
 }

--- a/p2panda-rs/src/test_utils/fixtures/operation_fixtures.rs
+++ b/p2panda-rs/src/test_utils/fixtures/operation_fixtures.rs
@@ -8,7 +8,7 @@ use crate::document::DocumentViewId;
 use crate::entry::EntrySigned;
 use crate::identity::Author;
 use crate::operation::{
-    Operation, OperationEncoded, OperationFields, OperationId, OperationValue, OperationWithMeta,
+    Operation, OperationEncoded, OperationFields, OperationId, OperationValue, VerifiedOperation,
 };
 use crate::schema::SchemaId;
 use crate::test_utils::constants::{self, TEST_SCHEMA_ID};
@@ -139,7 +139,7 @@ pub fn operation(
     }
 }
 
-/// Fixture which injects a test `OperationWithMeta` into a test method.
+/// Fixture which injects a test `VerifiedOperation` into a test method.
 ///
 /// Default value can be overidden at testing time by passing in custom parameters.
 ///
@@ -154,8 +154,8 @@ pub fn operation_with_meta(
     #[default(Some(TEST_SCHEMA_ID.parse().unwrap()))] schema: Option<SchemaId>,
     #[default(Some(public_key()))] author: Option<Author>,
     #[default(Some(random_operation_id()))] operation_id: Option<OperationId>,
-) -> OperationWithMeta {
-    OperationWithMeta::new_test_operation(
+) -> VerifiedOperation {
+    VerifiedOperation::new_test_operation(
         &operation_id.unwrap_or_else(random_operation_id),
         &author.unwrap_or_else(public_key),
         &operation(fields, previous_operations, schema),
@@ -171,15 +171,15 @@ pub fn encoded_create_string(operation: Operation) -> String {
         .to_owned()
 }
 
-/// Fixture which injects an `OperationWithMeta` into a test method.
+/// Fixture which injects an `VerifiedOperation` into a test method.
 ///
 /// Constructed from an encoded entry and operation.
 #[fixture]
 pub fn meta_operation(
     entry_signed_encoded: EntrySigned,
     operation_encoded: OperationEncoded,
-) -> OperationWithMeta {
-    OperationWithMeta::new_from_entry(&entry_signed_encoded, &operation_encoded).unwrap()
+) -> VerifiedOperation {
+    VerifiedOperation::new_from_entry(&entry_signed_encoded, &operation_encoded).unwrap()
 }
 
 /// Fixture which injects an `OperationEncoded` into a test method.

--- a/p2panda-rs/src/test_utils/mocks/node.rs
+++ b/p2panda-rs/src/test_utils/mocks/node.rs
@@ -88,7 +88,7 @@ use crate::document::{Document, DocumentBuilder};
 use crate::entry::{decode_entry, EntrySigned, SeqNum};
 use crate::hash::Hash;
 use crate::identity::Author;
-use crate::operation::{AsOperation, Operation, OperationEncoded, OperationWithMeta};
+use crate::operation::{AsOperation, Operation, OperationEncoded, VerifiedOperation};
 use crate::test_utils::mocks::logs::{AuthorLogs, LogEntry};
 use crate::test_utils::mocks::utils::Result;
 use crate::test_utils::mocks::Client;
@@ -475,7 +475,7 @@ impl Node {
         let operations = entries
             .iter()
             .map(|entry| {
-                OperationWithMeta::new_from_entry(
+                VerifiedOperation::new_from_entry(
                     &entry.entry_encoded(),
                     &entry.operation_encoded(),
                 )

--- a/p2panda-rs/src/test_utils/templates/operation_templates.rs
+++ b/p2panda-rs/src/test_utils/templates/operation_templates.rs
@@ -82,7 +82,7 @@ fn many_valid_operations(#[case] operation: Operation) {}
     None,
     None
 ))]
-fn various_operation_with_meta(#[case] operation: OperationWithMeta) {}
+fn various_operation_with_meta(#[case] operation: VerifiedOperation) {}
 
 /// This template contains examples of all structs which implement the `AsOperation` trait.
 #[template]


### PR DESCRIPTION
- [ ] rename `OperationWithMeta` to `VerifiedOperation`
- [ ] introduce `AsVerifiedOperation` trait
- [ ] remove `AsStorageOperation` trait and instead require `AsVerifiedOperation` in `OperationStore` :star: 

Breaking Change: needs implementing in `aquadoggo` before merging to main.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
- [ ] Check if descriptions and terminology match `handbook` content (and visa-versa) 
