### PR TITLE
`p2panda-store`: basic storage traits plus `MemoryStore` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ Highlights are marked with a pancake 🥞
 ### Added
 
 - Introduce all core p2panda types [#535](https://github.com/p2panda/p2panda/pull/535)
+- introduce basic storage traits w/ MemoryStore implementation [#536](https://github.com/p2panda/p2panda/pull/536)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 resolver = "2"
-members = ["p2panda-core", "fuzz"]
+members = ["p2panda-core", "p2panda-store", "fuzz"]
 
 [workspace.lints.rust]

--- a/p2panda-core/src/extensions.rs
+++ b/p2panda-core/src/extensions.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Header;
 
-#[derive(Clone, Default, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct DefaultExtensions {}
 
 impl<T> Extension<T> for DefaultExtensions {

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -9,7 +9,7 @@ use crate::hash::Hash;
 use crate::identity::{PrivateKey, PublicKey, Signature};
 
 #[derive(Clone, Debug)]
-pub struct Operation<E> {
+pub struct Operation<E = DefaultExtensions> {
     pub hash: Hash,
     pub header: Header<E>,
     pub body: Option<Body>,

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -7,3 +7,8 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+serde = { version = "1.0.203" }
+thiserror = "1.0.61"
+
+[dependencies.p2panda-core]
+path = "../p2panda-core"

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "p2panda-store"
+version = "0.1.0"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-serde = { version = "1.0.203" }
 thiserror = "1.0.61"
+
+[dev-dependencies]
+serde = { version = "1.0.203" }
 
 [dependencies.p2panda-core]
 path = "../p2panda-core"

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -3,4 +3,5 @@
 mod memory_store;
 mod traits;
 
-pub use traits::{OperationStore, StoreError};
+pub use traits::{LogStore, OperationStore, StoreError, StreamStore};
+

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -4,4 +4,3 @@ mod memory_store;
 mod traits;
 
 pub use traits::{LogStore, OperationStore, StoreError, StreamStore};
-

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -5,8 +5,3 @@ pub mod traits;
 
 pub use memory_store::MemoryStore;
 pub use traits::{LogStore, OperationStore, StoreError};
-
-use serde::{Deserialize, Serialize};
-
-#[derive(Clone, PartialEq, Eq, std::hash::Hash, Deserialize, Serialize, Default)]
-struct LogId(String);

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-mod memory_store;
-mod traits;
+pub mod memory_store;
+pub mod traits;
 
+pub use memory_store::MemoryStore;
 pub use traits::{LogStore, OperationStore, StoreError, StreamStore};

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+mod traits;

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -4,7 +4,7 @@ pub mod memory_store;
 pub mod traits;
 
 pub use memory_store::MemoryStore;
-pub use traits::{LogStore, OperationStore, StoreError, StreamStore};
+pub use traits::{LogStore, OperationStore, StoreError};
 
 use serde::{Deserialize, Serialize};
 

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -4,22 +4,9 @@ pub mod memory_store;
 pub mod traits;
 
 pub use memory_store::MemoryStore;
-use p2panda_core::PublicKey;
 pub use traits::{LogStore, OperationStore, StoreError, StreamStore};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LogId(pub String);
-
-impl LogId {
-    pub fn from_public_key(public_key: PublicKey) -> Self {
-        Self(public_key.to_string())
-    }
-}
-
-impl From<String> for LogId {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
+#[derive(Clone, PartialEq, Eq, std::hash::Hash, Deserialize, Serialize, Default)]
+struct LogId(String);

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -1,3 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+mod memory_store;
 mod traits;
+
+pub use traits::{OperationStore, StoreError};

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -10,3 +10,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LogId(pub String);
+
+impl From<String> for LogId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -4,12 +4,19 @@ pub mod memory_store;
 pub mod traits;
 
 pub use memory_store::MemoryStore;
+use p2panda_core::PublicKey;
 pub use traits::{LogStore, OperationStore, StoreError, StreamStore};
 
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LogId(pub String);
+
+impl LogId {
+    pub fn from_public_key(public_key: PublicKey) -> Self {
+        Self(public_key.to_string())
+    }
+}
 
 impl From<String> for LogId {
     fn from(value: String) -> Self {

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -5,3 +5,8 @@ pub mod traits;
 
 pub use memory_store::MemoryStore;
 pub use traits::{LogStore, OperationStore, StoreError, StreamStore};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogId(pub String);

--- a/p2panda-store/src/main.rs
+++ b/p2panda-store/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/p2panda-store/src/main.rs
+++ b/p2panda-store/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -11,6 +11,7 @@ use crate::{OperationStore, StoreError};
 type LogId = String;
 type SeqNum = u64;
 type Timestamp = u64;
+type LogMeta = (SeqNum, Timestamp, Hash);
 
 #[derive(Debug, Default)]
 pub struct MemoryStore<E>
@@ -18,7 +19,7 @@ where
     E: Clone + Default + Serialize + DeserializeOwned + Extension<LogId>,
 {
     operations: HashMap<Hash, Operation<E>>,
-    logs: HashMap<(PublicKey, LogId), BTreeSet<(SeqNum, Timestamp, Hash)>>,
+    logs: HashMap<(PublicKey, LogId), BTreeSet<LogMeta>>,
 }
 
 impl<E> OperationStore<E> for MemoryStore<E>
@@ -42,7 +43,7 @@ where
             })
             .or_insert(BTreeSet::from([entry]));
         self.operations.insert(operation.hash, operation);
-        return Ok(true);
+        Ok(true)
     }
 
     fn get_operation(&self, hash: Hash) -> Result<Option<Operation<E>>, StoreError> {

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -80,7 +80,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p2panda_core::{Body, Extension, Extensions, Header, Operation, PrivateKey};
+    use p2panda_core::{
+        validate_operation, Body, Extension, Extensions, Header, Operation, PrivateKey,
+    };
     use serde::{Deserialize, Serialize};
 
     use crate::OperationStore;
@@ -120,7 +122,7 @@ mod tests {
     }
 
     #[test]
-    fn test() {
+    fn generic_extensions_mem_store_support() {
         // MemoryStore can handle operations which contain MyExtensions
         let private_key = PrivateKey::new();
         let body = Body::new("hello!".as_bytes());
@@ -143,11 +145,12 @@ mod tests {
             header,
             body: Some(body),
         };
+        assert!(validate_operation(&operation).is_ok());
+
+        let mut my_store = MemoryStore::default();
+        assert_eq!(my_store.insert_operation(operation).ok(), Some(true));
 
         // MemoryStore can handle operations which contain PenguinExtensions
-        let mut my_store = MemoryStore::default();
-        let _ = my_store.insert_operation(operation);
-
         let private_key = PrivateKey::new();
         let body = Body::new("hello!".as_bytes());
         let mut header = Header {
@@ -169,8 +172,12 @@ mod tests {
             header,
             body: Some(body),
         };
+        assert!(validate_operation(&penguin_operation).is_ok());
 
         let mut penguin_store = MemoryStore::default();
-        let _ = penguin_store.insert_operation(penguin_operation);
+        assert_eq!(
+            penguin_store.insert_operation(penguin_operation).ok(),
+            Some(true)
+        );
     }
 }

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -86,8 +86,6 @@ mod tests {
 
     use super::{MemoryStore, StreamName};
 
-    const PENGUIN_STREAM_NAME: &str = "penguins_are_cool_v1";
-
     #[derive(Clone, Debug, Default, Serialize, Deserialize)]
     pub struct MyExtensions {
         stream_name: Option<StreamName>,
@@ -97,8 +95,7 @@ mod tests {
 
     impl Extension<StreamName> for MyExtensions {
         fn extract(operation: &Operation<MyExtensions>) -> StreamName {
-            let extensions = &operation.header.extensions;
-            match extensions {
+            match &operation.header.extensions {
                 Some(extensions) => match &extensions.stream_name {
                     Some(stream_name) => stream_name.to_owned(),
                     None => StreamName(operation.header.public_key.to_string()),
@@ -107,6 +104,8 @@ mod tests {
             }
         }
     }
+
+    const PENGUIN_STREAM_NAME: &str = "penguins_are_cool_v1";
 
     #[derive(Clone, Debug, Default, Serialize, Deserialize)]
     pub struct PenguinExtensions {}

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -139,6 +139,7 @@ where
         todo!()
     }
 }
+
 #[cfg(test)]
 mod tests {
     use p2panda_core::{validate_operation, Body, Header, Operation, PrivateKey};

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -4,13 +4,11 @@ use std::collections::{BTreeSet, HashMap};
 
 use p2panda_core::{Extension, Hash, Operation, PublicKey};
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::{OperationStore, StoreError};
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
-pub struct LogId(pub String);
-
+type LogId = String;
 type SeqNum = u64;
 type Timestamp = u64;
 
@@ -101,9 +99,9 @@ mod tests {
             match &operation.header.extensions {
                 Some(extensions) => match &extensions.stream_name {
                     Some(stream_name) => stream_name.to_owned(),
-                    None => LogId(operation.header.public_key.to_string()),
+                    None => operation.header.public_key.to_string(),
                 },
-                None => LogId(operation.header.public_key.to_string()),
+                None => operation.header.public_key.to_string(),
             }
         }
     }
@@ -117,7 +115,7 @@ mod tests {
 
     impl Extension<LogId> for PenguinExtensions {
         fn extract(_operation: &Operation<PenguinExtensions>) -> LogId {
-            LogId(String::from(PENGUIN_STREAM_NAME))
+            String::from(PENGUIN_STREAM_NAME)
         }
     }
 

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::traits::{OperationStore, StoreError};
-use crate::LogId;
+use crate::{LogId, LogStore};
 
 type SeqNum = u64;
 type Timestamp = u64;
@@ -77,6 +77,55 @@ where
     }
 }
 
+impl<E> LogStore<E> for MemoryStore<E>
+where
+    E: Clone + Serialize + DeserializeOwned + Extension<LogId>,
+{
+    type LogId = LogId;
+
+    fn get_log(
+        &self,
+        public_key: PublicKey,
+        log_id: LogId,
+    ) -> Result<Option<Vec<Operation<E>>>, StoreError> {
+        todo!()
+    }
+
+    fn latest_operation(
+        &self,
+        public_key: PublicKey,
+        log_id: LogId,
+    ) -> Result<Option<Operation<E>>, StoreError> {
+        let latest = match self.logs.get(&(public_key, log_id)) {
+            Some(log) => match log.last() {
+                Some((_, _, hash)) => self.operations.get(&hash),
+                None => None,
+            },
+            None => None,
+        };
+        Ok(latest.cloned())
+    }
+
+    fn delete_operations(
+        &mut self,
+        public_key: PublicKey,
+        log_id: LogId,
+        from: u64,
+        to: Option<u64>,
+    ) -> Result<(), StoreError> {
+        todo!()
+    }
+
+    fn delete_payloads(
+        &mut self,
+        public_key: PublicKey,
+        log_id: LogId,
+        from: u64,
+        to: Option<u64>,
+    ) -> Result<(), StoreError> {
+        todo!()
+    }
+}
 #[cfg(test)]
 mod tests {
     use p2panda_core::{

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -112,7 +112,7 @@ where
         log_id: LogId,
         from: u64,
         to: Option<u64>,
-    ) -> Result<(), StoreError> {
+    ) -> Result<bool, StoreError> {
         todo!()
     }
 
@@ -122,7 +122,7 @@ where
         log_id: LogId,
         from: u64,
         to: Option<u64>,
-    ) -> Result<(), StoreError> {
+    ) -> Result<bool, StoreError> {
         todo!()
     }
 }

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -6,7 +6,7 @@ use p2panda_core::{Extension, Hash, Operation, PublicKey};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::{OperationStore, StoreError};
+use crate::traits::{OperationStore, StoreError};
 
 type LogId = String;
 type SeqNum = u64;
@@ -84,7 +84,7 @@ mod tests {
     };
     use serde::{Deserialize, Serialize};
 
-    use crate::OperationStore;
+    use crate::traits::OperationStore;
 
     use super::{LogId, MemoryStore};
 

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -7,8 +7,8 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::traits::{OperationStore, StoreError};
+use crate::LogId;
 
-type LogId = String;
 type SeqNum = u64;
 type Timestamp = u64;
 type LogMeta = (SeqNum, Timestamp, Hash);
@@ -16,7 +16,7 @@ type LogMeta = (SeqNum, Timestamp, Hash);
 #[derive(Debug, Default)]
 pub struct MemoryStore<E>
 where
-    E: Clone + Default + Serialize + DeserializeOwned + Extension<LogId>,
+    E: Clone + Serialize + DeserializeOwned + Extension<LogId>,
 {
     operations: HashMap<Hash, Operation<E>>,
     logs: HashMap<(PublicKey, LogId), BTreeSet<LogMeta>>,
@@ -24,7 +24,7 @@ where
 
 impl<E> OperationStore<E> for MemoryStore<E>
 where
-    E: Clone + Default + Serialize + DeserializeOwned + Extension<LogId>,
+    E: Clone + Serialize + DeserializeOwned + Extension<LogId>,
 {
     type LogId = LogId;
 
@@ -100,9 +100,9 @@ mod tests {
             match &operation.header.extensions {
                 Some(extensions) => match &extensions.stream_name {
                     Some(stream_name) => stream_name.to_owned(),
-                    None => operation.header.public_key.to_string(),
+                    None => LogId(operation.header.public_key.to_string()),
                 },
-                None => operation.header.public_key.to_string(),
+                None => LogId(operation.header.public_key.to_string()),
             }
         }
     }
@@ -116,7 +116,7 @@ mod tests {
 
     impl Extension<LogId> for PenguinExtensions {
         fn extract(_operation: &Operation<PenguinExtensions>) -> LogId {
-            String::from(PENGUIN_STREAM_NAME)
+            LogId(String::from(PENGUIN_STREAM_NAME))
         }
     }
 

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -14,30 +14,41 @@ type Timestamp = u64;
 type LogMeta = (SeqNum, Timestamp, Hash);
 
 #[derive(Debug, Default)]
-pub struct MemoryStore<E>
-where
-    E: Clone + Serialize + DeserializeOwned + Extension<LogId>,
-{
+pub struct MemoryStore<E> {
     operations: HashMap<Hash, Operation<E>>,
     logs: HashMap<(PublicKey, LogId), BTreeSet<LogMeta>>,
 }
 
+impl<E> MemoryStore<E>
+where
+    E: Clone + Extension<LogId>,
+{
+    pub fn new() -> Self {
+        Self {
+            operations: Default::default(),
+            logs: Default::default(),
+        }
+    }
+}
+
 impl<E> OperationStore<E> for MemoryStore<E>
 where
-    E: Clone + Serialize + DeserializeOwned + Extension<LogId>,
+    E: Clone + Extension<LogId>,
 {
     type LogId = LogId;
 
     fn insert_operation(&mut self, operation: Operation<E>) -> Result<bool, StoreError> {
-        let stream_name = E::extract(&operation);
         let entry = (
             operation.header.seq_num,
             operation.header.timestamp,
             operation.hash,
         );
 
+        let log_id = Extension::<Self::LogId>::extract(&operation.header)
+            .unwrap_or(LogId::from_public_key(operation.header.public_key));
+
         self.logs
-            .entry((operation.header.public_key, stream_name))
+            .entry((operation.header.public_key, log_id))
             .and_modify(|log| {
                 log.insert(entry);
             })
@@ -52,9 +63,11 @@ where
 
     fn delete_operation(&mut self, hash: Hash) -> Result<bool, StoreError> {
         if let Some(operation) = self.operations.remove(&hash) {
-            let stream_name = E::extract(&operation);
+            let log_id = Extension::<Self::LogId>::extract(&operation.header)
+                .unwrap_or(LogId::from_public_key(operation.header.public_key));
+
             self.logs
-                .get_mut(&(operation.header.public_key, stream_name))
+                .get_mut(&(operation.header.public_key, log_id))
                 .unwrap()
                 .remove(&(
                     operation.header.seq_num,
@@ -128,52 +141,32 @@ where
 }
 #[cfg(test)]
 mod tests {
-    use p2panda_core::{
-        validate_operation, Body, Extension, Extensions, Header, Operation, PrivateKey,
-    };
+    use p2panda_core::{validate_operation, Body, Extension, Header, Operation, PrivateKey};
     use serde::{Deserialize, Serialize};
 
     use crate::traits::OperationStore;
 
     use super::{LogId, MemoryStore};
 
-    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-    pub struct MyExtensions {
-        stream_name: Option<LogId>,
+    #[derive(Clone, Deserialize, Serialize)]
+    pub struct MyCustomExtensions {
+        log_id: LogId,
     }
 
-    impl Extensions for MyExtensions {}
-
-    impl Extension<LogId> for MyExtensions {
-        fn extract(operation: &Operation<MyExtensions>) -> LogId {
-            match &operation.header.extensions {
-                Some(extensions) => match &extensions.stream_name {
-                    Some(stream_name) => stream_name.to_owned(),
-                    None => LogId(operation.header.public_key.to_string()),
-                },
-                None => LogId(operation.header.public_key.to_string()),
-            }
-        }
-    }
-
-    const PENGUIN_STREAM_NAME: &str = "penguins_are_cool_v1";
-
-    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-    pub struct PenguinExtensions {}
-
-    impl Extensions for PenguinExtensions {}
-
-    impl Extension<LogId> for PenguinExtensions {
-        fn extract(_operation: &Operation<PenguinExtensions>) -> LogId {
-            LogId(String::from(PENGUIN_STREAM_NAME))
+    impl Extension<LogId> for MyCustomExtensions {
+        fn extract(&self) -> Option<LogId> {
+            Some(self.log_id.clone())
         }
     }
 
     #[test]
     fn generic_extensions_mem_store_support() {
-        // MemoryStore can handle operations which contain MyExtensions
         let private_key = PrivateKey::new();
         let body = Body::new("hello!".as_bytes());
+        let extensions = MyCustomExtensions {
+            log_id: "messages".to_string().into(),
+        };
+
         let mut header = Header {
             version: 1,
             public_key: private_key.public_key(),
@@ -184,7 +177,7 @@ mod tests {
             seq_num: 0,
             backlink: None,
             previous: vec![],
-            extensions: Some(MyExtensions::default()),
+            extensions: Some(extensions),
         };
         header.sign(&private_key);
 
@@ -195,37 +188,7 @@ mod tests {
         };
         assert!(validate_operation(&operation).is_ok());
 
-        let mut my_store = MemoryStore::default();
+        let mut my_store = MemoryStore::new();
         assert_eq!(my_store.insert_operation(operation).ok(), Some(true));
-
-        // MemoryStore can handle operations which contain PenguinExtensions
-        let private_key = PrivateKey::new();
-        let body = Body::new("hello!".as_bytes());
-        let mut header = Header {
-            version: 1,
-            public_key: private_key.public_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            timestamp: 0,
-            seq_num: 0,
-            backlink: None,
-            previous: vec![],
-            extensions: Some(PenguinExtensions::default()),
-        };
-        header.sign(&private_key);
-
-        let penguin_operation = Operation {
-            hash: header.hash(),
-            header,
-            body: Some(body),
-        };
-        assert!(validate_operation(&penguin_operation).is_ok());
-
-        let mut penguin_store = MemoryStore::default();
-        assert_eq!(
-            penguin_store.insert_operation(penguin_operation).ok(),
-            Some(true)
-        );
     }
 }

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -1,8 +1,10 @@
-use p2panda_core::extensions::Extension;
-use p2panda_core::{Hash, Operation, PublicKey};
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::collections::{BTreeSet, HashMap};
+
+use p2panda_core::{Extension, Hash, Operation, PublicKey};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashMap};
 
 use crate::{OperationStore, StoreError};
 
@@ -18,7 +20,6 @@ where
     E: Clone + Default + Serialize + DeserializeOwned + Extension<LogId>,
 {
     operations: HashMap<Hash, Operation<E>>,
-
     logs: HashMap<(PublicKey, LogId), BTreeSet<(SeqNum, Timestamp, Hash)>>,
 }
 
@@ -79,12 +80,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p2panda_core::{extensions::Extension, Body, Extensions, Header, Operation, PrivateKey};
+    use p2panda_core::{Body, Extension, Extensions, Header, Operation, PrivateKey};
     use serde::{Deserialize, Serialize};
 
     use crate::OperationStore;
 
-    use super::{MemoryStore, LogId};
+    use super::{LogId, MemoryStore};
 
     #[derive(Clone, Debug, Default, Serialize, Deserialize)]
     pub struct MyExtensions {
@@ -120,7 +121,7 @@ mod tests {
 
     #[test]
     fn test() {
-        // MemoryStore can handle operations which contain MyExtensions 
+        // MemoryStore can handle operations which contain MyExtensions
         let private_key = PrivateKey::new();
         let body = Body::new("hello!".as_bytes());
         let mut header = Header {
@@ -143,7 +144,7 @@ mod tests {
             body: Some(body),
         };
 
-        // MemoryStore can handle operations which contain PenguinExtensions 
+        // MemoryStore can handle operations which contain PenguinExtensions
         let mut my_store = MemoryStore::default();
         let _ = my_store.insert_operation(operation);
 

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -32,7 +32,7 @@ where
     fn delete_payload(&mut self, hash: Hash) -> Result<bool, StoreError>;
 }
 
-pub trait LogStore<E, S>
+pub trait LogStore<E>
 where
     E: Extension<Self::LogId>,
 {
@@ -41,13 +41,13 @@ where
     fn get_log(
         &self,
         public_key: PublicKey,
-        log_id: S,
+        log_id: Self::LogId,
     ) -> Result<Option<Vec<Operation<E>>>, StoreError>;
 
     fn delete_operations(
         &mut self,
         public_key: PublicKey,
-        log_id: S,
+        log_id: Self::LogId,
         from: u64,
         to: Option<u64>,
     ) -> Result<(), StoreError>;
@@ -55,19 +55,19 @@ where
     fn delete_payloads(
         &mut self,
         public_key: PublicKey,
-        log_id: S,
+        log_id: Self::LogId,
         from: u64,
         to: Option<u64>,
     ) -> Result<(), StoreError>;
 }
 
-pub trait StreamStore<E, S>
+pub trait StreamStore<E>
 where
     E: Extension<Self::StreamId>,
 {
     type StreamId;
 
-    fn get_stream(stream_name: S) -> Result<Option<Vec<Operation<E>>>, StoreError>;
+    fn get_stream(stream_name: Self::StreamId) -> Result<Option<Vec<Operation<E>>>, StoreError>;
 }
 
 #[derive(Error, Debug)]

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -61,6 +61,9 @@ pub trait LogStore<LogId, Extensions> {
     ) -> Result<bool, StoreError>;
 
     /// Delete a range of operation payloads in an authors' log.
+    /// 
+    /// The range of deleted payloads includes it's lower bound `from` but excludes the upper
+    /// bound `to`.
     ///
     /// Returns `true` when operations within the requested range were deleted, or `false` when
     /// the author or log could not be found, or no operations were deleted.

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -3,9 +3,11 @@
 use p2panda_core::{Extension, Hash, Operation, PublicKey};
 use thiserror::Error;
 
+use crate::LogId;
+
 pub trait OperationStore<E>
 where
-    E: Extension<Self::LogId>,
+    E: Extension<LogId>,
 {
     type LogId;
 
@@ -33,20 +35,20 @@ where
 
 pub trait LogStore<E>
 where
-    E: Extension<Self::LogId>,
+    E: Extension<LogId>,
 {
     type LogId;
 
     fn get_log(
         &self,
         public_key: PublicKey,
-        log_id: Self::LogId,
+        log_id: LogId,
     ) -> Result<Option<Vec<Operation<E>>>, StoreError>;
 
     fn delete_operations(
         &mut self,
         public_key: PublicKey,
-        log_id: Self::LogId,
+        log_id: LogId,
         from: u64,
         to: Option<u64>,
     ) -> Result<(), StoreError>;
@@ -54,7 +56,7 @@ where
     fn delete_payloads(
         &mut self,
         public_key: PublicKey,
-        log_id: Self::LogId,
+        log_id: LogId,
         from: u64,
         to: Option<u64>,
     ) -> Result<(), StoreError>;

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -33,12 +33,12 @@ pub trait OperationStore<LogId, Extensions> {
 pub trait LogStore<LogId, Extensions> {
     /// Get all operations from an authors' log ordered by sequence number.
     ///
-    /// Returns None when the author or a log with the requested id was not found.
+    /// Returns an empty Vec when the author or a log with the requested id was not found.
     fn get_log(
         &self,
         public_key: PublicKey,
         log_id: LogId,
-    ) -> Result<Option<Vec<Operation<Extensions>>>, StoreError>;
+    ) -> Result<Vec<Operation<Extensions>>, StoreError>;
 
     /// Get only the latest operation from an authors' log.
     ///
@@ -49,19 +49,18 @@ pub trait LogStore<LogId, Extensions> {
         log_id: LogId,
     ) -> Result<Option<Operation<Extensions>>, StoreError>;
 
-    /// Delete a range of operations from an authors' log.
+    /// Delete all operations in a log before the given sequence number.
     ///
-    /// Returns `true` when operations within the requested range were deleted, or `false` when
+    /// Returns `true` when any operations were deleted, returns `false` when
     /// the author or log could not be found, or no operations were deleted.
     fn delete_operations(
         &mut self,
         public_key: PublicKey,
         log_id: LogId,
-        from: u64,
-        to: Option<u64>,
+        before: u64,
     ) -> Result<bool, StoreError>;
 
-    /// Delete a range of operation payloads from an authors' log.
+    /// Delete a range of operation payloads in an authors' log.
     ///
     /// Returns `true` when operations within the requested range were deleted, or `false` when
     /// the author or log could not be found, or no operations were deleted.
@@ -70,7 +69,7 @@ pub trait LogStore<LogId, Extensions> {
         public_key: PublicKey,
         log_id: LogId,
         from: u64,
-        to: Option<u64>,
+        to: u64,
     ) -> Result<bool, StoreError>;
 }
 

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -4,10 +4,12 @@ use p2panda_core::extensions::Extension;
 use p2panda_core::{Hash, Operation, PublicKey};
 use thiserror::Error;
 
-pub trait OperationStore<E, S>
+pub trait OperationStore<E>
 where
-    E: Extension<S>,
+    E: Extension<Self::LogId>,
 {
+    type LogId;
+
     /// Insert an operation.
     ///
     /// Returns `true` when the insert occurred, or `false` when the operation
@@ -32,8 +34,10 @@ where
 
 pub trait LogStore<E, S>
 where
-    E: Extension<S>,
+    E: Extension<Self::LogId>,
 {
+    type LogId;
+
     fn get_log(
         &self,
         public_key: PublicKey,
@@ -59,8 +63,10 @@ where
 
 pub trait StreamStore<E, S>
 where
-    E: Extension<S>,
+    E: Extension<Self::StreamId>,
 {
+    type StreamId;
+
     fn get_stream(stream_name: S) -> Result<Option<Vec<Operation<E>>>, StoreError>;
 }
 

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use p2panda_core::extensions::Extension;
-use p2panda_core::{Hash, Operation, PublicKey};
+use p2panda_core::{Extension, Hash, Operation, PublicKey};
 use thiserror::Error;
 
 pub trait OperationStore<E>

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -61,7 +61,7 @@ pub trait LogStore<LogId, Extensions> {
     ) -> Result<bool, StoreError>;
 
     /// Delete a range of operation payloads in an authors' log.
-    /// 
+    ///
     /// The range of deleted payloads includes it's lower bound `from` but excludes the upper
     /// bound `to`.
     ///

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -45,6 +45,12 @@ where
         log_id: LogId,
     ) -> Result<Option<Vec<Operation<E>>>, StoreError>;
 
+    fn latest_operation(
+        &self,
+        public_key: PublicKey,
+        log_id: LogId,
+    ) -> Result<Option<Operation<E>>, StoreError>;
+
     fn delete_operations(
         &mut self,
         public_key: PublicKey,

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -3,12 +3,7 @@
 use p2panda_core::{Extension, Hash, Operation, PublicKey};
 use thiserror::Error;
 
-use crate::LogId;
-
-pub trait OperationStore<E>
-where
-    E: Extension<LogId>,
-{
+pub trait OperationStore<E> {
     type LogId;
 
     /// Insert an operation.
@@ -33,10 +28,7 @@ where
     fn delete_payload(&mut self, hash: Hash) -> Result<bool, StoreError>;
 }
 
-pub trait LogStore<E>
-where
-    E: Extension<LogId>,
-{
+pub trait LogStore<E> {
     type LogId;
 
     /// Get all operations from an authors' log ordered by sequence number.
@@ -45,7 +37,7 @@ where
     fn get_log(
         &self,
         public_key: PublicKey,
-        log_id: LogId,
+        log_id: Self::LogId,
     ) -> Result<Option<Vec<Operation<E>>>, StoreError>;
 
     /// Get only the latest operation from an authors' log.
@@ -54,7 +46,7 @@ where
     fn latest_operation(
         &self,
         public_key: PublicKey,
-        log_id: LogId,
+        log_id: Self::LogId,
     ) -> Result<Option<Operation<E>>, StoreError>;
 
     /// Delete a range of operations from an authors' log.
@@ -64,7 +56,7 @@ where
     fn delete_operations(
         &mut self,
         public_key: PublicKey,
-        log_id: LogId,
+        log_id: Self::LogId,
         from: u64,
         to: Option<u64>,
     ) -> Result<bool, StoreError>;
@@ -76,7 +68,7 @@ where
     fn delete_payloads(
         &mut self,
         public_key: PublicKey,
-        log_id: LogId,
+        log_id: Self::LogId,
         from: u64,
         to: Option<u64>,
     ) -> Result<bool, StoreError>;

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -13,7 +13,7 @@ where
     ///
     /// Returns `true` when the insert occurred, or `false` when the operation
     /// already existed and no insertion occurred.
-    fn insert(header: Header<E>, body: Body) -> Result<bool, StoreError>;
+    fn insert(header: Header<E>, body: Option<Body>) -> Result<bool, StoreError>;
 
     /// Get a single operation.
     fn get(hash: &Hash) -> Result<Option<Operation<E>>, StoreError>;

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -8,7 +8,11 @@ pub trait OperationStore<LogId, Extensions> {
     ///
     /// Returns `true` when the insert occurred, or `false` when the operation
     /// already existed and no insertion occurred.
-    fn insert_operation(&mut self, operation: Operation<Extensions>, log_id: LogId) -> Result<bool, StoreError>;
+    fn insert_operation(
+        &mut self,
+        operation: Operation<Extensions>,
+        log_id: LogId,
+    ) -> Result<bool, StoreError>;
 
     /// Get an operation.
     fn get_operation(&self, hash: Hash) -> Result<Option<Operation<Extensions>>, StoreError>;
@@ -68,16 +72,6 @@ pub trait LogStore<LogId, Extensions> {
         from: u64,
         to: Option<u64>,
     ) -> Result<bool, StoreError>;
-}
-
-pub trait StreamStore<StreamId, Extensions> {
-    /// Get all operations from a stream.
-    ///
-    /// A stream contains operations from all author logs which share the same `LogId`.
-    /// Conceptually they can be understood as multi-writer logs. The operations in the returned
-    /// collection are "locally" ordered (ordered by sequence number per-log) but globally
-    /// unordered.
-    fn get_stream(stream_name: StreamId) -> Result<Option<Vec<Operation<Extensions>>>, StoreError>;
 }
 
 #[derive(Error, Debug)]

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -39,33 +39,47 @@ where
 {
     type LogId;
 
+    /// Get all operations from an authors' log ordered by sequence number.
+    ///
+    /// Returns None when the author or a log with the requested id was not found.
     fn get_log(
         &self,
         public_key: PublicKey,
         log_id: LogId,
     ) -> Result<Option<Vec<Operation<E>>>, StoreError>;
 
+    /// Get only the latest operation from an authors' log.
+    ///
+    /// Returns None when the author or a log with the requested id was not found.
     fn latest_operation(
         &self,
         public_key: PublicKey,
         log_id: LogId,
     ) -> Result<Option<Operation<E>>, StoreError>;
 
+    /// Delete a range of operations from an authors' log.
+    ///
+    /// Returns `true` when operations within the requested range were deleted, or `false` when
+    /// the author or log could not be found, or no operations were deleted.
     fn delete_operations(
         &mut self,
         public_key: PublicKey,
         log_id: LogId,
         from: u64,
         to: Option<u64>,
-    ) -> Result<(), StoreError>;
+    ) -> Result<bool, StoreError>;
 
+    /// Delete a range of operation payloads from an authors' log.
+    ///
+    /// Returns `true` when operations within the requested range were deleted, or `false` when
+    /// the author or log could not be found, or no operations were deleted.
     fn delete_payloads(
         &mut self,
         public_key: PublicKey,
         log_id: LogId,
         from: u64,
         to: Option<u64>,
-    ) -> Result<(), StoreError>;
+    ) -> Result<bool, StoreError>;
 }
 
 pub trait StreamStore<E>
@@ -74,6 +88,12 @@ where
 {
     type StreamId;
 
+    /// Get all operations from a stream.
+    ///
+    /// A stream contains operations from all author logs which share the same `LogId`.
+    /// Conceptually they can be understood as multi-writer logs. The operations in the returned
+    /// collection are "locally" ordered (ordered by sequence number per-log) but globally
+    /// unordered.
     fn get_stream(stream_name: Self::StreamId) -> Result<Option<Vec<Operation<E>>>, StoreError>;
 }
 

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use p2panda_core::{Body, Hash, Header, Operation, PublicKey};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use thiserror::Error;
+
+pub trait OperationStore<E>
+where
+    E: Clone + Serialize + DeserializeOwned,
+{
+    /// Insert an operation.
+    ///
+    /// Returns `true` when the insert occurred, or `false` when the operation
+    /// already existed and no insertion occurred.
+    fn insert(header: Header<E>, body: Body) -> Result<bool, StoreError>;
+
+    /// Get a single operation.
+    fn get(hash: &Hash) -> Result<Option<Operation<E>>, StoreError>;
+
+    /// Remove a single operation.
+    ///
+    /// Returns `true` when the removal occurred and `false` when the operation
+    /// was not found in the store.
+    fn remove(hash: &Hash) -> Result<bool, StoreError>;
+
+    /// Get all operations from a single authors log.
+    ///
+    /// Returns `None` if the requested log or author was not found in the store.
+    fn all(public_key: &PublicKey, log_id: &str) -> Result<Option<Vec<Operation<E>>>, StoreError>;
+}
+
+#[derive(Error, Debug)]
+pub enum StoreError {
+    #[error("Error occurred in OperationStore: {0}")]
+    OperationStoreError(String),
+}


### PR DESCRIPTION
Storage traits outlining basic API for inserting, getting and deleting operations and their payloads. This is a low-level API intended to be used when validating and persisting operations which arrive on a node, retrieving all operations from a log during replication, or pruning operations and/or their payloads.

- [x] `OperationStore` trait describing API for handling individual operations
- [x] `LogStore` trait describing API for performing actions involving logs 
- [x] `MemoryStore` implementation of above traits   

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] New files contain a SPDX license header