### PR TITLE
Fix de-/serialization for human-readable encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,13 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
-### Added
-
-### Changed
-
 ### Fixed
+
+- Fix serialization for human-readable encodings [#529](https://github.com/p2panda/p2panda/pull/529)
 
 ## [0.8.0]
 
 Released on 2023-10-12: :package: `p2panda-js` and :package: `p2panda-rs`
-
-### Added
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Fixed
 
-- Fix serialization for human-readable encodings [#529](https://github.com/p2panda/p2panda/pull/529)
+- Fix de-/serialization for human-readable encodings [#529](https://github.com/p2panda/p2panda/pull/529)
 
 ## [0.8.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Fixed
 
-- Fix de-/serialization for human-readable encodings [#529](https://github.com/p2panda/p2panda/pull/529)
+- Fix de-/serialization for human-readable encodings [#529](https://github.com/p2panda/p2panda/pull/529) `rs`
 
 ## [0.8.0]
 

--- a/p2panda-rs/Cargo.toml
+++ b/p2panda-rs/Cargo.toml
@@ -64,6 +64,7 @@ wasm-bindgen = "0.2.87"
 async-trait = "0.1.64"
 rstest = "0.16.0"
 rstest_reuse = "0.5.0"
+serde_json = "1.0.108"
 tokio = { version = "1.25.0", features = ["rt", "macros"] }
 varu64 = { version = "0.7.0", default-features = false }
 

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -158,9 +158,12 @@ impl<'de> Deserialize<'de> for DocumentViewId {
             type Value = DocumentViewId;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("schema id as string")
+                formatter.write_str("document view id as array or in string representation")
             }
 
+            /// Document view ids can be represented as strings, using underscores as separators
+            /// between the operation ids. This is especially useful when using arrays is not
+            /// possible or unergonomic (for example in GraphQL)
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
@@ -168,6 +171,7 @@ impl<'de> Deserialize<'de> for DocumentViewId {
                 DocumentViewId::from_str(value).map_err(serde::de::Error::custom)
             }
 
+            /// Document view ids can be represented as arrays of operation ids.
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
             where
                 A: serde::de::SeqAccess<'de>,

--- a/p2panda-rs/src/document/document_view_id.rs
+++ b/p2panda-rs/src/document/document_view_id.rs
@@ -467,4 +467,31 @@ mod tests {
 
         assert_eq!(result.unwrap_err().to_string(), expected_result.to_string());
     }
+
+    #[test]
+    fn deserialize_human_readable() {
+        let hash_str = "0020cfb0fa37f36d082faad3886a9ffbcc2813b7afe90f0609a556d425f1a76ec805";
+
+        #[derive(serde::Deserialize, Debug, PartialEq)]
+        struct Test {
+            document_view_id: DocumentViewId,
+        }
+
+        // Deserialize from human-readable (hex-encoded) JSON string
+        let json = format!(
+            r#"
+            {{
+                "document_view_id": "{hash_str}"
+            }}
+        "#
+        );
+
+        let result: Test = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            Test {
+                document_view_id: Hash::new(hash_str).unwrap().into(),
+            },
+            result
+        );
+    }
 }

--- a/p2panda-rs/src/hash/hash.rs
+++ b/p2panda-rs/src/hash/hash.rs
@@ -309,9 +309,15 @@ mod tests {
     #[test]
     fn deserialize() {
         let hash_str = "0020cfb0fa37f36d082faad3886a9ffbcc2813b7afe90f0609a556d425f1a76ec805";
+
+        // Deserialize from bytes
         let hash_bytes = hex::decode(hash_str).unwrap();
         let hash: Hash =
             deserialize_into(&serialize_value(cbor!(ByteBuf::from(hash_bytes)))).unwrap();
+        assert_eq!(Hash::new(hash_str).unwrap(), hash);
+
+        // Deserialize from string
+        let hash: Hash = deserialize_into(&serialize_value(cbor!(hash_str))).unwrap();
         assert_eq!(Hash::new(hash_str).unwrap(), hash);
 
         // Invalid hashes

--- a/p2panda-rs/src/operation/decode.rs
+++ b/p2panda-rs/src/operation/decode.rs
@@ -127,11 +127,11 @@ mod tests {
         "missing action field in operation format"
     )]
     #[case::invalid_action(
-        cbor!([1, "this is not an action", SCHEMA_ID, { "is_cute" => true } ]),
+        cbor!([1, "this is not an action", SCHEMA_ID, { "is_cute" => true }]),
         "invalid type: string, expected integer"
     )]
     #[case::unsupported_action(
-        cbor!([1, 100, SCHEMA_ID, { "is_cute" => true } ]),
+        cbor!([1, 100, SCHEMA_ID, { "is_cute" => true }]),
         "unknown operation action 100"
     )]
     #[case::missing_schema_id(
@@ -139,15 +139,15 @@ mod tests {
         "missing schema id field in operation format"
     )]
     #[case::invalid_schema_id_incomplete(
-        cbor!([1, 0, "venue_0020", { "name" => "Panda" } ]),
+        cbor!([1, 0, "venue_0020", { "name" => "Panda" }]),
         "encountered invalid hash while parsing application schema id: invalid hash length 2 bytes, expected 34 bytes"
     )]
     #[case::invalid_schema_id_hex(
-        cbor!([1, 0, "this is not a hash", { "name" => "Panda" } ]),
+        cbor!([1, 0, "this is not a hash", { "name" => "Panda" }]),
         "malformed schema id `this is not a hash`: doesn't contain an underscore"
     )]
     #[case::invalid_schema_id_name_missing(
-        cbor!([1, 0, HASH, { "name" => "Panda" } ]),
+        cbor!([1, 0, HASH, { "name" => "Panda" }]),
         "malformed schema id `0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543`: doesn't contain an underscore"
     )]
     #[case::non_canonic_schema_id_unsorted(
@@ -173,16 +173,16 @@ mod tests {
         "encountered invalid document view id while parsing application schema id: expected sorted operation ids in document view id"
     )]
     #[case::invalid_previous_operations_hex(
-        cbor!([1, 2, SCHEMA_ID, [serde_bytes::ByteBuf::from("_correct_num_of_bytes_but_not_hex_")] ]),
+        cbor!([1, 2, SCHEMA_ID, [serde_bytes::ByteBuf::from("_correct_num_of_bytes_but_not_hex_")]]),
         "can not decode YASMF BLAKE3 hash"
     )]
     #[case::invalid_previous_operations_incomplete(
-        cbor!([1, 2, SCHEMA_ID, [hex_string_to_bytes("0020")] ]),
+        cbor!([1, 2, SCHEMA_ID, [hex_string_to_bytes("0020")]]),
         "invalid hash length 2 bytes, expected 34 bytes"
     )]
     #[case::invalid_previous_operations_array(
-        cbor!([1, 2, SCHEMA_ID, {} ]),
-        "invalid type: map, expected array"
+        cbor!([1, 2, SCHEMA_ID, {}]),
+        "invalid type: map, expected document view id as array or in string representation"
     )]
     #[case::non_canonic_previous_operations_unsorted(
         cbor!([1, 2, SCHEMA_ID, [
@@ -200,11 +200,11 @@ mod tests {
         "expected sorted operation ids in document view id"
     )]
     #[case::invalid_fields_key_type_1(
-        cbor!([1, 0, SCHEMA_ID, { 12 => "Panda" } ]),
+        cbor!([1, 0, SCHEMA_ID, { 12 => "Panda" }]),
         "invalid type: integer `12`, expected string"
     )]
     #[case::invalid_fields_key_type_2(
-        cbor!([1, 0, SCHEMA_ID, { "a" => "value", "b" => { "nested" => "wrong " } }]),
+        cbor!([1, 0, SCHEMA_ID, { "a" => "value", "b" => { "nested" => "wrong " }}]),
         "error deserializing plain value: data did not match any variant of untagged enum PlainValue"
     )]
     #[case::invalid_fields_value_type(
@@ -228,8 +228,8 @@ mod tests {
         "invalid type: sequence, expected map"
     )]
     #[case::missing_previous_operations_update(
-        cbor!([1, 1, SCHEMA_ID, { "is_cute" => true } ]),
-        "invalid type: map, expected array"
+        cbor!([1, 1, SCHEMA_ID, { "is_cute" => true }]),
+        "invalid type: map, expected document view id as array or in string representation"
     )]
     #[case::missing_previous_operations_delete(
         cbor!([1, 2, SCHEMA_ID ]),
@@ -240,7 +240,7 @@ mod tests {
         "missing fields for this operation action"
     )]
     #[case::missing_fields_update(
-        cbor!([1, 1, SCHEMA_ID, [hex_string_to_bytes(HASH)] ]),
+        cbor!([1, 1, SCHEMA_ID, [hex_string_to_bytes(HASH)]]),
         "missing fields for this operation action"
     )]
     #[case::invalid_fields_delete(

--- a/p2panda-rs/src/operation/plain/plain_operation.rs
+++ b/p2panda-rs/src/operation/plain/plain_operation.rs
@@ -221,7 +221,9 @@ mod tests {
     #[case::hash_too_small(cbor!([1, 1, "schema_field_definition_v1", [[0, 1]]]))]
     #[should_panic(expected = "invalid type: string, expected byte buf")]
     #[case::hash_too_small(cbor!([1, 1, "schema_field_definition_v1", ["0020"]]))]
-    #[should_panic(expected = "invalid type: map, expected array")]
+    #[should_panic(
+        expected = "invalid type: map, expected document view id as array or in string representation"
+    )]
     #[case::fields_wrong_type(cbor!([1, 1, "schema_field_definition_v1", { "type" => "int" }]))]
     fn deserialize_invalid_operations(#[case] cbor: Result<Value, Error>) {
         // Check the cbor is valid.

--- a/p2panda-rs/src/operation/plain/plain_operation.rs
+++ b/p2panda-rs/src/operation/plain/plain_operation.rs
@@ -15,7 +15,7 @@ use crate::schema::SchemaId;
 ///
 /// Use plain operations to already read important data from them, like the schema id or operation
 /// action.
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize)]
 pub struct PlainOperation(
     OperationVersion,
     OperationAction,

--- a/p2panda-rs/src/operation/plain/plain_value.rs
+++ b/p2panda-rs/src/operation/plain/plain_value.rs
@@ -173,7 +173,7 @@ fn to_plain_value_list(
     is_human_readable: bool,
     array: Vec<Value>,
 ) -> Result<PlainValue, PlainValueError> {
-    // Helper method to convert the given value to a hexadecimal string. 
+    // Helper method to convert the given value to a hexadecimal string.
     //
     // If we're working with a human-readable encoding format we can expect the value to already be
     // a hexadecimal string, for non human-readable formats we need to encode it from the bytes
@@ -358,6 +358,36 @@ mod tests {
         assert_eq!(
             deserialize_into::<PlainValue>(&serialize_value(cbor!([]))).unwrap(),
             PlainValue::AmbiguousRelation(vec![])
+        );
+    }
+
+    #[test]
+    fn deserialize_human_readable() {
+        assert_eq!(
+            serde_json::from_str::<PlainValue>("12").unwrap(),
+            PlainValue::Integer(12)
+        );
+        assert_eq!(
+            serde_json::from_str::<PlainValue>("12.0").unwrap(),
+            PlainValue::Float(12.0)
+        );
+        assert_eq!(
+            serde_json::from_str::<PlainValue>("\"hello\"").unwrap(),
+            PlainValue::String("hello".to_string())
+        );
+        assert_eq!(
+            serde_json::from_str::<PlainValue>("[]").unwrap(),
+            PlainValue::AmbiguousRelation(vec![])
+        );
+        assert_eq!(
+            serde_json::from_str::<PlainValue>(
+                "[[\"00200801063d8aaba76c283a2fb63cf5cd4ec86765424452ce7327fda04c5da80d62\"]]"
+            )
+            .unwrap(),
+            PlainValue::PinnedRelationList(vec![vec![Hash::new(
+                "00200801063d8aaba76c283a2fb63cf5cd4ec86765424452ce7327fda04c5da80d62"
+            )
+            .unwrap()]])
         );
     }
 


### PR DESCRIPTION
This PR fixes two issues concerning deserialization and serialization for human-readable encodings (for example JSON):

1. Deserialization of `PlainOperation` was not possible when coming from a human-readable format. That's an edge case as operations should _never_ be encoded in anything else than CBOR (as per specification), but we have exceptions when it is a nice user-interface, for example in `send-to-node`
2. `DocumentViewId` can be represented as a string in human-facing scenarios, but we didn't account for that during deserialization

Closes: https://github.com/p2panda/p2panda/issues/528

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
