### PR TITLE
Pass non-copy values into store by reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,7 @@ Highlights are marked with a pancake 🥞
   services [#540](https://github.com/p2panda/p2panda/pull/540)
 - Introduce all core p2panda types [#535](https://github.com/p2panda/p2panda/pull/535)
 - Introduce basic storage traits w/ MemoryStore implementation [#536](https://github.com/p2panda/p2panda/pull/536)
+
+### Changed
+
+- Handle non-copy store method parameters by reference [#558](https://github.com/p2panda/p2panda/pull/558)

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -973,7 +973,7 @@ mod tests {
     async fn e2e_log_height_sync() {
         const NETWORK_ID: [u8; 32] = [1; 32];
         const TOPIC_ID: [u8; 32] = [0u8; 32];
-        const LOG_ID: &str = "messages";
+        let log_id = String::from("messages");
 
         let peer_a_private_key = PrivateKey::new();
         let peer_b_private_key = PrivateKey::new();
@@ -981,7 +981,7 @@ mod tests {
         // Construct a store and log height protocol for peer a
         let store_a = MemoryStore::default();
         let protocol_a = LogHeightSyncProtocol {
-            log_ids: HashMap::from([(TOPIC_ID, LOG_ID.to_string())]),
+            log_ids: HashMap::from([(TOPIC_ID, log_id.clone())]),
             store: store_a,
         };
 
@@ -1008,22 +1008,22 @@ mod tests {
         // Create store for peer b and populate with operations
         let mut store_b = MemoryStore::default();
         store_b
-            .insert_operation(operation0.clone(), LOG_ID.to_string())
+            .insert_operation(&operation0, &log_id)
             .await
             .unwrap();
         store_b
-            .insert_operation(operation1.clone(), LOG_ID.to_string())
+            .insert_operation(&operation1, &log_id)
             .await
             .unwrap();
         store_b
-            .insert_operation(operation2.clone(), LOG_ID.to_string())
+            .insert_operation(&operation2, &log_id)
             .await
             .unwrap();
 
         // Construct log height protocol for peer b
         let protocol_b = LogHeightSyncProtocol {
             store: store_b,
-            log_ids: HashMap::from([(TOPIC_ID, LOG_ID.to_string())]),
+            log_ids: HashMap::from([(TOPIC_ID, log_id.clone())]),
         };
 
         // Build peer a's node

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -13,8 +13,8 @@ pub trait LocalOperationStore<LogId, Extensions> {
     /// already existed and no insertion occurred.
     async fn insert_operation(
         &mut self,
-        operation: Operation<Extensions>,
-        log_id: LogId,
+        operation: &Operation<Extensions>,
+        log_id: &LogId,
     ) -> Result<bool, StoreError>;
 
     /// Get an operation.
@@ -40,20 +40,21 @@ pub trait LocalLogStore<LogId, Extensions> {
     /// Returns an empty Vec when the author or a log with the requested id was not found.
     async fn get_log(
         &self,
-        public_key: PublicKey,
-        log_id: LogId,
+        public_key: &PublicKey,
+        log_id: &LogId,
     ) -> Result<Vec<Operation<Extensions>>, StoreError>;
 
     /// Get the log heights of all logs, by any author, which are stored under the passed log id.
-    async fn get_log_heights(&self, log_id: LogId) -> Result<Vec<(PublicKey, SeqNum)>, StoreError>;
+    async fn get_log_heights(&self, log_id: &LogId)
+        -> Result<Vec<(PublicKey, SeqNum)>, StoreError>;
 
     /// Get only the latest operation from an authors' log.
     ///
     /// Returns None when the author or a log with the requested id was not found.
     async fn latest_operation(
         &self,
-        public_key: PublicKey,
-        log_id: LogId,
+        public_key: &PublicKey,
+        log_id: &LogId,
     ) -> Result<Option<Operation<Extensions>>, StoreError>;
 
     /// Delete all operations in a log before the given sequence number.
@@ -62,8 +63,8 @@ pub trait LocalLogStore<LogId, Extensions> {
     /// the author or log could not be found, or no operations were deleted.
     async fn delete_operations(
         &mut self,
-        public_key: PublicKey,
-        log_id: LogId,
+        public_key: &PublicKey,
+        log_id: &LogId,
         before: u64,
     ) -> Result<bool, StoreError>;
 
@@ -76,8 +77,8 @@ pub trait LocalLogStore<LogId, Extensions> {
     /// the author or log could not be found, or no operations were deleted.
     async fn delete_payloads(
         &mut self,
-        public_key: PublicKey,
-        log_id: LogId,
+        public_key: &PublicKey,
+        log_id: &LogId,
         from: u64,
         to: u64,
     ) -> Result<bool, StoreError>;


### PR DESCRIPTION
Handle all non-copy method parameters by reference. We want to allow store implementations to decide to clone or not.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
