### PR TITLE
Improve `Sync` error types for implementers and API users

### DIFF
--- a/p2panda-engine/src/stream/decode.rs
+++ b/p2panda-engine/src/stream/decode.rs
@@ -64,7 +64,7 @@ where
         let mut this = self.project();
         let res = ready!(this.stream.as_mut().poll_next(cx));
         Poll::Ready(res.map(|(header_bytes, body_bytes)| {
-            match decode_cbor::<Header<E>>(&header_bytes) {
+            match decode_cbor::<Header<E>, _>(&header_bytes[..]) {
                 Ok(header) => Ok((header, body_bytes.map(Body::from), header_bytes)),
                 Err(err) => Err(err),
             }

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -748,7 +748,7 @@ mod sync_protocols {
                 match message {
                     Message::Topic(_) => panic!(),
                     Message::Ping => {
-                        return Err(SyncError::RemoteUnexpectedBehaviour(
+                        return Err(SyncError::UnexpectedBehaviour(
                             "unexpected Ping message received".to_string(),
                         ));
                     }
@@ -788,7 +788,7 @@ mod sync_protocols {
                         break;
                     }
                     Message::Pong => {
-                        return Err(SyncError::RemoteUnexpectedBehaviour(
+                        return Err(SyncError::UnexpectedBehaviour(
                             "unexpected Pong message received".to_string(),
                         ));
                     }

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -748,7 +748,7 @@ mod sync_protocols {
                 match message {
                     Message::Topic(_) => panic!(),
                     Message::Ping => {
-                        return Err(SyncError::Protocol(
+                        return Err(SyncError::RemoteUnexpectedBehaviour(
                             "unexpected Ping message received".to_string(),
                         ));
                     }
@@ -788,7 +788,7 @@ mod sync_protocols {
                         break;
                     }
                     Message::Pong => {
-                        return Err(SyncError::Protocol(
+                        return Err(SyncError::RemoteUnexpectedBehaviour(
                             "unexpected Pong message received".to_string(),
                         ));
                     }

--- a/p2panda-net/src/sync/handler.rs
+++ b/p2panda-net/src/sync/handler.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use futures_lite::future::Boxed as BoxedFuture;
 use iroh_net::endpoint::{self, Connecting, Connection};
-use p2panda_sync::{SyncError, SyncProtocol};
+use p2panda_sync::SyncProtocol;
 use tokio::sync::mpsc;
 use tracing::{debug, debug_span};
 
@@ -42,10 +42,7 @@ impl SyncConnection {
         let _span = debug_span!("connection", connection_id, %remote_addr);
 
         // Create a bidirectional stream on the connection.
-        let (mut send, mut recv) = connection
-            .accept_bi()
-            .await
-            .map_err(|e| SyncError::Protocol(e.to_string()))?;
+        let (mut send, mut recv) = connection.accept_bi().await?;
 
         let sync_protocol = self.sync_protocol.clone();
         let engine_actor_tx = self.engine_actor_tx.clone();

--- a/p2panda-net/src/sync/mod.rs
+++ b/p2panda-net/src/sync/mod.rs
@@ -35,7 +35,7 @@ pub async fn initiate_sync<S: AsyncWrite + Send + Unpin, R: AsyncRead + Send + U
 
     // Set up a channel for receiving new application messages.
     let (tx, mut rx) = mpsc::channel(128);
-    let mut sink = PollSender::new(tx).sink_map_err(|e| SyncError::Protocol(e.to_string()));
+    let mut sink = PollSender::new(tx).sink_map_err(|e| SyncError::Critical(e.to_string()));
 
     // Spawn a task which picks up any new application messages and sends them on to the engine
     // for handling.
@@ -115,7 +115,7 @@ pub async fn accept_sync<S: AsyncWrite + Send + Unpin, R: AsyncRead + Send + Unp
 
     // Set up a channel for receiving new application messages.
     let (tx, mut rx) = mpsc::channel(128);
-    let mut sink = PollSender::new(tx).sink_map_err(|e| SyncError::Protocol(e.to_string()));
+    let mut sink = PollSender::new(tx).sink_map_err(|e| SyncError::Critical(e.to_string()));
 
     // Spawn a task which picks up any new application messages and sends them on to the engine
     // for handling.

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [features]
 cbor = [
-    "dep:ciborium",
     "dep:serde",
     "dep:tokio",
     "dep:tokio-stream",
@@ -15,7 +14,6 @@ log-sync = ["dep:p2panda-core", "dep:p2panda-store", "cbor"]
 
 [dependencies]
 async-trait = "0.1.82"
-ciborium = { version = "0.2.2", optional = true }
 futures = "0.3.30"
 p2panda-core = { path = "../p2panda-core", optional = true }
 p2panda-store = { path = "../p2panda-store", optional = true }

--- a/p2panda-sync/src/cbor.rs
+++ b/p2panda-sync/src/cbor.rs
@@ -66,9 +66,7 @@ where
                         // @TODO
                         panic!("{}", err);
                     }
-                    err => Err(SyncError::RemoteUnexpectedBehaviour(format!(
-                        "CBOR codec failed decoding message from remote peer, {err}"
-                    ))),
+                    err => Err(SyncError::InvalidEncoding(err.to_string())),
                 }
             }
         }

--- a/p2panda-sync/src/cbor.rs
+++ b/p2panda-sync/src/cbor.rs
@@ -58,17 +58,13 @@ where
         let reader = src.reader();
         let result: Result<Self::Item, _> = decode_cbor(reader);
         match result {
-            // If we read the item, we also need to advance the underlying buffer.
             Ok(item) => Ok(Some(item)),
-            Err(ref error) => {
-                match error {
-                    DecodeError::Io(err) => {
-                        // @TODO
-                        panic!("{}", err);
-                    }
-                    err => Err(SyncError::InvalidEncoding(err.to_string())),
-                }
-            }
+            Err(ref error) => match error {
+                DecodeError::Io(err) => Err(SyncError::Critical(format!(
+                    "CBOR codec failed decoding message due to i/o error, {err}"
+                ))),
+                err => Err(SyncError::InvalidEncoding(err.to_string())),
+            },
         }
     }
 }

--- a/p2panda-sync/src/cbor.rs
+++ b/p2panda-sync/src/cbor.rs
@@ -3,9 +3,10 @@
 use std::marker::PhantomData;
 
 use futures::{AsyncRead, AsyncWrite, Sink, Stream};
+use p2panda_core::cbor::{decode_cbor, encode_cbor, DecodeError};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use tokio_util::bytes::Buf;
+use tokio_util::bytes::{Buf, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
@@ -37,13 +38,10 @@ where
 {
     type Error = SyncError;
 
-    fn encode(
-        &mut self,
-        item: T,
-        dst: &mut tokio_util::bytes::BytesMut,
-    ) -> Result<(), Self::Error> {
-        let mut bytes = Vec::new();
-        ciborium::into_writer(&item, &mut bytes).map_err(|e| SyncError::Codec(e.to_string()))?;
+    fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let bytes = encode_cbor(&item).map_err(|err| {
+            SyncError::Critical(format!("CBOR codec failed encoding message, {err}"))
+        })?;
         dst.extend_from_slice(&bytes);
         Ok(())
     }
@@ -56,20 +54,23 @@ where
     type Item = T;
     type Error = SyncError;
 
-    fn decode(
-        &mut self,
-        src: &mut tokio_util::bytes::BytesMut,
-    ) -> Result<Option<Self::Item>, Self::Error> {
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         let reader = src.reader();
-        let result: Result<Self::Item, _> = ciborium::from_reader(reader);
+        let result: Result<Self::Item, _> = decode_cbor(reader);
         match result {
             // If we read the item, we also need to advance the underlying buffer.
             Ok(item) => Ok(Some(item)),
-            Err(ref error) => match error {
-                // Sometimes the EOF is signalled as IO error
-                ciborium::de::Error::Io(_) => Ok(None),
-                e => Err(SyncError::Codec(e.to_string())),
-            },
+            Err(ref error) => {
+                match error {
+                    DecodeError::Io(err) => {
+                        // @TODO
+                        panic!("{}", err);
+                    }
+                    err => Err(SyncError::RemoteUnexpectedBehaviour(format!(
+                        "CBOR codec failed decoding message from remote peer, {err}"
+                    ))),
+                }
+            }
         }
     }
 }

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -67,7 +67,7 @@ pub enum SyncError {
     Critical(String),
 }
 
-/// Concerts critical I/O error which occurs during stream handling into [`SyncError`].
+/// Converts critical I/O error which occurs during stream handling into [`SyncError`].
 ///
 /// This is usually a critical system failure indicating an implementation bug or lacking resources
 /// on the user's machine.

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -45,19 +45,20 @@ pub enum SyncError {
     /// Error due to unexpected (buggy or malicious) behaviour of the remote peer.
     ///
     /// Indicates that the sync protocol was not correctly followed, for example due to unexpected
-    /// or missing messages, invalid encoding, etc.
+    /// or missing messages, etc.
     ///
     /// Can be used to re-attempt syncing with this peer or down-grading it in priority,
     /// potentially deny-listing if communication failed too often.
     #[error("sync session failed due to unexpected protocol behaviour of remote peer: {0}")]
-    RemoteUnexpectedBehaviour(String),
+    UnexpectedBehaviour(String),
 
-    /// Remote peer didn't show any activity for some time.
+    /// Error due to invalid encoding of a message sent by remote peer.
     ///
-    /// Can be used to re-attempt syncing with this peer or down-grading it in priority,
-    /// potentially deny-listing if communication failed too often.
-    #[error("sync session failed due to remote peer timeout")]
-    RemoteTimeout,
+    /// Note that this error is intended for receiving messages from _remote_ peers which we can't
+    /// decode properly. If we fail with encoding our _own_ messages we should rather consider this
+    /// an `Critical` error type, as it likely means that there's a buggy implementation.
+    #[error("sync session failed due to invalid encoding of message sent by remote peer: {0}")]
+    InvalidEncoding(String),
 
     /// Critical error due to system failure on our end.
     ///

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -26,7 +26,7 @@ pub trait SyncProtocol<'a>: Send + Sync + Debug {
 
     async fn initiate(
         self: Arc<Self>,
-        topic_id: &TopicId,
+        topic: &TopicId,
         tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
         rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
         app_tx: Box<&'a mut (dyn Sink<FromSync, Error = SyncError> + Send + Unpin)>,

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -109,7 +109,7 @@ where
 
             match message {
                 Message::Have(_, _) => {
-                    return Err(SyncError::RemoteUnexpectedBehaviour(
+                    return Err(SyncError::UnexpectedBehaviour(
                         "unexpected \"have\" message received".to_string(),
                     ))
                 }
@@ -159,7 +159,7 @@ where
 
                     // Get the log ids which are associated with this topic.
                     let Some(log_ids) = self.topic_map.get(topic).await else {
-                        return Err(SyncError::RemoteUnexpectedBehaviour(format!(
+                        return Err(SyncError::UnexpectedBehaviour(format!(
                             "unknown topic {topic:?} requested from remote peer"
                         )));
                     };
@@ -223,7 +223,7 @@ where
                     sync_done_sent = true;
                 }
                 Message::Operation(_, _) => {
-                    return Err(SyncError::RemoteUnexpectedBehaviour(
+                    return Err(SyncError::UnexpectedBehaviour(
                         "unexpected \"operation\" message received".to_string(),
                     ));
                 }

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -32,9 +32,7 @@ where
     T: Serialize,
 {
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        ciborium::into_writer(&self, &mut bytes).expect("type can be serialized");
-        bytes
+        p2panda_core::cbor::encode_cbor(&self).expect("type can be serialized")
     }
 }
 
@@ -78,44 +76,41 @@ where
         let mut sink = into_cbor_sink(tx);
         let mut stream = into_cbor_stream(rx);
 
-        // Get the log ids which are associated with this topic.
+        // Get the log ids which are associated with this topic
         let Some(log_ids) = self.topic_map.get(topic).await else {
-            return Err(SyncError::Protocol("Unknown topic id".to_string()));
+            return Err(SyncError::Critical(format!("unknown {topic:?} topic")));
         };
 
-        // Get local log heights for all authors who have published under the requested log ids.
+        // Get local log heights for all authors who have published under the requested log ids
         // @TODO: this will require changes soon when `get_log_heights` method includes the public
         // key as an argument.
         let mut local_log_heights = Vec::new();
         for log_id in log_ids {
-            let log_heights = self
-                .store
-                .get_log_heights(&log_id)
-                .await
-                .expect("memory store error");
-
+            let log_heights = self.store.get_log_heights(&log_id).await.map_err(|err| {
+                SyncError::Critical(format!("can't retreive log heights from store, {err}"))
+            })?;
             local_log_heights.push((log_id, log_heights));
         }
 
-        // Send our `Have` message to the remote peer.
+        // Send our `Have` message to the remote peer
         sink.send(Message::<T>::Have(*topic, local_log_heights.clone()))
             .await?;
 
-        // As we initiated this sync session we are done after sending the `Have` message.
+        // As we initiated this sync session we are done after sending the `Have` message
         sink.send(Message::SyncDone).await?;
 
-        // Announce the topic of the sync session to the app layer.
+        // Announce the topic of the sync session to the app layer
         app_tx.send(FromSync::Topic(*topic)).await?;
 
-        // Consume messages arriving on the receive stream.
+        // Consume messages arriving on the receive stream
         while let Some(result) = stream.next().await {
             let message: Message<T> = result?;
             debug!("message received: {:?}", message);
 
             match message {
                 Message::Have(_, _) => {
-                    return Err(SyncError::Protocol(
-                        "unexpected Have message received".to_string(),
+                    return Err(SyncError::RemoteUnexpectedBehaviour(
+                        "unexpected \"have\" message received".to_string(),
                     ))
                 }
                 Message::Operation(header, payload) => {
@@ -164,34 +159,37 @@ where
 
                     // Get the log ids which are associated with this topic.
                     let Some(log_ids) = self.topic_map.get(topic).await else {
-                        return Err(SyncError::Protocol("Unknown topic id".to_string()));
+                        return Err(SyncError::RemoteUnexpectedBehaviour(format!(
+                            "unknown topic {topic:?} requested from remote peer"
+                        )));
                     };
 
                     let remote_log_heights_map: HashMap<T, Vec<(PublicKey, u64)>> =
                         remote_log_heights.clone().into_iter().collect();
 
                     // For every log id we need to:
-                    // - retrieve the local log heights for all contributing authors
-                    // - compare our local log heights with those sent from the remote peer
-                    // - send any operations the remote peer is missing
+                    // * Retrieve the local log heights for all contributing authors
+                    // * Compare our local log heights with those sent from the remote peer
+                    // * Send any operations the remote peer is missing
                     for log_id in log_ids {
-                        let local_log_heights = self
-                            .store
-                            .get_log_heights(&log_id)
-                            .await
-                            .expect("memory store error");
+                        let local_log_heights =
+                            self.store.get_log_heights(&log_id).await.map_err(|err| {
+                                SyncError::Critical(format!(
+                                    "can't retreive log heights from store, {err}"
+                                ))
+                            })?;
 
                         for (public_key, seq_num) in local_log_heights {
                             let Some(remote_log_heights) = remote_log_heights_map.get(&log_id)
                             else {
-                                // The remote peer didn't request logs with this id.
+                                // The remote peer didn't request logs with this id
                                 continue;
                             };
 
                             for (remote_pub_key, remote_seq_num) in remote_log_heights.iter() {
                                 // Compare log heights sent by the remote with our local logs, if
                                 // our logs are more advanced calculate and send operations the
-                                // remote is missing.
+                                // remote is missing
                                 if *remote_pub_key == public_key && *remote_seq_num < seq_num {
                                     let messages = remote_needs(
                                         &self.store,
@@ -206,7 +204,7 @@ where
                             }
 
                             // If we know of an author the remote does not yet know about send all
-                            // their operations.
+                            // their operations
                             if !remote_log_heights
                                 .iter()
                                 .any(|(remote_public_key, _)| public_key == *remote_public_key)
@@ -220,13 +218,13 @@ where
                     }
 
                     // As we have processed the remotes `Have` message then we are "done" from
-                    // this end.
+                    // this end
                     sink.send(Message::SyncDone).await?;
                     sync_done_sent = true;
                 }
                 Message::Operation(_, _) => {
-                    return Err(SyncError::Protocol(
-                        "unexpected operation received".to_string(),
+                    return Err(SyncError::RemoteUnexpectedBehaviour(
+                        "unexpected \"operation\" message received".to_string(),
                     ));
                 }
                 Message::SyncDone => {
@@ -263,7 +261,7 @@ where
     let log = store
         .get_raw_log(public_key, log_id)
         .await
-        .map_err(|err| SyncError::Custom(format!("could not retrieve log from store: {err}")))?;
+        .map_err(|err| SyncError::Critical(format!("could not retrieve log from store, {err}")))?;
 
     let messages: Vec<Message<T>> = log
         .unwrap_or_default()
@@ -291,7 +289,7 @@ mod tests {
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
     use tokio_util::sync::PollSender;
 
-    use crate::{FromSync, SyncProtocol, TopicId};
+    use crate::{FromSync, SyncError, SyncProtocol, TopicId};
 
     use super::{LogSyncProtocol, Message, TopicMap};
 
@@ -386,7 +384,7 @@ mod tests {
         topic_map.insert(TOPIC_ID, vec![log_id.clone()]);
         let protocol = Arc::new(LogSyncProtocol { topic_map, store });
         let mut sink =
-            PollSender::new(app_tx).sink_map_err(|e| crate::SyncError::Protocol(e.to_string()));
+            PollSender::new(app_tx).sink_map_err(|err| SyncError::Critical(err.to_string()));
         let _ = protocol
             .accept(
                 Box::new(&mut peer_a_write.compat_write()),
@@ -429,7 +427,7 @@ mod tests {
         topic_map.insert(TOPIC_ID, vec![log_id.clone()]);
         let protocol = Arc::new(LogSyncProtocol { topic_map, store });
         let mut sink =
-            PollSender::new(app_tx).sink_map_err(|e| crate::SyncError::Protocol(e.to_string()));
+            PollSender::new(app_tx).sink_map_err(|err| crate::SyncError::Critical(err.to_string()));
         let _ = protocol
             .initiate(
                 &TOPIC_ID,
@@ -510,7 +508,7 @@ mod tests {
         topic_map.insert(TOPIC_ID, vec![log_id.clone()]);
         let protocol = Arc::new(LogSyncProtocol { topic_map, store });
         let mut sink =
-            PollSender::new(app_tx).sink_map_err(|e| crate::SyncError::Protocol(e.to_string()));
+            PollSender::new(app_tx).sink_map_err(|err| SyncError::Critical(err.to_string()));
         let _ = protocol
             .accept(
                 Box::new(&mut peer_a_write.compat_write()),
@@ -579,7 +577,7 @@ mod tests {
         topic_map.insert(TOPIC_ID, vec![log_id.clone()]);
         let protocol = Arc::new(LogSyncProtocol { topic_map, store });
         let mut sink =
-            PollSender::new(app_tx).sink_map_err(|e| crate::SyncError::Protocol(e.to_string()));
+            PollSender::new(app_tx).sink_map_err(|err| SyncError::Critical(err.to_string()));
         let _ = protocol
             .initiate(
                 &TOPIC_ID,
@@ -669,8 +667,8 @@ mod tests {
         // Spawn a task which opens a sync session from peer a runs it to completion
         let peer_a_protocol_clone = peer_a_protocol.clone();
         let (peer_a_app_tx, mut peer_a_app_rx) = mpsc::channel(128);
-        let mut sink = PollSender::new(peer_a_app_tx)
-            .sink_map_err(|e| crate::SyncError::Protocol(e.to_string()));
+        let mut sink =
+            PollSender::new(peer_a_app_tx).sink_map_err(|err| SyncError::Critical(err.to_string()));
         let handle_1 = tokio::spawn(async move {
             peer_a_protocol_clone
                 .initiate(
@@ -686,8 +684,8 @@ mod tests {
         // Spawn a task which accepts a sync session on peer b runs it to completion
         let peer_b_protocol_clone = peer_b_protocol.clone();
         let (peer_b_app_tx, mut peer_b_app_rx) = mpsc::channel(128);
-        let mut sink = PollSender::new(peer_b_app_tx)
-            .sink_map_err(|e| crate::SyncError::Protocol(e.to_string()));
+        let mut sink =
+            PollSender::new(peer_b_app_tx).sink_map_err(|err| SyncError::Critical(err.to_string()));
         let handle_2 = tokio::spawn(async move {
             peer_b_protocol_clone
                 .accept(
@@ -780,8 +778,8 @@ mod tests {
         // Spawn a task which opens a sync session from peer a runs it to completion
         let peer_a_protocol_clone = peer_a_protocol.clone();
         let (peer_a_app_tx, mut peer_a_app_rx) = mpsc::channel(128);
-        let mut sink = PollSender::new(peer_a_app_tx)
-            .sink_map_err(|e| crate::SyncError::Protocol(e.to_string()));
+        let mut sink =
+            PollSender::new(peer_a_app_tx).sink_map_err(|err| SyncError::Critical(err.to_string()));
         let handle_1 = tokio::spawn(async move {
             peer_a_protocol_clone
                 .initiate(
@@ -797,8 +795,8 @@ mod tests {
         // Spawn a task which accepts a sync session on peer b runs it to completion
         let peer_b_protocol_clone = peer_b_protocol.clone();
         let (peer_b_app_tx, mut peer_b_app_rx) = mpsc::channel(128);
-        let mut sink = PollSender::new(peer_b_app_tx)
-            .sink_map_err(|e| crate::SyncError::Protocol(e.to_string()));
+        let mut sink =
+            PollSender::new(peer_b_app_tx).sink_map_err(|err| SyncError::Critical(err.to_string()));
         let handle_2 = tokio::spawn(async move {
             peer_b_protocol_clone
                 .accept(


### PR DESCRIPTION
This PR is a draft for a different take on `p2panda-sync` error types. This hopefully gives them more semantic meaning and clearer guidance on how they can be understood when writing and using a `Sync` implementation.

See comments below for details and some open questions!