### PR TITLE
Add `latest_log_id` to log store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Highlights are marked with a pancake 🥞
 
 - Refactor mock `Node` implementation to use `StorageProvider` traits [#383](https://github.com/p2panda/p2panda/pull/383) `rs`
 - Deserialize from string and u64 for `LogId` and `SeqNum` [#401](https://github.com/p2panda/p2panda/pull/401) `rs`
-- Remove generic parameters from `StorageProvider` #[408](https://github.com/p2panda/p2panda/pull/408) `rs` 
+- Remove generic parameters from `StorageProvider` #[408](https://github.com/p2panda/p2panda/pull/408) `rs`
+- Add latest_log_id method to `LogStore` [#413](https://github.com/p2panda/p2panda/pull/413) `rs`
 
 ### Fixed
 

--- a/p2panda-rs/src/storage_provider/traits/log_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/log_store.rs
@@ -27,6 +27,9 @@ pub trait LogStore<StorageLog: AsStorageLog> {
     /// Determines the next unused log_id of an author.
     async fn next_log_id(&self, author: &Author) -> Result<LogId, LogStorageError>;
 
+    /// Determines the next unused log_id of an author.
+    async fn latest_log_id(&self, author: &Author) -> Result<LogId, LogStorageError>;
+
     /// Returns registered or possible log id for a document.
     ///
     /// If no log has been previously registered for this document it

--- a/p2panda-rs/src/storage_provider/traits/log_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/log_store.rs
@@ -27,7 +27,9 @@ pub trait LogStore<StorageLog: AsStorageLog> {
     /// Determines the next unused log_id of an author.
     async fn next_log_id(&self, author: &Author) -> Result<LogId, LogStorageError>;
 
-    /// Determines the next unused log_id of an author.
+    /// Determines the latest used log id for an author.
+    /// 
+    /// Returns None when no log has been used yet.
     async fn latest_log_id(&self, author: &Author) -> Result<Option<LogId>, LogStorageError>;
 
     /// Returns registered or possible log id for a document.

--- a/p2panda-rs/src/storage_provider/traits/log_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/log_store.rs
@@ -28,7 +28,7 @@ pub trait LogStore<StorageLog: AsStorageLog> {
     async fn next_log_id(&self, author: &Author) -> Result<LogId, LogStorageError>;
 
     /// Determines the next unused log_id of an author.
-    async fn latest_log_id(&self, author: &Author) -> Result<LogId, LogStorageError>;
+    async fn latest_log_id(&self, author: &Author) -> Result<Option<LogId>, LogStorageError>;
 
     /// Returns registered or possible log id for a document.
     ///

--- a/p2panda-rs/src/storage_provider/traits/log_store.rs
+++ b/p2panda-rs/src/storage_provider/traits/log_store.rs
@@ -28,7 +28,7 @@ pub trait LogStore<StorageLog: AsStorageLog> {
     async fn next_log_id(&self, author: &Author) -> Result<LogId, LogStorageError>;
 
     /// Determines the latest used log id for an author.
-    /// 
+    ///
     /// Returns None when no log has been used yet.
     async fn latest_log_id(&self, author: &Author) -> Result<Option<LogId>, LogStorageError>;
 

--- a/p2panda-rs/src/test_utils/db/stores/log.rs
+++ b/p2panda-rs/src/test_utils/db/stores/log.rs
@@ -49,16 +49,18 @@ impl LogStore<StorageLog> for MemoryStore {
         let next_log_id = author_logs.count();
         Ok(LogId::new(next_log_id as u64))
     }
-    
+
     async fn latest_log_id(&self, author: &Author) -> Result<Option<LogId>, LogStorageError> {
         let logs = self.logs.lock().unwrap();
 
         let author_logs = logs.values().filter(|log| log.author() == *author);
         let log_count = author_logs.count();
-        
-        if log_count == 0 {Ok(None)} else {
-            let latest_log_id = log_count -1;
-            Ok(Some(LogId::new(latest_log_id as u64)))            
+
+        if log_count == 0 {
+            Ok(None)
+        } else {
+            let latest_log_id = log_count - 1;
+            Ok(Some(LogId::new(latest_log_id as u64)))
         }
     }
 }

--- a/p2panda-rs/src/test_utils/db/stores/log.rs
+++ b/p2panda-rs/src/test_utils/db/stores/log.rs
@@ -50,12 +50,16 @@ impl LogStore<StorageLog> for MemoryStore {
         Ok(LogId::new(next_log_id as u64))
     }
     
-    async fn latest_log_id(&self, author: &Author) -> Result<LogId, LogStorageError> {
+    async fn latest_log_id(&self, author: &Author) -> Result<Option<LogId>, LogStorageError> {
         let logs = self.logs.lock().unwrap();
 
         let author_logs = logs.values().filter(|log| log.author() == *author);
-        let latest_log_id = author_logs.count() -1;
-        Ok(LogId::new(latest_log_id as u64))
+        let log_count = author_logs.count();
+        
+        if log_count == 0 {Ok(None)} else {
+            let latest_log_id = log_count -1;
+            Ok(Some(LogId::new(latest_log_id as u64)))            
+        }
     }
 }
 

--- a/p2panda-rs/src/test_utils/db/stores/log.rs
+++ b/p2panda-rs/src/test_utils/db/stores/log.rs
@@ -49,6 +49,14 @@ impl LogStore<StorageLog> for MemoryStore {
         let next_log_id = author_logs.count();
         Ok(LogId::new(next_log_id as u64))
     }
+    
+    async fn latest_log_id(&self, author: &Author) -> Result<LogId, LogStorageError> {
+        let logs = self.logs.lock().unwrap();
+
+        let author_logs = logs.values().filter(|log| log.author() == *author);
+        let latest_log_id = author_logs.count() -1;
+        Ok(LogId::new(latest_log_id as u64))
+    }
 }
 
 #[cfg(test)]

--- a/p2panda-rs/src/test_utils/db/stores/log.rs
+++ b/p2panda-rs/src/test_utils/db/stores/log.rs
@@ -115,4 +115,22 @@ mod tests {
         let log_id = store.next_log_id(&author).await.unwrap();
         assert_eq!(log_id, LogId::new(1));
     }
+
+    #[rstest]
+    #[tokio::test]
+    async fn get_latest_log_id(key_pair: KeyPair, schema: SchemaId, document_id: DocumentId) {
+        // Instantiate a new store.
+        let store = MemoryStore::default();
+
+        let author = Author::try_from(key_pair.public_key().to_owned()).unwrap();
+        let log_id = store.latest_log_id(&author).await.unwrap();
+        assert_eq!(log_id, None);
+
+        let log = StorageLog::new(&author, &schema, &document_id, &LogId::default());
+
+        assert!(store.insert_log(log).await.is_ok());
+
+        let log_id = store.latest_log_id(&author).await.unwrap();
+        assert_eq!(log_id, Some(LogId::default()));
+    }
 }


### PR DESCRIPTION
Add one needed trait method for: https://github.com/p2panda/aquadoggo/pull/204

This is a breaking change for `aquadoggo`, handled with in the above PR.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
