### PR TITLE
Validate schema for UPDATE operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Changed
 
+- Validate an operation's schema id matches the target document's in `publish` [#486](https://github.com/p2panda/p2panda/pull/486) `rs` 
 - Introduce `SchemaName`, `SchemaDescription` and `SchemaFields` structs [#481](https://github.com/p2panda/p2panda/pull/481) `rs`
 - Add `commit` method to `Document` for applying operations incrementally [#485](https://github.com/p2panda/p2panda/pull/485) `rs`
 - Introduce `api` module which publicly exports `publish` and `next_args` [#483](https://github.com/p2panda/p2panda/pull/483) `rs`

--- a/p2panda-rs/src/api/errors.rs
+++ b/p2panda-rs/src/api/errors.rs
@@ -3,6 +3,7 @@
 use crate::entry::error::DecodeEntryError;
 use crate::operation::error::ValidateOperationError;
 use crate::operation::OperationId;
+use crate::schema::SchemaId;
 use crate::storage_provider::error::{EntryStorageError, LogStorageError, OperationStorageError};
 
 /// Error type used in the validation module.
@@ -32,6 +33,10 @@ pub enum ValidationError {
     #[error("Entry with seq num 1 can not have skiplink")]
     FirstEntryWithSkiplink,
 
+    /// Claimed schema does not match the documents expected schema.
+    #[error("Operation {0} claims incorrect schema {1} for document with schema {2}")]
+    InvalidClaimedSchema(OperationId, SchemaId, SchemaId),
+
     /// This document is deleted.
     #[error("Document is deleted")]
     DocumentDeleted,
@@ -45,8 +50,8 @@ pub enum ValidationError {
     MaxLogId,
 
     /// An operation in the `previous` field was not found in the store.
-    #[error("Operation {0} not found, could not determine document id")]
-    PreviousNotFound(OperationId),
+    #[error("Previous operation {0} not found in store")]
+    PreviousOperationNotFound(OperationId),
 
     /// A document view id was provided which contained operations from different documents.
     #[error("Operations in passed document view id originate from different documents")]

--- a/p2panda-rs/src/api/next_args.rs
+++ b/p2panda-rs/src/api/next_args.rs
@@ -226,7 +226,7 @@ mod tests {
         KeyPair::new()
     )]
     #[should_panic(
-        expected = "Operation 00209038901221ce1002f023461f1530adf632081d9fcd2da1082c7c91fdcb534d03 not found, could not determine document id"
+        expected = "Previous operation 00209038901221ce1002f023461f1530adf632081d9fcd2da1082c7c91fdcb534d03 not found in store"
     )]
     #[case::previous_operation_missing(
         &[(0, 8)],
@@ -234,7 +234,7 @@ mod tests {
         KeyPair::from_private_key_str(PRIVATE_KEY).unwrap()
     )]
     #[should_panic(
-        expected = "Operation 00201971f1257645a2f6d3465f8713991d269709f81a5c6c458168b9461d68af5ecf not found, could not determine document id"
+        expected = "Previous operation 00201971f1257645a2f6d3465f8713991d269709f81a5c6c458168b9461d68af5ecf not found in store"
     )]
     #[case::one_of_some_previous_missing(
         &[(0, 7)],
@@ -242,7 +242,7 @@ mod tests {
         KeyPair::from_private_key_str(PRIVATE_KEY).unwrap()
     )]
     #[should_panic(
-        expected = "Operation 00209038901221ce1002f023461f1530adf632081d9fcd2da1082c7c91fdcb534d03 not found, could not determine document id"
+        expected = "Previous operation 00209038901221ce1002f023461f1530adf632081d9fcd2da1082c7c91fdcb534d03 not found in store"
     )]
     #[case::one_of_some_previous_missing(
         &[(0, 8)],
@@ -250,7 +250,7 @@ mod tests {
         KeyPair::from_private_key_str(PRIVATE_KEY).unwrap()
     )]
     #[should_panic(
-        expected = "Operation 00209038901221ce1002f023461f1530adf632081d9fcd2da1082c7c91fdcb534d03 not found, could not determine document id"
+        expected = "Previous operation 00209038901221ce1002f023461f1530adf632081d9fcd2da1082c7c91fdcb534d03 not found in store"
     )]
     #[case::missing_previous_operation_multi_writer(
         &[(0, 8)],
@@ -443,7 +443,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("could not determine document id") // This is a partial string match, preceded by "<Operation xxxxx> not found,"
+                .contains("not found in store") // This is a partial string match, preceded by "Previous operation <XXXXXX...>"
         );
 
         // Here we are missing the skiplink.


### PR DESCRIPTION
When an operation arrives via `publish` we validate it's contained fields match the claimed schema, but when it's an UPDATE (therefore being applied to an existing document) we don't check if it's claimed schema matches that of the existing document.

This PR adds that validation step.

closes: https://github.com/p2panda/aquadoggo/issues/50

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
