### PR TITLE
CBOR encode and decode methods for operation headers

### DIFF
--- a/p2panda-core/src/cbor.rs
+++ b/p2panda-core/src/cbor.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use ciborium::de::Error as DeserializeError;
+use ciborium::ser::Error as SerializeError;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::Header;
+
+pub fn encode_header<E: Serialize>(header: &Header<E>) -> Result<Vec<u8>, EncodeError> {
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(header, &mut bytes).map_err(Into::<EncodeError>::into)?;
+    Ok(bytes)
+}
+
+pub fn decode_header<E: for<'a> Deserialize<'a>>(bytes: &[u8]) -> Result<Header<E>, DecodeError> {
+    let header = ciborium::from_reader::<Header<E>, _>(bytes).map_err(Into::<DecodeError>::into)?;
+    Ok(header)
+}
+
+#[derive(Debug, Error)]
+pub enum EncodeError {
+    /// An error occurred while writing bytes.
+    ///
+    /// Contains the underlying error returned while reading.
+    #[error("an error occurred while reading bytes: {0}")]
+    Io(std::io::Error),
+
+    /// An error indicating a value that cannot be serialized.
+    ///
+    /// Contains a description of the problem delivered from serde.
+    #[error("an error occurred while deserializing value: {0}")]
+    Value(String),
+}
+
+impl From<SerializeError<std::io::Error>> for EncodeError {
+    fn from(value: SerializeError<std::io::Error>) -> Self {
+        match value {
+            SerializeError::Io(err) => EncodeError::Io(err),
+            SerializeError::Value(err) => EncodeError::Value(err),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DecodeError {
+    /// An error occurred while reading bytes.
+    ///
+    /// Contains the underlying error returned while reading.
+    #[error("an error occurred while reading bytes: {0}")]
+    Io(std::io::Error),
+
+    /// An error occurred while parsing bytes.
+    ///
+    /// Contains the offset into the stream where the syntax error occurred.
+    #[error("an error occurred while parsing bytes at position {0}")]
+    Syntax(usize),
+
+    /// An error occurred while processing a parsed value.
+    ///
+    /// Contains a description of the error that occurred and (optionally) the offset into the
+    /// stream indicating the start of the item being processed when the error occurred.
+    #[error("an error occurred while processing a parsed value at position {0:?}: {1}")]
+    Semantic(Option<usize>, String),
+
+    /// The input caused serde to recurse too much.
+    ///
+    /// This error prevents a stack overflow.
+    #[error("recursion limit exceeded while decoding")]
+    RecursionLimitExceeded,
+}
+
+impl From<DeserializeError<std::io::Error>> for DecodeError {
+    fn from(value: DeserializeError<std::io::Error>) -> Self {
+        match value {
+            DeserializeError::Io(err) => DecodeError::Io(err),
+            DeserializeError::Syntax(offset) => DecodeError::Syntax(offset),
+            DeserializeError::Semantic(offset, description) => {
+                DecodeError::Semantic(offset, description)
+            }
+            DeserializeError::RecursionLimitExceeded => DecodeError::RecursionLimitExceeded,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::extensions::DefaultExtensions;
+    use crate::{Body, Header, PrivateKey};
+
+    use super::{decode_header, encode_header};
+
+    #[test]
+    fn encode_decode() {
+        let private_key = PrivateKey::new();
+        let body = Body::new(&[1, 2, 3]);
+        let mut header = Header::<DefaultExtensions> {
+            public_key: private_key.public_key(),
+            payload_size: body.size(),
+            payload_hash: Some(body.hash()),
+            ..Default::default()
+        };
+        header.sign(&private_key);
+
+        let bytes = encode_header(&header).unwrap();
+        let header_again: Header<DefaultExtensions> = decode_header(&bytes).unwrap();
+
+        assert_eq!(header.hash(), header_again.hash());
+    }
+}

--- a/p2panda-core/src/lib.rs
+++ b/p2panda-core/src/lib.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+pub mod cbor;
 pub mod extensions;
 pub mod hash;
 pub mod identity;

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -4,6 +4,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use thiserror::Error;
 
+use crate::cbor::{decode_header, encode_header, DecodeError};
 use crate::extensions::DefaultExtensions;
 use crate::hash::Hash;
 use crate::identity::{PrivateKey, PublicKey, Signature};
@@ -99,14 +100,10 @@ where
     E: Clone + Serialize,
 {
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-
-        ciborium::ser::into_writer(&self, &mut bytes)
+        encode_header(&self)
             // We can be sure that all values in this module are serializable and _if_ ciborium
             // still fails then because of something really bad ..
-            .expect("CBOR encoder failed due to an critical IO error");
-
-        bytes
+            .expect("CBOR encoder failed due to an critical IO error")
     }
 
     pub fn sign(&mut self, private_key: &PrivateKey) {
@@ -162,6 +159,14 @@ impl<E> Header<E> {
     }
 }
 
+impl TryFrom<&[u8]> for Header {
+    type Error = DecodeError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        decode_header(value)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Body(pub(super) Vec<u8>);
 
@@ -180,6 +185,18 @@ impl Body {
 
     pub fn size(&self) -> u64 {
         self.0.len() as u64
+    }
+}
+
+impl From<&[u8]> for Body {
+    fn from(value: &[u8]) -> Self {
+        Body::new(value)
+    }
+}
+
+impl From<Vec<u8>> for Body {
+    fn from(value: Vec<u8>) -> Self {
+        Body(value)
     }
 }
 

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -100,7 +100,7 @@ where
     E: Clone + Serialize,
 {
     pub fn to_bytes(&self) -> Vec<u8> {
-        encode_header(&self)
+        encode_header(self)
             // We can be sure that all values in this module are serializable and _if_ ciborium
             // still fails then because of something really bad ..
             .expect("CBOR encoder failed due to an critical IO error")

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -87,7 +87,7 @@ impl<E> Default for Header<E> {
             payload_size: 0,
             payload_hash: None,
             timestamp: 0,
-            seq_num: 1,
+            seq_num: 0,
             backlink: None,
             previous: vec![],
             extensions: None,

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -4,7 +4,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use thiserror::Error;
 
-use crate::cbor::{decode_header, encode_header, DecodeError};
+use crate::cbor::{decode_cbor, encode_cbor, DecodeError};
 use crate::extensions::DefaultExtensions;
 use crate::hash::Hash;
 use crate::identity::{PrivateKey, PublicKey, Signature};
@@ -100,7 +100,7 @@ where
     E: Clone + Serialize,
 {
     pub fn to_bytes(&self) -> Vec<u8> {
-        encode_header(self)
+        encode_cbor(self)
             // We can be sure that all values in this module are serializable and _if_ ciborium
             // still fails then because of something really bad ..
             .expect("CBOR encoder failed due to an critical IO error")
@@ -163,7 +163,7 @@ impl TryFrom<&[u8]> for Header {
     type Error = DecodeError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        decode_header(value)
+        decode_cbor(value)
     }
 }
 


### PR DESCRIPTION
This PR introduces generic methods to encode and decode values into and from CBOR.

This is then internally used to implement conversion traits from bytes to `Header` and vice-versa.