### PR TITLE
Add p2panda-sync placeholder crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace]
 resolver = "2"
-members = ["p2panda-core", "p2panda-store", "p2panda-net", "fuzz"]
+members = [
+    "p2panda-core",
+    "p2panda-net",
+    "p2panda-store",
+    "p2panda-sync"
+    "fuzz",
+]
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ members = [
     "p2panda-core",
     "p2panda-net",
     "p2panda-store",
-    "p2panda-sync"
-    "fuzz",
+    "p2panda-sync",
+    "fuzz"
 ]
 
 [workspace.lints.rust]

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "p2panda-sync"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/p2panda-sync/README.md
+++ b/p2panda-sync/README.md
@@ -1,0 +1,3 @@
+# p2panda-sync
+
+> Nothing to see here yet

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
Simply introduces a placeholder crate for `p2panda-sync` (currently under active development).

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
- [ ] Check if descriptions and terminology match `handbook` content (and visa-versa) 
