### PR TITLE
Replace `Ready` network message with oneshot receiver on subscribe

### DIFF
--- a/p2panda-net/src/engine/mod.rs
+++ b/p2panda-net/src/engine/mod.rs
@@ -105,12 +105,14 @@ impl Engine {
         topic: TopicId,
         from_network_tx: broadcast::Sender<FromNetwork>,
         to_network_rx: mpsc::Receiver<ToNetwork>,
+        gossip_ready_tx: oneshot::Sender<()>,
     ) -> Result<()> {
         self.engine_actor_tx
             .send(ToEngineActor::Subscribe {
                 topic: topic.into(),
                 from_network_tx,
                 to_network_rx,
+                gossip_ready_tx,
             })
             .await?;
         Ok(())


### PR DESCRIPTION
- [x] Remove `Ready` variant from `FromNetwork` enum
- [x] Return a oneshot receiver from `subscribe()`
- [x] Send `()` on the oneshot channel when the gossip overlay has been joined for a particular topic

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes