### PR TITLE
`p2panda-sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
+- Introduce `p2panda-sync` offering generic sync tools and opinionated sync protocols [#549](https://github.com/p2panda/p2panda/pull/549)
 - Introduce blobs functionality, including import, export and download
   [#546](https://github.com/p2panda/p2panda/pull/546)
 - Bump `iroh` dependencies to `0.22.0` [#543](https://github.com/p2panda/p2panda/pull/543)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [workspace]
 resolver = "2"
 members = [
-    "p2panda-blobs",
     "p2panda-core",
+    "p2panda-blobs",
     "p2panda-net",
     "p2panda-store",
-    "fuzz"
+    "p2panda-sync",
+    "fuzz",
 ]
 
 [workspace.lints.rust]

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -177,6 +177,25 @@ where
         };
         Ok(deletion_occurred)
     }
+
+    fn get_log_heights(&self, log_id: T) -> Result<Vec<(PublicKey, SeqNum)>, StoreError> {
+        let log_heights = self
+            .logs
+            .iter()
+            .filter_map(|((public_key, inner_log_id), log)| {
+                if *inner_log_id == log_id {
+                    let log_height = log
+                        .last()
+                        .expect("all logs contain at least one operation")
+                        .0;
+                    Some((*public_key, log_height))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Ok(log_heights)
+    }
 }
 
 #[cfg(test)]

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -3,6 +3,8 @@
 use p2panda_core::{Hash, Operation, PublicKey};
 use thiserror::Error;
 
+type SeqNum = u64;
+
 pub trait OperationStore<LogId, Extensions> {
     /// Insert an operation.
     ///
@@ -39,6 +41,9 @@ pub trait LogStore<LogId, Extensions> {
         public_key: PublicKey,
         log_id: LogId,
     ) -> Result<Vec<Operation<Extensions>>, StoreError>;
+
+    /// Get the log heights of all logs, by any author, which are stored under the passed log id.
+    fn get_log_heights(&self, log_id: LogId) -> Result<Vec<(PublicKey, SeqNum)>, StoreError>;
 
     /// Get only the latest operation from an authors' log.
     ///

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -4,14 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["protocols"]
-protocols = ["dep:p2panda-core", "dep:p2panda-store", "dep:ciborium", "core"]
+default = ["core"]
+log-height = ["dep:p2panda-core", "dep:p2panda-store", "core"]
 core = [
+    "dep:anyhow",
+    "dep:ciborium",
+    "dep:serde",
     "dep:tokio",
     "dep:tokio-stream",
     "dep:tokio-util",
-    "dep:serde",
-    "dep:anyhow",
 ]
 
 [dependencies]

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "p2panda-sync"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["protocols"]
+protocols = ["dep:p2panda-core", "dep:p2panda-store", "dep:ciborium", "core"]
+core = [
+    "dep:tokio",
+    "dep:tokio-stream",
+    "dep:tokio-util",
+    "dep:serde",
+    "dep:anyhow",
+]
+
+[dependencies]
+futures = "0.3.30"
+anyhow = { version = "1.0.86", optional = true }
+p2panda-core = { path = "../p2panda-core", optional = true }
+p2panda-store = { path = "../p2panda-store", optional = true }
+serde = { version = "1.0.208", optional = true }
+tokio-stream = { version = "0.1.15", optional = true }
+tokio-util = { version = "0.7.11", features = [
+    "codec",
+    "compat",
+], optional = true }
+ciborium = { version = "0.2.2", optional = true }
+tokio = { version = "1.39.3", features = ["rt", "macros"], optional = true }
+tracing = "0.1.40"
+thiserror = "1.0.63"
+trait-variant = "0.1.2"
+
+[dev-dependencies]
+tokio = { version = "1.39.3", features = ["rt", "macros", "net", "io-util"] }

--- a/p2panda-sync/README.md
+++ b/p2panda-sync/README.md
@@ -1,0 +1,3 @@
+# p2panda-sync
+
+> Nothing to see here yet

--- a/p2panda-sync/src/codec.rs
+++ b/p2panda-sync/src/codec.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::marker::PhantomData;
 
 use serde::de::DeserializeOwned;

--- a/p2panda-sync/src/codec.rs
+++ b/p2panda-sync/src/codec.rs
@@ -1,0 +1,70 @@
+use std::marker::PhantomData;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tokio_util::bytes::Buf;
+use tokio_util::codec::{Decoder, Encoder};
+
+use crate::traits::SyncError;
+
+#[derive(Clone, Debug)]
+pub struct CborCodec<T> {
+    _phantom: PhantomData<T>,
+}
+
+impl<M> CborCodec<M> {
+    pub fn new() -> Self {
+        CborCodec {
+            _phantom: PhantomData {},
+        }
+    }
+}
+
+impl<M> Default for CborCodec<M> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Encoder<T> for CborCodec<T>
+where
+    T: Serialize,
+{
+    type Error = SyncError;
+
+    fn encode(
+        &mut self,
+        item: T,
+        dst: &mut tokio_util::bytes::BytesMut,
+    ) -> Result<(), Self::Error> {
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&item, &mut bytes).map_err(|e| SyncError::Codec(e.to_string()))?;
+        dst.extend_from_slice(&bytes);
+        Ok(())
+    }
+}
+
+impl<T> Decoder for CborCodec<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    type Item = T;
+    type Error = SyncError;
+
+    fn decode(
+        &mut self,
+        src: &mut tokio_util::bytes::BytesMut,
+    ) -> Result<Option<Self::Item>, Self::Error> {
+        let reader = src.reader();
+        let result: Result<Self::Item, _> = ciborium::from_reader(reader);
+        match result {
+            // If we read the item, we also need to advance the underlying buffer.
+            Ok(item) => Ok(Some(item)),
+            Err(ref error) => match error {
+                // Sometimes the EOF is signalled as IO error
+                ciborium::de::Error::Io(_) => Ok(None),
+                e => Err(SyncError::Codec(e.to_string())),
+            },
+        }
+    }
+}

--- a/p2panda-sync/src/engine.rs
+++ b/p2panda-sync/src/engine.rs
@@ -63,3 +63,119 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, RwLock};
+
+    use futures::{Sink, SinkExt, Stream, StreamExt};
+    use serde::{Deserialize, Serialize};
+    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+    use crate::engine::Engine;
+    use crate::traits::{SyncEngine, SyncError, SyncProtocol};
+
+    #[tokio::test]
+    async fn protocol_impl() {
+        // The topic (can represent a sub-set of all items) we are performing sync over.
+        const TOPIC_ID: &str = "all_animals";
+
+        // The protocol message types.
+        #[derive(Serialize, Deserialize)]
+        enum Message {
+            Have(HashSet<String>),
+            Take(HashSet<String>),
+        }
+
+        // Protocol struct and implementation of `SyncProtocol` trait.
+        #[derive(Clone)]
+        struct MyProtocol {
+            set: Arc<RwLock<HashSet<String>>>,
+        }
+
+        // A very naive sync protocol.
+        impl SyncProtocol for MyProtocol {
+            type Topic = &'static str;
+            type Message = Message;
+
+            async fn run(
+                self,
+                topic: Self::Topic,
+                mut sink: impl Sink<Message, Error = SyncError> + Unpin,
+                mut stream: impl Stream<Item = Result<Message, SyncError>> + Unpin,
+            ) -> Result<(), SyncError> {
+                if topic != TOPIC_ID {
+                    return Err(SyncError::Protocol("not my animal topic".to_string()));
+                }
+                let local_set = self.set.read().unwrap().clone();
+                sink.send(Message::Have(local_set.clone())).await?;
+
+                while let Some(result) = stream.next().await {
+                    let message = result?;
+
+                    match message {
+                        Message::Have(remote_set) => {
+                            let remote_needs = local_set.difference(&remote_set).cloned().collect();
+                            sink.send(Message::Take(remote_needs)).await?;
+                        }
+                        Message::Take(from_remote) => {
+                            self.set.write().unwrap().extend(from_remote.into_iter());
+                            break;
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+        }
+
+        // Construct a sync engine for peer a and b.
+        let peer_a_set =
+            HashSet::from(["Cat".to_string(), "Dog".to_string(), "Rabbit".to_string()]);
+        let peer_a_set = Arc::new(RwLock::new(peer_a_set));
+        let peer_a_engine = Engine {
+            protocol: MyProtocol {
+                set: peer_a_set.clone(),
+            },
+        };
+
+        let peer_b_set = HashSet::from([
+            "Cat".to_string(),
+            "Penguin".to_string(),
+            "Panda".to_string(),
+        ]);
+        let peer_b_set = Arc::new(RwLock::new(peer_b_set));
+        let peer_b_engine = Engine {
+            protocol: MyProtocol {
+                set: peer_b_set.clone(),
+            },
+        };
+
+        // Create a duplex stream which simulate both ends of a bi-directional network connection.
+        let (peer_a, peer_b) = tokio::io::duplex(64 * 1024);
+        let (peer_a_read, peer_a_write) = tokio::io::split(peer_a);
+        let (peer_b_read, peer_b_write) = tokio::io::split(peer_b);
+
+        // Create and spawn a task for running sync sessions for peer a and peer b.
+        let peer_a_session =
+            peer_a_engine.session(peer_a_write.compat_write(), peer_a_read.compat());
+        let handle1 = tokio::spawn(async move {
+            let _ = peer_a_session.run(TOPIC_ID).await.unwrap();
+        });
+
+        let peer_b_session =
+            peer_b_engine.session(peer_b_write.compat_write(), peer_b_read.compat());
+        let handle2 = tokio::spawn(async move {
+            let _ = peer_b_session.run(TOPIC_ID).await.unwrap();
+        });
+
+        // Wait for both sessions to complete.
+        let _ = tokio::join!(handle1, handle2);
+
+        // Both peers' sets now contain the same items.
+        let peer_a_set = peer_a_set.read().unwrap().clone();
+        let peer_b_set = peer_b_set.read().unwrap().clone();
+        assert_eq!(peer_a_set, peer_b_set);
+    }
+}

--- a/p2panda-sync/src/engine.rs
+++ b/p2panda-sync/src/engine.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use futures::{AsyncRead, AsyncWrite, Sink, Stream};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
@@ -37,7 +36,7 @@ type EngineStream<RX, M> = FramedRead<Compat<RX>, CborCodec<M>>;
 impl<P, TX, RX> SyncEngine<P, TX, RX> for Engine<P>
 where
     <P as SyncProtocol>::Topic: Send,
-    <P as SyncProtocol>::Message: Serialize + DeserializeOwned + Send,
+    for<'de> <P as SyncProtocol>::Message: Serialize + Send + Deserialize<'de>,
     P: Clone + SyncProtocol,
     TX: AsyncWrite + Send + Unpin,
     RX: AsyncRead + Send + Unpin,

--- a/p2panda-sync/src/engine.rs
+++ b/p2panda-sync/src/engine.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use futures::{AsyncRead, AsyncWrite, Sink, Stream};
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/p2panda-sync/src/engine.rs
+++ b/p2panda-sync/src/engine.rs
@@ -53,9 +53,14 @@ where
     fn session(&self, tx: TX, rx: RX) -> Self::Session {
         // Convert the `AsyncRead` and `AsyncWrite` into framed (typed) `Stream` and `Sink`. We provide a custom
         // `tokio_util::codec::Decoder` and `tokio_util::codec::Encoder` for this purpose.
-        let codec = CborCodec::<<P as SyncProtocol>::Message>::new();
-        let sink = FramedWrite::new(tx.compat_write(), codec.clone());
-        let stream = FramedRead::new(rx.compat(), codec);
+        let sink = FramedWrite::new(
+            tx.compat_write(),
+            CborCodec::<<P as SyncProtocol>::Message>::new(),
+        );
+        let stream = FramedRead::new(
+            rx.compat(),
+            CborCodec::<<P as SyncProtocol>::Message>::new(),
+        );
 
         Session {
             protocol: self.protocol.clone(),

--- a/p2panda-sync/src/engine.rs
+++ b/p2panda-sync/src/engine.rs
@@ -1,0 +1,64 @@
+use futures::{AsyncRead, AsyncWrite, Sink, Stream};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tokio_util::codec::{FramedRead, FramedWrite};
+use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
+
+use crate::codec::CborCodec;
+use crate::traits::{SyncEngine, SyncError, SyncProtocol, SyncSession};
+
+pub struct Engine<P> {
+    pub protocol: P,
+}
+
+pub struct Session<P, SI, ST> {
+    protocol: P,
+    sink: SI,
+    stream: ST,
+}
+
+impl<P, SI, ST> SyncSession<P, SI, ST> for Session<P, SI, ST>
+where
+    <P as SyncProtocol>::Topic: Send,
+    P: SyncProtocol + Send,
+    SI: Sink<<P as SyncProtocol>::Message, Error = SyncError> + Send + Unpin,
+    ST: Stream<Item = Result<<P as SyncProtocol>::Message, SyncError>> + Send + Unpin,
+{
+    async fn run(self, topic: <P as SyncProtocol>::Topic) -> Result<(), SyncError> {
+        self.protocol.run(topic, self.sink, self.stream).await
+    }
+}
+
+type EngineSink<TX, M> = FramedWrite<Compat<TX>, CborCodec<M>>;
+type EngineStream<RX, M> = FramedRead<Compat<RX>, CborCodec<M>>;
+
+impl<P, TX, RX> SyncEngine<P, TX, RX> for Engine<P>
+where
+    <P as SyncProtocol>::Topic: Send,
+    <P as SyncProtocol>::Message: Serialize + DeserializeOwned + Send,
+    P: Clone + SyncProtocol,
+    TX: AsyncWrite + Send + Unpin,
+    RX: AsyncRead + Send + Unpin,
+{
+    type Sink = EngineSink<TX, <P as SyncProtocol>::Message>;
+    type Stream = EngineStream<RX, <P as SyncProtocol>::Message>;
+    type Session = Session<P, Self::Sink, Self::Stream>;
+
+    fn new(protocol: P) -> Engine<P> {
+        Engine { protocol }
+    }
+
+    fn session(&self, tx: TX, rx: RX) -> Self::Session {
+        // Convert the `AsyncRead` and `AsyncWrite` into framed (typed) `Stream` and `Sink`. We provide a custom
+        // `tokio_util::codec::Decoder` and `tokio_util::codec::Encoder` for this purpose.
+        let codec = CborCodec::<<P as SyncProtocol>::Message>::new();
+        let sink = FramedWrite::new(tx.compat_write(), codec.clone());
+        let stream = FramedRead::new(rx.compat(), codec);
+
+        Session {
+            protocol: self.protocol.clone(),
+            stream,
+            sink,
+        }
+    }
+}

--- a/p2panda-sync/src/engine.rs
+++ b/p2panda-sync/src/engine.rs
@@ -46,10 +46,6 @@ where
     type Stream = EngineStream<RX, <P as SyncProtocol>::Message>;
     type Session = Session<P, Self::Sink, Self::Stream>;
 
-    fn new(protocol: P) -> Engine<P> {
-        Engine { protocol }
-    }
-
     fn session(&self, tx: TX, rx: RX) -> Self::Session {
         // Convert the `AsyncRead` and `AsyncWrite` into framed (typed) `Stream` and `Sink`. We provide a custom
         // `tokio_util::codec::Decoder` and `tokio_util::codec::Encoder` for this purpose.

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 #[cfg(feature = "core")]
 mod codec;
 #[cfg(feature = "core")]

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(feature = "core")]
+mod codec;
+#[cfg(feature = "core")]
+pub mod engine;
+#[cfg(feature = "protocols")]
+pub mod protocols;
+pub mod traits;

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -4,6 +4,5 @@
 mod codec;
 #[cfg(feature = "core")]
 pub mod engine;
-#[cfg(feature = "protocols")]
 pub mod protocols;
 pub mod traits;

--- a/p2panda-sync/src/protocols.rs
+++ b/p2panda-sync/src/protocols.rs
@@ -13,6 +13,7 @@ type LogId = String;
 type SeqNum = u64;
 pub type LogHeights = Vec<(PublicKey, SeqNum)>;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum Message<E = DefaultExtensions> {
     Have(LogHeights),

--- a/p2panda-sync/src/protocols.rs
+++ b/p2panda-sync/src/protocols.rs
@@ -165,13 +165,14 @@ impl SyncProtocol for LogHeightSyncProtocol {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::sync::{Arc, RwLock};
 
-    use futures::{Sink, Stream};
+    use futures::{Sink, SinkExt, Stream, StreamExt};
     use p2panda_core::extensions::DefaultExtensions;
     use p2panda_core::{Body, Hash, Header, Operation, PrivateKey};
     use p2panda_store::{LogStore, MemoryStore, OperationStore};
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -210,36 +211,105 @@ mod tests {
 
     #[tokio::test]
     async fn protocol_impl() {
-        // Create a duplex stream which simulate both ends of a bi-directional network connection
-        let (peer_a, _peer_b) = tokio::io::duplex(64 * 1024);
-        let (peer_a_read, peer_a_write) = tokio::io::split(peer_a);
+        // The topic (can represent a sub-set of all items) we are performing sync over.
+        const TOPIC_ID: &str = "all_animals";
 
+        // The protocol message types.
+        #[derive(Serialize, Deserialize)]
+        enum Message {
+            Have(HashSet<String>),
+            Take(HashSet<String>),
+        }
+
+        // Protocol struct and implementation of `SyncProtocol` trait.
         #[derive(Clone)]
-        struct MyProtocol;
+        struct MyProtocol {
+            set: Arc<RwLock<HashSet<String>>>,
+        }
+
+        // A very naive sync protocol.
         impl SyncProtocol for MyProtocol {
             type Topic = &'static str;
-            type Message = String;
+            type Message = Message;
 
             async fn run(
                 self,
-                _topic: Self::Topic,
-                _sink: impl Sink<String, Error = SyncError>,
-                _stream: impl Stream<Item = Result<String, SyncError>>,
+                topic: Self::Topic,
+                mut sink: impl Sink<Message, Error = SyncError> + Unpin,
+                mut stream: impl Stream<Item = Result<Message, SyncError>> + Unpin,
             ) -> Result<(), SyncError> {
+                if topic != TOPIC_ID {
+                    return Err(SyncError::Protocol("not my animal topic".to_string()));
+                }
+                let local_set = self.set.read().unwrap().clone();
+                sink.send(Message::Have(local_set.clone())).await?;
+
+                while let Some(result) = stream.next().await {
+                    let message = result?;
+
+                    match message {
+                        Message::Have(remote_set) => {
+                            let remote_needs = local_set.difference(&remote_set).cloned().collect();
+                            sink.send(Message::Take(remote_needs)).await?;
+                        }
+                        Message::Take(from_remote) => {
+                            self.set.write().unwrap().extend(from_remote.into_iter());
+                            break;
+                        }
+                    }
+                }
+
                 Ok(())
             }
         }
 
-        let engine = Engine {
-            protocol: MyProtocol,
+        // Construct a sync engine for peer a and b.
+        let peer_a_set =
+            HashSet::from(["Cat".to_string(), "Dog".to_string(), "Rabbit".to_string()]);
+        let peer_a_set = Arc::new(RwLock::new(peer_a_set));
+        let peer_a_engine = Engine {
+            protocol: MyProtocol {
+                set: peer_a_set.clone(),
+            },
         };
 
-        const TOPIC_ID: &str = "my_topic";
-        let session = engine.session(peer_a_write.compat_write(), peer_a_read.compat());
-        let handle = tokio::spawn(async move {
-            let _ = session.run(TOPIC_ID).await.unwrap();
+        let peer_b_set = HashSet::from([
+            "Cat".to_string(),
+            "Penguin".to_string(),
+            "Panda".to_string(),
+        ]);
+        let peer_b_set = Arc::new(RwLock::new(peer_b_set));
+        let peer_b_engine = Engine {
+            protocol: MyProtocol {
+                set: peer_b_set.clone(),
+            },
+        };
+
+        // Create a duplex stream which simulate both ends of a bi-directional network connection.
+        let (peer_a, peer_b) = tokio::io::duplex(64 * 1024);
+        let (peer_a_read, peer_a_write) = tokio::io::split(peer_a);
+        let (peer_b_read, peer_b_write) = tokio::io::split(peer_b);
+
+        // Create and spawn a task for running sync sessions for peer a and peer b.
+        let peer_a_session =
+            peer_a_engine.session(peer_a_write.compat_write(), peer_a_read.compat());
+        let handle1 = tokio::spawn(async move {
+            let _ = peer_a_session.run(TOPIC_ID).await.unwrap();
         });
-        assert!(handle.await.is_ok());
+
+        let peer_b_session =
+            peer_b_engine.session(peer_b_write.compat_write(), peer_b_read.compat());
+        let handle2 = tokio::spawn(async move {
+            let _ = peer_b_session.run(TOPIC_ID).await.unwrap();
+        });
+
+        // Wait for both sessions to complete.
+        let _ = tokio::join!(handle1, handle2);
+
+        // Both peers' sets now contain the same items.
+        let peer_a_set = peer_a_set.read().unwrap().clone();
+        let peer_b_set = peer_b_set.read().unwrap().clone();
+        assert_eq!(peer_a_set, peer_b_set);
     }
 
     #[tokio::test]

--- a/p2panda-sync/src/protocols.rs
+++ b/p2panda-sync/src/protocols.rs
@@ -1,0 +1,423 @@
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use p2panda_core::extensions::DefaultExtensions;
+use p2panda_core::{Body, Header, Operation, PublicKey};
+use p2panda_store::{LogStore, MemoryStore, OperationStore};
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::traits::{SyncError, SyncProtocol};
+
+type LogId = String;
+type SeqNum = u64;
+pub type LogHeights = Vec<(PublicKey, SeqNum)>;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum Message<E = DefaultExtensions> {
+    Have(LogHeights),
+    Operation(Header<E>, Option<Body>),
+    SyncDone,
+}
+
+#[cfg(test)]
+impl<E> Message<E>
+where
+    E: Serialize,
+{
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&self, &mut bytes).expect("type can be serialized");
+        bytes
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LogHeightSyncProtocol {
+    pub sync_done_sent: bool,
+    pub sync_done_received: bool,
+    pub store: Arc<RwLock<MemoryStore<LogId, DefaultExtensions>>>,
+}
+
+impl LogHeightSyncProtocol {
+    pub fn read_store(&self) -> RwLockReadGuard<MemoryStore<LogId, DefaultExtensions>> {
+        self.store.read().expect("error getting read lock on store")
+    }
+
+    pub fn write_store(&self) -> RwLockWriteGuard<MemoryStore<LogId, DefaultExtensions>> {
+        self.store
+            .write()
+            .expect("error getting write lock on store")
+    }
+}
+
+impl SyncProtocol for LogHeightSyncProtocol {
+    type Topic = LogId;
+    type Message = Message;
+
+    async fn run(
+        mut self,
+        topic: Self::Topic,
+        mut sink: impl Sink<Self::Message, Error = SyncError> + Unpin,
+        mut stream: impl Stream<Item = Result<Self::Message, SyncError>> + Unpin,
+    ) -> Result<(), SyncError> {
+        let local_log_heights = self
+            .read_store()
+            .get_log_heights(topic.to_string())
+            .expect("memory store error");
+
+        sink.send(Message::Have(local_log_heights.clone())).await?;
+
+        while let Some(result) = stream.next().await {
+            let message = result?;
+            debug!("message received: {:?}", message);
+
+            let replies = match &message {
+                Message::Have(log_heights) => {
+                    let mut messages = vec![];
+
+                    let local_log_heights = self
+                        .read_store()
+                        .get_log_heights(topic.to_string())
+                        .expect("memory store error");
+
+                    for (public_key, seq_num) in local_log_heights {
+                        let mut remote_needs = vec![];
+
+                        for (remote_pub_key, remote_seq_num) in log_heights.iter() {
+                            // For logs where both peers know of the author, compare seq numbers
+                            // and if ours is higher then we know the peer needs to be sent the
+                            // newer operations we have.
+                            if *remote_pub_key == public_key && *remote_seq_num < seq_num {
+                                remote_needs.push((public_key, *remote_seq_num));
+                                continue;
+                            };
+                        }
+
+                        // If the author is not known by both peers, then see if _we_ are the
+                        // ones who know of log the remote needs.
+                        if !log_heights
+                            .iter()
+                            .any(|(remote_public_key, _)| public_key == *remote_public_key)
+                        {
+                            remote_needs.push((public_key, 0));
+                        }
+
+                        // For every log the remote needs send only the operations they are missing.
+                        for (public_key, seq_num) in remote_needs {
+                            let mut log = self
+                                .read_store()
+                                .get_log(public_key, topic.to_string())
+                                .map_err(|e| SyncError::Protocol(e.to_string()))?;
+                            log.split_off(seq_num as usize + 1)
+                                .into_iter()
+                                .for_each(|operation| {
+                                    messages
+                                        .push(Message::Operation(operation.header, operation.body))
+                                });
+                        }
+                    }
+
+                    // As we have processed the remotes `Have` message then we are "done" from
+                    // this end.
+                    messages.push(Message::SyncDone);
+                    self.sync_done_sent = true;
+                    messages
+                }
+                Message::Operation(header, body) => {
+                    let operation = Operation {
+                        hash: header.hash(),
+                        header: header.clone(),
+                        body: body.clone(),
+                    };
+                    self.write_store()
+                        .insert_operation(operation, topic.to_string())
+                        .map_err(|e| SyncError::Protocol(e.to_string()))?;
+                    vec![]
+                }
+                Message::SyncDone => {
+                    self.sync_done_received = true;
+                    vec![]
+                }
+            };
+
+            // @TODO: we'd rather process all messages at once using `send_all`. For this
+            // we need to turn `replies` into a stream.
+            for message in replies {
+                sink.send(message).await?;
+            }
+
+            if self.sync_done_received && self.sync_done_sent {
+                break;
+            }
+        }
+
+        // @TODO: should we actually need to do this?
+        sink.close().await?;
+        debug!("sync session finished");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, RwLock};
+
+    use futures::{Sink, Stream};
+    use p2panda_core::extensions::DefaultExtensions;
+    use p2panda_core::{Body, Hash, Header, Operation, PrivateKey};
+    use p2panda_store::{LogStore, MemoryStore, OperationStore};
+    use serde::Serialize;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+    use crate::engine::Engine;
+    use crate::protocols::{LogHeightSyncProtocol, Message};
+    use crate::traits::{SyncEngine, SyncError, SyncProtocol, SyncSession};
+
+    fn generate_operation<E: Clone + Serialize>(
+        private_key: &PrivateKey,
+        body: Body,
+        seq_num: u64,
+        timestamp: u64,
+        backlink: Option<Hash>,
+        extensions: Option<E>,
+    ) -> Operation<E> {
+        let mut header = Header {
+            version: 1,
+            public_key: private_key.public_key(),
+            signature: None,
+            payload_size: body.size(),
+            payload_hash: Some(body.hash()),
+            timestamp,
+            seq_num,
+            backlink,
+            previous: vec![],
+            extensions,
+        };
+        header.sign(&private_key);
+
+        Operation {
+            hash: header.hash(),
+            header,
+            body: Some(body),
+        }
+    }
+
+    #[tokio::test]
+    async fn protocol_impl() {
+        // Create a duplex stream which simulate both ends of a bi-directional network connection
+        let (peer_a, _peer_b) = tokio::io::duplex(64 * 1024);
+        let (peer_a_read, peer_a_write) = tokio::io::split(peer_a);
+
+        #[derive(Clone)]
+        struct MyProtocol;
+        impl SyncProtocol for MyProtocol {
+            type Topic = &'static str;
+            type Message = String;
+
+            async fn run(
+                self,
+                _topic: Self::Topic,
+                _sink: impl Sink<String, Error = SyncError>,
+                _stream: impl Stream<Item = Result<String, SyncError>>,
+            ) -> Result<(), SyncError> {
+                Ok(())
+            }
+        }
+
+        let engine = Engine {
+            protocol: MyProtocol,
+        };
+
+        const TOPIC_ID: &str = "my_topic";
+        let session = engine.session(peer_a_write.compat_write(), peer_a_read.compat());
+        let handle = tokio::spawn(async move {
+            let _ = session.run(TOPIC_ID).await.unwrap();
+        });
+        assert!(handle.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_sync_strategy() {
+        const TOPIC_ID: &str = "my_topic";
+
+        // Setup store with 3 operations in it
+        let mut store = MemoryStore::<String, DefaultExtensions>::new();
+        let private_key = PrivateKey::new();
+
+        let body = Body::new("Hello, Sloth!".as_bytes());
+        let operation0 = generate_operation(&private_key, body.clone(), 0, 0, None, None);
+        let operation1 = generate_operation(
+            &private_key,
+            body.clone(),
+            1,
+            100,
+            Some(operation0.hash),
+            None,
+        );
+        let operation2 = generate_operation(
+            &private_key,
+            body.clone(),
+            2,
+            200,
+            Some(operation1.hash),
+            None,
+        );
+
+        // Insert these operations to the store using `TOPIC_ID` as the log id
+        store
+            .insert_operation(operation0.clone(), TOPIC_ID.to_string())
+            .unwrap();
+        store
+            .insert_operation(operation1.clone(), TOPIC_ID.to_string())
+            .unwrap();
+        store
+            .insert_operation(operation2.clone(), TOPIC_ID.to_string())
+            .unwrap();
+
+        // Create a duplex stream which simulate both ends of a bi-directional network connection
+        let (peer_a, mut peer_b) = tokio::io::duplex(64 * 1024);
+        let (peer_a_read, peer_a_write) = tokio::io::split(peer_a);
+
+        // Write some message into peer_b's send buffer
+        let message1: Message<DefaultExtensions> =
+            Message::Have(vec![(private_key.public_key(), 0)]);
+        let message2: Message<DefaultExtensions> = Message::SyncDone;
+        let message_bytes = vec![message1.to_bytes(), message2.to_bytes()].concat();
+        peer_b.write_all(&message_bytes[..]).await.unwrap();
+
+        // Run the sync session (which consumes the above messages)
+        let protocol = LogHeightSyncProtocol {
+            sync_done_sent: false,
+            sync_done_received: false,
+            store: Arc::new(RwLock::new(store)),
+        };
+        let engine = Engine { protocol };
+        let session = engine.session(peer_a_write.compat_write(), peer_a_read.compat());
+        let handle = tokio::spawn(async move {
+            let _ = session.run(TOPIC_ID.to_string()).await.unwrap();
+        });
+        handle.await.unwrap();
+
+        // Read the entire buffer out of peer_b's read stream
+        let mut buf = Vec::new();
+        peer_b.read_to_end(&mut buf).await.unwrap();
+
+        // It should contain the following two sync messages (these are the ones peer_b is
+        // missing)
+        let received_message0 =
+            Message::<DefaultExtensions>::Have(vec![(private_key.public_key(), 2)]);
+        let received_message1 =
+            Message::Operation(operation1.header.clone(), operation1.body.clone());
+        let received_message2 =
+            Message::Operation(operation2.header.clone(), operation2.body.clone());
+        let receive_message3 = Message::<DefaultExtensions>::SyncDone;
+        assert_eq!(
+            buf,
+            [
+                received_message0.to_bytes(),
+                received_message1.to_bytes(),
+                received_message2.to_bytes(),
+                receive_message3.to_bytes()
+            ]
+            .concat()
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_operation_store() {
+        const TOPIC_ID: &str = "my_topic";
+
+        // Create a store for peer a and populate it with operations
+        let mut store1 = MemoryStore::default();
+
+        let private_key1 = PrivateKey::new();
+        let body = Body::new("Hello, Sloth!".as_bytes());
+        let operation0 = generate_operation(&private_key1, body.clone(), 0, 0, None, None);
+        let operation1 = generate_operation(
+            &private_key1,
+            body.clone(),
+            1,
+            100,
+            Some(operation0.hash),
+            None,
+        );
+        let operation2 = generate_operation(
+            &private_key1,
+            body.clone(),
+            2,
+            200,
+            Some(operation1.hash),
+            None,
+        );
+
+        // Insert these operations to the store using `TOPIC_ID` as the log id
+        store1
+            .insert_operation(operation0.clone(), TOPIC_ID.to_string())
+            .unwrap();
+        store1
+            .insert_operation(operation1.clone(), TOPIC_ID.to_string())
+            .unwrap();
+        store1
+            .insert_operation(operation2.clone(), TOPIC_ID.to_string())
+            .unwrap();
+
+        // Construct a log height protocol and engine for peer a
+        let peer_a_protocol = LogHeightSyncProtocol {
+            sync_done_sent: false,
+            sync_done_received: false,
+            store: Arc::new(RwLock::new(store1)),
+        };
+        let peer_a_engine = Engine {
+            protocol: peer_a_protocol.clone(),
+        };
+
+        // Create an empty store for peer a and construct their sync protocol and engine
+        let store2 = MemoryStore::default();
+        let peer_b_protocol = LogHeightSyncProtocol {
+            sync_done_sent: false,
+            sync_done_received: false,
+            store: Arc::new(RwLock::new(store2)),
+        };
+        let peer_b_engine = Engine {
+            protocol: peer_b_protocol.clone(),
+        };
+
+        // Create a duplex stream which simulate both ends of a bi-directional network connection
+        let (peer_a, peer_b) = tokio::io::duplex(64 * 1024);
+        let (peer_a_read, peer_a_write) = tokio::io::split(peer_a);
+        let (peer_b_read, peer_b_write) = tokio::io::split(peer_b);
+
+        // Create a sync session for both peers and spawn them in two separate threads
+        let peer_a_session =
+            peer_a_engine.session(peer_a_write.compat_write(), peer_a_read.compat());
+        let peer_b_session =
+            peer_b_engine.session(peer_b_write.compat_write(), peer_b_read.compat());
+
+        let handle1 = tokio::spawn(async move {
+            peer_a_session.run(TOPIC_ID.to_string()).await.unwrap();
+        });
+
+        let handle2 = tokio::spawn(async move {
+            peer_b_session.run(TOPIC_ID.to_string()).await.unwrap();
+        });
+
+        // Wait on both to complete
+        let (_, _) = tokio::join!(handle1, handle2);
+
+        // Check log heights are now equal
+        let peer_a_log_heights = peer_a_protocol
+            .read_store()
+            .get_log_heights(TOPIC_ID.to_string())
+            .unwrap();
+
+        let peer_b_log_heights = peer_b_protocol
+            .read_store()
+            .get_log_heights(TOPIC_ID.to_string())
+            .unwrap();
+
+        assert_eq!(peer_a_log_heights, peer_b_log_heights);
+    }
+}

--- a/p2panda-sync/src/protocols.rs
+++ b/p2panda-sync/src/protocols.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use futures::{Sink, SinkExt, Stream, StreamExt};

--- a/p2panda-sync/src/protocols.rs
+++ b/p2panda-sync/src/protocols.rs
@@ -177,7 +177,7 @@ mod tests {
 
     use crate::engine::Engine;
     use crate::protocols::{LogHeightSyncProtocol, Message};
-    use crate::traits::{SyncEngine, SyncError, SyncProtocol, SyncSession};
+    use crate::traits::{SyncEngine, SyncError, SyncProtocol};
 
     fn generate_operation<E: Clone + Serialize>(
         private_key: &PrivateKey,

--- a/p2panda-sync/src/protocols/log_height.rs
+++ b/p2panda-sync/src/protocols/log_height.rs
@@ -155,6 +155,7 @@ impl SyncProtocol for LogHeightSyncProtocol {
             }
         }
 
+        sink.close().await?;
         debug!("sync session finished");
 
         Ok(())

--- a/p2panda-sync/src/protocols/log_height.rs
+++ b/p2panda-sync/src/protocols/log_height.rs
@@ -165,20 +165,19 @@ impl SyncProtocol for LogHeightSyncProtocol {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
     use std::sync::{Arc, RwLock};
 
-    use futures::{Sink, SinkExt, Stream, StreamExt};
     use p2panda_core::extensions::DefaultExtensions;
     use p2panda_core::{Body, Hash, Header, Operation, PrivateKey};
     use p2panda_store::{LogStore, MemoryStore, OperationStore};
-    use serde::{Deserialize, Serialize};
+    use serde::Serialize;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
     use crate::engine::Engine;
-    use crate::protocols::{LogHeightSyncProtocol, Message};
-    use crate::traits::{SyncEngine, SyncError, SyncProtocol};
+    use crate::traits::SyncEngine;
+
+    use super::{LogHeightSyncProtocol, Message};
 
     fn generate_operation<E: Clone + Serialize>(
         private_key: &PrivateKey,
@@ -207,109 +206,6 @@ mod tests {
             header,
             body: Some(body),
         }
-    }
-
-    #[tokio::test]
-    async fn protocol_impl() {
-        // The topic (can represent a sub-set of all items) we are performing sync over.
-        const TOPIC_ID: &str = "all_animals";
-
-        // The protocol message types.
-        #[derive(Serialize, Deserialize)]
-        enum Message {
-            Have(HashSet<String>),
-            Take(HashSet<String>),
-        }
-
-        // Protocol struct and implementation of `SyncProtocol` trait.
-        #[derive(Clone)]
-        struct MyProtocol {
-            set: Arc<RwLock<HashSet<String>>>,
-        }
-
-        // A very naive sync protocol.
-        impl SyncProtocol for MyProtocol {
-            type Topic = &'static str;
-            type Message = Message;
-
-            async fn run(
-                self,
-                topic: Self::Topic,
-                mut sink: impl Sink<Message, Error = SyncError> + Unpin,
-                mut stream: impl Stream<Item = Result<Message, SyncError>> + Unpin,
-            ) -> Result<(), SyncError> {
-                if topic != TOPIC_ID {
-                    return Err(SyncError::Protocol("not my animal topic".to_string()));
-                }
-                let local_set = self.set.read().unwrap().clone();
-                sink.send(Message::Have(local_set.clone())).await?;
-
-                while let Some(result) = stream.next().await {
-                    let message = result?;
-
-                    match message {
-                        Message::Have(remote_set) => {
-                            let remote_needs = local_set.difference(&remote_set).cloned().collect();
-                            sink.send(Message::Take(remote_needs)).await?;
-                        }
-                        Message::Take(from_remote) => {
-                            self.set.write().unwrap().extend(from_remote.into_iter());
-                            break;
-                        }
-                    }
-                }
-
-                Ok(())
-            }
-        }
-
-        // Construct a sync engine for peer a and b.
-        let peer_a_set =
-            HashSet::from(["Cat".to_string(), "Dog".to_string(), "Rabbit".to_string()]);
-        let peer_a_set = Arc::new(RwLock::new(peer_a_set));
-        let peer_a_engine = Engine {
-            protocol: MyProtocol {
-                set: peer_a_set.clone(),
-            },
-        };
-
-        let peer_b_set = HashSet::from([
-            "Cat".to_string(),
-            "Penguin".to_string(),
-            "Panda".to_string(),
-        ]);
-        let peer_b_set = Arc::new(RwLock::new(peer_b_set));
-        let peer_b_engine = Engine {
-            protocol: MyProtocol {
-                set: peer_b_set.clone(),
-            },
-        };
-
-        // Create a duplex stream which simulate both ends of a bi-directional network connection.
-        let (peer_a, peer_b) = tokio::io::duplex(64 * 1024);
-        let (peer_a_read, peer_a_write) = tokio::io::split(peer_a);
-        let (peer_b_read, peer_b_write) = tokio::io::split(peer_b);
-
-        // Create and spawn a task for running sync sessions for peer a and peer b.
-        let peer_a_session =
-            peer_a_engine.session(peer_a_write.compat_write(), peer_a_read.compat());
-        let handle1 = tokio::spawn(async move {
-            let _ = peer_a_session.run(TOPIC_ID).await.unwrap();
-        });
-
-        let peer_b_session =
-            peer_b_engine.session(peer_b_write.compat_write(), peer_b_read.compat());
-        let handle2 = tokio::spawn(async move {
-            let _ = peer_b_session.run(TOPIC_ID).await.unwrap();
-        });
-
-        // Wait for both sessions to complete.
-        let _ = tokio::join!(handle1, handle2);
-
-        // Both peers' sets now contain the same items.
-        let peer_a_set = peer_a_set.read().unwrap().clone();
-        let peer_b_set = peer_b_set.read().unwrap().clone();
-        assert_eq!(peer_a_set, peer_b_set);
     }
 
     #[tokio::test]

--- a/p2panda-sync/src/protocols/log_height.rs
+++ b/p2panda-sync/src/protocols/log_height.rs
@@ -155,8 +155,6 @@ impl SyncProtocol for LogHeightSyncProtocol {
             }
         }
 
-        // @TODO: should we actually need to do this?
-        sink.close().await?;
         debug!("sync session finished");
 
         Ok(())

--- a/p2panda-sync/src/protocols/mod.rs
+++ b/p2panda-sync/src/protocols/mod.rs
@@ -1,3 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+#[cfg(feature = "log-height")]
 mod log_height;

--- a/p2panda-sync/src/protocols/mod.rs
+++ b/p2panda-sync/src/protocols/mod.rs
@@ -1,0 +1,1 @@
+mod log_height;

--- a/p2panda-sync/src/protocols/mod.rs
+++ b/p2panda-sync/src/protocols/mod.rs
@@ -1,1 +1,3 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 mod log_height;

--- a/p2panda-sync/src/traits.rs
+++ b/p2panda-sync/src/traits.rs
@@ -1,0 +1,52 @@
+use futures::{AsyncRead, AsyncWrite, Sink, Stream};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SyncError {
+    #[error("protocol error: {0}")]
+    Protocol(String),
+    #[error("input/output error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("codec error: {0}")]
+    Codec(String),
+    #[error("custom error: {0}")]
+    Custom(String),
+}
+
+#[trait_variant::make(SyncProtocol: Send)]
+pub trait LocalSyncProtocol {
+    type Topic;
+    type Message: Clone;
+
+    async fn run(
+        self,
+        topic: Self::Topic,
+        sink: impl Sink<Self::Message, Error = SyncError> + Send + Unpin,
+        stream: impl Stream<Item = Result<Self::Message, SyncError>> + Send + Unpin,
+    ) -> Result<(), SyncError>;
+}
+
+#[trait_variant::make(SyncSession: Send)]
+pub trait LocalSyncSession<P, SI, ST>
+where
+    P: SyncProtocol,
+    SI: Sink<<P as SyncProtocol>::Message, Error = SyncError>,
+    ST: Stream<Item = Result<<P as SyncProtocol>::Message, SyncError>>,
+{
+    async fn run(self, topic: <P as SyncProtocol>::Topic) -> Result<(), SyncError>;
+}
+
+pub trait SyncEngine<P, TX, RX>
+where
+    P: SyncProtocol,
+    TX: AsyncWrite,
+    RX: AsyncRead,
+{
+    type Sink: Sink<<P as SyncProtocol>::Message, Error = SyncError>;
+    type Stream: Stream<Item = Result<<P as SyncProtocol>::Message, SyncError>>;
+    type Session: SyncSession<P, Self::Sink, Self::Stream>;
+
+    fn new(strategy: P) -> Self;
+
+    fn session(&self, tx: TX, rx: RX) -> Self::Session;
+}

--- a/p2panda-sync/src/traits.rs
+++ b/p2panda-sync/src/traits.rs
@@ -48,7 +48,5 @@ where
     type Stream: Stream<Item = Result<<P as SyncProtocol>::Message, SyncError>>;
     type Session: SyncSession<P, Self::Sink, Self::Stream>;
 
-    fn new(strategy: P) -> Self;
-
     fn session(&self, tx: TX, rx: RX) -> Self::Session;
 }

--- a/p2panda-sync/src/traits.rs
+++ b/p2panda-sync/src/traits.rs
@@ -18,7 +18,7 @@ pub enum SyncError {
 #[trait_variant::make(SyncProtocol: Send)]
 pub trait LocalSyncProtocol {
     type Topic;
-    type Message: Clone;
+    type Message;
 
     async fn run(
         self,

--- a/p2panda-sync/src/traits.rs
+++ b/p2panda-sync/src/traits.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 use futures::{AsyncRead, AsyncWrite, Sink, Stream};
 use thiserror::Error;
 


### PR DESCRIPTION
Introduces traits describing simple interfaces for synchronising generic sets of data over bi-directional pairs of `AsyncRead` and `AsyncWrite` streams. Additionally opinionated implementations which use `tokio` runtime and stream tools and `cbor` encoding are publicly exported. Finally, an even more opinionated `LogHeightSyncProtocol` is introduced which synchronises two p2panda log stores.  

## `SyncProtocol` and `SyncEngine` traits

```rust
#[trait_variant::make(SyncProtocol: Send)]
pub trait LocalSyncProtocol {
    type Topic;
    type Message;

    async fn run(
        self,
        topic: Self::Topic,
        sink: impl Sink<Self::Message, Error = SyncError> + Send + Unpin,
        stream: impl Stream<Item = Result<Self::Message, SyncError>> + Send + Unpin,
    ) -> Result<(), SyncError>;
}

pub trait SyncEngine<P, TX, RX>
where
    P: SyncProtocol,
    TX: AsyncWrite,
    RX: AsyncRead,
{
    type Sink: Sink<<P as SyncProtocol>::Message, Error = SyncError>;
    type Stream: Stream<Item = Result<<P as SyncProtocol>::Message, SyncError>>;

    fn session(&self, tx: TX, rx: RX) -> Session<P, Self::Sink, Self::Stream>;
}
```
## Example use
```rust
// The topic (can represent a sub-set of all items) we are performing sync over.
const TOPIC_ID: &str = "all_animals";

// The protocol message types.
#[derive(Serialize, Deserialize)]
enum Message {
    Have(HashSet<String>),
    Take(HashSet<String>),
}

// Protocol struct and implementation of `SyncProtocol` trait.
#[derive(Clone)]
struct MyProtocol {
    set: Arc<RwLock<HashSet<String>>>,
}

// A very naive sync protocol.
impl SyncProtocol for MyProtocol {
    type Topic = &'static str;
    type Message = Message;

    async fn run(
        self,
        topic: Self::Topic,
        mut sink: impl Sink<Message, Error = SyncError> + Unpin,
        mut stream: impl Stream<Item = Result<Message, SyncError>> + Unpin,
    ) -> Result<(), SyncError> {
        if topic != TOPIC_ID {
            return Err(SyncError::Protocol("not my animal topic".to_string()));
        }
        let local_set = self.set.read().unwrap().clone();
        sink.send(Message::Have(local_set.clone())).await?;

        while let Some(result) = stream.next().await {
            let message = result?;

            match message {
                Message::Have(remote_set) => {
                    let remote_needs = local_set.difference(&remote_set).cloned().collect();
                    sink.send(Message::Take(remote_needs)).await?;
                }
                Message::Take(from_remote) => {
                    self.set.write().unwrap().extend(from_remote.into_iter());
                    break;
                }
            }
        }

        Ok(())
    }
}

// Construct a sync engine for peer a and b.
let peer_a_set =
    HashSet::from(["Cat".to_string(), "Dog".to_string(), "Rabbit".to_string()]);
let peer_a_set = Arc::new(RwLock::new(peer_a_set));
let peer_a_engine = Engine {
    protocol: MyProtocol {
        set: peer_a_set.clone(),
    },
};

let peer_b_set = HashSet::from([
    "Cat".to_string(),
    "Penguin".to_string(),
    "Panda".to_string(),
]);
let peer_b_set = Arc::new(RwLock::new(peer_b_set));
let peer_b_engine = Engine {
    protocol: MyProtocol {
        set: peer_b_set.clone(),
    },
};

// Create a duplex stream which simulate both ends of a bi-directional network connection.
let (peer_a, peer_b) = tokio::io::duplex(64 * 1024);
let (peer_a_read, peer_a_write) = tokio::io::split(peer_a);
let (peer_b_read, peer_b_write) = tokio::io::split(peer_b);

// Create and spawn a task for running sync sessions for peer a and peer b.
let peer_a_session =
    peer_a_engine.session(peer_a_write.compat_write(), peer_a_read.compat());
let handle1 = tokio::spawn(async move {
    let _ = peer_a_session.run(TOPIC_ID).await.unwrap();
});

let peer_b_session =
    peer_b_engine.session(peer_b_write.compat_write(), peer_b_read.compat());
let handle2 = tokio::spawn(async move {
    let _ = peer_b_session.run(TOPIC_ID).await.unwrap();
});

// Wait for both sessions to complete.
let _ = tokio::join!(handle1, handle2);

// Both peers' sets now contain the same items.
let peer_a_set = peer_a_set.read().unwrap().clone();
let peer_b_set = peer_b_set.read().unwrap().clone();
assert_eq!(peer_a_set, peer_b_set);

```

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
