### PR TITLE
Update `Human` for `SchemaId` and `DocumentViewId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,15 +18,15 @@ Highlights are marked with a pancake 🥞
 - Refactor mock `Node` implementation to use `StorageProvider` traits [#383](https://github.com/p2panda/p2panda/pull/383) `rs`
 - Deserialize from string and u64 for `LogId` and `SeqNum` [#401](https://github.com/p2panda/p2panda/pull/401) `rs`
 - Add latest_log_id method to `LogStore` [#413](https://github.com/p2panda/p2panda/pull/413) `rs`
-- Remove generic parameters from `StorageProvider` [#408](https://github.com/p2panda/p2panda/pull/408) `rs` 
+- Remove generic parameters from `StorageProvider` [#408](https://github.com/p2panda/p2panda/pull/408) `rs`
 - Consistent `as_str` and `to_string` functions, introduce `Human` trait with `display` method for short strings [#389](https://github.com/p2panda/p2panda/pull/389) `rs`
-- Update `Human` impl for `SchemaId` and `DocumentViewId` [#414](https://github.com/p2panda/p2panda/pull/414) `rs`
 
 ### Fixed
 
 - Set log id default to `0` [#398](https://github.com/p2panda/p2panda/pull/398) `rs`
 - Fix iterator implementations for `SeqNum` and `LogId` [#404](https://github.com/p2panda/p2panda/pull/404) `rs`
 - Fix system schema CDDL definitions [#393](https://github.com/p2panda/p2panda/pull/393) `rs`
+- Fix `Human` impl for `SchemaId` and `DocumentViewId` [#414](https://github.com/p2panda/p2panda/pull/414) `rs`
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Highlights are marked with a pancake 🥞
 - Add latest_log_id method to `LogStore` [#413](https://github.com/p2panda/p2panda/pull/413) `rs`
 - Remove generic parameters from `StorageProvider` [#408](https://github.com/p2panda/p2panda/pull/408) `rs` 
 - Consistent `as_str` and `to_string` functions, introduce `Human` trait with `display` method for short strings [#389](https://github.com/p2panda/p2panda/pull/389) `rs`
+- Update `Human` impl for `SchemaId` and `DocumentViewId` [#414](https://github.com/p2panda/p2panda/pull/414) `rs`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,13 @@ Highlights are marked with a pancake 🥞
 - Add latest_log_id method to `LogStore` [#413](https://github.com/p2panda/p2panda/pull/413) `rs`
 - Remove generic parameters from `StorageProvider` [#408](https://github.com/p2panda/p2panda/pull/408) `rs`
 - Consistent `as_str` and `to_string` functions, introduce `Human` trait with `display` method for short strings [#389](https://github.com/p2panda/p2panda/pull/389) `rs`
+- Update `Human` impl for `SchemaId` and `DocumentViewId` [#414](https://github.com/p2panda/p2panda/pull/414) `rs`
 
 ### Fixed
 
 - Set log id default to `0` [#398](https://github.com/p2panda/p2panda/pull/398) `rs`
 - Fix iterator implementations for `SeqNum` and `LogId` [#404](https://github.com/p2panda/p2panda/pull/404) `rs`
 - Fix system schema CDDL definitions [#393](https://github.com/p2panda/p2panda/pull/393) `rs`
-- Fix `Human` impl for `SchemaId` and `DocumentViewId` [#414](https://github.com/p2panda/p2panda/pull/414) `rs`
 
 ## [0.4.0]
 

--- a/p2panda-rs/src/document/document_view.rs
+++ b/p2panda-rs/src/document/document_view.rs
@@ -79,7 +79,7 @@ impl Display for DocumentView {
 
 impl Human for DocumentView {
     fn display(&self) -> String {
-        format!("<DocumentView {}>", self.id.display())
+        self.id.display()
     }
 }
 

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -59,6 +59,22 @@ impl DocumentViewId {
         graph_tips.sort();
         graph_tips
     }
+
+    /// Can be used as a human-readable representation of a document view id.
+    ///
+    /// The return value contains all view graph tips' last 6 characters
+    /// concatenated with an underscore.
+    pub fn to_short_string(&self) -> String {
+        let mut result = String::new();
+
+        let offset = yasmf_hash::MAX_YAMF_HASH_SIZE * 2 - 6;
+
+        for (i, operation_id) in self.0.clone().into_iter().enumerate() {
+            let separator = if i == 0 { "" } else { "_" };
+            write!(result, "{}{}", &separator, &operation_id.as_str()[offset..]).unwrap();
+        }
+        result
+    }
 }
 
 impl Display for DocumentViewId {
@@ -74,15 +90,7 @@ impl Display for DocumentViewId {
 
 impl Human for DocumentViewId {
     fn display(&self) -> String {
-        let mut result = String::new();
-        let offset = yasmf_hash::MAX_YAMF_HASH_SIZE * 2 - 6;
-
-        for (i, operation_id) in self.0.clone().into_iter().enumerate() {
-            let separator = if i == 0 { "" } else { "_" };
-            write!(result, "{}{}", &separator, &operation_id.as_str()[offset..]).unwrap();
-        }
-
-        result
+        format!("<DocumentView {}>", self.to_short_string())
     }
 }
 
@@ -314,7 +322,7 @@ mod tests {
             .unwrap();
 
         let view_id_unmerged = DocumentViewId::new(&[operation_1, operation_2]).unwrap();
-        assert_eq!(view_id_unmerged.display(), "496543_f16e79");
+        assert_eq!(view_id_unmerged.display(), "<DocumentView 496543_f16e79>");
     }
 
     #[rstest]

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -62,9 +62,9 @@ impl DocumentViewId {
 
     /// Can be used as a human-readable representation of a document view id.
     ///
-    /// The return value contains all view graph tips' last 6 characters
-    /// concatenated with an underscore.
-    pub fn to_short_string(&self) -> String {
+    /// The return value contains all view graph tips' last 6 characters concatenated with an
+    /// underscore.
+    pub(crate) fn to_short_string(&self) -> String {
         let mut result = String::new();
 
         let offset = yasmf_hash::MAX_YAMF_HASH_SIZE * 2 - 6;

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -227,7 +227,7 @@ impl Display for Schema {
 
 impl Human for Schema {
     fn display(&self) -> String {
-        format!("<Schema {}>", self.id.display())
+        self.id.display()
     }
 }
 
@@ -329,7 +329,7 @@ mod tests {
             vec![("number", FieldType::Int)],
         )
         .unwrap();
-        assert_eq!(schema.display(), "<Schema venue 496543>");
+        assert_eq!(schema.display(), "<Schema venue_496543>");
 
         let schema_definition = Schema::get_system(SchemaId::SchemaDefinition(1)).unwrap();
         assert_eq!(schema_definition.display(), "<Schema schema_definition_v1>");

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::fmt;
-use std::fmt::Display;
+use std::fmt::{Display, Write};
 use std::str::FromStr;
 
 use serde::de::Visitor;
@@ -173,10 +173,16 @@ impl Display for SchemaId {
 
 impl Human for SchemaId {
     fn display(&self) -> String {
+        let mut rv = String::new();
+        write!(rv, "<Schema ").unwrap();
         match self {
-            SchemaId::Application(name, view_id) => format!("{} {}", name, view_id.display()),
-            system_schema => format!("{}", system_schema),
+            SchemaId::Application(name, view_id) => {
+                write!(rv, "{}_{}", name, view_id.to_short_string()).unwrap()
+            }
+            system_schema => write!(rv, "{}", system_schema).unwrap(),
         }
+        write!(rv, ">").unwrap();
+        rv
     }
 }
 
@@ -360,10 +366,10 @@ mod test {
 
     #[rstest]
     fn short_representation(schema: SchemaId) {
-        assert_eq!(schema.display(), "venue 8fc78b");
+        assert_eq!(schema.display(), "<Schema venue_8fc78b>");
         assert_eq!(
             SchemaId::SchemaDefinition(1).display(),
-            "schema_definition_v1"
+            "<Schema schema_definition_v1>"
         );
     }
 }


### PR DESCRIPTION
When we want to include `SchemaId` or `DocumentViewId` in log lines etc. they will represent the respective schema or document view themselves and not just the ID. The current implementation of `Human` for these traits just returns their shortened ids, which leads to log lines like 

```
Dispatch dependency task for view with id: 30e31e
```

when instead we would rather like to have

```
Dispatch dependency task for <DocumentView 30e31e>
```

This PR changes the `Human` impl on `SchemaId` and `DocumentViewId` to represent these items like the respective `Schema` and `DocumentView`.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
