### PR TITLE
Introduce a scheduler to the sync manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
+- Introduce a scheduler to the sync manager [#574](https://github.com/p2panda/p2panda/pull/574)
 - Add `log-sync` feature flag to `p2panda-net` and move `JoinErrToStr` [#572](https://github.com/p2panda/p2panda/pull/572)
 - Move discovery from `p2panda-net` into new `p2panda-discovery` crate [#571](https://github.com/p2panda/p2panda/pull/571) 
 - Replace `Ready` network message with oneshot receiver on subscribe [#570](https://github.com/p2panda/p2panda/pull/570)

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -27,6 +27,7 @@ p2panda-discovery = { path = "../p2panda-discovery" }
 p2panda-sync = { path = "../p2panda-sync", features = ["log-sync"] }
 rand = "0.8.5"
 serde = { version = "1.0.203", features = ["derive"] }
+thiserror = "1.0.63"
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["codec", "io-util", "io"] }

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -17,7 +17,7 @@ use tracing::{debug, error, warn};
 use crate::engine::gossip::{GossipActor, ToGossipActor};
 use crate::engine::message::NetworkMessage;
 use crate::network::{FromNetwork, ToNetwork};
-use crate::sync::{SyncManager, ToSyncManager};
+use crate::sync::manager::{SyncManager, ToSyncManager};
 use crate::{FromBytes, ToBytes};
 
 /// Maximum size of random sample set when choosing peers to join gossip overlay.

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -11,12 +11,13 @@ use iroh_net::{Endpoint, NodeAddr, NodeId};
 use rand::seq::IteratorRandom;
 use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
 use tokio::time::interval;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 
 use crate::engine::gossip::{GossipActor, ToGossipActor};
 use crate::engine::message::NetworkMessage;
 use crate::network::{FromNetwork, ToNetwork};
-use crate::sync::SyncManager;
+use crate::sync::{SyncManager, ToSyncManager};
 use crate::{FromBytes, ToBytes};
 
 /// Maximum size of random sample set when choosing peers to join gossip overlay.
@@ -125,7 +126,7 @@ impl GossipBuffer {
 pub struct EngineActor {
     endpoint: Endpoint,
     gossip_actor_tx: mpsc::Sender<ToGossipActor>,
-    sync_manager: Option<SyncManager>,
+    sync_manager_tx: Option<mpsc::Sender<ToSyncManager>>,
     inbox: mpsc::Receiver<ToEngineActor>,
     // @TODO: Think about field naming here; perhaps these fields would be more accurately prefixed
     // by `topic_` or `gossip_`, since they are not referencing the overall network swarm (aka.
@@ -141,15 +142,15 @@ pub struct EngineActor {
 impl EngineActor {
     pub fn new(
         endpoint: Endpoint,
-        gossip_actor_tx: mpsc::Sender<ToGossipActor>,
-        sync_manager: Option<SyncManager>,
         inbox: mpsc::Receiver<ToEngineActor>,
+        gossip_actor_tx: mpsc::Sender<ToGossipActor>,
+        sync_manager_tx: Option<mpsc::Sender<ToSyncManager>>,
         network_id: TopicId,
     ) -> Self {
         Self {
             endpoint,
             gossip_actor_tx,
-            sync_manager,
+            sync_manager_tx,
             inbox,
             network_id,
             network_joined: false,
@@ -160,7 +161,22 @@ impl EngineActor {
         }
     }
 
-    pub async fn run(mut self, mut gossip_actor: GossipActor) -> Result<()> {
+    pub async fn run(
+        mut self,
+        mut gossip_actor: GossipActor,
+        sync_manager: Option<SyncManager>,
+    ) -> Result<()> {
+        let sync_manager_token = CancellationToken::new();
+        let cloned_sync_manager_token = sync_manager_token.clone();
+
+        if let Some(sync_manager) = sync_manager {
+            tokio::task::spawn(async move {
+                if let Err(err) = sync_manager.run(cloned_sync_manager_token).await {
+                    error!("sync manager failed to run: {err:?}");
+                }
+            });
+        }
+
         let gossip_handle = tokio::task::spawn(async move {
             if let Err(err) = gossip_actor.run().await {
                 error!("gossip recv actor failed: {err:?}");
@@ -174,6 +190,7 @@ impl EngineActor {
             error!(?err, "error during shutdown");
         }
 
+        sync_manager_token.cancel();
         gossip_handle.await?;
         drop(self);
 
@@ -548,10 +565,13 @@ impl EngineActor {
         //
         // NOTE: This will only return once sync has been attempted with all novel peer-topic
         // combinations.
-        if let Some(ref mut sync_manager) = self.sync_manager {
-            sync_manager
-                .update_peer_topics(delivered_from, topics)
-                .await?;
+        if let Some(sync_manager_tx) = &self.sync_manager_tx {
+            //sync_manager
+            //    .update_peer_topics(delivered_from, topics)
+            //    .await?;
+
+            let peer_topics = ToSyncManager::new(delivered_from, topics);
+            sync_manager_tx.send(peer_topics).await?
         }
 
         Ok(())

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -562,14 +562,7 @@ impl EngineActor {
         self.join_earmarked_topics().await?;
 
         // Inform the connection manager about the peer topics
-        //
-        // NOTE: This will only return once sync has been attempted with all novel peer-topic
-        // combinations.
         if let Some(sync_manager_tx) = &self.sync_manager_tx {
-            //sync_manager
-            //    .update_peer_topics(delivered_from, topics)
-            //    .await?;
-
             let peer_topics = ToSyncManager::new(delivered_from, topics);
             sync_manager_tx.send(peer_topics).await?
         }

--- a/p2panda-net/src/sync/manager.rs
+++ b/p2panda-net/src/sync/manager.rs
@@ -3,45 +3,141 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Error, Result};
 use iroh_gossip::proto::TopicId;
 use iroh_net::{Endpoint, NodeId};
-use p2panda_sync::{SyncError, SyncProtocol};
-use tokio::sync::mpsc::Sender;
-use tracing::{debug, warn};
+use p2panda_sync::SyncProtocol;
+use thiserror::Error;
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, warn};
 
 use crate::engine::ToEngineActor;
 use crate::sync::{self, SYNC_CONNECTION_ALPN};
 
+const MAX_RETRY_ATTEMPTS: u8 = 5;
+
+#[derive(Debug)]
+pub struct ToSyncManager {
+    peer: NodeId,
+    topics: Vec<TopicId>,
+}
+
+impl ToSyncManager {
+    pub fn new(peer: NodeId, topics: Vec<TopicId>) -> Self {
+        Self { peer, topics }
+    }
+}
+
+#[derive(Debug)]
+struct SyncAttempt {
+    peer: NodeId,
+    topic: TopicId,
+    attempts: u8,
+}
+
+impl SyncAttempt {
+    fn new(peer: NodeId, topic: TopicId) -> Self {
+        Self {
+            peer,
+            topic,
+            attempts: 0,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+enum SyncAttemptError {
+    #[error("connection error")]
+    Connection,
+    #[error("sync error")]
+    Sync,
+}
+
 #[derive(Debug)]
 pub struct SyncManager {
-    known_peer_topics: HashMap<NodeId, HashSet<TopicId>>,
     active_sync_sessions: HashMap<TopicId, HashSet<NodeId>>,
     completed_sync_sessions: HashMap<TopicId, HashSet<NodeId>>,
-    engine_actor_tx: Sender<ToEngineActor>,
     endpoint: Endpoint,
+    engine_actor_tx: Sender<ToEngineActor>,
+    inbox: Receiver<ToSyncManager>,
+    known_peer_topics: HashMap<NodeId, HashSet<TopicId>>,
+    max_retry_attempts: u8,
     sync_protocol: Arc<dyn for<'a> SyncProtocol<'a> + 'static>,
+    sync_queue_tx: Sender<SyncAttempt>,
+    sync_queue_rx: Receiver<SyncAttempt>,
 }
 
 impl SyncManager {
     pub fn new(
         endpoint: Endpoint,
         engine_actor_tx: Sender<ToEngineActor>,
+        inbox: Option<Receiver<ToSyncManager>>,
         sync_protocol: Arc<dyn for<'a> SyncProtocol<'a> + 'static>,
     ) -> Self {
+        let inbox = inbox.expect("channel receiver provided to sync manager");
+        let (sync_queue_tx, sync_queue_rx) = mpsc::channel(128);
+
         Self {
-            known_peer_topics: HashMap::new(),
             active_sync_sessions: HashMap::new(),
             completed_sync_sessions: HashMap::new(),
-            engine_actor_tx,
             endpoint,
+            engine_actor_tx,
+            inbox,
+            known_peer_topics: HashMap::new(),
+            max_retry_attempts: MAX_RETRY_ATTEMPTS,
             sync_protocol,
+            sync_queue_tx,
+            sync_queue_rx,
         }
+    }
+
+    async fn schedule_attempt(&mut self, peer: NodeId, topic: TopicId) -> Result<()> {
+        let sync_attempt = SyncAttempt::new(peer, topic);
+        self.sync_queue_tx.send(sync_attempt).await?;
+
+        Ok(())
+    }
+
+    async fn reschedule_attempt(&mut self, mut sync_attempt: SyncAttempt) -> Result<()> {
+        sync_attempt.attempts += 1;
+        self.sync_queue_tx.send(sync_attempt).await?;
+
+        Ok(())
+    }
+
+    /// Connection + sync loop.
+    pub async fn run(mut self, token: CancellationToken) -> Result<()> {
+        loop {
+            tokio::select! {
+                biased;
+
+                _ = token.cancelled() => {
+                    debug!("sync manager received shutdown signal from engine");
+                    break;
+                }
+                Some(sync_attempt) = self.sync_queue_rx.recv() => {
+                    match self
+                       .connect_and_sync(sync_attempt.peer, sync_attempt.topic)
+                       .await
+                   {
+                       Ok(()) => self.complete_successful_sync(sync_attempt),
+                       Err(err) => self.complete_failed_sync(sync_attempt, err).await?,
+                   }
+                },
+                msg = self.inbox.recv() => {
+                    let msg = msg.context("sync manager inbox closed")?;
+                    self.update_peer_topics(msg.peer, msg.topics).await?
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Respond to newly discovered peer topics by initiating a new connection if one is not
     /// currently underway and a successful sync session has not already been completed.
-    pub async fn update_peer_topics(&mut self, peer: NodeId, topics: Vec<TopicId>) -> Result<()> {
+    async fn update_peer_topics(&mut self, peer: NodeId, topics: Vec<TopicId>) -> Result<()> {
         debug!("updating peer topics in connection manager");
 
         // Create a list of (previously) unknown topics that we might like to sync over.
@@ -68,14 +164,9 @@ impl SyncManager {
                 .or_default()
                 .contains(&peer);
 
-            // Attempt connection in order to initiate a sync session.
+            // Schedule a sync attempt.
             if !active_peers.contains(&peer) && !sync_complete {
-                active_peers.insert(peer);
-                // @TODO: We might want to disentangle this call from the `update_peer_topics`
-                // method so that it returns immediately and the `connect` method has its own life.
-                if let Err(err) = self.connect(peer, topic).await {
-                    warn!("outbound connection attempt failed: {}", err)
-                }
+                self.schedule_attempt(peer, topic).await?;
             }
         }
 
@@ -83,25 +174,26 @@ impl SyncManager {
     }
 
     /// Attempt to connect with the given peer and initiate a sync session.
-    pub async fn connect(&mut self, peer: NodeId, topic: TopicId) -> Result<()> {
+    pub async fn connect_and_sync(&mut self, peer: NodeId, topic: TopicId) -> Result<()> {
         debug!("attempting peer connection for sync");
 
         let connection = self
             .endpoint
             .connect_by_node_id(peer, SYNC_CONNECTION_ALPN)
-            .await?;
+            .await
+            .map_err(|_| SyncAttemptError::Connection)?;
 
         // Create a bidirectional stream on the connection.
         let (mut send, mut recv) = connection
             .open_bi()
             .await
-            .map_err(|e| SyncError::Protocol(e.to_string()))?;
+            .map_err(|_| SyncAttemptError::Connection)?;
 
         let sync_protocol = self.sync_protocol.clone();
         let engine_actor_tx = self.engine_actor_tx.clone();
 
         // Run a sync session as the initiator.
-        let result = sync::initiate_sync(
+        sync::initiate_sync(
             &mut send,
             &mut recv,
             peer,
@@ -109,45 +201,51 @@ impl SyncManager {
             sync_protocol,
             engine_actor_tx,
         )
-        .await;
+        .await
+        .map_err(|_| SyncAttemptError::Sync)?;
 
         // Clean-up the streams.
         send.finish()?;
         send.stopped().await?;
         recv.read_to_end(0).await?;
 
-        if result.is_ok() {
-            debug!("sync success: initiate");
-            self.complete_successful_sync(peer, topic)
-        } else {
-            debug!("sync failure: initiate");
-            self.complete_failed_sync(peer, topic)
+        Ok(())
+    }
+
+    /// Remove the given topic from the set of active sync sessions for the given peer.
+    async fn complete_failed_sync(&mut self, sync_attempt: SyncAttempt, err: Error) -> Result<()> {
+        self.active_sync_sessions
+            .get_mut(&sync_attempt.topic)
+            .expect("active outbound sync session exists")
+            .remove(&sync_attempt.peer);
+
+        match err.downcast_ref() {
+            Some(SyncAttemptError::Connection) => {
+                warn!("sync attempt failed due to connection error");
+                if sync_attempt.attempts <= self.max_retry_attempts {
+                    self.reschedule_attempt(sync_attempt).await?;
+                }
+            }
+            Some(SyncAttemptError::Sync) => {
+                error!("sync attempt failed due to protocol error");
+            }
+            _ => (),
         }
 
         Ok(())
     }
 
-    /// Remove the given topic from the set of active sync sessions for the given peer.
-    pub fn complete_failed_sync(&mut self, peer: NodeId, topic: TopicId) {
-        // @TODO: Add peer to the retry queue.
-
-        self.active_sync_sessions
-            .get_mut(&topic)
-            .expect("active outbound sync session exists")
-            .remove(&peer);
-    }
-
     /// Remove the given topic from the set of active sync sessions for the given peer and add them
     /// to the set of completed sync sessions.
-    pub fn complete_successful_sync(&mut self, peer: NodeId, topic: TopicId) {
+    fn complete_successful_sync(&mut self, sync_attempt: SyncAttempt) {
         self.active_sync_sessions
-            .get_mut(&topic)
+            .get_mut(&sync_attempt.topic)
             .expect("active outbound sync session exists")
-            .remove(&peer);
+            .remove(&sync_attempt.peer);
 
         self.completed_sync_sessions
-            .entry(topic)
+            .entry(sync_attempt.topic)
             .or_default()
-            .insert(peer);
+            .insert(sync_attempt.peer);
     }
 }

--- a/p2panda-net/src/sync/manager.rs
+++ b/p2panda-net/src/sync/manager.rs
@@ -57,9 +57,12 @@ impl SyncAttempt {
 
 #[derive(Debug, Error)]
 enum SyncAttemptError {
-    #[error("connection error")]
+    /// Error occurred while attempting to connect to a peer or while attempting to open a
+    /// bidirectional stream.
+    #[error("sync attempt failed due to connection or stream error")]
     Connection,
-    #[error("sync error")]
+    /// Error occurred while initiating a sync session.
+    #[error("sync attempt failed due to sync protocol error")]
     Sync,
 }
 

--- a/p2panda-net/src/sync/mod.rs
+++ b/p2panda-net/src/sync/mod.rs
@@ -4,7 +4,7 @@ mod handler;
 mod manager;
 
 pub use handler::{SyncConnection, SYNC_CONNECTION_ALPN};
-pub use manager::SyncManager;
+pub use manager::{SyncManager, ToSyncManager};
 
 use std::sync::Arc;
 

--- a/p2panda-net/src/sync/mod.rs
+++ b/p2panda-net/src/sync/mod.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 mod handler;
-mod manager;
+pub(crate) mod manager;
 
 pub use handler::{SyncConnection, SYNC_CONNECTION_ALPN};
-pub use manager::{SyncManager, ToSyncManager};
 
 use std::sync::Arc;
 


### PR DESCRIPTION
A simple connection / sync scheduler:

- Incorporated into the existing sync manager
- Receives new peer-topic combinations from the engine (gossip announcements)
- Adds attempts to a scheduler queue
  - Connection errors result in a reattempt
  - Sync errors result in the attempt being dropped
- Keeps track of pending, active and successfully completed attempts

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
- [ ] Check if descriptions and terminology match `handbook` content (and visa-versa) 
