### PR TITLE
Easy operations and schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Highlights are marked with a pancake 🥞
 ### Added
 
 - `MemoryStore` in memory implementation of storage traits [#383](https://github.com/p2panda/p2panda/pull/383) `rs`
+- Helpers and conversion implementations to create schemas and operations more easily [#416](https://github.com/p2panda/p2panda/pull/416) `rs`
 
 ### Changed
 

--- a/p2panda-rs/src/operation/error.rs
+++ b/p2panda-rs/src/operation/error.rs
@@ -25,6 +25,10 @@ pub enum OperationError {
     /// Invalid hash found.
     #[error(transparent)]
     HashError(#[from] crate::hash::HashError),
+
+    /// Error from operation fields.
+    #[error(transparent)]
+    OperationFieldsError(#[from] OperationFieldsError),
 }
 
 /// Error types for methods of `OperationFields` struct.

--- a/p2panda-rs/src/operation/operation_value.rs
+++ b/p2panda-rs/src/operation/operation_value.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::document::{DocumentId, DocumentViewId};
 use crate::hash::HashError;
 use crate::operation::{PinnedRelation, PinnedRelationList, Relation, RelationList};
 use crate::Validate;
@@ -118,6 +119,30 @@ impl From<&str> for OperationValue {
     }
 }
 
+impl From<DocumentId> for OperationValue {
+    fn from(value: DocumentId) -> Self {
+        OperationValue::Relation(Relation::new(value))
+    }
+}
+
+impl From<Vec<DocumentId>> for OperationValue {
+    fn from(value: Vec<DocumentId>) -> Self {
+        OperationValue::RelationList(RelationList::new(value))
+    }
+}
+
+impl From<DocumentViewId> for OperationValue {
+    fn from(value: DocumentViewId) -> Self {
+        OperationValue::PinnedRelation(PinnedRelation::new(value))
+    }
+}
+
+impl From<Vec<DocumentViewId>> for OperationValue {
+    fn from(value: Vec<DocumentViewId>) -> Self {
+        OperationValue::PinnedRelationList(PinnedRelationList::new(value))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -128,13 +153,16 @@ mod tests {
         OperationId, PinnedRelation, PinnedRelationList, Relation, RelationList,
     };
     use crate::schema::FieldType;
-    use crate::test_utils::fixtures::{random_document_id, random_operation_id};
+    use crate::test_utils::fixtures::{
+        document_id, document_view_id, random_document_id, random_operation_id,
+    };
     use crate::Validate;
 
     use super::OperationValue;
 
-    #[test]
-    fn converstion() {
+    #[rstest]
+    fn conversion(document_id: DocumentId, document_view_id: DocumentViewId) {
+        // Scalar types
         assert_eq!(OperationValue::Boolean(true), true.into());
         assert_eq!(OperationValue::Float(1.5), 1.5.into());
         assert_eq!(OperationValue::Integer(3), 3.into());
@@ -142,6 +170,26 @@ mod tests {
         assert_eq!(
             OperationValue::Text("hellö".to_string()),
             "hellö".to_string().into()
+        );
+
+        // Relation types
+        assert_eq!(
+            OperationValue::Relation(Relation::new(document_id.clone())),
+            document_id.clone().into()
+        );
+        assert_eq!(
+            OperationValue::RelationList(RelationList::new(vec![document_id.clone()])),
+            vec![document_id].into()
+        );
+        assert_eq!(
+            OperationValue::PinnedRelation(PinnedRelation::new(document_view_id.clone())),
+            document_view_id.clone().into()
+        );
+        assert_eq!(
+            OperationValue::PinnedRelationList(PinnedRelationList::new(vec![
+                document_view_id.clone()
+            ])),
+            vec![document_view_id.clone()].into()
         );
     }
 

--- a/p2panda-rs/src/operation/operation_value.rs
+++ b/p2panda-rs/src/operation/operation_value.rs
@@ -88,6 +88,36 @@ impl OperationValue {
     }
 }
 
+impl From<bool> for OperationValue {
+    fn from(value: bool) -> Self {
+        OperationValue::Boolean(value)
+    }
+}
+
+impl From<f64> for OperationValue {
+    fn from(value: f64) -> Self {
+        OperationValue::Float(value)
+    }
+}
+
+impl From<i64> for OperationValue {
+    fn from(value: i64) -> Self {
+        OperationValue::Integer(value)
+    }
+}
+
+impl From<String> for OperationValue {
+    fn from(value: String) -> Self {
+        OperationValue::Text(value)
+    }
+}
+
+impl From<&str> for OperationValue {
+    fn from(value: &str) -> Self {
+        OperationValue::Text(value.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -102,6 +132,18 @@ mod tests {
     use crate::Validate;
 
     use super::OperationValue;
+
+    #[test]
+    fn converstion() {
+        assert_eq!(OperationValue::Boolean(true), true.into());
+        assert_eq!(OperationValue::Float(1.5), 1.5.into());
+        assert_eq!(OperationValue::Integer(3), 3.into());
+        assert_eq!(OperationValue::Text("hellö".to_string()), "hellö".into());
+        assert_eq!(
+            OperationValue::Text("hellö".to_string()),
+            "hellö".to_string().into()
+        );
+    }
 
     #[rstest]
     #[allow(clippy::too_many_arguments)]

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -313,8 +313,7 @@ mod tests {
     use crate::operation::{OperationId, OperationValue, PinnedRelationList};
     use crate::schema::system::{SchemaFieldView, SchemaView};
     use crate::schema::{FieldType, Schema, SchemaId, SchemaVersion};
-    use crate::test_utils::fixtures::{document_view_id, random_key_pair, random_operation_id};
-    use crate::test_utils::mocks::{send_to_node, Client, Node};
+    use crate::test_utils::fixtures::{document_view_id, random_operation_id};
     use crate::Human;
 
     fn create_schema_view(
@@ -646,9 +645,18 @@ mod tests {
         )
         .is_err());
     }
+}
+// Exclude wasm which doesn't support `Node`
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod tests_wasm_not_invited {
+    use rstest::rstest;
 
-    // Exclude wasm which doesn't support `Node`
-    #[cfg(not(target_arch = "wasm32"))]
+    use crate::operation::OperationValue;
+    use crate::schema::{FieldType, Schema};
+    use crate::test_utils::fixtures::random_key_pair;
+    use crate::test_utils::mocks::{send_to_node, Client, Node};
+
     #[rstest]
     #[tokio::test]
     // Override because Clippy does not recognise that `matches` consumes its parameters

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -647,6 +647,8 @@ mod tests {
         .is_err());
     }
 
+    // Exclude wasm which doesn't support `Node`
+    #[cfg(not(target_arch = "wasm32"))]
     #[rstest]
     #[tokio::test]
     // Override because Clippy does not recognise that `matches` consumes its parameters

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -121,7 +121,7 @@ impl Schema {
     /// #
     /// # #[rstest]
     /// # fn main(#[from(document_view_id)] schema_document_view_id: DocumentViewId) {
-    ///
+    /// #
     /// # let from_field_view_id = random_operation_id();
     /// # let to_field_view_id = random_operation_id();
     /// // Assuming you have created two fields beforehand:
@@ -129,8 +129,8 @@ impl Schema {
     ///     "chess_move",
     ///     "a move in my chess game",
     ///     vec![from_field_view_id, to_field_view_id].into()
-    /// );
-    /// assert!(create_operation.is_ok());
+    /// ).unwrap();
+    /// assert!(create_operation.validate().is_ok());
     /// # }
     /// # }
     /// ```
@@ -165,8 +165,8 @@ impl Schema {
     /// let create_operation: Operation = Schema::create_field(
     ///     "field_name",
     ///     FieldType::String,
-    /// );
-    /// assert!(create_operation.is_ok());
+    /// ).unwrap();
+    /// assert!(create_operation.validate().is_ok());
     /// # }
     /// # }
     /// ```


### PR DESCRIPTION
Writing tests for the GraphQL api I kept thinking about how much I wanted to use all the test utils even for things that should be easy even when not writing tests. Like creating operations without having to initialise `OperationFields` instances or making operations that create schemas when sent to a node without jumping through all kinds of hoops. 

When we write examples (and p2panda apps!) we don't want to have to use test utils all the time I guess sooo..

So here I have implemented 

**A) conversion implementations for `OperationValue` and `OperationFields`:**

for example:

```rust
assert_eq!(OperationValue::Text("pingu".to_string()), "pingu".into());
```

these can now be used with the `Operation::new_create` etc. methods we already had:

```rust
let op = Operation::new_create(
    SchemaId::SchemaFieldDefinition(1),
    vec![ // <-- No `OperationFields::new()` here
        ("name", "field_name".into()), // <-- or here
        ("type", FieldType::String.into()),
    ]
    .try_into()
    .unwrap(),
);
assert!(op.is_ok());
```

**B) helper to create schema `create` operations**

(the same exists for schema field definitions on `Schema::create_field`)

```rust
let operation = Schema::create_field("title", FieldType::Bool).unwrap();
let (field_entry, _) = send_to_node(&mut node, &client, &operation).await.unwrap();

let field_view_id: DocumentViewId = field_entry.as_str().parse().unwrap();

// Create schema definition
let operation = Schema::create(
    "books",
    "books in my library",
    vec![field_view_id].into(),
)
.unwrap();

let (schema_view_id, _) = send_to_node(&mut node, &client, &operation).await.unwrap();
```

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
