### PR TITLE
Introduce `TopicMap` trait and use in `LogHeightSyncProtocol` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
+- Introduce `TopicMap` trait [#560](https://github.com/p2panda/p2panda/pull/560)
 - Sync past state for subscribed topics in `p2panda-net` [#553](https://github.com/p2panda/p2panda/pull/553)
 - Make all store methods async and use interior mutability patterns [#550](https://github.com/p2panda/p2panda/pull/550)
 - Introduce `p2panda-sync` offering generic sync tools and opinionated sync protocols [#549](https://github.com/p2panda/p2panda/pull/549)

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -794,8 +794,8 @@ mod tests {
 
     use iroh_net::relay::{RelayNode, RelayUrl as IrohRelayUrl};
     use p2panda_core::{Body, Hash, Header, Operation, PrivateKey};
-    use p2panda_store::{MemoryStore, OperationStore};
-    use p2panda_sync::protocols::log_height::{LogHeightSyncProtocol, TopicMap};
+    use p2panda_store::{MemoryStore, OperationStore, TopicMap};
+    use p2panda_sync::protocols::log_height::LogHeightSyncProtocol;
     use serde::Serialize;
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
@@ -978,12 +978,14 @@ mod tests {
         }
     }
 
-    impl TopicMap<String> for LogIdTopicMap {
+    impl TopicMap<TopicId, String> for LogIdTopicMap {
         fn get(&self, topic: &TopicId) -> Option<&String> {
             self.0.get(topic)
         }
+    }
 
-        fn insert(&mut self, topic: TopicId, scope: String) -> Option<String> {
+    impl LogIdTopicMap {
+        pub fn insert(&mut self, topic: TopicId, scope: String) -> Option<String> {
             self.0.insert(topic, scope)
         }
     }

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -4,4 +4,4 @@ pub mod memory_store;
 pub mod traits;
 
 pub use memory_store::MemoryStore;
-pub use traits::{TopicMap, LogStore, OperationStore, StoreError};
+pub use traits::{LogStore, OperationStore, StoreError, TopicMap};

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -4,4 +4,4 @@ pub mod memory_store;
 pub mod traits;
 
 pub use memory_store::MemoryStore;
-pub use traits::{LogStore, OperationStore, StoreError};
+pub use traits::{TopicMap, LogStore, OperationStore, StoreError};

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -89,3 +89,8 @@ pub enum StoreError {
     #[error("Error occurred in OperationStore: {0}")]
     OperationStoreError(String),
 }
+
+/// Trait used to mapping a generic topic to a single or collection of logs
+pub trait TopicMap<K, V> {
+    fn get(&self, topic: &K) -> Option<&V>;
+}

--- a/p2panda-store/src/traits.rs
+++ b/p2panda-store/src/traits.rs
@@ -90,7 +90,7 @@ pub enum StoreError {
     OperationStoreError(String),
 }
 
-/// Trait used to mapping a generic topic to a single or collection of logs
+/// Trait used for mapping a generic topic to a single or collection of logs
 pub trait TopicMap<K, V> {
     fn get(&self, topic: &K) -> Option<&V>;
 }


### PR DESCRIPTION
We need a way to allow users of sync protocol implementations to define custom topic -> scope mappings. This is used internally in a sync session when only the topic id is given. We also imagine this mapping being used during validation of messages arriving via gossip.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
