### PR TITLE
Bump `iroh` dependencies to `0.22.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
+- Bump `iroh` dependencies to `0.22.0` [#543](https://github.com/p2panda/p2panda/pull/543)
 - Introduce networking functionality, including discovery and gossip
   services [#540](https://github.com/p2panda/p2panda/pull/540)
 - Introduce all core p2panda types [#535](https://github.com/p2panda/p2panda/pull/535)
-- introduce basic storage traits w/ MemoryStore implementation [#536](https://github.com/p2panda/p2panda/pull/536)
+- Introduce basic storage traits w/ MemoryStore implementation [#536](https://github.com/p2panda/p2panda/pull/536)

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -14,8 +14,6 @@ workspace = true
 [dependencies]
 anyhow = "1.0.86"
 ciborium = { version = "0.2.2", optional = true }
-# @TODO: remove this pinned-dependency after `iroh` version bump
-#derive_more = "=1.0.0-beta.6"
 flume = "0.11.0"
 futures-buffered = "0.2.6"
 futures-lite = "2.3.0"

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -15,15 +15,15 @@ workspace = true
 anyhow = "1.0.86"
 ciborium = { version = "0.2.2", optional = true }
 # @TODO: remove this pinned-dependency after `iroh` version bump
-derive_more = "=1.0.0-beta.6"
+#derive_more = "=1.0.0-beta.6"
 flume = "0.11.0"
 futures-buffered = "0.2.6"
 futures-lite = "2.3.0"
 futures-util = "0.3.30"
 hickory-proto = { version = "0.24.1", optional = true }
-iroh-base = "0.20.0"
-iroh-gossip = "0.20.0"
-iroh-net = "0.20.0"
+iroh-base = "0.22.0"
+iroh-gossip = "0.22.0"
+iroh-net = "0.22.0"
 p2panda-core = { path = "../p2panda-core" }
 rand = "0.8.5"
 serde = { version = "1.0.203", features = ["derive"] }

--- a/p2panda-net/src/engine/mod.rs
+++ b/p2panda-net/src/engine/mod.rs
@@ -31,7 +31,6 @@ impl Engine {
 
         let engine_actor = EngineActor::new(
             endpoint,
-            gossip.clone(),
             gossip_actor_tx,
             engine_actor_rx,
             network_id.into(),


### PR DESCRIPTION
The transition from `0.20.0` to `0.22.0` introduced some breaking API changes, specifically to `iroh-gossip`. This PR brings our code into line with those changes.

The main difference is in the way we interact with gossip streams for a given topic. Calling `Gossip::join(topic)` now returns [`GossipTopic`](https://docs.rs/iroh-gossip/latest/iroh_gossip/net/struct.GossipTopic.html), a combined sender and receiver which can be conveniently `split()` when required. Our `GossipActor` has been updated to hold a `StreamMap` of receivers (events) and a handle to the sender for each topic (see `gossip_events` and `gossip_senders` fields).

Since the `broadcast()` method has moved from `Gossip` to the `GossipTopic` sender, I've added a `Broadcast` variant on `ToGossipActor`. It feels appropriate to have this action grouped with the other gossip topic interactions.

As a result of the aforementioned changes, `Engine` no longer needs a handle to `Gossip` (just the channel sender into the gossip actor which was already present).

-----

Accidentally reverted to my old ways and forgot to begin commit messages with a capital letter -_- My bad!

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header