### PR TITLE
Handle operation header and body as raw bytes in sync protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ Highlights are marked with a pancake 🥞
 ### Changed
 
 - Handle non-copy store method parameters by reference [#558](https://github.com/p2panda/p2panda/pull/558)
+- Handle operation header and body as bytes in log height sync [#561](https://github.com/p2panda/p2panda/pull/561)


### PR DESCRIPTION
We currently  decode an operation into it's typed `Header` and `Body` inside the sync protocol, however as storing of the operations now occurs up-stream (in the engine) we can rather handle them as raw bytes.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
- [x] Check if descriptions and terminology match `handbook` content (and visa-versa) 
