### PR TITLE
Make from_bytes public for encoded entry and operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Highlights are marked with a pancake 🥞
 - Introduce new node and browser builds for JavaScript, export TypeScript definitions [#429](https://github.com/p2panda/p2panda/pull/429) `js`
 - Refactored benchmarks to include schema validation [#430](https://github.com/p2panda/p2panda/pull/414) `rs`
 - Replace `@apollo/client` with `graphql-request` [#441](https://github.com/p2panda/p2panda/pull/441) `js`
-- Make from_str public for `EncodedOperation` & `EncodedEntry`[#445](https://github.com/p2panda/p2panda/pull/445) `rs`
+- Make from_bytes public for `EncodedOperation` & `EncodedEntry`[#445](https://github.com/p2panda/p2panda/pull/445) `rs`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Highlights are marked with a pancake 🥞
 - Introduce new node and browser builds for JavaScript, export TypeScript definitions [#429](https://github.com/p2panda/p2panda/pull/429) `js`
 - Refactored benchmarks to include schema validation [#430](https://github.com/p2panda/p2panda/pull/414) `rs`
 - Replace `@apollo/client` with `graphql-request` [#441](https://github.com/p2panda/p2panda/pull/441) `js`
+- Make from_str public for `EncodedOperation` & `EncodedEntry`[#445](https://github.com/p2panda/p2panda/pull/445) `rs`
 
 ### Fixed
 

--- a/p2panda-rs/src/entry/encoded_entry.rs
+++ b/p2panda-rs/src/entry/encoded_entry.rs
@@ -32,7 +32,7 @@ impl EncodedEntry {
     ///
     /// This does not apply any validation and should only be used in methods where all checks have
     /// taken place before.
-    pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
+    pub fn from_bytes(bytes: &[u8]) -> Self {
         Self(bytes.to_owned())
     }
 

--- a/p2panda-rs/src/operation/encoded_operation.rs
+++ b/p2panda-rs/src/operation/encoded_operation.rs
@@ -27,7 +27,7 @@ impl EncodedOperation {
     ///
     /// This does not apply any validation and should only be used in methods where all checks have
     /// taken place before.
-    pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
+    pub fn from_bytes(bytes: &[u8]) -> Self {
         Self(bytes.to_owned())
     }
 


### PR DESCRIPTION

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
