### PR TITLE
Update rust dependencies, remove `automock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Highlights are marked with a pancake 🥞
 - Implement `OperationStore` on test provider `SimplestStorageProvider` [#361](https://github.com/p2panda/p2panda/pull/361) `rs`
 - Improve validation in `EntrySigned` constructor [#367](https://github.com/p2panda/p2panda/pull/367) `rs`
 - `Session` interface using GraphQL [#364](https://github.com/p2panda/p2panda/pull/377) `js`
+- Updated dependencies, remove `automock` crate [#379](https://github.com/p2panda/p2panda/pull/379) `rs`
 
 ## Fixed
 

--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -28,32 +28,29 @@ testing = ["dep:rstest", "dep:rstest_reuse", "dep:varu64"]
 
 [dependencies]
 arrayvec = "^0.5.2"
-async-trait = "0.1.52"
+async-trait = "^0.1.56"
 bamboo-rs-core-ed25519-yasmf = "^0.1.1"
-cddl-cat = { version = "^0.6.1", default-features = false, features = [
-  "serde_cbor",
-] }
+cddl-cat = { version = "^0.6.1", default-features = false, features = ["serde_cbor"] }
 ciborium = "^0.2.0"
-ed25519 = "^1.3.0"
+ed25519 = "^1.5.2"
 ed25519-dalek = "^1.0.1"
 hex = "^0.4.3"
 lazy_static = "^1.4.0"
 lipmaa-link = "^0.2.2"
-log = "^0.4"
-mockall = "0.11.0"
+log = "^0.4.17"
 openmls = { version = "^0.4.1", features = ["crypto-subtle"] }
 openmls_memory_keystore = "^0.1.0"
 openmls_rust_crypto = "^0.1.0"
 openmls_traits = "^0.1.0"
-regex = "^1.5.5"
-rstest = { version = "0.12.0", optional = true }
-rstest_reuse = { version = "0.1.3", optional = true }
-serde = { version = "^1.0.136", features = ["derive"] }
-serde-wasm-bindgen = "^0.4.2"
-serde_repr = "^0.1.7"
-thiserror = "^1.0.30"
+regex = "^1.5.6"
+rstest = { version = "^0.15.0", optional = true }
+rstest_reuse = { version = "^0.3.0", optional = true }
+serde = { version = "^1.0.137", features = ["derive"] }
+serde-wasm-bindgen = "^0.4.3"
+serde_repr = "^0.1.8"
+thiserror = "^1.0.31"
 tls_codec = { version = "^0.2.0", features = ["derive", "serde_serialize"] }
-varu64 = { version = "0.6.2", default-features = false, optional = true }
+varu64 = { version = "^0.7.0", default-features = false, optional = true }
 yasmf-hash = "^0.1.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -61,22 +58,22 @@ rand = "^0.7.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "^0.1.7"
-js-sys = "^0.3.57"
+js-sys = "^0.3.58"
 rand = { version = "^0.7.3", features = ["wasm-bindgen"] }
-wasm-bindgen = "^0.2.78"
+wasm-bindgen = "^0.2.81"
 
 [dev-dependencies]
-async-std = { version = "1.10.0", features = ["attributes"] }
-criterion = "0.3.4"
-ctor = "0.1.2"
-incremental-topo = "0.1.2"
+async-std = { version = "^1.12.0", features = ["attributes"] }
+criterion = "^0.3.5"
+ctor = "^0.1.22"
+incremental-topo = "^0.1.2"
 openmls = { version = "^0.4.1", features = ["crypto-subtle", "test-utils"] }
-pretty_env_logger = "0.4"
-proptest = { version = "0.9.6", default-features = false, features = ["std"] }
-rstest = "0.12.0"
-rstest_reuse = "0.1.3"
-varu64 = { version = "0.6.2", default-features = false }
-wasm-bindgen-test = "0.3.30"
+pretty_env_logger = "^0.4.0"
+proptest = { version = "^1.0.0", default-features = false, features = ["std"] }
+rstest = "^0.15.0"
+rstest_reuse = "^0.3.0"
+varu64 = { version = "^0.7.0", default-features = false }
+wasm-bindgen-test = "^0.3.31"
 
 [[bench]]
 name = "graph"

--- a/p2panda-rs/src/storage_provider/traits/entry_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/entry_store.rs
@@ -1,6 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use async_trait::async_trait;
 use bamboo_rs_core_ed25519_yasmf::entry::is_lipmaa_required;
-use mockall::automock;
 
 use crate::entry::LogId;
 use crate::entry::SeqNum;
@@ -14,7 +15,6 @@ use crate::storage_provider::traits::AsStorageEntry;
 ///
 /// This trait should be implemented on the root storage provider struct. It's definitions make up
 /// the required methods for inserting and querying entries from storage.
-#[automock]
 #[async_trait]
 pub trait EntryStore<StorageEntry: AsStorageEntry> {
     /// Insert an entry into storage.

--- a/p2panda-rs/src/storage_provider/traits/log_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/log_store.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use async_trait::async_trait;
-use mockall::automock;
 
 use crate::document::DocumentId;
 use crate::entry::LogId;
@@ -13,7 +12,6 @@ use crate::storage_provider::traits::AsStorageLog;
 ///
 /// This trait should be implemented on the root storage provider struct. It's definitions
 /// make up the required methods for inserting and querying logs from storage.
-#[automock]
 #[async_trait]
 pub trait LogStore<StorageLog: AsStorageLog> {
     /// Insert a log into storage.


### PR DESCRIPTION
Updates some Rust dependencies because we can, removes `automock` as it seems not to be required in `aquadoggo` anymore.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
