### PR TITLE
Re-export `SharedAbortingJoinHandle` from iroh-net

### DIFF
--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -17,6 +17,8 @@ pub use message::{FromBytes, ToBytes};
 pub use network::{Network, NetworkBuilder, RelayMode};
 pub use protocols::ProtocolHandler;
 
+pub use iroh_net::util::SharedAbortingJoinHandle;
+
 pub type NetworkId = [u8; 32];
 
 pub type TopicId = [u8; 32];


### PR DESCRIPTION
One tiny change here: we re-export `SharedAbortingJoinHandle` from `iroh-net` so that downstream libraries can avoid having to include `iroh-net` as a direct dependency on their project.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
- [ ] Check if descriptions and terminology match `handbook` content (and visa-versa) 
