### PR TITLE
Bump `iroh` dependencies to `0.25.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
+- Bump `iroh` dependencies to `0.25.0` [#562](https://github.com/p2panda/p2panda/pull/562)
 - Implement sync connection manager [#559](https://github.com/p2panda/p2panda/pull/559)
 - Introduce `TopicMap` trait [#560](https://github.com/p2panda/p2panda/pull/560)
 - Sync past state for subscribed topics in `p2panda-net` [#553](https://github.com/p2panda/p2panda/pull/553)

--- a/p2panda-blobs/Cargo.toml
+++ b/p2panda-blobs/Cargo.toml
@@ -11,13 +11,13 @@ flume = "0.11.0"
 futures-buffered = "0.2.8"
 futures-lite = "2.3.0"
 futures-util = "0.3.30"
-iroh-base = "0.22.0"
-iroh-blobs = { version = "0.22.0", features = ["downloader", "fs-store"], default-features = false }
-iroh-io = "0.6.0"
-iroh-net = "0.22.0"
+iroh-base = "0.25.0"
+iroh-blobs = { version = "0.25.0", features = ["downloader", "fs-store"], default-features = false }
+iroh-io = "0.6.1"
+iroh-net = "0.25.0"
 num_cpus = "1.16.0"
-p2panda-core = { git = "https://github.com/p2panda/p2panda.git", branch = "v2" }
-p2panda-net = { git = "https://github.com/p2panda/p2panda.git", branch = "v2" }
+p2panda-core = { path = "../p2panda-core" }
+p2panda-net = { path = "../p2panda-net" }
 serde = { version = "1.0.204", features = ["derive"] }
 tempdir = "0.3.7"
 tokio = { version = "1.38.0", features = ["full"] }

--- a/p2panda-blobs/src/export.rs
+++ b/p2panda-blobs/src/export.rs
@@ -7,13 +7,13 @@ use anyhow::Context;
 use iroh_base::hash::Hash as IrohHash;
 use iroh_blobs::export::ExportProgress;
 use iroh_blobs::store::{ExportMode, MapEntry, Store};
-use iroh_blobs::util::progress::{FlumeProgressSender, IdGenerator, ProgressSender};
+use iroh_blobs::util::progress::{AsyncChannelProgressSender, IdGenerator, ProgressSender};
 use p2panda_core::Hash;
 use tracing::trace;
 
 pub async fn export_blob<S: Store>(store: &S, hash: Hash, outpath: &PathBuf) -> anyhow::Result<()> {
-    let (sender, _receiver) = flume::bounded(1024);
-    let progress = FlumeProgressSender::new(sender);
+    let (sender, _receiver) = async_channel::bounded(1024);
+    let progress = AsyncChannelProgressSender::new(sender);
 
     if let Some(parent) = outpath.parent() {
         tokio::fs::create_dir_all(parent).await?;

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -20,10 +20,10 @@ futures-buffered = "0.2.8"
 futures-lite = "2.3.0"
 futures-util = "0.3.30"
 hickory-proto = { version = "0.24.1", optional = true }
-iroh-base = "0.22.0"
-iroh-gossip = "0.22.0"
-iroh-net = "0.22.0"
-iroh-quinn = { version = "0.10.5", features = ["futures-io"] }
+iroh-base = "0.25.0"
+iroh-gossip = "0.25.0"
+iroh-net = "0.25.0"
+iroh-quinn = { version = "0.11.3", features = ["futures-io"] }
 p2panda-core = { path = "../p2panda-core" }
 p2panda-sync = { path = "../p2panda-sync" }
 rand = "0.8.5"

--- a/p2panda-net/src/discovery/mdns/mod.rs
+++ b/p2panda-net/src/discovery/mdns/mod.rs
@@ -5,7 +5,6 @@ mod socket;
 
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -36,7 +35,7 @@ enum Message {
 #[derive(Debug)]
 pub struct LocalDiscovery {
     #[allow(dead_code)]
-    handle: Arc<AbortOnDropHandle<()>>,
+    handle: AbortOnDropHandle<()>,
     tx: Sender<Message>,
 }
 
@@ -124,7 +123,7 @@ impl LocalDiscovery {
         });
 
         Ok(Self {
-            handle: Arc::new(AbortOnDropHandle::new(handle)),
+            handle: AbortOnDropHandle::new(handle),
             tx,
         })
     }

--- a/p2panda-net/src/engine/mod.rs
+++ b/p2panda-net/src/engine/mod.rs
@@ -11,11 +11,14 @@ pub use engine::ToEngineActor;
 use std::sync::Arc;
 
 use anyhow::Result;
+use futures_util::future::{MapErr, Shared};
+use futures_util::{FutureExt, TryFutureExt};
 use iroh_gossip::net::Gossip;
 use iroh_net::{Endpoint, NodeAddr};
 use p2panda_sync::traits::SyncProtocol;
 use sync::SyncActor;
 use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::task::JoinError;
 use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error};
 
@@ -23,14 +26,14 @@ use crate::connection::{ConnectionActor, SyncConnection, ToConnectionActor};
 use crate::engine::engine::EngineActor;
 use crate::engine::gossip::GossipActor;
 use crate::network::{InEvent, OutEvent};
-use crate::{NetworkId, TopicId};
+use crate::{JoinErrToStr, NetworkId, TopicId};
 
 #[derive(Debug)]
 pub struct Engine {
     engine_actor_tx: mpsc::Sender<ToEngineActor>,
     connection_actor_tx: Option<mpsc::Sender<ToConnectionActor>>,
     #[allow(dead_code)]
-    actor_handle: Arc<AbortOnDropHandle<()>>,
+    actor_handle: Shared<MapErr<AbortOnDropHandle<()>, JoinErrToStr>>,
 }
 
 impl Engine {
@@ -88,10 +91,14 @@ impl Engine {
             }
         });
 
+        let actor_drop_handle = AbortOnDropHandle::new(actor_handle)
+            .map_err(Box::new(|e: JoinError| e.to_string()) as JoinErrToStr)
+            .shared();
+
         Self {
             engine_actor_tx,
             connection_actor_tx,
-            actor_handle: Arc::new(AbortOnDropHandle::new(actor_handle)),
+            actor_handle: actor_drop_handle,
         }
     }
 

--- a/p2panda-net/src/engine/mod.rs
+++ b/p2panda-net/src/engine/mod.rs
@@ -12,11 +12,11 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use iroh_gossip::net::Gossip;
-use iroh_net::util::SharedAbortingJoinHandle;
 use iroh_net::{Endpoint, NodeAddr};
 use p2panda_sync::traits::SyncProtocol;
 use sync::SyncActor;
 use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error};
 
 use crate::connection::{ConnectionActor, SyncConnection, ToConnectionActor};
@@ -30,7 +30,7 @@ pub struct Engine {
     engine_actor_tx: mpsc::Sender<ToEngineActor>,
     connection_actor_tx: Option<mpsc::Sender<ToConnectionActor>>,
     #[allow(dead_code)]
-    actor_handle: SharedAbortingJoinHandle<()>,
+    actor_handle: Arc<AbortOnDropHandle<()>>,
 }
 
 impl Engine {
@@ -91,7 +91,7 @@ impl Engine {
         Self {
             engine_actor_tx,
             connection_actor_tx,
-            actor_handle: actor_handle.into(),
+            actor_handle: Arc::new(AbortOnDropHandle::new(actor_handle)),
         }
     }
 

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -18,7 +18,7 @@ pub use message::{FromBytes, ToBytes};
 pub use network::{Network, NetworkBuilder, RelayMode};
 pub use protocols::ProtocolHandler;
 
-pub use iroh_net::util::SharedAbortingJoinHandle;
+pub use tokio_util::task::AbortOnDropHandle;
 
 pub type NetworkId = [u8; 32];
 

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -17,9 +17,11 @@ pub use discovery::mdns::LocalDiscovery;
 pub use message::{FromBytes, ToBytes};
 pub use network::{Network, NetworkBuilder, RelayMode};
 pub use protocols::ProtocolHandler;
-
 pub use tokio_util::task::AbortOnDropHandle;
 
-pub type NetworkId = [u8; 32];
+// This is used in the construction of the shared `AbortOnDropHandle`.
+pub(crate) type JoinErrToStr =
+    Box<dyn Fn(tokio::task::JoinError) -> String + Send + Sync + 'static>;
 
+pub type NetworkId = [u8; 32];
 pub type TopicId = [u8; 32];

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -388,10 +388,6 @@ impl NetworkInner {
                     tokio::select! {
                         // Learn about our direct addresses and changes to them
                         Some(endpoints) = addrs_stream.next() => {
-                            if let Err(err) = inner.gossip.update_direct_addresses(&endpoints) {
-                                warn!("Failed to update direct addresses for gossip: {err:?}");
-                            }
-
                             let direct_addresses = endpoints.iter().map(|endpoint| endpoint.addr).collect();
                             my_node_addr.info.direct_addresses = direct_addresses;
                             if let Err(err) = inner.discovery.update_local_address(&my_node_addr) {


### PR DESCRIPTION
Updates `iroh` dependencies from `0.22.0` to `0.25.0`.
Updates `iroh-io` from `0.6.0` to `0.6.1`.
Updates `iroh-quinn` from `0.10.5` to `0.11.3`.

Tests have been fixed in https://github.com/p2panda/p2panda/pull/563.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header