### PR TITLE
Drop -rs from crate package name

### DIFF
--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "p2panda-rs"
+name = "p2panda"
 version = "0.7.1"
 authors = [
   "adz <x12@adz.garden>",


### PR DESCRIPTION
Closes https://github.com/p2panda/p2panda/issues/509.

As the library gains popularity nefarious actors could claim p2panda and people could install it unintentionally as its the simpler variation. In addition to a supply chain attack vector, it's just redundant/not necessary to have the file type for the language its written in in a library name. No change to the repository directory structure/naming is necessary, just drop the -rs in Cargo.toml and publishing.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
- [ ] Check if descriptions and terminology match `handbook` content (and visa-versa) 
