### PR TITLE
Add `commit` method on document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Changed
 
+- Add `commit` method to `Document` for applying operations incrementally [#485](https://github.com/p2panda/p2panda/pull/485) `rs`
 - Add schema name tests when deserializing plain operations [#480](https://github.com/p2panda/p2panda/pull/480) `rs`
 - Introduce typed errors in `domain` and `validation` modules [#478](https://github.com/p2panda/p2panda/pull/478) `rs`
 - Refactor storage API: Rename methods, remove `StorageProvider` and document "caching" layers [#469](https://github.com/p2panda/p2panda/pull/469) `rs`

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -26,7 +26,7 @@ use crate::{Human, WithId};
 ///
 /// Documents are constructed through the [`DocumentBuilder`] or by conversion from vectors of a type implementing
 /// the [`AsOperation`], [`WithId<OperationId>`] and [`WithPublicKey`].
-/// 
+///
 /// To efficiently commit more operations to an already constructed document use the `commit`
 /// method. Any operations committed in this way must refer to the documents current view id in
 /// their `previous` field.

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -26,6 +26,10 @@ use crate::{Human, WithId};
 ///
 /// Documents are constructed through the [`DocumentBuilder`] or by conversion from vectors of a type implementing
 /// the [`AsOperation`], [`WithId<OperationId>`] and [`WithPublicKey`].
+/// 
+/// To efficiently commit more operations to an already constructed document use the `commit`
+/// method. Any operations committed in this way must refer to the documents current view id in
+/// their `previous` field.
 ///
 /// See module docs for example uses.
 #[derive(Debug, Clone)]

--- a/p2panda-rs/src/document/document.rs
+++ b/p2panda-rs/src/document/document.rs
@@ -795,14 +795,14 @@ mod tests {
         assert_eq!(document.get("age").unwrap(), &OperationValue::Integer(28));
 
         // Update the document with an UPDATE operation.
-        document.update(&update_operation).unwrap();
+        document.commit(&update_operation).unwrap();
 
         assert_eq!(document.is_edited(), true);
         assert_eq!(document.view_id(), &update_view_id);
         assert_eq!(document.get("age").unwrap(), &OperationValue::Integer(21));
 
         // Update the document with a DELETE operation.
-        document.update(&delete_operation).unwrap();
+        document.commit(&delete_operation).unwrap();
 
         assert_eq!(document.is_deleted(), true);
         assert_eq!(document.view_id(), &delete_view_id);

--- a/p2panda-rs/src/document/document_view.rs
+++ b/p2panda-rs/src/document/document_view.rs
@@ -107,13 +107,11 @@ mod tests {
         operation_fields: OperationFields,
     ) {
         // Reduce a single CREATE `Operation`
-        let (view, is_edited, is_deleted) = reduce(&[(id.clone(), create_operation, public_key)]);
+        let view = reduce(&[(id.clone(), create_operation, public_key)]);
 
         let document_view = DocumentView::new(&document_view_id, &view.unwrap());
 
         assert!(!document_view.is_empty());
-        assert!(!is_edited);
-        assert!(!is_deleted);
         assert_eq!(document_view.len(), 8);
         assert_eq!(document_view.keys(), operation_fields.keys());
         for key in operation_fields.keys() {
@@ -143,7 +141,7 @@ mod tests {
             (random_operation_id(), create_operation, public_key),
             (update_id.clone(), update_operation, public_key),
         ];
-        let (view, is_edited, is_deleted) = reduce(&operations);
+        let view = reduce(&operations);
 
         let document_view = DocumentView::new(&document_view_id, &view.unwrap());
 
@@ -163,8 +161,6 @@ mod tests {
             document_view.get("is_admin").unwrap(),
             &DocumentViewValue::new(&update_id, &OperationValue::Boolean(true))
         );
-        assert!(is_edited);
-        assert!(!is_deleted);
     }
 
     #[rstest]
@@ -177,7 +173,7 @@ mod tests {
             .unwrap();
 
         let document_view_id = DocumentViewId::new(&[id_1.clone(), id_2.clone()]);
-        let (view, _, _) = reduce(&[(id_1.clone(), create_operation, public_key)]);
+        let view = reduce(&[(id_1.clone(), create_operation, public_key)]);
         let document_view = DocumentView::new(&document_view_id, &view.unwrap());
 
         assert_eq!(format!("{id_1}_{id_2}"), document_view.to_string());

--- a/p2panda-rs/src/document/error.rs
+++ b/p2panda-rs/src/document/error.rs
@@ -41,21 +41,21 @@ pub enum DocumentBuilderError {
 /// Error types for methods of `Document` struct.
 #[derive(Error, Debug)]
 pub enum DocumentError {
-    /// Operation passed to update does not refer to this documents current view.
+    /// Operation passed to commit does not refer to this documents current view.
     #[error("operation {0} does not update the documents current view")]
     PreviousDoesNotMatch(OperationId),
 
-    /// Invalid operation type used to update document.
+    /// Operation passed to commit has incorrect operation type.
     #[error("CREATE operation used to update document")]
     InvalidOperationType,
 
-    /// Cannot update a deleted document.
-    #[error("Cannot update a deleted document")]
-    UpdateOnDeleted,
+    /// Operation passed to commit does not the same schema as the document.
+    #[error("Operation {0} does not match the documents schema")]
+    InvalidSchemaId(OperationId),
 
-    /// Only fields existing on the document can be updated.
-    #[error("Attempted to update a non-existent field")]
-    InvalidUpdate,
+    /// Cannot perform a commit on a deleted document.
+    #[error("Cannot perform a commit on a deleted document")]
+    UpdateOnDeleted,
 
     /// Handle errors from validating CBOR schemas.
     #[error(transparent)]

--- a/p2panda-rs/src/document/error.rs
+++ b/p2panda-rs/src/document/error.rs
@@ -41,6 +41,22 @@ pub enum DocumentBuilderError {
 /// Error types for methods of `Document` struct.
 #[derive(Error, Debug)]
 pub enum DocumentError {
+    /// Operation passed to update does not refer to this documents current view.
+    #[error("operation {0} does not update the documents current view")]
+    PreviousDoesNotMatch(OperationId),
+
+    /// Invalid operation type used to update document.
+    #[error("CREATE operation used to update document")]
+    InvalidOperationType,
+
+    /// Cannot update a deleted document.
+    #[error("Cannot update a deleted document")]
+    UpdateOnDeleted,
+
+    /// Only fields existing on the document can be updated.
+    #[error("Attempted to update a non-existent field")]
+    InvalidUpdate,
+
     /// Handle errors from validating CBOR schemas.
     #[error(transparent)]
     DocumentViewError(#[from] DocumentViewError),

--- a/p2panda-rs/src/document/mod.rs
+++ b/p2panda-rs/src/document/mod.rs
@@ -142,7 +142,7 @@ pub mod error;
 pub mod materialization;
 pub mod traits;
 
-pub use document::{Document, DocumentBuilder, IsDeleted, IsEdited};
+pub use document::{Document, DocumentBuilder};
 pub use document_id::DocumentId;
 pub use document_view::DocumentView;
 pub use document_view_fields::{DocumentViewFields, DocumentViewValue};

--- a/p2panda-rs/src/document/traits.rs
+++ b/p2panda-rs/src/document/traits.rs
@@ -29,7 +29,6 @@ pub trait AsDocument {
     /// Get the fields of this document.
     fn fields(&self) -> Option<&DocumentViewFields>;
 
-
     /// Update the view of this document.
     fn update_view(&mut self, id: &DocumentViewId, view: Option<&DocumentViewFields>);
 

--- a/p2panda-rs/src/document/traits.rs
+++ b/p2panda-rs/src/document/traits.rs
@@ -35,7 +35,7 @@ pub trait AsDocument {
     /// Returns true if this document has processed a DELETE operation.
     fn is_deleted(&self) -> bool;
 
-    /// Update the view of this document. 
+    /// Update the view of this document.
     fn update_view(&mut self, id: &DocumentViewId, view: Option<&DocumentViewFields>);
 
     /// The current document view for this document. Returns None if this document
@@ -79,22 +79,19 @@ pub trait AsDocument {
         }
 
         let next_fields = match operation.fields() {
-            Some(fields) => {
-                match self.fields().cloned() {
-                    Some(mut document_fields) => {
-                        for (name, value) in fields.iter() {
-                            let document_field_value =
-                                DocumentViewValue::new(operation.id(), value);
-                            match document_fields.insert(name, document_field_value) {
-                                Some(_) => (),
-                                None => return Err(DocumentError::InvalidUpdate),
-                            };
-                        }
-                        Some(document_fields)
+            Some(fields) => match self.fields().cloned() {
+                Some(mut document_fields) => {
+                    for (name, value) in fields.iter() {
+                        let document_field_value = DocumentViewValue::new(operation.id(), value);
+                        match document_fields.insert(name, document_field_value) {
+                            Some(_) => (),
+                            None => return Err(DocumentError::InvalidUpdate),
+                        };
                     }
-                    None => None,
+                    Some(document_fields)
                 }
-            }
+                None => None,
+            },
             None => None,
         };
 

--- a/p2panda-rs/src/document/traits.rs
+++ b/p2panda-rs/src/document/traits.rs
@@ -57,7 +57,7 @@ pub trait AsDocument {
     ///
     /// For the update to be successful the passed operation must refer to this documents' current
     /// view id in it's previous field and must update a field which exists on this document.
-    fn update<O>(&mut self, operation: &O) -> Result<(), DocumentError>
+    fn commit<O>(&mut self, operation: &O) -> Result<(), DocumentError>
     where
         O: AsOperation + WithId<OperationId>,
     {

--- a/p2panda-rs/src/document/traits.rs
+++ b/p2panda-rs/src/document/traits.rs
@@ -2,10 +2,15 @@
 
 //! Interfaces for interactions for document-like structs.
 
-use crate::document::{DocumentId, DocumentView, DocumentViewFields, DocumentViewId};
+use crate::document::error::DocumentError;
+use crate::document::{
+    DocumentId, DocumentView, DocumentViewFields, DocumentViewId, DocumentViewValue,
+};
 use crate::identity::PublicKey;
-use crate::operation::OperationValue;
+use crate::operation::traits::AsOperation;
+use crate::operation::{OperationId, OperationValue};
 use crate::schema::SchemaId;
+use crate::WithId;
 
 /// Trait representing an "document-like" struct.
 pub trait AsDocument {
@@ -30,6 +35,9 @@ pub trait AsDocument {
     /// Returns true if this document has processed a DELETE operation.
     fn is_deleted(&self) -> bool;
 
+    /// Update the view of this document. 
+    fn update_view(&mut self, id: &DocumentViewId, view: Option<&DocumentViewFields>);
+
     /// The current document view for this document. Returns None if this document
     /// has been deleted.
     fn view(&self) -> Option<DocumentView> {
@@ -43,5 +51,56 @@ pub trait AsDocument {
             return fields.get(key).map(|view_value| view_value.value());
         }
         None
+    }
+
+    /// Update a documents current view with a single operation.
+    ///
+    /// For the update to be successful the passed operation must refer to this documents' current
+    /// view id in it's previous field and must update a field which exists on this document.
+    fn update<O>(&mut self, operation: &O) -> Result<(), DocumentError>
+    where
+        O: AsOperation + WithId<OperationId>,
+    {
+        if operation.is_create() {
+            return Err(DocumentError::InvalidOperationType);
+        }
+
+        // Unwrap as all other operation types contain `previous`.
+        let previous = operation.previous().unwrap();
+
+        if self.view_id() != &previous {
+            return Err(DocumentError::PreviousDoesNotMatch(
+                operation.id().to_owned(),
+            ));
+        }
+
+        if self.is_deleted() {
+            return Err(DocumentError::UpdateOnDeleted);
+        }
+
+        let next_fields = match operation.fields() {
+            Some(fields) => {
+                match self.fields().cloned() {
+                    Some(mut document_fields) => {
+                        for (name, value) in fields.iter() {
+                            let document_field_value =
+                                DocumentViewValue::new(operation.id(), value);
+                            match document_fields.insert(name, document_field_value) {
+                                Some(_) => (),
+                                None => return Err(DocumentError::InvalidUpdate),
+                            };
+                        }
+                        Some(document_fields)
+                    }
+                    None => None,
+                }
+            }
+            None => None,
+        };
+
+        let document_view_id = DocumentViewId::new(&[operation.id().to_owned()]);
+        self.update_view(&document_view_id, next_fields.as_ref());
+
+        Ok(())
     }
 }

--- a/p2panda-rs/src/document/traits.rs
+++ b/p2panda-rs/src/document/traits.rs
@@ -29,14 +29,24 @@ pub trait AsDocument {
     /// Get the fields of this document.
     fn fields(&self) -> Option<&DocumentViewFields>;
 
-    /// Returns true if this document has applied an UPDATE operation.
-    fn is_edited(&self) -> bool;
-
-    /// Returns true if this document has processed a DELETE operation.
-    fn is_deleted(&self) -> bool;
 
     /// Update the view of this document.
     fn update_view(&mut self, id: &DocumentViewId, view: Option<&DocumentViewFields>);
+
+    /// Returns true if this document has applied an UPDATE operation.
+    fn is_edited(&self) -> bool {
+        match self.fields() {
+            Some(fields) => fields.iter().any(|(_, document_view_value)| {
+                &DocumentId::new(document_view_value.id()) != self.id()
+            }),
+            None => true,
+        }
+    }
+
+    /// Returns true if this document has processed a DELETE operation.
+    fn is_deleted(&self) -> bool {
+        self.fields().is_none()
+    }
 
     /// The current document view for this document. Returns None if this document
     /// has been deleted.

--- a/p2panda-rs/src/document/traits.rs
+++ b/p2panda-rs/src/document/traits.rs
@@ -65,6 +65,10 @@ pub trait AsDocument {
             return Err(DocumentError::InvalidOperationType);
         }
 
+        if &operation.schema_id() != self.schema_id() {
+            return Err(DocumentError::InvalidSchemaId(operation.id().to_owned()))
+        }
+
         // Unwrap as all other operation types contain `previous`.
         let previous = operation.previous().unwrap();
 
@@ -83,10 +87,7 @@ pub trait AsDocument {
                 Some(mut document_fields) => {
                     for (name, value) in fields.iter() {
                         let document_field_value = DocumentViewValue::new(operation.id(), value);
-                        match document_fields.insert(name, document_field_value) {
-                            Some(_) => (),
-                            None => return Err(DocumentError::InvalidUpdate),
-                        };
+                        document_fields.insert(name, document_field_value);
                     }
                     Some(document_fields)
                 }


### PR DESCRIPTION
:tada: 

- `commit` method on `Document` / `AsDocument` which allows applying operations incrementally on an already constructed document
- refactoring of `is_edited` and `is_deleted` patterns

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
