### PR TITLE
Fix `SeqNum` and `LogId` iterator implementations

### DIFF
--- a/p2panda-rs/src/entry/log_id.rs
+++ b/p2panda-rs/src/entry/log_id.rs
@@ -13,7 +13,7 @@ use crate::entry::error::LogIdError;
 pub struct LogId(u64);
 
 impl LogId {
-    /// Validates and wraps log id value into a new `LogId` instance.
+    /// Returns a new `LogId` instance.
     pub fn new(value: u64) -> Self {
         Self(value)
     }
@@ -34,7 +34,13 @@ impl Iterator for LogId {
     type Item = LogId;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(Self(self.0 + 1))
+        match self.0 == std::u64::MAX {
+            true => None,
+            false => {
+                self.0 += 1;
+                Some(*self)
+            }
+        }
     }
 }
 
@@ -75,6 +81,20 @@ mod tests {
 
         let next_log_id = next_log_id.next().unwrap();
         assert_eq!(next_log_id, LogId::new(2));
+    }
+
+    #[test]
+    fn iterator() {
+        let mut log_id = LogId::default();
+
+        assert_eq!(Some(LogId(1)), log_id.next());
+        assert_eq!(Some(LogId(2)), log_id.next());
+        assert_eq!(Some(LogId(3)), log_id.next());
+
+        let mut log_id = LogId(std::u64::MAX - 1);
+
+        assert_eq!(Some(LogId(std::u64::MAX)), log_id.next());
+        assert_eq!(None, log_id.next());
     }
 
     #[test]

--- a/p2panda-rs/src/entry/seq_num.rs
+++ b/p2panda-rs/src/entry/seq_num.rs
@@ -103,7 +103,13 @@ impl Iterator for SeqNum {
     type Item = SeqNum;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(Self(self.0 + 1))
+        match self.0 == std::u64::MAX {
+            true => None,
+            false => {
+                self.0 += 1;
+                Some(*self)
+            }
+        }
     }
 }
 
@@ -135,6 +141,19 @@ mod tests {
     fn validate() {
         assert!(SeqNum::new(0).is_err());
         assert!(SeqNum::new(100).is_ok());
+    }
+
+    #[test]
+    fn iterator() {
+        let mut seq_num = SeqNum::new(1).unwrap();
+
+        assert_eq!(Some(SeqNum(2)), seq_num.next());
+        assert_eq!(Some(SeqNum(3)), seq_num.next());
+
+        seq_num = SeqNum(std::u64::MAX - 1);
+
+        assert_eq!(Some(SeqNum(std::u64::MAX)), seq_num.next());
+        assert_eq!(None, seq_num.next());
     }
 
     #[test]


### PR DESCRIPTION
- iterator mutates the value and returns the new value
- iterator returns `None` when max value is reached
- tests cover this

Closes #403 

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
