### PR TITLE
Make all storage traits async (and use interior mutability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Highlights are marked with a pancake 🥞
 ### Added
 
 - Sync past state for subscribed topics in `p2panda-net` [#553](https://github.com/p2panda/p2panda/pull/553)
+- Make all store methods async and use interior mutability patterns [#550](https://github.com/p2panda/p2panda/pull/550)
 - Introduce `p2panda-sync` offering generic sync tools and opinionated sync protocols [#549](https://github.com/p2panda/p2panda/pull/549)
 - Introduce blobs functionality, including import, export and download
   [#546](https://github.com/p2panda/p2panda/pull/546)

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -790,7 +790,6 @@ mod sync_protocols {
 mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
-    use std::sync::{Arc, RwLock};
     use std::time::Duration;
 
     use iroh_net::relay::{RelayNode, RelayUrl as IrohRelayUrl};
@@ -983,7 +982,7 @@ mod tests {
         let store_a = MemoryStore::default();
         let protocol_a = LogHeightSyncProtocol {
             log_ids: HashMap::from([(TOPIC_ID, LOG_ID.to_string())]),
-            store: Arc::new(RwLock::new(store_a)),
+            store: store_a,
         };
 
         // Create some operations
@@ -1010,17 +1009,20 @@ mod tests {
         let mut store_b = MemoryStore::default();
         store_b
             .insert_operation(operation0.clone(), LOG_ID.to_string())
+            .await
             .unwrap();
         store_b
             .insert_operation(operation1.clone(), LOG_ID.to_string())
+            .await
             .unwrap();
         store_b
             .insert_operation(operation2.clone(), LOG_ID.to_string())
+            .await
             .unwrap();
 
         // Construct log height protocol for peer b
         let protocol_b = LogHeightSyncProtocol {
-            store: Arc::new(RwLock::new(store_b)),
+            store: store_b,
             log_ids: HashMap::from([(TOPIC_ID, LOG_ID.to_string())]),
         };
 

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -11,8 +11,8 @@ thiserror = "1.0.61"
 trait-variant = "0.1.2"
 
 [dev-dependencies]
-serde = { version = "1.0.203" }
-tokio = { version = "1.38.0", features = ["full"] }
+serde = "1.0.203"
+tokio = { version = "1.38.0", features = ["rt", "macros"] }
 
 [dependencies.p2panda-core]
 path = "../p2panda-core"

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -8,9 +8,11 @@ workspace = true
 
 [dependencies]
 thiserror = "1.0.61"
+trait-variant = "0.1.2"
 
 [dev-dependencies]
 serde = { version = "1.0.203" }
+tokio = { version = "1.38.0", features = ["full"] }
 
 [dependencies.p2panda-core]
 path = "../p2panda-core"

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use p2panda_core::extensions::DefaultExtensions;
-use p2panda_core::{operation, Hash, Operation, PublicKey};
+use p2panda_core::{Hash, Operation, PublicKey};
 
 use crate::traits::{OperationStore, StoreError};
 use crate::LogStore;

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -13,12 +13,13 @@ type SeqNum = u64;
 type Timestamp = u64;
 type LogMeta = (SeqNum, Timestamp, Hash);
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InnerMemoryStore<T, E> {
     operations: HashMap<Hash, Operation<E>>,
     logs: HashMap<(PublicKey, T), BTreeSet<LogMeta>>,
 }
 
+#[derive(Clone, Debug)]
 pub struct MemoryStore<T, E> {
     inner: Arc<RwLock<InnerMemoryStore<T, E>>>,
 }

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -223,8 +223,9 @@ where
         Ok(!deleted.is_empty())
     }
 
-    fn get_log_heights(&self, log_id: T) -> Result<Vec<(PublicKey, SeqNum)>, StoreError> {
+    async fn get_log_heights(&self, log_id: T) -> Result<Vec<(PublicKey, SeqNum)>, StoreError> {
         let log_heights = self
+            .read_store()
             .logs
             .iter()
             .filter_map(|((public_key, inner_log_id), log)| {

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -45,7 +45,7 @@ pub trait LocalLogStore<LogId, Extensions> {
     ) -> Result<Vec<Operation<Extensions>>, StoreError>;
 
     /// Get the log heights of all logs, by any author, which are stored under the passed log id.
-    fn get_log_heights(&self, log_id: LogId) -> Result<Vec<(PublicKey, SeqNum)>, StoreError>;
+    async fn get_log_heights(&self, log_id: LogId) -> Result<Vec<(PublicKey, SeqNum)>, StoreError>;
 
     /// Get only the latest operation from an authors' log.
     ///

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -5,38 +5,40 @@ use thiserror::Error;
 
 type SeqNum = u64;
 
-pub trait OperationStore<LogId, Extensions> {
+#[trait_variant::make(OperationStore: Send)]
+pub trait LocalOperationStore<LogId, Extensions> {
     /// Insert an operation.
     ///
     /// Returns `true` when the insert occurred, or `false` when the operation
     /// already existed and no insertion occurred.
-    fn insert_operation(
+    async fn insert_operation(
         &mut self,
         operation: Operation<Extensions>,
         log_id: LogId,
     ) -> Result<bool, StoreError>;
 
     /// Get an operation.
-    fn get_operation(&self, hash: Hash) -> Result<Option<Operation<Extensions>>, StoreError>;
+    async fn get_operation(&self, hash: Hash) -> Result<Option<Operation<Extensions>>, StoreError>;
 
     /// Delete an operation.
     ///
     /// Returns `true` when the removal occurred and `false` when the operation
     /// was not found in the store.
-    fn delete_operation(&mut self, hash: Hash) -> Result<bool, StoreError>;
+    async fn delete_operation(&mut self, hash: Hash) -> Result<bool, StoreError>;
 
     /// Delete the payload of an operation.
     ///
     /// Returns `true` when the removal occurred and `false` when the operation
     /// was not found in the store or the payload was already deleted.
-    fn delete_payload(&mut self, hash: Hash) -> Result<bool, StoreError>;
+    async fn delete_payload(&mut self, hash: Hash) -> Result<bool, StoreError>;
 }
 
-pub trait LogStore<LogId, Extensions> {
+#[trait_variant::make(LogStore: Send)]
+pub trait LocalLogStore<LogId, Extensions> {
     /// Get all operations from an authors' log ordered by sequence number.
     ///
     /// Returns an empty Vec when the author or a log with the requested id was not found.
-    fn get_log(
+    async fn get_log(
         &self,
         public_key: PublicKey,
         log_id: LogId,
@@ -48,7 +50,7 @@ pub trait LogStore<LogId, Extensions> {
     /// Get only the latest operation from an authors' log.
     ///
     /// Returns None when the author or a log with the requested id was not found.
-    fn latest_operation(
+    async fn latest_operation(
         &self,
         public_key: PublicKey,
         log_id: LogId,
@@ -58,7 +60,7 @@ pub trait LogStore<LogId, Extensions> {
     ///
     /// Returns `true` when any operations were deleted, returns `false` when
     /// the author or log could not be found, or no operations were deleted.
-    fn delete_operations(
+    async fn delete_operations(
         &mut self,
         public_key: PublicKey,
         log_id: LogId,
@@ -72,7 +74,7 @@ pub trait LogStore<LogId, Extensions> {
     ///
     /// Returns `true` when operations within the requested range were deleted, or `false` when
     /// the author or log could not be found, or no operations were deleted.
-    fn delete_payloads(
+    async fn delete_payloads(
         &mut self,
         public_key: PublicKey,
         log_id: LogId,


### PR DESCRIPTION
- changes all store methods to be `async fn`
- moves internal store data types into an `InnerStore` which is then wrapped in `Arc<RwLock<InnerStore>>` to enable shared read and write access to the store.

BREAKING: this is a breaking change anywhere where we currently need the store would need updating.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
