### PR TITLE
Introduce optional `from` parameter when retrieving log

### DIFF
--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -56,22 +56,30 @@ pub trait LocalOperationStore<LogId, Extensions> {
 pub trait LocalLogStore<LogId, Extensions> {
     type Error: Display + Debug;
 
-    /// Get all operations from an authors' log ordered by sequence number.
+    /// Get operations from an authors' log ordered by sequence number.
+    ///
+    /// The `from` value will be used as the starting index for log retrieval, if supplied,
+    /// otherwise all operations will be returned.
     ///
     /// Returns an empty Vec when the author or a log with the requested id was not found.
     async fn get_log(
         &self,
         public_key: &PublicKey,
         log_id: &LogId,
+        from: Option<u64>,
     ) -> Result<Option<Vec<(Header<Extensions>, Option<Body>)>>, Self::Error>;
 
-    /// Get all "raw" header and body bytes from an authors' log ordered by sequence number.
+    /// Get "raw" header and body bytes from an authors' log ordered by sequence number.
+    ///
+    /// The `from` value will be used as the starting index for log retrieval, if supplied,
+    /// otherwise all operations will be returned.
     ///
     /// Returns `None` when the author or a log with the requested id was not found.
     async fn get_raw_log(
         &self,
         public_key: &PublicKey,
         log_id: &LogId,
+        from: Option<u64>,
     ) -> Result<Option<Vec<RawOperation>>, Self::Error>;
 
     /// Get the log heights of all logs, by any author, which are stored under the passed log id.

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -280,13 +280,12 @@ where
     E: Clone + Serialize,
 {
     let log = store
-        .get_raw_log(public_key, log_id)
+        .get_raw_log(public_key, log_id, Some(from))
         .await
         .map_err(|err| SyncError::Critical(format!("could not retrieve log from store, {err}")))?;
 
     let messages = log
         .unwrap_or_default()
-        .split_off(from as usize)
         .into_iter()
         .map(|(header, payload)| Message::Operation(header, payload))
         .collect();


### PR DESCRIPTION
Previously we were only able to retrieve _all_ operations from the store when calling `get_log()` or `get_raw_log()`. This PR introduces an optional `from` parameter (`Option<u64>`) to specify the start of the range. Specifying the range is useful when retrieving operations during log sync.