### PR TITLE
Updates for schema provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Highlights are marked with a pancake 🥞
 - Restructure / refactor `test_utils` and place behind `testing` flag [#344](https://github.com/p2panda/p2panda/pull/344) `rs`
 - Update `openmls` crate to `v0.4.1` [#336](https://github.com/p2panda/p2panda/pull/336) `rs`
 - Replace `OperationWithMeta` with `VerifiedOperation` [#353](https://github.com/p2panda/p2panda/pull/353) `rs`
+- Added definitions for system schemas and other updates around schema functionality [#365](https://github.com/p2panda/p2panda/pull/365) `rs`
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,6 @@ Highlights are marked with a pancake 🥞
 - Restructure / refactor `test_utils` and place behind `testing` flag [#344](https://github.com/p2panda/p2panda/pull/344) `rs`
 - Update `openmls` crate to `v0.4.1` [#336](https://github.com/p2panda/p2panda/pull/336) `rs`
 - Replace `OperationWithMeta` with `VerifiedOperation` [#353](https://github.com/p2panda/p2panda/pull/353) `rs`
-- Added definitions for system schemas and other updates around schema functionality [#365](https://github.com/p2panda/p2panda/pull/365) `rs`
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Highlights are marked with a pancake 🥞
 - `Graph` method for selecting sub-section of graph [#335](https://github.com/p2panda/p2panda/pull/335) `rs`
 - Storage traits for documents [#343](https://github.com/p2panda/p2panda/pull/343) `rs`
 - Materialise a document at a specific document view [#337](https://github.com/p2panda/p2panda/pull/337) `rs`
-- Static definitions of system schemas and other updates for schema provider in aquadoggo [#365](https://github.com/p2panda/p2panda/pull/365)
+- Static definitions of system schemas and other updates for schema provider in aquadoggo [#365](https://github.com/p2panda/p2panda/pull/365) `rs`
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Highlights are marked with a pancake 🥞
 - `Graph` method for selecting sub-section of graph [#335](https://github.com/p2panda/p2panda/pull/335) `rs`
 - Storage traits for documents [#343](https://github.com/p2panda/p2panda/pull/343) `rs`
 - Materialise a document at a specific document view [#337](https://github.com/p2panda/p2panda/pull/337) `rs`
+- Static definitions of system schemas and other updates for schema provider in aquadoggo [#365](https://github.com/p2panda/p2panda/pull/365)
 
 ## Changed
 

--- a/p2panda-rs/src/document/error.rs
+++ b/p2panda-rs/src/document/error.rs
@@ -7,7 +7,7 @@ use crate::operation::OperationId;
 
 /// Error types for methods of `DocumentBuilder` struct.
 #[allow(missing_copy_implementations)]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum DocumentBuilderError {
     /// No create operation found.
     #[error("Every document must contain one create operation")]
@@ -40,7 +40,7 @@ pub enum DocumentBuilderError {
 
 /// Error types for methods of `Document` struct.
 #[allow(missing_copy_implementations)]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum DocumentError {
     /// Handle errors when sorting the graph.
     #[error(transparent)]
@@ -53,7 +53,7 @@ pub enum DocumentError {
 
 /// Custom error types for `DocumentView`.
 #[allow(missing_copy_implementations)]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum DocumentViewError {
     /// TryFrom operation must be CREATE.
     #[error("Operation must be instantiated from a CREATE operation")]
@@ -66,7 +66,7 @@ pub enum DocumentViewError {
 
 /// Error types for `DocumentViewId`
 #[allow(missing_copy_implementations)]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum DocumentViewIdError {
     /// Document view ids must contain sorted operation ids
     #[error("Expected sorted operation ids in document view id")]

--- a/p2panda-rs/src/graph/error.rs
+++ b/p2panda-rs/src/graph/error.rs
@@ -3,7 +3,7 @@
 use thiserror::Error;
 
 /// Error types for methods of `materialiser` module.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[allow(missing_copy_implementations)]
 pub enum GraphError {
     /// Cycle detected in graph.

--- a/p2panda-rs/src/hash/error.rs
+++ b/p2panda-rs/src/hash/error.rs
@@ -3,7 +3,7 @@
 use thiserror::Error;
 
 /// Custom error types for `Hash`.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[allow(missing_copy_implementations)]
 pub enum HashError {
     /// Hash string has an invalid length.

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -2,8 +2,10 @@
 
 use thiserror::Error;
 
+use crate::schema::SchemaId;
+
 /// Custom errors related to `SchemaId`.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum SchemaIdError {
     /// Handle errors from validating operation id hashes.
     #[error(transparent)]
@@ -27,11 +29,19 @@ pub enum SchemaIdError {
 }
 
 /// Custom errors related to `Schema`.
-#[derive(Error, Debug, Clone, Copy)]
+#[derive(Error, Debug, Clone)]
 pub enum SchemaError {
     /// Invalid fields in schema.
     #[error("invalid fields found for this schema")]
     InvalidFields,
+
+    /// Use static definitions of system schemas instead of defining them dynamically.
+    #[error("dynamic definition of system schema {0}")]
+    DynamicSystemSchema(SchemaId),
+
+    /// Schemas must have valid schema ids.
+    #[error(transparent)]
+    SchemaIdError(#[from] SchemaIdError),
 }
 
 /// Custom error types for field types.

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -2,6 +2,8 @@
 
 use thiserror::Error;
 
+use super::SchemaId;
+
 /// Custom errors related to `SchemaId`.
 #[derive(Error, Debug)]
 pub enum SchemaIdError {
@@ -14,8 +16,8 @@ pub enum SchemaIdError {
     HashError(#[from] crate::hash::HashError),
 
     /// Encountered a malformed schema id.
-    #[error("malformed schema id: {0}")]
-    MalformedSchemaId(String),
+    #[error("malformed schema id `{0}`: {1}")]
+    MalformedSchemaId(String, String),
 
     /// Application schema ids must start with the schema's name.
     #[error("application schema id is missing a name: {0}")]

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -2,8 +2,6 @@
 
 use thiserror::Error;
 
-use super::SchemaId;
-
 /// Custom errors related to `SchemaId`.
 #[derive(Error, Debug)]
 pub enum SchemaIdError {

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -36,7 +36,7 @@ pub enum SchemaError {
     InvalidFields,
 
     /// Use static definitions of system schemas instead of defining them dynamically.
-    #[error("dynamic definition of system schema {0}")]
+    #[error("dynamic redefinition of system schema {0}, use `Schema::get_system` instead")]
     DynamicSystemSchema(SchemaId),
 
     /// Schemas must have valid schema ids.

--- a/p2panda-rs/src/schema/error.rs
+++ b/p2panda-rs/src/schema/error.rs
@@ -24,7 +24,7 @@ pub enum SchemaIdError {
     MissingApplicationSchemaName(String),
 
     /// Invalid system schema id.
-    #[error("not a known system schema: {0}")]
+    #[error("unsupported system schema: {0}")]
     UnknownSystemSchema(String),
 }
 

--- a/p2panda-rs/src/schema/field_types.rs
+++ b/p2panda-rs/src/schema/field_types.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 use lazy_static::lazy_static;
@@ -20,7 +21,7 @@ use super::{FieldTypeError, SchemaId};
 /// field_definition.add("name", OperationValue::Text("document_title".to_string()));
 /// field_definition.add("type", FieldType::String.into());
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum FieldType {
     /// Defines a boolean field.
     Bool,

--- a/p2panda-rs/src/schema/field_types.rs
+++ b/p2panda-rs/src/schema/field_types.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 use lazy_static::lazy_static;
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 
 use crate::operation::OperationValue;
-
-use super::{FieldTypeError, SchemaId};
+use crate::schema::{FieldTypeError, SchemaId};
 
 /// Valid field types for publishing an application schema.
 ///

--- a/p2panda-rs/src/schema/mod.rs
+++ b/p2panda-rs/src/schema/mod.rs
@@ -12,3 +12,4 @@ pub use error::{FieldTypeError, SchemaError, SchemaIdError};
 pub use field_types::FieldType;
 pub use schema::Schema;
 pub use schema_id::{SchemaId, SchemaVersion};
+pub use system::SYSTEM_SCHEMAS;

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -292,7 +292,7 @@ mod tests {
 
     #[rstest]
     #[case(vec![("message", FieldType::String)])]
-    // This should error
+    // This should error but requires validation of schema instances.
     #[case(vec![])]
     fn new_schema(
         #[from(document_view_id)] schema_view_id: DocumentViewId,
@@ -313,7 +313,7 @@ mod tests {
             "description",
             vec![("wrong", FieldType::Int)],
         );
-        // This should error
+        // This should
         assert_eq!(
             format!("{}", result.unwrap_err()),
             "dynamic redefinition of system schema schema_definition_v1, use `Schema::get_system` instead"

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -32,8 +32,9 @@ type FieldKey = String;
 ///
 /// ## Define a schema without going through document views
 ///
-/// Use [`Schema::new`] for testing. This method of constructing a schema doesn't validate that the
-/// given schema id matches the provided schema's published description and field definitions.
+/// [`Schema::new`] is only available for testing. This method of constructing a schema doesn't
+/// validate that the given schema id matches the provided schema's published description and field
+/// definitions.
 ///
 // @NOTE: Fields on this struct are `pub(super)` to enable making static instances of system
 // schemas from their respective files in the `./system` subdirectory. Making system schema
@@ -79,6 +80,7 @@ impl Schema {
     /// # }
     /// # }
     /// ```
+    #[cfg(any(feature = "testing", test))]
     pub fn new(
         id: &SchemaId,
         description: &str,

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -16,22 +16,24 @@ type FieldKey = String;
 
 /// A struct representing a materialised schema.
 ///
-///Use `Schema::from_views()` to construct it from a [`SchemaView`] and all related
-/// [`SchemaFieldView`]s.
+///Use `Schema::from_views()` to infer it from a [`SchemaView`] and all related
+/// [`SchemaFieldView`]s or use `Schema::new()` to directly construct an application schema instance.
+///
+/// Use `Schema::get_system()` to access static definitions of all system schemas.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Schema {
     /// The application schema id for this schema.
-    pub id: SchemaId,
+    pub(super) id: SchemaId,
 
     /// Describes the schema's intended use.
-    pub description: String,
+    pub(super) description: String,
 
     /// Maps all of the schema's field names to their respective types.
-    pub fields: BTreeMap<FieldKey, FieldType>,
+    pub(super) fields: BTreeMap<FieldKey, FieldType>,
 }
 
 impl Schema {
-    /// Create a schema instance with the given id, description and fields.
+    /// Create an application schema instance with the given id, description and fields.
     pub fn new(
         id: &SchemaId,
         description: &str,

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -314,7 +314,6 @@ mod tests {
             "description",
             vec![("wrong", FieldType::Int)],
         );
-        // This should
         assert_eq!(
             format!("{}", result.unwrap_err()),
             "dynamic redefinition of system schema schema_definition_v1, use `Schema::get_system` instead"

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -92,7 +92,7 @@ impl Schema {
     ///
     /// Returns an error if this library version doesn't support the given system schema or this
     /// particular version.
-    pub fn get_system(schema_id: SchemaId) -> Result<Schema, SchemaIdError> {
+    pub fn get_system(schema_id: SchemaId) -> Result<&'static Schema, SchemaIdError> {
         match schema_id {
             SchemaId::SchemaDefinition(version) => get_schema_definition(version),
             SchemaId::SchemaFieldDefinition(version) => get_schema_field_definition(version),

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
 
 use crate::cddl::generate_cddl_definition;
 use crate::document::DocumentViewHash;
@@ -18,25 +19,25 @@ type FieldKey = String;
 ///
 /// ## Load application schemas from document views
 ///
-/// In most cases you should construct schema instances from their materialised views to ensure that
-/// your definition aligns with a published version of a schema.
+/// In most cases you should construct schema instances from their materialised views to ensure
+/// that your definition aligns with a published version of a schema.
 ///
 /// Use [`Schema::from_views`] to infer a schema instance from a [`SchemaView`] and all related
-/// [`SchemaFieldView`]s
+/// [`SchemaFieldView`]s.
 ///
 /// ## Access system schemas
 ///
 /// Use [`Schema::get_system`] to access static definitions of all system schemas available in this
 /// version of the p2panda library.
 ///
-/// ## Define a schema without going through document views.
+/// ## Define a schema without going through document views
 ///
-/// Use [`Schema::new`] for testing. This method of constructing a schema doesn't validate that the given
-/// schema id matches the provided schema's published description and field definitions.
+/// Use [`Schema::new`] for testing. This method of constructing a schema doesn't validate that the
+/// given schema id matches the provided schema's published description and field definitions.
 ///
-// Fields on this struct are `pub(super)` to enable making static instances of system schemas
-// from their respective files in the `./system` subdirectory. Making system schema instances is
-// not supported by `Schema::new()` to prevent their dynamic redefinition.
+// @NOTE: Fields on this struct are `pub(super)` to enable making static instances of system
+// schemas from their respective files in the `./system` subdirectory. Making system schema
+// instances is not supported by `Schema::new()` to prevent their dynamic redefinition.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Schema {
     /// The application schema id for this schema.
@@ -100,7 +101,7 @@ impl Schema {
         }
     }
 
-    /// Instantiate a new `Schema` from a `SchemaView` and it's `SchemaFieldView`s
+    /// Instantiate a new `Schema` from a `SchemaView` and it's `SchemaFieldView`s.
     pub fn from_views(
         schema: SchemaView,
         fields: Vec<SchemaFieldView>,
@@ -136,8 +137,8 @@ impl Schema {
 
     /// Return a static `Schema` instance for a system schema.
     ///
-    /// Returns an error if this library version doesn't support the system schema with the
-    /// given version.
+    /// Returns an error if this library version doesn't support the system schema with the given
+    /// version.
     ///
     /// ## Example
     ///

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -90,13 +90,16 @@ impl Schema {
         for (field_name, field_type) in fields {
             field_map.insert(field_name.to_owned(), field_type.to_owned());
         }
+
         if let SchemaId::Application(_, _) = id {
             let schema = Self {
                 id: id.to_owned(),
                 description: description.to_owned(),
                 fields: field_map,
             };
-            // TODO: Implement `Validate` for `Schema` and call it here
+
+            // @TODO: Implement `Validate` for `Schema` and call it here
+
             Ok(schema)
         } else {
             Err(SchemaError::DynamicSystemSchema(id.clone()))
@@ -295,7 +298,7 @@ mod tests {
 
     #[rstest]
     #[case(vec![("message", FieldType::String)])]
-    // This should error but requires validation of schema instances.
+    // @TODO: This should error but requires validation of schema instances.
     #[case(vec![])]
     fn new_schema(
         #[from(document_view_id)] schema_view_id: DocumentViewId,

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Display;
 
@@ -14,16 +15,16 @@ type FieldKey = String;
 /// A struct representing a materialised schema.
 ///
 /// It is constructed from a [`SchemaView`] and all related [`SchemaFieldView`]s.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Schema {
     /// The application schema id for this schema.
-    id: SchemaId,
+    pub(crate) id: SchemaId,
 
     /// Describes the schema's intended use.
-    description: String,
+    pub(crate) description: String,
 
     /// Maps all of the schema's field names to their respective types.
-    fields: BTreeMap<FieldKey, FieldType>,
+    pub(crate) fields: BTreeMap<FieldKey, FieldType>,
 }
 
 impl Schema {

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -16,7 +16,7 @@ type FieldKey = String;
 
 /// A struct representing a p2panda schema.
 ///
-/// ## Load a schema from document views
+/// ## Load application schemas from document views
 ///
 /// In most cases you should construct schema instances from their materialised views to ensure that
 /// your definition aligns with a published version of a schema.
@@ -24,17 +24,15 @@ type FieldKey = String;
 /// Use [`Schema::from_views`] to infer a schema instance from a [`SchemaView`] and all related
 /// [`SchemaFieldView`]s
 ///
-// TODO: Add example
+/// ## Access system schemas
+///
+/// Use [`Schema::get_system`] to access static definitions of all system schemas available in this
+/// version of the p2panda library.
 ///
 /// ## Define a schema without going through document views.
 ///
 /// Use [`Schema::new`] for testing. This method of constructing a schema doesn't validate that the given
 /// schema id matches the provided schema's published description and field definitions.
-///
-/// ## Access system schemas
-///
-/// Use [`Schema::get_system`] to access static definitions of all system schemas available in this
-/// version of the p2panda library.
 ///
 // Fields on this struct are `pub(super)` to enable making static instances of system schemas
 // from their respective files in the `./system` subdirectory. Making system schema instances is

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -318,7 +318,7 @@ mod tests {
         // This should error
         assert_eq!(
             format!("{}", result.unwrap_err()),
-            "dynamic definition of system schema schema_definition_v1"
+            "dynamic redefinition of system schema schema_definition_v1, use `Schema::get_system` instead"
         );
     }
 

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -338,6 +338,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_unsupported_system_schema() {
+        let result = Schema::get_system(SchemaId::SchemaDefinition(0));
+        assert_eq!(
+            format!("{}", result.unwrap_err()),
+            "unsupported system schema: schema_definition_v0"
+        );
+
+        let result = Schema::get_system(SchemaId::SchemaFieldDefinition(0));
+        assert_eq!(
+            format!("{}", result.unwrap_err()),
+            "unsupported system schema: schema_field_definition_v0"
+        );
+    }
+
     #[rstest]
     fn test_error_application_schema(document_view_id: DocumentViewId) {
         let schema = Schema::get_system(SchemaId::Application(

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -93,7 +93,7 @@ impl Schema {
                 description: description.to_owned(),
                 fields: field_map,
             };
-            // schema.validate?;
+            // TODO: Implement `Validate` for `Schema` and call it here
             Ok(schema)
         } else {
             Err(SchemaError::DynamicSystemSchema(id.clone()))

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -292,7 +292,7 @@ mod test {
     // this looks like a system schema, but it is not
     #[case(
         "unknown_system_schema_name_v1",
-        "not a known system schema: unknown_system_schema_name"
+        "unsupported system schema: unknown_system_schema_name"
     )]
     // malformed system schema version number
     #[case(

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -31,7 +31,7 @@ pub enum SchemaVersion {
 /// [`Document`][`crate::document::Document`].
 ///
 /// Every schema id has a name and version.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum SchemaId {
     /// An application schema.
     Application(String, DocumentViewId),

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -62,7 +62,10 @@ impl SchemaId {
         let rightmost_section = id
             .rsplit_once('_')
             .ok_or_else(|| {
-                SchemaIdError::MalformedSchemaId("doesn't contain an underscore".to_string())
+                SchemaIdError::MalformedSchemaId(
+                    id.to_string(),
+                    "doesn't contain an underscore".to_string(),
+                )
             })?
             .1;
         let is_system_schema =
@@ -82,10 +85,10 @@ impl SchemaId {
     fn parse_system_schema_str(id_str: &str) -> Result<Self, SchemaIdError> {
         let (name, version_str) = id_str.rsplit_once('_').unwrap();
         let version = version_str[1..].parse::<u8>().map_err(|_| {
-            SchemaIdError::MalformedSchemaId(format!(
-                "couldn't parse system schema version from '{}'",
-                id_str
-            ))
+            SchemaIdError::MalformedSchemaId(
+                id_str.to_string(),
+                "couldn't parse system schema version".to_string(),
+            )
         })?;
         match name {
             SCHEMA_DEFINITION_NAME => Ok(Self::SchemaDefinition(version)),

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -263,12 +263,12 @@ mod test {
     #[rstest]
     #[case(
         "This is not a hash",
-        "malformed schema id: doesn't contain an underscore"
+        "malformed schema id `This is not a hash`: doesn't contain an underscore"
     )]
     // Only an operation id, could be interpreted as document view id but still missing the name
     #[case(
         "0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b",
-        "malformed schema id: doesn't contain an underscore"
+        "malformed schema id `0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b`: doesn't contain an underscore"
     )]
     // Only the name is missing now
     #[case(
@@ -297,7 +297,7 @@ mod test {
     // malformed system schema version number
     #[case(
         "schema_definition_v1.5",
-        "malformed schema id: couldn't parse system schema version from 'schema_definition_v1.5'"
+        "malformed schema id `schema_definition_v1.5`: couldn't parse system schema version"
     )]
     fn invalid_deserialization(#[case] schema_id_str: &str, #[case] expected_err: &str) {
         assert_eq!(

--- a/p2panda-rs/src/schema/system/mod.rs
+++ b/p2panda-rs/src/schema/system/mod.rs
@@ -7,6 +7,8 @@
 
 use lazy_static::lazy_static;
 
+use crate::schema::Schema;
+
 mod error;
 mod schema_definition;
 mod schema_field_definition;
@@ -17,8 +19,6 @@ pub use schema_views::{SchemaFieldView, SchemaView};
 
 pub(super) use schema_definition::get_schema_definition;
 pub(super) use schema_field_definition::get_schema_field_definition;
-
-use crate::schema::Schema;
 
 lazy_static! {
     /// A vector of all system schemas in this version of the library.

--- a/p2panda-rs/src/schema/system/mod.rs
+++ b/p2panda-rs/src/schema/system/mod.rs
@@ -5,7 +5,61 @@
 //! They are defined as part of the p2panda specification and may differ from application schemas
 //! in how they are materialised.
 mod error;
+mod schema_definition;
+mod schema_field_definition;
 mod schema_views;
 
 pub use error::SystemSchemaError;
 pub use schema_views::{SchemaFieldView, SchemaView};
+
+use self::schema_definition::get_schema_definition;
+use self::schema_field_definition::get_schema_field_definition;
+
+use super::{Schema, SchemaId, SchemaIdError};
+
+/// Return the schema struct for a system schema id.
+///
+/// Returns an error if this library version doesn't support the given system schema or this
+/// particular version.
+pub fn get_system_schema(schema_id: SchemaId) -> Result<Schema, SchemaIdError> {
+    match schema_id {
+        SchemaId::SchemaDefinition(version) => get_schema_definition(version),
+        SchemaId::SchemaFieldDefinition(version) => get_schema_field_definition(version),
+        _ => Err(SchemaIdError::UnknownSystemSchema(schema_id.as_str())),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::document::DocumentViewId;
+    use crate::schema::SchemaId;
+    use crate::test_utils::fixtures::document_view_id;
+    use rstest::rstest;
+
+    use super::get_system_schema;
+
+    #[test]
+    fn test_all_system_schemas() {
+        let schema_definition = get_system_schema(SchemaId::SchemaDefinition(1)).unwrap();
+        assert_eq!(
+            schema_definition.to_string(),
+            "<Schema schema_definition_v1>"
+        );
+
+        let schema_field_definition =
+            get_system_schema(SchemaId::SchemaFieldDefinition(1)).unwrap();
+        assert_eq!(
+            schema_field_definition.to_string(),
+            "<Schema schema_field_definition_v1>"
+        );
+    }
+
+    #[rstest]
+    fn test_error_application_schema(document_view_id: DocumentViewId) {
+        let schema = get_system_schema(SchemaId::Application(
+            "events".to_string(),
+            document_view_id,
+        ));
+        assert!(schema.is_err())
+    }
+}

--- a/p2panda-rs/src/schema/system/mod.rs
+++ b/p2panda-rs/src/schema/system/mod.rs
@@ -4,7 +4,6 @@
 //!
 //! They are defined as part of the p2panda specification and may differ from application schemas
 //! in how they are materialised.
-
 use lazy_static::lazy_static;
 
 use crate::schema::Schema;

--- a/p2panda-rs/src/schema/system/mod.rs
+++ b/p2panda-rs/src/schema/system/mod.rs
@@ -4,6 +4,9 @@
 //!
 //! They are defined as part of the p2panda specification and may differ from application schemas
 //! in how they are materialised.
+
+use lazy_static::lazy_static;
+
 mod error;
 mod schema_definition;
 mod schema_field_definition;
@@ -14,3 +17,23 @@ pub use schema_views::{SchemaFieldView, SchemaView};
 
 pub(super) use schema_definition::get_schema_definition;
 pub(super) use schema_field_definition::get_schema_field_definition;
+
+use crate::schema::Schema;
+
+lazy_static! {
+    /// A vector of all system schemas in this version of the library.
+    pub static ref SYSTEM_SCHEMAS: Vec<&'static Schema> = vec![
+        get_schema_definition(1).unwrap(),
+        get_schema_field_definition(1).unwrap(),
+    ];
+}
+
+#[cfg(test)]
+mod test {
+    use super::SYSTEM_SCHEMAS;
+
+    #[test]
+    fn test_static_system_schemas() {
+        assert_eq!(SYSTEM_SCHEMAS.len(), 2);
+    }
+}

--- a/p2panda-rs/src/schema/system/mod.rs
+++ b/p2panda-rs/src/schema/system/mod.rs
@@ -12,5 +12,5 @@ mod schema_views;
 pub use error::SystemSchemaError;
 pub use schema_views::{SchemaFieldView, SchemaView};
 
-pub(super) use self::schema_definition::get_schema_definition;
-pub(super) use self::schema_field_definition::get_schema_field_definition;
+pub(super) use schema_definition::get_schema_definition;
+pub(super) use schema_field_definition::get_schema_field_definition;

--- a/p2panda-rs/src/schema/system/mod.rs
+++ b/p2panda-rs/src/schema/system/mod.rs
@@ -12,54 +12,5 @@ mod schema_views;
 pub use error::SystemSchemaError;
 pub use schema_views::{SchemaFieldView, SchemaView};
 
-use self::schema_definition::get_schema_definition;
-use self::schema_field_definition::get_schema_field_definition;
-
-use super::{Schema, SchemaId, SchemaIdError};
-
-/// Return the schema struct for a system schema id.
-///
-/// Returns an error if this library version doesn't support the given system schema or this
-/// particular version.
-pub fn get_system_schema(schema_id: SchemaId) -> Result<Schema, SchemaIdError> {
-    match schema_id {
-        SchemaId::SchemaDefinition(version) => get_schema_definition(version),
-        SchemaId::SchemaFieldDefinition(version) => get_schema_field_definition(version),
-        _ => Err(SchemaIdError::UnknownSystemSchema(schema_id.as_str())),
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::document::DocumentViewId;
-    use crate::schema::SchemaId;
-    use crate::test_utils::fixtures::document_view_id;
-    use rstest::rstest;
-
-    use super::get_system_schema;
-
-    #[test]
-    fn test_all_system_schemas() {
-        let schema_definition = get_system_schema(SchemaId::SchemaDefinition(1)).unwrap();
-        assert_eq!(
-            schema_definition.to_string(),
-            "<Schema schema_definition_v1>"
-        );
-
-        let schema_field_definition =
-            get_system_schema(SchemaId::SchemaFieldDefinition(1)).unwrap();
-        assert_eq!(
-            schema_field_definition.to_string(),
-            "<Schema schema_field_definition_v1>"
-        );
-    }
-
-    #[rstest]
-    fn test_error_application_schema(document_view_id: DocumentViewId) {
-        let schema = get_system_schema(SchemaId::Application(
-            "events".to_string(),
-            document_view_id,
-        ));
-        assert!(schema.is_err())
-    }
-}
+pub(super) use self::schema_definition::get_schema_definition;
+pub(super) use self::schema_field_definition::get_schema_field_definition;

--- a/p2panda-rs/src/schema/system/schema_definition.rs
+++ b/p2panda-rs/src/schema/system/schema_definition.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use lazy_static::lazy_static;
 use std::collections::BTreeMap;
+
+use lazy_static::lazy_static;
 
 use crate::schema::{FieldType, Schema, SchemaId, SchemaIdError};
 

--- a/p2panda-rs/src/schema/system/schema_definition.rs
+++ b/p2panda-rs/src/schema/system/schema_definition.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::collections::BTreeMap;
+
+use crate::schema::{FieldType, Schema, SchemaId, SchemaIdError};
+
+const DESCRIPTION: &str = "publish data schemas for your application";
+
+/// Returns the `schema_definition` system schema with a given version.
+pub fn get_schema_definition(version: u8) -> Result<Schema, SchemaIdError> {
+    match version {
+        1 => {
+            let mut fields = BTreeMap::new();
+            fields.insert("name".to_string(), FieldType::String);
+            fields.insert("description".to_string(), FieldType::String);
+            fields.insert(
+                "fields".to_string(),
+                FieldType::PinnedRelationList(SchemaId::SchemaFieldDefinition(1)),
+            );
+            Ok(Schema {
+                id: SchemaId::SchemaDefinition(version),
+                description: DESCRIPTION.to_owned(),
+                fields,
+            })
+        }
+        _ => Err(SchemaIdError::UnknownSystemSchema(
+            SchemaId::SchemaDefinition(version).as_str(),
+        )),
+    }
+}

--- a/p2panda-rs/src/schema/system/schema_definition.rs
+++ b/p2panda-rs/src/schema/system/schema_definition.rs
@@ -1,28 +1,33 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use lazy_static::lazy_static;
 use std::collections::BTreeMap;
 
 use crate::schema::{FieldType, Schema, SchemaId, SchemaIdError};
 
 const DESCRIPTION: &str = "Publish data schemas for your application.";
 
-/// Returns the `schema_definition` system schema with a given version.
-pub fn get_schema_definition(version: u8) -> Result<Schema, SchemaIdError> {
-    match version {
-        1 => {
-            let mut fields = BTreeMap::new();
-            fields.insert("name".to_string(), FieldType::String);
-            fields.insert("description".to_string(), FieldType::String);
-            fields.insert(
-                "fields".to_string(),
-                FieldType::PinnedRelationList(SchemaId::SchemaFieldDefinition(1)),
-            );
-            Ok(Schema {
-                id: SchemaId::SchemaDefinition(version),
-                description: DESCRIPTION.to_owned(),
-                fields,
-            })
+lazy_static! {
+    pub static ref SCHEMA_DEFINITION_V1: Schema = {
+        let mut fields = BTreeMap::new();
+        fields.insert("name".to_string(), FieldType::String);
+        fields.insert("description".to_string(), FieldType::String);
+        fields.insert(
+            "fields".to_string(),
+            FieldType::PinnedRelationList(SchemaId::SchemaFieldDefinition(1)),
+        );
+        Schema {
+            id: SchemaId::SchemaDefinition(1),
+            description: DESCRIPTION.to_owned(),
+            fields,
         }
+    };
+}
+
+/// Returns the `schema_definition` system schema with a given version.
+pub fn get_schema_definition(version: u8) -> Result<&'static Schema, SchemaIdError> {
+    match version {
+        1 => Ok(&SCHEMA_DEFINITION_V1),
         _ => Err(SchemaIdError::UnknownSystemSchema(
             SchemaId::SchemaDefinition(version).as_str(),
         )),

--- a/p2panda-rs/src/schema/system/schema_definition.rs
+++ b/p2panda-rs/src/schema/system/schema_definition.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use crate::schema::{FieldType, Schema, SchemaId, SchemaIdError};
 
-const DESCRIPTION: &str = "publish data schemas for your application";
+const DESCRIPTION: &str = "Publish data schemas for your application.";
 
 /// Returns the `schema_definition` system schema with a given version.
 pub fn get_schema_definition(version: u8) -> Result<Schema, SchemaIdError> {

--- a/p2panda-rs/src/schema/system/schema_field_definition.rs
+++ b/p2panda-rs/src/schema/system/schema_field_definition.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use crate::schema::{FieldType, Schema, SchemaId, SchemaIdError};
 
-const DESCRIPTION: &str = "define fields for application data schemas";
+const DESCRIPTION: &str = "Define fields for application data schemas.";
 
 /// Returns the `schema_field_definition` system schema with a given version.
 pub fn get_schema_field_definition(version: u8) -> Result<Schema, SchemaIdError> {

--- a/p2panda-rs/src/schema/system/schema_field_definition.rs
+++ b/p2panda-rs/src/schema/system/schema_field_definition.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::collections::BTreeMap;
+
+use crate::schema::{FieldType, Schema, SchemaId, SchemaIdError};
+
+const DESCRIPTION: &str = "define fields for application data schemas";
+
+/// Returns the `schema_field_definition` system schema with a given version.
+pub fn get_schema_field_definition(version: u8) -> Result<Schema, SchemaIdError> {
+    match version {
+        1 => {
+            let mut fields = BTreeMap::new();
+            fields.insert("name".to_string(), FieldType::String);
+            fields.insert("type".to_string(), FieldType::String);
+            Ok(Schema {
+                id: SchemaId::SchemaFieldDefinition(version),
+                description: DESCRIPTION.to_owned(),
+                fields,
+            })
+        }
+        _ => Err(SchemaIdError::UnknownSystemSchema(
+            SchemaId::SchemaFieldDefinition(version).as_str(),
+        )),
+    }
+}

--- a/p2panda-rs/src/schema/system/schema_field_definition.rs
+++ b/p2panda-rs/src/schema/system/schema_field_definition.rs
@@ -1,24 +1,29 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use lazy_static::lazy_static;
 use std::collections::BTreeMap;
 
 use crate::schema::{FieldType, Schema, SchemaId, SchemaIdError};
 
 const DESCRIPTION: &str = "Define fields for application data schemas.";
 
-/// Returns the `schema_field_definition` system schema with a given version.
-pub fn get_schema_field_definition(version: u8) -> Result<Schema, SchemaIdError> {
-    match version {
-        1 => {
-            let mut fields = BTreeMap::new();
-            fields.insert("name".to_string(), FieldType::String);
-            fields.insert("type".to_string(), FieldType::String);
-            Ok(Schema {
-                id: SchemaId::SchemaFieldDefinition(version),
-                description: DESCRIPTION.to_owned(),
-                fields,
-            })
+lazy_static! {
+    pub static ref SCHEMA_FIELD_DEFINITION_V1: Schema = {
+        let mut fields = BTreeMap::new();
+        fields.insert("name".to_string(), FieldType::String);
+        fields.insert("type".to_string(), FieldType::String);
+        Schema {
+            id: SchemaId::SchemaFieldDefinition(1),
+            description: DESCRIPTION.to_owned(),
+            fields,
         }
+    };
+}
+
+/// Returns the `schema_field_definition` system schema with a given version.
+pub fn get_schema_field_definition(version: u8) -> Result<&'static Schema, SchemaIdError> {
+    match version {
+        1 => Ok(&SCHEMA_FIELD_DEFINITION_V1),
         _ => Err(SchemaIdError::UnknownSystemSchema(
             SchemaId::SchemaFieldDefinition(version).as_str(),
         )),

--- a/p2panda-rs/src/schema/system/schema_field_definition.rs
+++ b/p2panda-rs/src/schema/system/schema_field_definition.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use lazy_static::lazy_static;
 use std::collections::BTreeMap;
+
+use lazy_static::lazy_static;
 
 use crate::schema::{FieldType, Schema, SchemaId, SchemaIdError};
 


### PR DESCRIPTION
This adds some derived traits and introduces functions for returning the definitions for system schemas.

I also made some existing errors `Clone` because that often makes it easier to work with these values as a library consumer.

Required for https://github.com/p2panda/aquadoggo/pull/166

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
