### PR TITLE
Handle Bytes fields when parsing schema field types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Released on 2023-07-27: :package: `p2panda-js` and :package: `p2panda-rs`
 ### Fixed
 
 - Handle parsing empty pinned relation lists from `PlainOperation` [#489](https://github.com/p2panda/p2panda/pull/489) `rs`
+- Fix missing bytes field validation in schema field definition [#519](https://github.com/p2panda/p2panda/pull/519) `rs`
 
 ### Lion on the street
 

--- a/p2panda-rs/src/schema/field_types.rs
+++ b/p2panda-rs/src/schema/field_types.rs
@@ -97,6 +97,7 @@ impl FromStr for FieldType {
             "int" => Ok(FieldType::Integer),
             "float" => Ok(FieldType::Float),
             "str" => Ok(FieldType::String),
+            "bytes" => Ok(FieldType::Bytes),
             _ => Err(FieldTypeError::InvalidFieldType(s.into())),
         };
 
@@ -146,6 +147,7 @@ mod tests {
         assert_eq!(FieldType::Integer.to_string(), "int");
         assert_eq!(FieldType::Float.to_string(), "float");
         assert_eq!(FieldType::String.to_string(), "str");
+        assert_eq!(FieldType::Bytes.to_string(), "bytes");
         assert_eq!(
             FieldType::Relation(SchemaId::SchemaFieldDefinition(1)).to_string(),
             "relation(schema_field_definition_v1)"
@@ -170,6 +172,7 @@ mod tests {
         assert_eq!(FieldType::Integer, "int".parse().unwrap());
         assert_eq!(FieldType::Float, "float".parse().unwrap());
         assert_eq!(FieldType::String, "str".parse().unwrap());
+        assert_eq!(FieldType::Bytes, "bytes".parse().unwrap());
         assert_eq!(
             FieldType::Relation(SchemaId::SchemaFieldDefinition(1)),
             "relation(schema_field_definition_v1)".parse().unwrap()

--- a/p2panda-rs/src/schema/validate/fields.rs
+++ b/p2panda-rs/src/schema/validate/fields.rs
@@ -493,8 +493,10 @@ mod tests {
             ("b", FieldType::String),
             ("a", FieldType::Integer),
             ("c", FieldType::Boolean),
+            ("d", FieldType::Bytes),
         ],
         vec![
+            ("d", PlainValue::Bytes(generate_random_bytes(100))),
             ("c", PlainValue::Boolean(false)),
             ("b", PlainValue::StringOrRelation("Panda-San!".to_string())),
             ("a", PlainValue::Integer(6)),

--- a/p2panda-rs/src/schema/validate/schema_field_definition.rs
+++ b/p2panda-rs/src/schema/validate/schema_field_definition.rs
@@ -30,7 +30,7 @@ pub fn validate_field_name(value: &str) -> bool {
 /// 2. Relations need to specify a valid and canonical schema id
 fn validate_type(value: &str) -> bool {
     match value {
-        "bool" | "int" | "float" | "str" => true,
+        "bool" | "int" | "float" | "str" | "bytes" => true,
         relation => validate_relation_type(relation),
     }
 }
@@ -199,6 +199,7 @@ mod test {
     #[case("bool")]
     #[case("int")]
     #[case("str")]
+    #[case("bytes")]
     #[case("float")]
     #[case("relation(schema_field_definition_v1)")]
     #[case("relation(schema_definition_v1)")]


### PR DESCRIPTION
Fix missing validation of bytes in schema field definitions of application schema.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
