### PR TITLE
Validation method for prunable logs

### DIFF
--- a/p2panda-core/Cargo.toml
+++ b/p2panda-core/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [lints]
 workspace = true
 
+[features]
+default = ["prune"]
+prune = []
+
 [dependencies]
 arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
 blake3 = "1.5.1"

--- a/p2panda-core/src/lib.rs
+++ b/p2panda-core/src/lib.rs
@@ -4,6 +4,8 @@ pub mod extensions;
 pub mod hash;
 pub mod identity;
 pub mod operation;
+#[cfg(feature = "prune")]
+pub mod prune;
 mod serde;
 
 pub use extensions::Extension;

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -86,7 +86,7 @@ impl<E> Default for Header<E> {
             payload_size: 0,
             payload_hash: None,
             timestamp: 0,
-            seq_num: 1,
+            seq_num: 0,
             backlink: None,
             previous: vec![],
             extensions: None,

--- a/p2panda-core/src/prune.rs
+++ b/p2panda-core/src/prune.rs
@@ -4,6 +4,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::{validate_backlink, Header, OperationError};
 
+/// Alternative backlink validation method for logs which allow pruning.
+///
+/// When a "prune flag" is set in an operation, an author signals to others that all operations can
+/// be deleted (including payloads) in that log _before_ it.
+///
+/// As soon as a prune flag was set for an operation we don't expect the header of a backlink,
+/// otherwise we go on with validation as usual.
+///
+/// Use this method instead of [`validate_backlink`] if you want to support prunable logs.
 pub fn validate_prunable_backlink<E>(
     past_header: Option<&Header<E>>,
     header: &Header<E>,

--- a/p2panda-core/src/prune.rs
+++ b/p2panda-core/src/prune.rs
@@ -1,24 +1,69 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use thiserror::Error;
+use serde::{Deserialize, Serialize};
 
-use crate::Header;
-
-#[derive(Error, Debug)]
-pub enum PruneError {
-    // @TODO
-    #[error("operation version {0} is not supported, needs to be <= {1}")]
-    UnsupportedVersion(u64, u64),
-}
+use crate::{validate_backlink, Header, OperationError};
 
 pub fn validate_prunable_backlink<E>(
     past_header: Option<&Header<E>>,
     header: &Header<E>,
-) -> Result<(), PruneError>
+    prune_flag: bool,
+) -> Result<(), OperationError>
 where
-    E: Clone + Serialize + DeserializeOwned,
+    E: Clone + Serialize + for<'a> Deserialize<'a>,
 {
-    todo!();
+    assert!(
+        !(past_header.is_some() && header.seq_num == 0),
+        "operation can't have backlink at seq_num = 0"
+    );
+
+    // If no pruning flag is set, we expect the log to have integrity with the previously given
+    // operation
+    if !prune_flag && header.seq_num > 0 {
+        match past_header {
+            Some(past_header) => validate_backlink(past_header, header),
+            None => Err(OperationError::BacklinkMissing),
+        }
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::extensions::DefaultExtensions;
+    use crate::{Hash, Header, PrivateKey};
+
+    use super::validate_prunable_backlink;
+
+    #[test]
+    fn validate_pruned_log() {
+        let private_key = PrivateKey::new();
+        let mut header = Header::<DefaultExtensions> {
+            public_key: private_key.public_key(),
+            seq_num: 7,
+            backlink: Some(Hash::new(&[1, 2, 3])),
+            ..Default::default()
+        };
+        header.sign(&private_key);
+
+        // When no pruning flag was set we expect a backlink for this operation at seq_num = 7,
+        // otherwise not
+        assert!(validate_prunable_backlink(None, &header, false).is_err());
+        assert!(validate_prunable_backlink(None, &header, true).is_ok());
+    }
+
+    #[test]
+    fn seq_num_zero() {
+        let private_key = PrivateKey::new();
+        let mut header = Header::<DefaultExtensions> {
+            public_key: private_key.public_key(),
+            ..Default::default()
+        };
+        header.sign(&private_key);
+
+        // Everything is fine at the beginning of the log
+        assert!(validate_prunable_backlink(None, &header, false).is_ok());
+        assert!(validate_prunable_backlink(None, &header, true).is_ok());
+    }
 }

--- a/p2panda-core/src/prune.rs
+++ b/p2panda-core/src/prune.rs
@@ -33,11 +33,6 @@ pub fn validate_prunable_backlink<E>(
 where
     E: Clone + Serialize + for<'a> Deserialize<'a>,
 {
-    assert!(
-        !(past_header.is_some() && header.seq_num == 0),
-        "operation can't have backlink at seq_num = 0"
-    );
-
     // If no pruning flag is set, we expect the log to have integrity with the previously given
     // operation
     if !prune_flag && header.seq_num > 0 {

--- a/p2panda-core/src/prune.rs
+++ b/p2panda-core/src/prune.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::Header;
+
+#[derive(Error, Debug)]
+pub enum PruneError {
+    // @TODO
+    #[error("operation version {0} is not supported, needs to be <= {1}")]
+    UnsupportedVersion(u64, u64),
+}
+
+pub fn validate_prunable_backlink<E>(
+    past_header: Option<&Header<E>>,
+    header: &Header<E>,
+) -> Result<(), PruneError>
+where
+    E: Clone + Serialize + DeserializeOwned,
+{
+    todo!();
+}

--- a/p2panda-core/src/prune.rs
+++ b/p2panda-core/src/prune.rs
@@ -9,6 +9,18 @@ use crate::{validate_backlink, Header, OperationError};
 /// When a "prune flag" is set in an operation, an author signals to others that all operations can
 /// be deleted (including payloads) in that log _before_ it.
 ///
+/// ```text
+/// Log of Author A with six Operations:
+///
+/// [ 0 ] <-- can be removed
+/// [ 1 ] <-- can be removed
+/// [ 2 ] <-- can be removed
+/// [ 3 ] <-- prune flag = true
+/// [ 4 ]
+/// [ 5 ]
+/// ...
+/// ```
+///
 /// As soon as a prune flag was set for an operation we don't expect the header of a backlink,
 /// otherwise we go on with validation as usual.
 ///


### PR DESCRIPTION
This PR introduces a separate validation method to check against backlinks in the context of prunable logs.

If a log is prunable we can look out for "prune flags", as soon as one was set for an operation we don't expect the header of a backlink, otherwise we go on with validation as usual.