### PR TITLE
`blob_v1` and `blob_piece_v1` schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Released on 2023-07-27: :package: `p2panda-js` and :package: `p2panda-rs`
 
 - Implement serde for `SchemaName` and `SchemaDescription` [#487](https://github.com/p2panda/p2panda/pull/487) `rs`
 - Implement `Ord` for `SchemaId` [#492](https://github.com/p2panda/p2panda/pull/492) `rs`
+- Introduce `blob_v1` and `blob_piece_v1` system schema [#507](https://github.com/p2panda/p2panda/pull/507) `rs`
 
 ### Changed
 

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -6,7 +6,7 @@ use crate::document::{DocumentViewHash, DocumentViewId};
 use crate::operation::{Operation, OperationBuilder};
 use crate::schema::error::{SchemaError, SchemaIdError};
 use crate::schema::system::{
-    get_schema_definition, get_schema_field_definition, SchemaFieldView, SchemaView,
+    get_schema_definition, get_schema_field_definition, get_blob, get_blob_piece, SchemaFieldView, SchemaView,
 };
 use crate::schema::SchemaName;
 use crate::schema::{FieldType, SchemaId, SchemaVersion};
@@ -229,6 +229,8 @@ impl Schema {
         match schema_id {
             SchemaId::SchemaDefinition(version) => get_schema_definition(version),
             SchemaId::SchemaFieldDefinition(version) => get_schema_field_definition(version),
+            SchemaId::Blob(version) => get_blob(version),
+            SchemaId::BlobPiece(version) => get_blob_piece(version),
             _ => Err(SchemaIdError::UnknownSystemSchema(schema_id.to_string())),
         }
     }

--- a/p2panda-rs/src/schema/schema.rs
+++ b/p2panda-rs/src/schema/schema.rs
@@ -6,7 +6,8 @@ use crate::document::{DocumentViewHash, DocumentViewId};
 use crate::operation::{Operation, OperationBuilder};
 use crate::schema::error::{SchemaError, SchemaIdError};
 use crate::schema::system::{
-    get_schema_definition, get_schema_field_definition, get_blob, get_blob_piece, SchemaFieldView, SchemaView,
+    get_blob, get_blob_piece, get_schema_definition, get_schema_field_definition, SchemaFieldView,
+    SchemaView,
 };
 use crate::schema::SchemaName;
 use crate::schema::{FieldType, SchemaId, SchemaVersion};

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -20,6 +20,9 @@ pub(super) const SCHEMA_DEFINITION_NAME: &str = "schema_definition";
 /// Spelling of _schema field definition_ schema
 pub(super) const SCHEMA_FIELD_DEFINITION_NAME: &str = "schema_field_definition";
 
+/// Spelling of _blob_ schema
+pub(super) const BLOB_NAME: &str = "blob";
+
 /// Spelling of _blob piece_ schema
 pub(super) const BLOB_PIECE_NAME: &str = "blob_piece";
 
@@ -47,6 +50,9 @@ pub enum SchemaId {
 
     /// A schema definition field.
     SchemaFieldDefinition(u8),
+
+    /// A blob.
+    Blob(u8),
 
     /// A blob piece.
     BlobPiece(u8),
@@ -97,6 +103,7 @@ impl SchemaId {
         match self {
             SchemaId::Application(name, _) => name.to_owned(),
             // We unwrap here as we know system schema names are valid names.
+            SchemaId::Blob(_) => SchemaName::new(BLOB_NAME).unwrap(),
             SchemaId::BlobPiece(_) => SchemaName::new(BLOB_PIECE_NAME).unwrap(),
             SchemaId::SchemaDefinition(_) => SchemaName::new(SCHEMA_DEFINITION_NAME).unwrap(),
             SchemaId::SchemaFieldDefinition(_) => {
@@ -109,6 +116,7 @@ impl SchemaId {
     pub fn version(&self) -> SchemaVersion {
         match self {
             SchemaId::Application(_, view_id) => SchemaVersion::Application(view_id.clone()),
+            SchemaId::Blob(version) => SchemaVersion::System(*version),
             SchemaId::BlobPiece(version) => SchemaVersion::System(*version),
             SchemaId::SchemaDefinition(version) => SchemaVersion::System(*version),
             SchemaId::SchemaFieldDefinition(version) => SchemaVersion::System(*version),
@@ -131,6 +139,8 @@ impl SchemaId {
         match name {
             SCHEMA_DEFINITION_NAME => Ok(Self::SchemaDefinition(version)),
             SCHEMA_FIELD_DEFINITION_NAME => Ok(Self::SchemaFieldDefinition(version)),
+            BLOB_NAME => Ok(Self::Blob(version)),
+            BLOB_PIECE_NAME => Ok(Self::BlobPiece(version)),
             _ => Err(SchemaIdError::UnknownSystemSchema(name.to_string())),
         }
     }
@@ -194,11 +204,14 @@ impl Display for SchemaId {
 
                 Ok(())
             }
+            SchemaId::Blob(version) => {
+                write!(f, "{}_v{}", BLOB_NAME, version)
+            }
             SchemaId::BlobPiece(version) => {
-                write!(f, "{}_v{}", SCHEMA_FIELD_DEFINITION_NAME, version)
+                write!(f, "{}_v{}", BLOB_PIECE_NAME, version)
             }
             SchemaId::SchemaDefinition(version) => {
-                write!(f, "{}_v{}", BLOB_PIECE_NAME, version)
+                write!(f, "{}_v{}", SCHEMA_DEFINITION_NAME, version)
             }
             SchemaId::SchemaFieldDefinition(version) => {
                 write!(f, "{}_v{}", SCHEMA_FIELD_DEFINITION_NAME, version)
@@ -277,6 +290,8 @@ mod test {
     )]
     #[case(SchemaId::SchemaDefinition(1), "schema_definition_v1")]
     #[case(SchemaId::SchemaFieldDefinition(1), "schema_field_definition_v1")]
+    #[case(SchemaId::Blob(1), "blob_v1")]
+    #[case(SchemaId::BlobPiece(1), "blob_piece_v1")]
     fn serialize(#[case] schema_id: SchemaId, #[case] expected_schema_id_string: &str) {
         let mut cbor_bytes = Vec::new();
         let mut expected_cbor_bytes = Vec::new();
@@ -295,6 +310,7 @@ mod test {
     )]
     #[case(SchemaId::SchemaDefinition(1), "schema_definition_v1")]
     #[case(SchemaId::SchemaFieldDefinition(1), "schema_field_definition_v1")]
+    #[case(SchemaId::Blob(1), "blob_v1")]
     #[case(SchemaId::BlobPiece(1), "blob_piece_v1")]
     fn deserialize(#[case] schema_id: SchemaId, #[case] expected_schema_id_string: &str) {
         let parsed_app_schema: SchemaId = expected_schema_id_string.parse().unwrap();
@@ -397,6 +413,8 @@ mod test {
             format!("{}", schema_id),
             "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
         );
+        assert_eq!(format!("{}", SchemaId::Blob(1)), "blob_v1");
+        assert_eq!(format!("{}", SchemaId::BlobPiece(1)), "blob_piece_v1");
         assert_eq!(
             format!("{}", SchemaId::SchemaDefinition(1)),
             "schema_definition_v1"

--- a/p2panda-rs/src/schema/schema_id.rs
+++ b/p2panda-rs/src/schema/schema_id.rs
@@ -20,6 +20,9 @@ pub(super) const SCHEMA_DEFINITION_NAME: &str = "schema_definition";
 /// Spelling of _schema field definition_ schema
 pub(super) const SCHEMA_FIELD_DEFINITION_NAME: &str = "schema_field_definition";
 
+/// Spelling of _blob piece_ schema
+pub(super) const BLOB_PIECE_NAME: &str = "blob_piece";
+
 /// Represent a schema's version.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SchemaVersion {
@@ -44,6 +47,9 @@ pub enum SchemaId {
 
     /// A schema definition field.
     SchemaFieldDefinition(u8),
+
+    /// A blob piece.
+    BlobPiece(u8),
 }
 
 impl SchemaId {
@@ -91,6 +97,7 @@ impl SchemaId {
         match self {
             SchemaId::Application(name, _) => name.to_owned(),
             // We unwrap here as we know system schema names are valid names.
+            SchemaId::BlobPiece(_) => SchemaName::new(BLOB_PIECE_NAME).unwrap(),
             SchemaId::SchemaDefinition(_) => SchemaName::new(SCHEMA_DEFINITION_NAME).unwrap(),
             SchemaId::SchemaFieldDefinition(_) => {
                 SchemaName::new(SCHEMA_FIELD_DEFINITION_NAME).unwrap()
@@ -102,6 +109,7 @@ impl SchemaId {
     pub fn version(&self) -> SchemaVersion {
         match self {
             SchemaId::Application(_, view_id) => SchemaVersion::Application(view_id.clone()),
+            SchemaId::BlobPiece(version) => SchemaVersion::System(*version),
             SchemaId::SchemaDefinition(version) => SchemaVersion::System(*version),
             SchemaId::SchemaFieldDefinition(version) => SchemaVersion::System(*version),
         }
@@ -186,8 +194,11 @@ impl Display for SchemaId {
 
                 Ok(())
             }
+            SchemaId::BlobPiece(version) => {
+                write!(f, "{}_v{}", SCHEMA_FIELD_DEFINITION_NAME, version)
+            }
             SchemaId::SchemaDefinition(version) => {
-                write!(f, "{}_v{}", SCHEMA_DEFINITION_NAME, version)
+                write!(f, "{}_v{}", BLOB_PIECE_NAME, version)
             }
             SchemaId::SchemaFieldDefinition(version) => {
                 write!(f, "{}_v{}", SCHEMA_FIELD_DEFINITION_NAME, version)
@@ -284,6 +295,7 @@ mod test {
     )]
     #[case(SchemaId::SchemaDefinition(1), "schema_definition_v1")]
     #[case(SchemaId::SchemaFieldDefinition(1), "schema_field_definition_v1")]
+    #[case(SchemaId::BlobPiece(1), "blob_piece_v1")]
     fn deserialize(#[case] schema_id: SchemaId, #[case] expected_schema_id_string: &str) {
         let parsed_app_schema: SchemaId = expected_schema_id_string.parse().unwrap();
         assert_eq!(schema_id, parsed_app_schema);

--- a/p2panda-rs/src/schema/system/blob.rs
+++ b/p2panda-rs/src/schema/system/blob.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 use crate::schema::error::SchemaIdError;
 use crate::schema::{FieldType, Schema, SchemaDescription, SchemaFields, SchemaId};
 
-const DESCRIPTION: &str = "Representation of the (partial) binary data of a file.";
+const DESCRIPTION: &str = "Definition of a blob file.";
 
 pub static BLOB_V1: Lazy<Schema> = Lazy::new(|| {
     let fields = SchemaFields::new(&[

--- a/p2panda-rs/src/schema/system/blob.rs
+++ b/p2panda-rs/src/schema/system/blob.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use once_cell::sync::Lazy;
+
+use crate::schema::error::SchemaIdError;
+use crate::schema::{FieldType, Schema, SchemaDescription, SchemaFields, SchemaId};
+
+const DESCRIPTION: &str = "Representation of the (partial) binary data of a file.";
+
+pub static BLOB_V1: Lazy<Schema> = Lazy::new(|| {
+    let fields = SchemaFields::new(&[
+        ("length", FieldType::Integer),
+        ("mime_type", FieldType::String),
+        (
+            "pieces",
+            FieldType::PinnedRelationList(SchemaId::BlobPiece(1)),
+        ),
+    ])
+    // Unwrap as we know the fields are valid.
+    .unwrap();
+
+    // We can unwrap here as we know the schema definition is valid.
+    let description = SchemaDescription::new(DESCRIPTION).unwrap();
+
+    Schema {
+        id: SchemaId::Blob(1),
+        description,
+        fields,
+    }
+});
+
+/// Returns the `blob` system schema with a given version.
+pub fn get_blob(version: u8) -> Result<&'static Schema, SchemaIdError> {
+    match version {
+        1 => Ok(&BLOB_V1),
+        _ => Err(SchemaIdError::UnknownSystemSchema(
+            SchemaId::Blob(version).to_string(),
+        )),
+    }
+}

--- a/p2panda-rs/src/schema/system/blob_piece.rs
+++ b/p2panda-rs/src/schema/system/blob_piece.rs
@@ -8,11 +8,9 @@ use crate::schema::{FieldType, Schema, SchemaDescription, SchemaFields, SchemaId
 const DESCRIPTION: &str = "Representation of the (partial) binary data of a file.";
 
 pub static BLOB_PIECE_V1: Lazy<Schema> = Lazy::new(|| {
-    let fields = SchemaFields::new(&[
-        ("data", FieldType::String),
-    ])
-    // Unwrap as we know the fields are valid.
-    .unwrap();
+    let fields = SchemaFields::new(&[("data", FieldType::String)])
+        // Unwrap as we know the fields are valid.
+        .unwrap();
 
     // We can unwrap here as we know the schema definition is valid.
     let description = SchemaDescription::new(DESCRIPTION).unwrap();
@@ -24,7 +22,7 @@ pub static BLOB_PIECE_V1: Lazy<Schema> = Lazy::new(|| {
     }
 });
 
-/// Returns the `schema_definition` system schema with a given version.
+/// Returns the `blob_piece` system schema with a given version.
 pub fn get_blob_piece(version: u8) -> Result<&'static Schema, SchemaIdError> {
     match version {
         1 => Ok(&BLOB_PIECE_V1),

--- a/p2panda-rs/src/schema/system/blob_piece.rs
+++ b/p2panda-rs/src/schema/system/blob_piece.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use once_cell::sync::Lazy;
+
+use crate::schema::error::SchemaIdError;
+use crate::schema::{FieldType, Schema, SchemaDescription, SchemaFields, SchemaId};
+
+const DESCRIPTION: &str = "Representation of the (partial) binary data of a file.";
+
+pub static BLOB_PIECE_V1: Lazy<Schema> = Lazy::new(|| {
+    let fields = SchemaFields::new(&[
+        ("data", FieldType::String),
+    ])
+    // Unwrap as we know the fields are valid.
+    .unwrap();
+
+    // We can unwrap here as we know the schema definition is valid.
+    let description = SchemaDescription::new(DESCRIPTION).unwrap();
+
+    Schema {
+        id: SchemaId::BlobPiece(1),
+        description,
+        fields,
+    }
+});
+
+/// Returns the `schema_definition` system schema with a given version.
+pub fn get_blob_piece(version: u8) -> Result<&'static Schema, SchemaIdError> {
+    match version {
+        1 => Ok(&BLOB_PIECE_V1),
+        _ => Err(SchemaIdError::UnknownSystemSchema(
+            SchemaId::BlobPiece(version).to_string(),
+        )),
+    }
+}

--- a/p2panda-rs/src/schema/system/mod.rs
+++ b/p2panda-rs/src/schema/system/mod.rs
@@ -8,6 +8,7 @@ use once_cell::sync::Lazy;
 
 use crate::schema::Schema;
 
+mod blob_piece;
 mod error;
 mod schema_definition;
 mod schema_field_definition;
@@ -16,6 +17,7 @@ mod schema_views;
 pub use error::SystemSchemaError;
 pub use schema_views::{SchemaFieldView, SchemaView};
 
+pub(super) use blob_piece::get_blob_piece;
 pub(super) use schema_definition::get_schema_definition;
 pub(super) use schema_field_definition::get_schema_field_definition;
 
@@ -25,6 +27,7 @@ pub static SYSTEM_SCHEMAS: Lazy<Vec<&'static Schema>> = Lazy::new(|| {
     vec![
         get_schema_definition(1).unwrap(),
         get_schema_field_definition(1).unwrap(),
+        get_blob_piece(1).unwrap(),
     ]
 });
 
@@ -34,6 +37,6 @@ mod test {
 
     #[test]
     fn test_static_system_schemas() {
-        assert_eq!(SYSTEM_SCHEMAS.len(), 2);
+        assert_eq!(SYSTEM_SCHEMAS.len(), 3);
     }
 }

--- a/p2panda-rs/src/schema/system/mod.rs
+++ b/p2panda-rs/src/schema/system/mod.rs
@@ -8,6 +8,7 @@ use once_cell::sync::Lazy;
 
 use crate::schema::Schema;
 
+mod blob;
 mod blob_piece;
 mod error;
 mod schema_definition;
@@ -17,6 +18,7 @@ mod schema_views;
 pub use error::SystemSchemaError;
 pub use schema_views::{SchemaFieldView, SchemaView};
 
+pub(super) use blob::get_blob;
 pub(super) use blob_piece::get_blob_piece;
 pub(super) use schema_definition::get_schema_definition;
 pub(super) use schema_field_definition::get_schema_field_definition;
@@ -27,6 +29,7 @@ pub static SYSTEM_SCHEMAS: Lazy<Vec<&'static Schema>> = Lazy::new(|| {
     vec![
         get_schema_definition(1).unwrap(),
         get_schema_field_definition(1).unwrap(),
+        get_blob(1).unwrap(),
         get_blob_piece(1).unwrap(),
     ]
 });
@@ -37,6 +40,6 @@ mod test {
 
     #[test]
     fn test_static_system_schemas() {
-        assert_eq!(SYSTEM_SCHEMAS.len(), 3);
+        assert_eq!(SYSTEM_SCHEMAS.len(), 4);
     }
 }

--- a/p2panda-rs/src/schema/validate/blob.rs
+++ b/p2panda-rs/src/schema/validate/blob.rs
@@ -73,12 +73,6 @@ mod test {
      ].into())]
     #[should_panic]
     #[case(vec![
-        ("length", 100001.into()),
-        ("mime_type", "application/vnd.openxmlformats-officedocument.presentationml.slideshow".into()),
-        ("pieces", vec![random_document_view_id()].into()),
-     ].into())]
-    #[should_panic]
-    #[case(vec![
         ("length", 100.into()),
         ("mime_type", "not a mime type".into()),
         ("pieces", vec![random_document_view_id()].into()),

--- a/p2panda-rs/src/schema/validate/blob.rs
+++ b/p2panda-rs/src/schema/validate/blob.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-&3.0-or-later
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::operation::plain::{PlainFields, PlainValue};
+use crate::schema::validate::error::BlobError;
+
+/// @TODO: Do we want a max and what should it be?
+const MAX_BLOB_LENGTH: i64 = 100000; // 1GB
+
+/// Checks "length" field of operations with "blob_v1" schema id.
+///
+/// 1. It must be less than `MAX_BLOB_LENGTH`
+pub fn validate_length(value: &i64) -> bool {
+    *value <= MAX_BLOB_LENGTH
+}
+
+/// Checks "mime_type" field of operations with "blob_v1" schema id.
+///
+/// 1. It matches expected mime type format
+pub fn validate_mime_type(value: &str) -> bool {
+    static NAME_REGEX: Lazy<Regex> = Lazy::new(|| {
+        // Unwrap as we checked the regular expression for correctness
+        Regex::new("^[a-z-]{1,12}\\/(([a-z0-9]{1,18})[\\.|+|-]){0,6}[a-z0-9]{1,16}$").unwrap()
+    });
+
+    NAME_REGEX.is_match(value)
+}
+
+/// Validate formatting for operations following `blob_v1` system schemas.
+///
+/// These operations contain a "length", "mime_type" and "pieces" field some of which have special
+/// limitations defined by the p2panda specification.
+///
+/// Please note that this does not check type field type or the operation fields in general, as
+/// this should be handled by other validation methods. This method is only checking the
+/// special requirements of this particular system schema.
+pub fn validate_blob_v1_fields(fields: &PlainFields) -> Result<(), BlobError> {
+    // Check "length" field
+    let blob_length = fields.get("length");
+
+    match blob_length {
+        Some(PlainValue::Integer(value)) => {
+            if validate_length(value) {
+                Ok(())
+            } else {
+                Err(BlobError::LengthInvalid)
+            }
+        }
+        _ => Ok(()),
+    }?;
+
+    // Check "mime_type" field
+    let blob_mime_type = fields.get("mime_type");
+
+    match blob_mime_type {
+        Some(PlainValue::StringOrRelation(value)) => {
+            if validate_mime_type(value) {
+                Ok(())
+            } else {
+                Err(BlobError::MimeTypeInvalid)
+            }
+        }
+        _ => Ok(()),
+    }?;
+
+    // We don't have anything to validate on the pieces field.
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use rstest::rstest;
+
+    use crate::operation::plain::PlainFields;
+    use crate::test_utils::fixtures::random_document_view_id;
+
+    use super::{validate_blob_v1_fields, validate_length, validate_mime_type};
+
+    #[rstest]
+    #[case(vec![
+       ("length", 1.into()),
+       ("mime_type", "image/png".into()),
+       ("pieces", vec![random_document_view_id()].into()),
+    ].into())]
+    #[case(vec![
+        ("length", 1000.into()),
+        ("mime_type", "application/x-zip-compressed".into()),
+        ("pieces", vec![random_document_view_id()].into()),
+     ].into())]
+    #[case(vec![
+        ("length", 99999.into()),
+        ("mime_type", "application/vnd.openxmlformats-officedocument.presentationml.slideshow".into()),
+        ("pieces", vec![random_document_view_id()].into()),
+     ].into())]
+    #[should_panic]
+    #[case(vec![
+        ("length", 100001.into()),
+        ("mime_type", "application/vnd.openxmlformats-officedocument.presentationml.slideshow".into()),
+        ("pieces", vec![random_document_view_id()].into()),
+     ].into())]
+    #[should_panic]
+    #[case(vec![
+        ("length", 100.into()),
+        ("mime_type", "not a mime type".into()),
+        ("pieces", vec![random_document_view_id()].into()),
+     ].into())]
+    fn check_fields(#[case] fields: PlainFields) {
+        assert!(validate_blob_v1_fields(&fields).is_ok());
+    }
+
+    #[rstest]
+    #[case("video/webm")]
+    #[case("image/webp")]
+    #[case("x-conference/x-cooltalk")]
+    #[case("application/vnd.cluetrust.cartomobile-config-pkg")]
+    #[case("application/emma+xml")]
+    #[case("my/made.up.mime.type")] // This still passes....
+    #[should_panic]
+    #[case("wrong format")]
+    #[should_panic]
+    #[case("wrong_format")]
+    #[should_panic]
+    #[case("wrong/f o r m a t")]
+    #[should_panic]
+    #[case("wrong/!format!")]
+    #[should_panic]
+    #[case("wrong/for..mat")]
+    #[should_panic]
+    #[case("wro.ng/for..mat")]
+    #[should_panic]
+    #[case("this/mime.type.has.one.too.many.elements.yes")]
+    #[should_panic]
+    #[case("this/mime.type.hasoneelementwhichiswaytoolong")]
+    #[should_panic]
+    #[case("thismimetypealsohasonelongelement/one.element.too.long")]
+    fn check_mime_type_field(#[case] name_str: &str) {
+        assert!(validate_mime_type(name_str));
+    }
+
+    #[rstest]
+    #[case(100)]
+    #[case(100000)]
+    #[should_panic]
+    #[case(100001)]
+    fn check_length_field(#[case] length_int: i64) {
+        assert!(validate_length(&length_int));
+    }
+}

--- a/p2panda-rs/src/schema/validate/blob_piece.rs
+++ b/p2panda-rs/src/schema/validate/blob_piece.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-&3.0-or-later
+
+use crate::operation::plain::{PlainFields, PlainValue};
+use crate::schema::validate::error::BlobPieceError;
+
+const MAX_BLOB_PIECE_LENGTH: usize = 256;
+
+/// Checks "data" field of operations with "blob_piece_v1" schema id.
+///
+/// 1. It must be less than `MAX_BLOB_PIECE_LENGTH`
+pub fn validate_data(value: &String) -> bool {
+    value.len() <= MAX_BLOB_PIECE_LENGTH
+}
+
+/// Validate formatting for operations following `blob_piece_v1` system schemas.
+///
+/// These operations contain a "data" field which has special limitations defined by the p2panda specification.
+///
+/// Please note that this does not check type field type or the operation fields in general, as
+/// this should be handled by other validation methods. This method is only checking the
+/// special requirements of this particular system schema.
+pub fn validate_blob_piece_v1_fields(fields: &PlainFields) -> Result<(), BlobPieceError> {
+    // Check "data" field
+    let blob_piece_data = fields.get("data");
+
+    match blob_piece_data {
+        Some(PlainValue::StringOrRelation(value)) => {
+            if validate_data(value) {
+                Ok(())
+            } else {
+                Err(BlobPieceError::DataInvalid)
+            }
+        }
+        _ => Ok(()),
+    }?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use rstest::rstest;
+
+    use crate::operation::plain::PlainFields;
+
+    use super::validate_blob_piece_v1_fields;
+
+    #[rstest]
+    #[case(vec![
+        ("data", "aGVsbG8gbXkgbmFtZSBpcyBzYW0=".into()),
+     ].into())]
+    #[should_panic]
+    #[case(vec![
+        ("data", "aGVsbG8gbXkgbmFtZSBpcyBzYW1oZWxsbyBteSBuYW1lIGlzIHNhbWhlbGxvIG15IG5hbW \
+                  UgaXMgc2FtaGVsbG8gbXkgbmFtZSBpcyBzYW1oZWxsbyBteSBuYW1lIGlzIHNhbWhlbGxv \
+                  G15IG5hbWUgaXMgc2FtaGVsbG8gbXkgbmFtZSBpcyBzYW1oZWxsbyBteSBuYW1lIGlzIHN \
+                  hbWhlbGxvIG15IG5hbWUgaXMgc2FtaGVsbG8gbXkgbmFtZSBpcyBzYW1oZWxsbyBteSBuY \
+                  W1lIGlzIHNhbWhlbGxvIG15IG5hbWUgaXMgc2FtaGVsbG8gbXkgbmFtZSBpcyBzYW1oZWx \
+                  sbyBteSBuYW1lIGlzIHNhbWhlbGxvIG15IG5hbWUgaXMgc2FtaGVsbG8gbXkgbmFtZS".into()),
+     ].into())]
+    fn check_fields(#[case] fields: PlainFields) {
+        assert!(validate_blob_piece_v1_fields(&fields).is_ok());
+    }
+}

--- a/p2panda-rs/src/schema/validate/error.rs
+++ b/p2panda-rs/src/schema/validate/error.rs
@@ -41,6 +41,14 @@ pub enum ValidationError {
     /// Error from validating system schema: `schema_field_definition_v1`.
     #[error("invalid 'schema_field_definition_v1' operation: {0}")]
     InvalidSchemaFieldDefinition(#[from] SchemaFieldDefinitionError),
+
+    /// Error from validating system schema: `blob_v1`.
+    #[error("invalid 'blob_v1' operation: {0}")]
+    InvalidBlob(#[from] BlobError),
+
+    /// Error from validating system schema: `blob_piece_v1`.
+    #[error("invalid 'blob_piece_v1' operation: {0}")]
+    InvalidBlobPiece(#[from] BlobPieceError),
 }
 
 /// Custom error types for validating operations against `schema_field_definition_v1` schema.
@@ -71,4 +79,30 @@ pub enum SchemaDefinitionError {
     /// "fields" is not correctly formatted as per specification.
     #[error("'fields' field in schema field definitions is wrongly formatted")]
     FieldsInvalid,
+}
+
+/// Custom error types for validating operations against `blob_v1` schema.
+#[derive(Error, Debug)]
+#[allow(missing_copy_implementations)]
+pub enum BlobError {
+    /// "length" is greater than the maximum allowed as per specification.
+    #[error("'length' field in blob is over maximum allowed length")]
+    LengthInvalid,
+
+    /// "mime_type" is not correctly formatted as per specification.
+    #[error("'mime_type' field in blob is wrongly formatted")]
+    MimeTypeInvalid,
+
+    /// "pieces" is not correctly formatted as per specification.
+    #[error("'pieces' field in blob is wrongly formatted")]
+    PiecesInvalid,
+}
+
+/// Custom error types for validating operations against `blob_piece_v1` schema.
+#[derive(Error, Debug)]
+#[allow(missing_copy_implementations)]
+pub enum BlobPieceError {
+    /// "data" is greater than the maximum allowed as per specification.
+    #[error("'data' field in blob is over maximum allowed length")]
+    DataInvalid,
 }

--- a/p2panda-rs/src/schema/validate/fields.rs
+++ b/p2panda-rs/src/schema/validate/fields.rs
@@ -811,15 +811,6 @@ mod tests {
         ],
         "invalid 'schema_field_definition_v1' operation: 'type' field in schema field definitions is wrongly formatted"
     )]
-    #[case::invalid_blob_length(
-        SchemaId::Blob(1),
-        vec![
-            ("length", 99999999.into()),
-            ("mime_type", "image/png".into()),
-            ("pieces", PlainValue::PinnedRelationList(vec![vec![HASH.to_owned()]])),
-         ],
-         "invalid 'blob_v1' operation: 'length' field in blob is over maximum allowed length"
-    )]
     #[case::invalid_blob_mime_type(
         SchemaId::Blob(1),
         vec![

--- a/p2panda-rs/src/schema/validate/fields.rs
+++ b/p2panda-rs/src/schema/validate/fields.rs
@@ -320,6 +320,7 @@ fn validate_system_schema_fields(
             validate_schema_field_definition_v1_fields(fields)?;
             Ok(())
         }
+        SchemaId::BlobPiece(_) => todo!(),
     }
 }
 

--- a/p2panda-rs/src/schema/validate/fields.rs
+++ b/p2panda-rs/src/schema/validate/fields.rs
@@ -312,6 +312,8 @@ fn validate_system_schema_fields(
 ) -> Result<(), ValidationError> {
     match schema.id() {
         SchemaId::Application(_, _) => Ok(()),
+        SchemaId::Blob(_) => todo!(),
+        SchemaId::BlobPiece(_) => todo!(),
         SchemaId::SchemaDefinition(_) => {
             validate_schema_definition_v1_fields(fields)?;
             Ok(())
@@ -320,7 +322,6 @@ fn validate_system_schema_fields(
             validate_schema_field_definition_v1_fields(fields)?;
             Ok(())
         }
-        SchemaId::BlobPiece(_) => todo!(),
     }
 }
 

--- a/p2panda-rs/src/schema/validate/mod.rs
+++ b/p2panda-rs/src/schema/validate/mod.rs
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! Methods around checking operation fields against application or system schemas.
+mod blob;
+mod blob_piece;
 pub mod error;
 mod fields;
 mod schema_definition;
 mod schema_field_definition;
 
+pub use blob::*;
+pub use blob_piece::*;
 pub use fields::*;
 pub use schema_definition::*;
 pub use schema_field_definition::*;


### PR DESCRIPTION
Introduces two new system schema:

- `blob_v1`
- `blob_piece_v1`

Each with methods for validating operations against their expected fields.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
