### PR TITLE
Implement serde traits for `DocumentId` and all relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Highlights are marked with a pancake 🥞
 - `MemoryStore` in memory implementation of storage traits [#383](https://github.com/p2panda/p2panda/pull/383) `rs`
 - Helpers and conversion implementations to create schemas and operations more easily [#416](https://github.com/p2panda/p2panda/pull/416) `rs`
 - Untagged operation format, schema validation, new operation and entry API [#415](https://github.com/p2panda/p2panda/pull/415) `rs`
+- Serde trait implementations for `DocumentId` and all relations [#446](https://github.com/p2panda/p2panda/pull/446) `rs`
 
 ### Changed
 

--- a/p2panda-rs/src/document/document_id.rs
+++ b/p2panda-rs/src/document/document_id.rs
@@ -4,6 +4,8 @@ use std::fmt::Display;
 use std::hash::Hash as StdHash;
 use std::str::FromStr;
 
+use serde::{Deserialize, Serialize};
+
 use crate::document::error::DocumentIdError;
 use crate::hash::Hash;
 use crate::operation::OperationId;
@@ -23,7 +25,7 @@ use crate::{Human, Validate};
 ///                         \
 ///                          \__ [UPDATE] (Hash: "eff..")
 /// ```
-#[derive(Clone, Debug, StdHash, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug, StdHash, Ord, PartialOrd, Eq, PartialEq, Serialize)]
 pub struct DocumentId(OperationId);
 
 impl DocumentId {
@@ -74,12 +76,33 @@ impl FromStr for DocumentId {
     }
 }
 
+impl<'de> Deserialize<'de> for DocumentId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Deserialize into `OperationId` struct
+        let operation_id: OperationId = Deserialize::deserialize(deserializer)?;
+
+        // Check format
+        operation_id
+            .validate()
+            .map_err(|err| serde::de::Error::custom(format!("invalid operation id, {}", err)))?;
+
+        Ok(Self(operation_id))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use ciborium::cbor;
     use rstest::rstest;
 
     use crate::hash::Hash;
     use crate::operation::OperationId;
+    use crate::serde::{deserialize_into, serialize_from, serialize_value};
     use crate::test_utils::fixtures::random_hash;
     use crate::Human;
 
@@ -119,5 +142,40 @@ mod tests {
         let document_id: DocumentId = hash_str.parse().unwrap();
 
         assert_eq!(document_id.display(), "<DocumentId 6ec805>");
+    }
+
+    #[test]
+    fn serialize() {
+        let bytes = serialize_from(
+            DocumentId::from_str(
+                "0020cfb0fa37f36d082faad3886a9ffbcc2813b7afe90f0609a556d425f1a76ec805",
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            bytes,
+            vec![
+                120, 68, 48, 48, 50, 48, 99, 102, 98, 48, 102, 97, 51, 55, 102, 51, 54, 100, 48,
+                56, 50, 102, 97, 97, 100, 51, 56, 56, 54, 97, 57, 102, 102, 98, 99, 99, 50, 56, 49,
+                51, 98, 55, 97, 102, 101, 57, 48, 102, 48, 54, 48, 57, 97, 53, 53, 54, 100, 52, 50,
+                53, 102, 49, 97, 55, 54, 101, 99, 56, 48, 53
+            ]
+        );
+    }
+
+    #[test]
+    fn deserialize() {
+        let hash_str = "0020cfb0fa37f36d082faad3886a9ffbcc2813b7afe90f0609a556d425f1a76ec805";
+        let document_id: DocumentId = deserialize_into(&serialize_value(cbor!(
+            "0020cfb0fa37f36d082faad3886a9ffbcc2813b7afe90f0609a556d425f1a76ec805"
+        )))
+        .unwrap();
+        assert_eq!(DocumentId::from_str(hash_str).unwrap(), document_id);
+
+        // Invalid hashes
+        let invalid_hash = deserialize_into::<DocumentId>(&serialize_value(cbor!("1234")));
+        assert!(invalid_hash.is_err());
+        let empty_hash = deserialize_into::<DocumentId>(&serialize_value(cbor!("")));
+        assert!(empty_hash.is_err());
     }
 }


### PR DESCRIPTION
This is not really used within `p2panda-rs` but helps maybe other developers and the `wasm` development.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
