### PR TITLE
Fix GraphQL queries with Apollo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Highlights are marked with a pancake 🥞
 - Set log id default to `0` [#398](https://github.com/p2panda/p2panda/pull/398) `rs`
 - Fix iterator implementations for `SeqNum` and `LogId` [#404](https://github.com/p2panda/p2panda/pull/404) `rs`
 - Fix system schema CDDL definitions [#393](https://github.com/p2panda/p2panda/pull/393) `rs`
+- Fix GraphQL queries via Apollo [#428](https://github.com/p2panda/p2panda/pull/428) `js`
 
 ## [0.4.0]
 

--- a/p2panda-js/src/document/document.test.ts
+++ b/p2panda-js/src/document/document.test.ts
@@ -30,9 +30,7 @@ describe('document', () => {
       const asyncFunctionMock = jest
         .fn()
         .mockResolvedValue(entryArgsFixture(1));
-      jest
-        .spyOn(session, 'getNextEntryArgs')
-        .mockImplementation(asyncFunctionMock);
+      jest.spyOn(session, 'getNextArgs').mockImplementation(asyncFunctionMock);
 
       const fields = entryFixture(1).operation?.fields as Fields;
 
@@ -55,9 +53,7 @@ describe('document', () => {
       const asyncFunctionMock = jest
         .fn()
         .mockResolvedValue(entryArgsFixture(2));
-      jest
-        .spyOn(session, 'getNextEntryArgs')
-        .mockImplementation(asyncFunctionMock);
+      jest.spyOn(session, 'getNextArgs').mockImplementation(asyncFunctionMock);
 
       // These are the fields for an update operation
       const fields = entryFixture(2).operation?.fields as Fields;
@@ -92,9 +88,7 @@ describe('document', () => {
       const asyncFunctionMock = jest
         .fn()
         .mockResolvedValue(entryArgsFixture(4));
-      jest
-        .spyOn(session, 'getNextEntryArgs')
-        .mockImplementation(asyncFunctionMock);
+      jest.spyOn(session, 'getNextArgs').mockImplementation(asyncFunctionMock);
 
       // This is the document id
       const id = documentIdFixture();

--- a/p2panda-js/src/entry/entry.ts
+++ b/p2panda-js/src/entry/entry.ts
@@ -21,44 +21,34 @@ export const signPublishEntry = async (
   documentId?: string,
 ): Promise<string> => {
   const { signEncodeEntry } = await wasm;
+  const publicKey = keyPair.publicKey();
 
   log('Signing and publishing entry');
+  const nextArgs = await session.getNextArgs(publicKey, documentId);
 
-  const entryArgs = await session.getNextEntryArgs(
-    keyPair.publicKey(),
+  log('Retrieved next args for', {
+    publicKey,
     documentId,
-  );
-
-  log('Retrieved next entry args for', {
-    keyPair: keyPair.publicKey(),
-    documentId,
-    entryArgs,
+    nextArgs,
   });
 
   const { entryEncoded, entryHash } = signEncodeEntry(
     keyPair,
     operationEncoded,
-    entryArgs.skiplink,
-    entryArgs.backlink,
-    BigInt(entryArgs.seqNum),
-    BigInt(entryArgs.logId),
+    nextArgs.skiplink,
+    nextArgs.backlink,
+    BigInt(nextArgs.seqNum),
+    BigInt(nextArgs.logId),
   );
   log('Signed and encoded entry');
 
-  const nextEntryArgs = await session.publishEntry(
-    entryEncoded,
-    operationEncoded,
-  );
+  const publishNextArgs = await session.publish(entryEncoded, operationEncoded);
   log('Published entry');
 
   // Cache next entry args for next publish. Use the entry hash as the document
   // id for CREATE operations.
-  session.setNextEntryArgs(
-    keyPair.publicKey(),
-    documentId || entryHash,
-    nextEntryArgs,
-  );
-  log('Cached next entry args');
+  session.setNextArgs(publicKey, documentId || entryHash, publishNextArgs);
+  log('Cached next arguments');
 
   return entryEncoded;
 };

--- a/p2panda-js/src/session/session.test.ts
+++ b/p2panda-js/src/session/session.test.ts
@@ -2,7 +2,6 @@
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import { DocumentNode } from 'graphql';
 import { createMockClient } from 'mock-apollo-client';
 
 import { KeyPair } from 'wasm';
@@ -19,7 +18,7 @@ import {
   entryFixture,
   schemaFixture,
 } from '../../test/fixtures';
-import { GQL_NEXT_ENTRY_ARGS, GQL_PUBLISH_ENTRY } from './session';
+import { GQL_NEXT_ARGS, GQL_PUBLISH } from './session';
 
 /**
  * Simple mock p2panda session.
@@ -37,7 +36,7 @@ const createMockSession = (): Session => {
   const mockClient = createMockClient();
 
   // Register nextEntryArgs handler
-  mockClient.setRequestHandler(GQL_NEXT_ENTRY_ARGS, () =>
+  mockClient.setRequestHandler(GQL_NEXT_ARGS, () =>
     Promise.resolve({
       data: {
         nextEntryArgs: entryArgsFixture(5),
@@ -46,7 +45,7 @@ const createMockSession = (): Session => {
   );
 
   // Register publishEntry handler
-  mockClient.setRequestHandler(GQL_PUBLISH_ENTRY, () =>
+  mockClient.setRequestHandler(GQL_PUBLISH, () =>
     Promise.resolve({
       data: {
         publishEntry: entryArgsFixture(5),
@@ -95,16 +94,16 @@ describe('Session', () => {
     );
   });
 
-  describe('publishEntry', () => {
+  describe('publish', () => {
     it('can publish entries', async () => {
       const session = createMockSession();
 
       try {
-        const nextEntryArgs = await session.publishEntry(
+        const nextArgs = await session.publish(
           encodedEntryFixture(4).entryBytes,
           encodedEntryFixture(4).payloadBytes,
         );
-        expect(nextEntryArgs.backlink).toEqual(entryArgsFixture(5).backlink);
+        expect(nextArgs.backlink).toEqual(entryArgsFixture(5).backlink);
       } catch (err) {
         console.error(err);
         throw err;
@@ -115,11 +114,11 @@ describe('Session', () => {
       const session = createMockSession();
       await expect(
         // @ts-ignore: We deliberately use the API wrong here
-        session.publishEntry(null, encodedEntryFixture(1).payloadBytes),
+        session.publish(null, encodedEntryFixture(1).payloadBytes),
       ).rejects.toThrow();
       await expect(
         // @ts-ignore: We deliberately use the API wrong here
-        session.publishEntry(encodedEntryFixture(1).entryBytes, null),
+        session.publish(encodedEntryFixture(1).entryBytes, null),
       ).rejects.toThrow();
     });
   });
@@ -128,14 +127,14 @@ describe('Session', () => {
     it('returns next entry args from node', async () => {
       const session = createMockSession();
 
-      const nextEntryArgs = await session.getNextEntryArgs(
+      const nextArgs = await session.getNextArgs(
         authorFixture().publicKey,
         documentIdFixture(),
       );
-      expect(nextEntryArgs.skiplink).toEqual(entryArgsFixture(5).skiplink);
-      expect(nextEntryArgs.backlink).toEqual(entryArgsFixture(5).backlink);
-      expect(nextEntryArgs.seqNum).toEqual(entryArgsFixture(5).seqNum);
-      expect(nextEntryArgs.logId).toEqual(entryArgsFixture(5).logId);
+      expect(nextArgs.skiplink).toEqual(entryArgsFixture(5).skiplink);
+      expect(nextArgs.backlink).toEqual(entryArgsFixture(5).backlink);
+      expect(nextArgs.seqNum).toEqual(entryArgsFixture(5).seqNum);
+      expect(nextArgs.logId).toEqual(entryArgsFixture(5).logId);
     });
 
     it('returns next entry args from cache', async () => {
@@ -146,24 +145,24 @@ describe('Session', () => {
       // @ts-ignore Yes, Typescript, a mock is not the same as the original.
       session.client.query = mockedFn;
 
-      const nextEntryArgs = {
+      const nextArgs = {
         // Treat json `null` as undefined
         backlink: entryArgsFixture(5).backlink as string | undefined,
         skiplink: entryArgsFixture(5).skiplink as string | undefined,
         logId: entryArgsFixture(5).logId,
         seqNum: entryArgsFixture(5).seqNum,
       };
-      session.setNextEntryArgs(
+      session.setNextArgs(
         authorFixture().publicKey,
         documentIdFixture(),
-        nextEntryArgs,
+        nextArgs,
       );
 
-      const cacheResponse = await session.getNextEntryArgs(
+      const cacheResponse = await session.getNextArgs(
         authorFixture().publicKey,
         documentIdFixture(),
       );
-      expect(cacheResponse.logId).toEqual(nextEntryArgs.logId);
+      expect(cacheResponse.logId).toEqual(nextArgs.logId);
       expect(mockedFn.mock.calls.length).toBe(0);
     });
   });
@@ -180,9 +179,7 @@ describe('Session', () => {
     });
 
     it('handles valid arguments', async () => {
-      jest
-        .spyOn(session, 'getNextEntryArgs')
-        .mockResolvedValue(entryArgsFixture(1));
+      jest.spyOn(session, 'getNextArgs').mockResolvedValue(entryArgsFixture(1));
 
       expect(
         await session.create(fields, {
@@ -216,9 +213,7 @@ describe('Session', () => {
     beforeEach(async () => {
       session = createMockSession();
       session.setKeyPair(keyPair);
-      jest
-        .spyOn(session, 'getNextEntryArgs')
-        .mockResolvedValue(entryArgsFixture(2));
+      jest.spyOn(session, 'getNextArgs').mockResolvedValue(entryArgsFixture(2));
     });
 
     it('handles valid arguments', async () => {
@@ -264,9 +259,7 @@ describe('Session', () => {
     beforeEach(async () => {
       session = createMockSession();
       session.setKeyPair(keyPair);
-      jest
-        .spyOn(session, 'getNextEntryArgs')
-        .mockResolvedValue(entryArgsFixture(3));
+      jest.spyOn(session, 'getNextArgs').mockResolvedValue(entryArgsFixture(3));
     });
 
     it('handles valid arguments', async () => {

--- a/p2panda-js/src/types.ts
+++ b/p2panda-js/src/types.ts
@@ -8,7 +8,7 @@ export type SchemaId =
 /**
  * Arguments for publishing the next entry.
  */
-export type EntryArgs = {
+export type NextArgs = {
   skiplink: string | undefined;
   backlink: string | undefined;
   seqNum: string;

--- a/p2panda-js/test/fixtures.ts
+++ b/p2panda-js/test/fixtures.ts
@@ -3,7 +3,7 @@ import { marshallResponseFields } from '~/utils';
 import type {
   EncodedEntry,
   Entry,
-  EntryArgs,
+  NextArgs,
   FieldsTagged,
   Operation,
   OperationTagged,
@@ -124,10 +124,10 @@ export const encodedEntryFixture = (seqNum: number): EncodedEntry => {
  * Takes a `seqNum` parameter, which is the sequence number of
  * the entry preceding the one we want arguments for.
  */
-export const entryArgsFixture = (seqNum: number): EntryArgs => {
+export const entryArgsFixture = (seqNum: number): NextArgs => {
   const index = seqNum - 1;
 
-  const entryArgs: EntryArgs = {
+  const entryArgs: NextArgs = {
     backlink: (nextEntryArgs[index].backlink || null) as string | undefined,
     skiplink: (nextEntryArgs[index].skiplink || null) as string | undefined,
     seqNum: nextEntryArgs[index].seqNum,


### PR DESCRIPTION
This fixes the issue https://github.com/p2panda/p2panda/issues/382. The problem was that we need to state the variables in the query definition:

**Wrong:**

```js
export const GQL_NEXT_ARGS = gql`
  {
    nextEntryArgs(publicKey: $publicKey, documentId: $viewId) {
      logId
      seqNum
      backlink
      skiplink
  }
`;
```

**Correct:**

```js
export const GQL_NEXT_ARGS = gql`
  query NextArgs($publicKey: String!, $viewId: String) {
    nextEntryArgs(publicKey: $publicKey, documentId: $viewId) {
      logId
      seqNum
      backlink
      skiplink
    }
  }
`;
```

This PR also already prepares the future query and field names (`viewId` instead of `documentId`, `publish` instead of `publishEntry` and `nextArgs` instead of `nextEntryArgs`).

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
