### PR TITLE
Remove generic parameters from StorageProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ Highlights are marked with a pancake 🥞
 
 - Refactor mock `Node` implementation to use `StorageProvider` traits [#383](https://github.com/p2panda/p2panda/pull/383) `rs`
 - Deserialize from string and u64 for `LogId` and `SeqNum` [#401](https://github.com/p2panda/p2panda/pull/401) `rs`
-- Remove generic parameters from `StorageProvider` #[408](https://github.com/p2panda/p2panda/pull/408) `rs` 
+- Remove generic parameters from `StorageProvider` [#408](https://github.com/p2panda/p2panda/pull/408) `rs` 
 
 ### Fixed
 
 - Set log id default to `0` [#398](https://github.com/p2panda/p2panda/pull/398) `rs`
 - Fix iterator implementations for `SeqNum` and `LogId` [#404](https://github.com/p2panda/p2panda/pull/404) `rs`
-- Fix system schema CDDL definitions #[393](https://github.com/p2panda/p2panda/pull/393) `rs`
+- Fix system schema CDDL definitions [#393](https://github.com/p2panda/p2panda/pull/393) `rs`
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Highlights are marked with a pancake 🥞
 
 - Refactor mock `Node` implementation to use `StorageProvider` traits [#383](https://github.com/p2panda/p2panda/pull/383) `rs`
 - Deserialize from string and u64 for `LogId` and `SeqNum` [#401](https://github.com/p2panda/p2panda/pull/401) `rs`
+- Add latest_log_id method to `LogStore` [#413](https://github.com/p2panda/p2panda/pull/413) `rs`
 - Remove generic parameters from `StorageProvider` [#408](https://github.com/p2panda/p2panda/pull/408) `rs` 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Highlights are marked with a pancake 🥞
 
 - Refactor mock `Node` implementation to use `StorageProvider` traits [#383](https://github.com/p2panda/p2panda/pull/383) `rs`
 - Deserialize from string and u64 for `LogId` and `SeqNum` [#401](https://github.com/p2panda/p2panda/pull/401) `rs`
+- Remove generic parameters from `StorageProvider` #[408](https://github.com/p2panda/p2panda/pull/408) `rs` 
 
 ### Fixed
 

--- a/p2panda-rs/src/storage_provider/traits/entry_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/entry_store.rs
@@ -17,7 +17,6 @@ use crate::storage_provider::traits::AsStorageEntry;
 /// the required methods for inserting and querying entries from storage.
 #[async_trait]
 pub trait EntryStore<StorageEntry: AsStorageEntry> {
-    
     /// Insert an entry into storage.
     ///
     /// Returns an error if a fatal storage error occured.

--- a/p2panda-rs/src/storage_provider/traits/entry_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/entry_store.rs
@@ -17,6 +17,7 @@ use crate::storage_provider::traits::AsStorageEntry;
 /// the required methods for inserting and querying entries from storage.
 #[async_trait]
 pub trait EntryStore<StorageEntry: AsStorageEntry> {
+    
     /// Insert an entry into storage.
     ///
     /// Returns an error if a fatal storage error occured.

--- a/p2panda-rs/src/storage_provider/traits/log_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/log_store.rs
@@ -27,6 +27,11 @@ pub trait LogStore<StorageLog: AsStorageLog> {
     /// Determines the next unused log_id of an author.
     async fn next_log_id(&self, author: &Author) -> Result<LogId, LogStorageError>;
 
+    /// Determines the latest used log id for an author.
+    ///
+    /// Returns None when no log has been used yet.
+    async fn latest_log_id(&self, author: &Author) -> Result<Option<LogId>, LogStorageError>;
+
     /// Returns registered or possible log id for a document.
     ///
     /// If no log has been previously registered for this document it

--- a/p2panda-rs/src/storage_provider/traits/storage_provider.rs
+++ b/p2panda-rs/src/storage_provider/traits/storage_provider.rs
@@ -35,9 +35,10 @@ use crate::Validate;
 /// which needs defining is `get_document_by_entry`. It is also possible to over-ride the default
 /// definitions for any of the trait methods.
 #[async_trait]
-pub trait StorageProvider: EntryStore<Self::StorageEntry> + LogStore<Self::StorageLog> + OperationStore<Self::StorageOperation>
-{ 
-    // @TODO: These req/res types will be deprecated along with publish_entry and next_entry_args 
+pub trait StorageProvider:
+    EntryStore<Self::StorageEntry> + LogStore<Self::StorageLog> + OperationStore<Self::StorageOperation>
+{
+    // @TODO: These req/res types will be deprecated along with publish_entry and next_entry_args
 
     /// Params when making a request to get the next entry args for an author and document.
     type EntryArgsRequest: AsEntryArgsRequest + Sync;
@@ -50,17 +51,17 @@ pub trait StorageProvider: EntryStore<Self::StorageEntry> + LogStore<Self::Stora
 
     /// Response from a call to publish a new entry.
     type PublishEntryResponse: AsPublishEntryResponse;
-    
+
     // TODO: We can move these types into their own stores once we deprecate the
     // higher level methods (publish_entry and next_entry_args) on StorageProvider.
-    
-    /// An associated type representing an entry as it passes in and out of storage. 
+
+    /// An associated type representing an entry as it passes in and out of storage.
     type StorageEntry: AsStorageEntry;
 
-    /// An associated type representing a log as it passes in and out of storage. 
+    /// An associated type representing a log as it passes in and out of storage.
     type StorageLog: AsStorageLog;
-    
-    /// An associated type representing an operation as it passes in and out of storage. 
+
+    /// An associated type representing an operation as it passes in and out of storage.
     type StorageOperation: AsVerifiedOperation;
 
     /// Returns the related document for any entry.

--- a/p2panda-rs/src/test_utils/db/provider.rs
+++ b/p2panda-rs/src/test_utils/db/provider.rs
@@ -12,8 +12,10 @@ use crate::schema::SchemaId;
 use crate::storage_provider::traits::StorageProvider;
 use crate::storage_provider::traits::{AsStorageEntry, AsStorageLog};
 use crate::storage_provider::utils::Result;
+use crate::test_utils::db::{
+    EntryArgsRequest, EntryArgsResponse, PublishEntryRequest, PublishEntryResponse,
+};
 use crate::test_utils::db::{StorageEntry, StorageLog};
-use crate::test_utils::db::{EntryArgsRequest, EntryArgsResponse, PublishEntryRequest, PublishEntryResponse};
 
 type AuthorPlusLogId = String;
 
@@ -40,7 +42,6 @@ pub struct MemoryStore {
 
 #[async_trait]
 impl StorageProvider for MemoryStore {
-    
     type EntryArgsRequest = EntryArgsRequest;
 
     type EntryArgsResponse = EntryArgsResponse;
@@ -48,7 +49,7 @@ impl StorageProvider for MemoryStore {
     type PublishEntryRequest = PublishEntryRequest;
 
     type PublishEntryResponse = PublishEntryResponse;
-    
+
     type StorageEntry = StorageEntry;
 
     type StorageLog = StorageLog;

--- a/p2panda-rs/src/test_utils/db/provider.rs
+++ b/p2panda-rs/src/test_utils/db/provider.rs
@@ -12,10 +12,7 @@ use crate::schema::SchemaId;
 use crate::storage_provider::traits::StorageProvider;
 use crate::storage_provider::traits::{AsStorageEntry, AsStorageLog};
 use crate::storage_provider::utils::Result;
-use crate::test_utils::db::{
-    EntryArgsRequest, EntryArgsResponse, PublishEntryRequest, PublishEntryResponse, StorageEntry,
-    StorageLog,
-};
+use crate::test_utils::db::{StorageEntry, StorageLog};
 
 type AuthorPlusLogId = String;
 
@@ -41,14 +38,13 @@ pub struct MemoryStore {
 }
 
 #[async_trait]
-impl StorageProvider<StorageEntry, StorageLog, VerifiedOperation> for MemoryStore {
-    type EntryArgsRequest = EntryArgsRequest;
+impl StorageProvider for MemoryStore {
+    
+    type StorageEntry = StorageEntry;
 
-    type EntryArgsResponse = EntryArgsResponse;
+    type StorageLog = StorageLog;
 
-    type PublishEntryRequest = PublishEntryRequest;
-
-    type PublishEntryResponse = PublishEntryResponse;
+    type StorageOperation = VerifiedOperation;
 
     async fn get_document_by_entry(&self, entry_hash: &Hash) -> Result<Option<DocumentId>> {
         let entries = self.entries.lock().unwrap();

--- a/p2panda-rs/src/test_utils/db/provider.rs
+++ b/p2panda-rs/src/test_utils/db/provider.rs
@@ -13,6 +13,7 @@ use crate::storage_provider::traits::StorageProvider;
 use crate::storage_provider::traits::{AsStorageEntry, AsStorageLog};
 use crate::storage_provider::utils::Result;
 use crate::test_utils::db::{StorageEntry, StorageLog};
+use crate::test_utils::db::{EntryArgsRequest, EntryArgsResponse, PublishEntryRequest, PublishEntryResponse};
 
 type AuthorPlusLogId = String;
 
@@ -39,6 +40,14 @@ pub struct MemoryStore {
 
 #[async_trait]
 impl StorageProvider for MemoryStore {
+    
+    type EntryArgsRequest = EntryArgsRequest;
+
+    type EntryArgsResponse = EntryArgsResponse;
+
+    type PublishEntryRequest = PublishEntryRequest;
+
+    type PublishEntryResponse = PublishEntryResponse;
     
     type StorageEntry = StorageEntry;
 


### PR DESCRIPTION
Remove generic parameters and replace with _associated types_. This makes the implementation of StorageProvider much cleaner and means we can work with the trait as generic parameter more easily. It is also a more correct way to define the types used inside the different stores, they are not actually generic, they are defined once per implementation (this is what associated types are used for). Later we can move the types inside their respective stores for even more neat clarity.

Follow-up steps for later on:
- deprecate `publish_entry` and `next_entry_args`
- deprecate req-res types only needed in these mthods

needed for: https://github.com/p2panda/aquadoggo/pull/204 and includes breaking changes so should be coordinated.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
