### PR TITLE
Introduce supertraits for `LogId` and `Extensions`

### DIFF
--- a/p2panda-core/src/extensions.rs
+++ b/p2panda-core/src/extensions.rs
@@ -6,9 +6,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::Header;
 
-pub trait Extensions: Clone + Debug + Default + Send + Sync {}
+pub trait Extensions:
+    Clone + Debug + Default + for<'de> Deserialize<'de> + Serialize + Send + Sync
+{
+}
 
-impl<T> Extensions for T where T: Clone + Debug + Default + Send + Sync {}
+impl<T> Extensions for T where
+    T: Clone + Debug + Default + for<'de> Deserialize<'de> + Serialize + Send + Sync
+{
+}
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct DefaultExtensions {}

--- a/p2panda-core/src/extensions.rs
+++ b/p2panda-core/src/extensions.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Header;
 
+/// Extensions can be used to define custom fields in the operation header.
 pub trait Extensions:
     Clone + Debug + Default + for<'de> Deserialize<'de> + Serialize + Send + Sync
 {

--- a/p2panda-core/src/extensions.rs
+++ b/p2panda-core/src/extensions.rs
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::fmt::Debug;
+
 use serde::{Deserialize, Serialize};
 
 use crate::Header;
+
+pub trait Extensions: Clone + Debug + Default + Send + Sync {}
+
+impl<T> Extensions for T where T: Clone + Debug + Default + Send + Sync {}
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct DefaultExtensions {}
@@ -13,7 +19,7 @@ impl<T> Extension<T> for DefaultExtensions {
     }
 }
 
-pub trait Extension<T> {
+pub trait Extension<T>: Extensions {
     fn extract(&self) -> Option<T> {
         None
     }

--- a/p2panda-core/src/lib.rs
+++ b/p2panda-core/src/lib.rs
@@ -9,7 +9,7 @@ pub mod operation;
 pub mod prune;
 mod serde;
 
-pub use extensions::Extension;
+pub use extensions::{Extension, Extensions};
 pub use hash::{Hash, HashError};
 pub use identity::{IdentityError, PrivateKey, PublicKey, Signature};
 pub use operation::{

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -506,13 +506,13 @@ mod tests {
 
     #[test]
     fn extensions() {
-        #[derive(Clone, Serialize, Deserialize)]
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
         struct LogId(u64);
 
-        #[derive(Clone, Serialize, Deserialize)]
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
         struct Expiry(u64);
 
-        #[derive(Clone, Serialize, Deserialize)]
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
         struct CustomExtensions {
             log_id: LogId,
             expires: Expiry,

--- a/p2panda-engine/Cargo.toml
+++ b/p2panda-engine/Cargo.toml
@@ -11,11 +11,11 @@ p2panda-core = { path = "../p2panda-core", features = ["prune"] }
 p2panda-store = { path = "../p2panda-store" }
 pin-project = "1.1.5"
 pin-utils = "0.1.0"
-serde = { version = "1.0.210", features = ["derive"] }
 thiserror = "1.0.63"
 
 [dev-dependencies]
 async-stream = "0.3.5"
+serde = { version = "1.0.210", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["rt", "macros"] }
 
 [lints]

--- a/p2panda-engine/src/operation.rs
+++ b/p2panda-engine/src/operation.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use p2panda_core::{
-    validate_backlink, validate_operation, Body, Header, Operation, OperationError,
+    validate_backlink, validate_operation, Body, Extensions, Header, Operation, OperationError,
 };
 use p2panda_store::{LogStore, OperationStore};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use thiserror::Error;
 
 /// Checks an incoming operation for log integrity and persists it into the store when valid.
@@ -24,7 +22,7 @@ pub async fn ingest_operation<S, L, E>(
 ) -> Result<IngestResult<E>, IngestError>
 where
     S: OperationStore<L, E> + LogStore<L, E>,
-    E: Clone + Serialize + DeserializeOwned,
+    E: Extensions,
 {
     let operation = Operation {
         hash: header.hash(),

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -12,8 +12,8 @@ memory = []
 
 [dependencies]
 p2panda-core = { path = "../p2panda-core" }
-serde = "1.0.203"
 trait-variant = "0.1.2"
 
 [dev-dependencies]
+serde = "1.0.203"
 tokio = { version = "1.38.0", features = ["rt", "macros"] }

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -12,8 +12,8 @@ memory = []
 
 [dependencies]
 p2panda-core = { path = "../p2panda-core" }
+serde = "1.0.203"
 trait-variant = "0.1.2"
 
 [dev-dependencies]
-serde = "1.0.203"
 tokio = { version = "1.38.0", features = ["rt", "macros"] }

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -8,28 +8,12 @@ use std::fmt::{Debug, Display};
 #[cfg(feature = "memory")]
 pub use memory_store::MemoryStore;
 
-use serde::{Deserialize, Serialize};
-
 use p2panda_core::{Body, Hash, Header, PublicKey, RawOperation};
 
 /// The unique identifier of a single-author log.
-pub trait LogId:
-    Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash + for<'de> Deserialize<'de> + Serialize
-{
-}
+pub trait LogId: Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash {}
 
-impl<T> LogId for T where
-    T: Clone
-        + Default
-        + Debug
-        + Eq
-        + Send
-        + Sync
-        + std::hash::Hash
-        + for<'de> Deserialize<'de>
-        + Serialize
-{
-}
+impl<T> LogId for T where T: Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash {}
 
 #[trait_variant::make(OperationStore: Send)]
 pub trait LocalOperationStore<LogId, Extensions> {

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -8,12 +8,28 @@ use std::fmt::{Debug, Display};
 #[cfg(feature = "memory")]
 pub use memory_store::MemoryStore;
 
+use serde::{Deserialize, Serialize};
+
 use p2panda_core::{Body, Hash, Header, PublicKey, RawOperation};
 
 /// The unique identifier of a single-author log.
-pub trait LogId: Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash {}
+pub trait LogId:
+    Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash + for<'de> Deserialize<'de> + Serialize
+{
+}
 
-impl<T> LogId for T where T: Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash {}
+impl<T> LogId for T where
+    T: Clone
+        + Default
+        + Debug
+        + Eq
+        + Send
+        + Sync
+        + std::hash::Hash
+        + for<'de> Deserialize<'de>
+        + Serialize
+{
+}
 
 #[trait_variant::make(OperationStore: Send)]
 pub trait LocalOperationStore<LogId, Extensions> {

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -10,6 +10,11 @@ pub use memory_store::MemoryStore;
 
 use p2panda_core::{Body, Hash, Header, PublicKey, RawOperation};
 
+/// The unique identifier of a single-author log.
+pub trait LogId: Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash {}
+
+impl<T> LogId for T where T: Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash {}
+
 #[trait_variant::make(OperationStore: Send)]
 pub trait LocalOperationStore<LogId, Extensions> {
     type Error: Display + Debug;

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -16,7 +16,7 @@ pub trait LogId: Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash {}
 impl<T> LogId for T where T: Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash {}
 
 #[trait_variant::make(OperationStore: Send)]
-pub trait LocalOperationStore<LogId, Extensions> {
+pub trait LocalOperationStore<LogId, Extensions>: Clone {
     type Error: Display + Debug;
 
     /// Insert an operation.

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use p2panda_core::extensions::DefaultExtensions;
-use p2panda_core::{Body, Hash, Header, PublicKey, RawOperation};
+use p2panda_core::{Body, Extensions, Hash, Header, PublicKey, RawOperation};
 
 use crate::{LogId, LogStore, OperationStore};
 
@@ -64,8 +64,7 @@ impl<T, E> MemoryStore<T, E> {
 impl<L, E> OperationStore<L, E> for MemoryStore<L, E>
 where
     L: LogId,
-    // @TODO(glyph): Introduce `Extensions` supertrait.
-    E: Clone + Send + Sync,
+    E: Extensions,
 {
     type Error = Infallible;
 
@@ -158,8 +157,7 @@ where
 impl<L, E> LogStore<L, E> for MemoryStore<L, E>
 where
     L: LogId,
-    // @TODO(glyph): Introduce `Extensions` supertrait.
-    E: Clone + Send + Sync,
+    E: Extensions,
 {
     type Error = Infallible;
 
@@ -375,7 +373,7 @@ mod tests {
     #[tokio::test]
     async fn generic_extensions_mem_store() {
         // Define our own custom extension type
-        #[derive(Clone, Serialize, Deserialize)]
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
         struct MyExtension {}
 
         // Construct a new store

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -32,7 +32,7 @@ pub trait Topic:
 /// implementation of `TopicMap` so that a scope `S` can be retrieved for a specific topic `T` when
 /// a peer initiates or accepts a sync session.
 #[async_trait]
-pub trait TopicMap<T, S>
+pub trait TopicMap<T, S>: Debug + Send + Sync
 where
     T: Topic,
 {

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -267,7 +267,7 @@ async fn remote_needs<T, L, E>(
     from: SeqNum,
 ) -> Result<Vec<Message<T, L>>, SyncError>
 where
-    E: Extensions + Serialize,
+    E: Extensions,
 {
     let log = store
         .get_raw_log(public_key, log_id, Some(from))

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -2,13 +2,12 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::hash::Hash as StdHash;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{stream, AsyncRead, AsyncWrite, Sink, SinkExt, StreamExt};
 use p2panda_core::PublicKey;
-use p2panda_store::{LogStore, MemoryStore};
+use p2panda_store::{LogId, LogStore, MemoryStore};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -50,17 +49,9 @@ pub struct LogSyncProtocol<TM, L, E> {
 impl<'a, T, TM, L, E> SyncProtocol<T, 'a> for LogSyncProtocol<TM, L, E>
 where
     T: Topic,
+    // @TODO(glyph): Can we add the Debug, Send and Sync bounds to the TopicMap trait?
     TM: Debug + TopicMap<T, Logs<L>> + Send + Sync,
-    L: Clone
-        + Debug
-        + Default
-        + Eq
-        + StdHash
-        + Send
-        + Sync
-        + for<'de> Deserialize<'de>
-        + Serialize
-        + 'a,
+    L: LogId + 'a,
     E: Clone + Debug + Default + Send + Sync + for<'de> Deserialize<'de> + Serialize + 'a,
 {
     fn name(&self) -> &'static str {

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -49,8 +49,7 @@ pub struct LogSyncProtocol<TM, L, E> {
 impl<'a, T, TM, L, E> SyncProtocol<T, 'a> for LogSyncProtocol<TM, L, E>
 where
     T: Topic,
-    // @TODO(glyph): Can we add the Debug, Send and Sync bounds to the TopicMap trait?
-    TM: Debug + TopicMap<T, Logs<L>> + Send + Sync,
+    TM: TopicMap<T, Logs<L>>,
     L: LogId + for<'de> Deserialize<'de> + Serialize + 'a,
     E: Extensions + for<'de> Deserialize<'de> + Serialize + 'a,
 {

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{stream, AsyncRead, AsyncWrite, Sink, SinkExt, StreamExt};
-use p2panda_core::PublicKey;
+use p2panda_core::{Extensions, PublicKey};
 use p2panda_store::{LogId, LogStore, MemoryStore};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
@@ -52,7 +52,7 @@ where
     // @TODO(glyph): Can we add the Debug, Send and Sync bounds to the TopicMap trait?
     TM: Debug + TopicMap<T, Logs<L>> + Send + Sync,
     L: LogId + for<'de> Deserialize<'de> + Serialize + 'a,
-    E: Clone + Debug + Default + Send + Sync + for<'de> Deserialize<'de> + Serialize + 'a,
+    E: Extensions + for<'de> Deserialize<'de> + Serialize + 'a,
 {
     fn name(&self) -> &'static str {
         LOG_SYNC_PROTOCOL_NAME
@@ -268,7 +268,7 @@ async fn remote_needs<T, L, E>(
     from: SeqNum,
 ) -> Result<Vec<Message<T, L>>, SyncError>
 where
-    E: Clone + Serialize,
+    E: Extensions + Serialize,
 {
     let log = store
         .get_raw_log(public_key, log_id, Some(from))

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -51,7 +51,7 @@ where
     T: Topic,
     // @TODO(glyph): Can we add the Debug, Send and Sync bounds to the TopicMap trait?
     TM: Debug + TopicMap<T, Logs<L>> + Send + Sync,
-    L: LogId + 'a,
+    L: LogId + for<'de> Deserialize<'de> + Serialize + 'a,
     E: Clone + Debug + Default + Send + Sync + for<'de> Deserialize<'de> + Serialize + 'a,
 {
     fn name(&self) -> &'static str {

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -51,7 +51,7 @@ where
     T: Topic,
     TM: TopicMap<T, Logs<L>>,
     L: LogId + for<'de> Deserialize<'de> + Serialize + 'a,
-    E: Extensions + for<'de> Deserialize<'de> + Serialize + 'a,
+    E: Extensions + 'a,
 {
     fn name(&self) -> &'static str {
         LOG_SYNC_PROTOCOL_NAME


### PR DESCRIPTION
Aims to improve API readability and ergonomics by grouping trait bounds into supertraits for `LogId` and `Extensions`. 

The new supertraits are used in `p2panda-store`, `p2panda-sync` and `p2panda-engine`.