### PR TITLE
Improve error handling in `sync` and introduce tests

### DIFF
--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 thiserror = "1.0.63"
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
-tokio-util = { version = "0.7", features = ["codec", "io-util", "io"] }
+tokio-util = { version = "0.7", features = ["compat", "codec", "io-util", "io"] }
 tracing = "0.1.40"
 
 [dev-dependencies]

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -20,6 +20,7 @@ use crate::network::{FromNetwork, ToNetwork};
 use crate::sync::manager::{SyncActor, ToSyncActor};
 use crate::{NetworkId, TopicId};
 
+#[derive(Debug)]
 pub enum ToEngineActor<T> {
     AddPeer {
         node_addr: NodeAddr,

--- a/p2panda-net/src/sync/mod.rs
+++ b/p2panda-net/src/sync/mod.rs
@@ -173,6 +173,7 @@ where
                         })
                         .await
                         .expect("engine channel closed");
+                    return;
                 },
                 Some(message) = rx.recv() => {
                     // 1. Handshake Phase.

--- a/p2panda-net/src/sync/mod.rs
+++ b/p2panda-net/src/sync/mod.rs
@@ -165,16 +165,6 @@ where
         loop {
             tokio::select! {
                 biased;
-                Ok(_) = &mut sync_error_rx => {
-                    engine_actor_tx
-                        .send(ToEngineActor::SyncFailed {
-                            peer,
-                            topic: topic.clone(),
-                        })
-                        .await
-                        .expect("engine channel closed");
-                    return;
-                },
                 Some(message) = rx.recv() => {
                     // 1. Handshake Phase.
                     // ~~~~~~~~~~~~~~~~~~~
@@ -231,6 +221,16 @@ where
                         })
                         .await
                         .expect("engine channel closed");
+                },
+                Ok(_) = &mut sync_error_rx => {
+                    engine_actor_tx
+                        .send(ToEngineActor::SyncFailed {
+                            peer,
+                            topic: topic.clone(),
+                        })
+                        .await
+                        .expect("engine channel closed");
+                    return;
                 },
                 else => {
                     break;

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -63,7 +63,7 @@ where
     ) -> Result<(), SyncError>;
 }
 
-#[derive(Error, Debug)]
+#[derive(Debug, Error, PartialEq)]
 pub enum SyncError {
     /// Error due to unexpected (buggy or malicious) behaviour of the remote peer.
     ///


### PR DESCRIPTION
We need to `return` from the `accept_sync()` loop when an error signal is received via the oneshot channel.

One symptom of this bug was a oneshot panic when a `Critical` error occurred during sync:

```
thread 'tokio-runtime-worker' panicked at /home/adz/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.1/src/sync/oneshot.rs:1116:13:
called after complete
```

Since our code was not returning after the error was sent, the oneshot receiver ended up being polled again (after `Poll::Ready` had already been returned once) and promptly panicked.

-----

 This PR also introduces tests for `accept_sync()` and `initate_sync()`, specifically to ensure correct behaviour when an error is returned by the underlying sync protocol implementation.