### PR TITLE
Sign topic discovery messages

### DIFF
--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -54,17 +54,16 @@ async fn main() -> Result<()> {
     tokio::task::spawn(async move {
         while let Ok(event) = rx.recv().await {
             match event {
-                FromNetwork::GossipMessage {
-                    bytes,
-                    delivered_from,
-                } => match Message::decode_and_verify(&bytes) {
-                    Ok(message) => {
-                        print!("{}: {}", message.public_key, message.text);
+                FromNetwork::GossipMessage { bytes, .. } => {
+                    match Message::decode_and_verify(&bytes) {
+                        Ok(message) => {
+                            print!("{}: {}", message.public_key, message.text);
+                        }
+                        Err(err) => {
+                            eprintln!("invalid gossip message: {err}");
+                        }
                     }
-                    Err(err) => {
-                        eprintln!("invalid message from {delivered_from}: {err}");
-                    }
-                },
+                }
                 _ => panic!("no sync messages expected"),
             }
         }

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -58,7 +58,7 @@ pub enum ToEngineActor<T> {
         topic: T,
         header: Vec<u8>,
         payload: Option<Vec<u8>>,
-        peer: PublicKey,
+        delivered_from: PublicKey,
     },
     SyncDone {
         topic: T,
@@ -245,10 +245,10 @@ where
                 topic,
                 header,
                 payload,
-                peer,
+                delivered_from,
             } => {
                 self.topic_streams
-                    .on_sync_message(topic, header, payload, peer)?;
+                    .on_sync_message(topic, header, payload, delivered_from)?;
             }
             ToEngineActor::SyncDone { topic, peer } => {
                 self.topic_streams.on_sync_done(topic, peer).await?;
@@ -363,11 +363,7 @@ where
         topic_id: [u8; 32],
     ) -> Result<()> {
         if topic_id == self.network_id {
-            match self
-                .topic_discovery
-                .on_gossip_message(&bytes)
-                .await
-            {
+            match self.topic_discovery.on_gossip_message(&bytes).await {
                 Ok((topic_ids, node_id)) => {
                     self.topic_streams
                         .on_discovered_topic_ids(topic_ids, node_id)

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -365,12 +365,12 @@ where
         if topic_id == self.network_id {
             match self
                 .topic_discovery
-                .on_gossip_message(&bytes, delivered_from)
+                .on_gossip_message(&bytes)
                 .await
             {
-                Ok(topic_ids) => {
+                Ok((topic_ids, node_id)) => {
                     self.topic_streams
-                        .on_discovered_topic_ids(topic_ids, delivered_from)
+                        .on_discovered_topic_ids(topic_ids, node_id)
                         .await?;
                 }
                 Err(err) => {

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -58,7 +58,7 @@ pub enum ToEngineActor<T> {
         topic: T,
         header: Vec<u8>,
         payload: Option<Vec<u8>>,
-        delivered_from: PublicKey,
+        peer: PublicKey,
     },
     SyncDone {
         topic: T,
@@ -245,10 +245,10 @@ where
                 topic,
                 header,
                 payload,
-                delivered_from,
+                peer,
             } => {
                 self.topic_streams
-                    .on_sync_message(topic, header, payload, delivered_from)?;
+                    .on_sync_message(topic, header, payload, peer)?;
             }
             ToEngineActor::SyncDone { topic, peer } => {
                 self.topic_streams.on_sync_done(topic, peer).await?;

--- a/p2panda-net/src/engine/gossip_buffer.rs
+++ b/p2panda-net/src/engine/gossip_buffer.rs
@@ -34,7 +34,7 @@ impl GossipBuffer {
                 );
                 *counter
             }
-            None => panic!(),
+            None => panic!("attempted to unlock non-existing gossip buffer"),
         }
     }
 

--- a/p2panda-net/src/engine/mod.rs
+++ b/p2panda-net/src/engine/mod.rs
@@ -15,6 +15,7 @@ use anyhow::Result;
 use futures_util::future::{MapErr, Shared};
 use futures_util::{FutureExt, TryFutureExt};
 use iroh_gossip::net::Gossip;
+use iroh_net::key::SecretKey;
 use iroh_net::{Endpoint, NodeAddr};
 use p2panda_sync::Topic;
 use tokio::sync::{broadcast, mpsc, oneshot};
@@ -46,6 +47,7 @@ where
     T: Topic + TopicId + 'static,
 {
     pub fn new(
+        secret_key: SecretKey,
         network_id: NetworkId,
         endpoint: Endpoint,
         gossip: Gossip,
@@ -68,6 +70,7 @@ where
         };
 
         let engine_actor = EngineActor::new(
+            secret_key,
             endpoint,
             address_book,
             engine_actor_rx,

--- a/p2panda-net/src/engine/topic_discovery.rs
+++ b/p2panda-net/src/engine/topic_discovery.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use anyhow::Result;
+use iroh_net::key::{PublicKey, SecretKey, Signature};
 use iroh_net::NodeId;
 use rand::random;
 use serde::{Deserialize, Serialize};
@@ -94,6 +95,11 @@ impl TopicDiscovery {
         bytes: &[u8],
         node_id: NodeId,
     ) -> Result<Vec<[u8; 32]>> {
+        let topic_discovery_message = TopicDiscoveryMessage::from_bytes(bytes)?;
+
+        // Verify that the signature of this message matches the claimed author public key.
+        topic_discovery_message.verify()?;
+
         let topic_ids = TopicDiscoveryMessage::from_bytes(bytes).map(|message| message.1)?;
         for topic_id in &topic_ids {
             self.address_book.add_topic_id(node_id, *topic_id).await;
@@ -101,12 +107,12 @@ impl TopicDiscovery {
         Ok(topic_ids)
     }
 
-    pub async fn announce(&self, topic_ids: Vec<[u8; 32]>) -> Result<()> {
+    pub async fn announce(&self, topic_ids: Vec<[u8; 32]>, secret_key: &SecretKey) -> Result<()> {
         if self.status != Status::Active {
             return Ok(());
         }
 
-        let message = TopicDiscoveryMessage::new(topic_ids);
+        let message = TopicDiscoveryMessage::new(topic_ids, secret_key);
 
         self.gossip_actor_tx
             .send(ToGossipActor::Broadcast {
@@ -122,12 +128,48 @@ impl TopicDiscovery {
 type MessageId = [u8; 32];
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TopicDiscoveryMessage(MessageId, pub Vec<[u8; 32]>);
+pub struct TopicDiscoveryMessage(MessageId, pub Vec<[u8; 32]>, PublicKey, Signature);
 
 impl TopicDiscoveryMessage {
-    pub fn new(topic_ids: Vec<[u8; 32]>) -> Self {
+    pub fn new(topic_ids: Vec<[u8; 32]>, secret_key: &SecretKey) -> Self {
         // Message id is used to make every message unique, as duplicates get otherwise dropped
         // during gossip broadcast.
-        Self(random(), topic_ids)
+        let message_id = random();
+
+        // The unsigned message values which will be signed.
+        let raw_message = (message_id, topic_ids, secret_key.public());
+
+        let signature = secret_key.sign(&raw_message.to_bytes());
+        Self(raw_message.0, raw_message.1, raw_message.2, signature)
+    }
+
+    /// Verify the signature against the public key of the message author.
+    pub fn verify(&self) -> Result<()> {
+        let public_key = self.2;
+        public_key.verify(&(self.0, &self.1, self.2).to_bytes(), &self.3)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iroh_net::key::SecretKey;
+
+    use crate::bytes::ToBytes;
+
+    use super::TopicDiscoveryMessage;
+
+    #[test]
+    fn verify_message() {
+        let secret_key = SecretKey::generate();
+        let topic_ids = vec![[0; 32]];
+        let message = TopicDiscoveryMessage::new(topic_ids.clone(), &secret_key);
+        assert!(message.verify().is_ok());
+
+        let wrong_secret_key = SecretKey::generate();
+        let wrong_signature = wrong_secret_key.sign(&topic_ids.to_bytes());
+        let mut message = message;
+        message.3 = wrong_signature;
+        assert!(message.verify().is_err())
     }
 }

--- a/p2panda-net/src/engine/topic_discovery.rs
+++ b/p2panda-net/src/engine/topic_discovery.rs
@@ -132,14 +132,14 @@ pub struct TopicDiscoveryMessage {
 }
 
 impl TopicDiscoveryMessage {
-    pub fn new(topic_ids: Vec<[u8; 32]>, private_key: &SecretKey) -> Self {
+    pub fn new(topic_ids: Vec<[u8; 32]>, secret_key: &SecretKey) -> Self {
         // Message id is used to make every message unique, as duplicates get otherwise dropped
         // during gossip broadcast.
         let id = random();
 
-        let public_key = private_key.public();
+        let public_key = secret_key.public();
         let raw_message = (id, topic_ids.clone(), public_key);
-        let signature = private_key.sign(&raw_message.to_bytes());
+        let signature = secret_key.sign(&raw_message.to_bytes());
 
         Self {
             id,

--- a/p2panda-net/src/engine/topic_streams.rs
+++ b/p2panda-net/src/engine/topic_streams.rs
@@ -265,11 +265,11 @@ where
     pub async fn on_discovered_topic_ids(
         &mut self,
         their_topic_ids: Vec<[u8; 32]>,
-        delivered_from: NodeId,
+        peer: NodeId,
     ) -> Result<()> {
         debug!(
-            "learned about topic ids from {}: {:?}",
-            delivered_from, their_topic_ids
+            "learned about topic ids of {}: {:?}",
+            peer, their_topic_ids
         );
 
         // Inform the sync manager about any peer-topic combinations which are of interest to us.
@@ -281,7 +281,7 @@ where
             for (topic, _) in self.subscribed.values() {
                 if their_topic_ids.contains(&topic.id()) {
                     found_common_topic = true;
-                    let peer_topic = ToSyncActor::new(delivered_from, topic.clone());
+                    let peer_topic = ToSyncActor::new(peer, topic.clone());
                     sync_actor_tx.send(peer_topic).await?
                 }
             }

--- a/p2panda-net/src/engine/topic_streams.rs
+++ b/p2panda-net/src/engine/topic_streams.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Result;
+use iroh_net::key::PublicKey;
 use iroh_net::NodeId;
 use p2panda_sync::Topic;
 use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
@@ -267,10 +268,7 @@ where
         their_topic_ids: Vec<[u8; 32]>,
         peer: NodeId,
     ) -> Result<()> {
-        debug!(
-            "learned about topic ids of {}: {:?}",
-            peer, their_topic_ids
-        );
+        debug!("learned about topic ids of {}: {:?}", peer, their_topic_ids);
 
         // Inform the sync manager about any peer-topic combinations which are of interest to us.
         //
@@ -318,7 +316,7 @@ where
         topic: T,
         header: Vec<u8>,
         payload: Option<Vec<u8>>,
-        delivered_from: NodeId,
+        delivered_from: PublicKey,
     ) -> Result<()> {
         let stream_ids = self
             .topic_to_stream

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -886,7 +886,7 @@ mod tests {
     use crate::addrs::DEFAULT_STUN_PORT;
     use crate::bytes::ToBytes;
     use crate::config::Config;
-    use crate::network::sync_protocols::{DummyProtocol, PingPongProtocol};
+    use crate::network::sync_protocols::PingPongProtocol;
     use crate::sync::SyncConfiguration;
     use crate::{NetworkBuilder, RelayMode, RelayUrl, TopicId};
 

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -1243,17 +1243,17 @@ mod tests {
         node_2.add_peer(node_1_addr).await.unwrap();
         node_3.add_peer(node_2_addr).await.unwrap();
 
-        // Subscribe to the same topic from both nodes
+        // Subscribe to the same topic from all nodes
         let (tx_1, _rx_1, ready_1) = node_1.subscribe(chat_topic.clone()).await.unwrap();
         let (_tx_2, mut rx_2, ready_2) = node_2.subscribe(chat_topic.clone()).await.unwrap();
         let (_tx_3, mut rx_3, ready_3) = node_3.subscribe(chat_topic).await.unwrap();
 
-        // Ensure the gossip-overlay has been joined by both nodes for the given topic
+        // Ensure the gossip-overlay has been joined by all three nodes for the given topic
         assert!(ready_3.await.is_ok());
         assert!(ready_2.await.is_ok());
         assert!(ready_1.await.is_ok());
 
-        // Broadcast a message and make sure it's received by the other node
+        // Broadcast a message and make sure it's received by the other nodes
         tx_1.send(ToNetwork::Message {
             bytes: "Hello, Node".to_bytes(),
         })

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -805,6 +805,10 @@ mod sync_protocols {
                     }
                     Message::Pong => {
                         debug!("pong message received");
+                        app_tx
+                            .send(FromSync::Data("PONG".as_bytes().to_owned(), None))
+                            .await
+                            .unwrap();
                         break;
                     }
                 }
@@ -836,6 +840,11 @@ mod sync_protocols {
                     Message::Topic(topic) => app_tx.send(FromSync::HandshakeSuccess(topic)).await?,
                     Message::Ping => {
                         debug!("ping message received");
+                        app_tx
+                            .send(FromSync::Data("PING".as_bytes().to_owned(), None))
+                            .await
+                            .unwrap();
+
                         sink.send(Message::Pong).await?;
                         debug!("pong message sent");
                         break;
@@ -869,6 +878,7 @@ mod tests {
     use p2panda_sync::log_sync::{LogSyncProtocol, Logs};
     use p2panda_sync::{Topic, TopicMap};
     use serde::{Deserialize, Serialize};
+    use tokio::task::JoinHandle;
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
     use tracing_subscriber::EnvFilter;
@@ -876,11 +886,11 @@ mod tests {
     use crate::addrs::DEFAULT_STUN_PORT;
     use crate::bytes::ToBytes;
     use crate::config::Config;
-    use crate::network::sync_protocols::PingPongProtocol;
+    use crate::network::sync_protocols::{DummyProtocol, PingPongProtocol};
     use crate::sync::SyncConfiguration;
     use crate::{NetworkBuilder, RelayMode, RelayUrl, TopicId};
 
-    use super::{FromNetwork, ToNetwork};
+    use super::{FromNetwork, Network, ToNetwork};
 
     fn setup_logging() {
         tracing_subscriber::registry()
@@ -1213,5 +1223,143 @@ mod tests {
 
         assert!(result1.is_ok());
         assert!(result2.is_ok())
+    }
+
+    #[tokio::test]
+    async fn multi_hop_join_gossip_overlay() {
+        setup_logging();
+
+        let network_id = [1; 32];
+        let chat_topic = TestTopic::new("chat");
+
+        let node_1 = NetworkBuilder::new(network_id).build().await.unwrap();
+        let node_2 = NetworkBuilder::new(network_id).build().await.unwrap();
+        let node_3 = NetworkBuilder::new(network_id).build().await.unwrap();
+
+        let node_1_addr = node_1.endpoint().node_addr().await.unwrap();
+        let node_2_addr = node_2.endpoint().node_addr().await.unwrap();
+
+        node_1.add_peer(node_2_addr.clone()).await.unwrap();
+        node_2.add_peer(node_1_addr).await.unwrap();
+        node_3.add_peer(node_2_addr).await.unwrap();
+
+        // Subscribe to the same topic from both nodes
+        let (tx_1, _rx_1, ready_1) = node_1.subscribe(chat_topic.clone()).await.unwrap();
+        let (_tx_2, mut rx_2, ready_2) = node_2.subscribe(chat_topic.clone()).await.unwrap();
+        let (_tx_3, mut rx_3, ready_3) = node_3.subscribe(chat_topic).await.unwrap();
+
+        // Ensure the gossip-overlay has been joined by both nodes for the given topic
+        assert!(ready_3.await.is_ok());
+        assert!(ready_2.await.is_ok());
+        assert!(ready_1.await.is_ok());
+
+        // Broadcast a message and make sure it's received by the other node
+        tx_1.send(ToNetwork::Message {
+            bytes: "Hello, Node".to_bytes(),
+        })
+        .await
+        .unwrap();
+
+        let rx_2_msg = rx_2.recv().await.unwrap();
+        assert_eq!(
+            rx_2_msg,
+            FromNetwork::GossipMessage {
+                bytes: "Hello, Node".to_bytes(),
+                // Node 2 receives the message and it is delivered by node 1
+                delivered_from: node_1.node_id(),
+            }
+        );
+
+        let rx_3_msg = rx_3.recv().await.unwrap();
+        assert_eq!(
+            rx_3_msg,
+            FromNetwork::GossipMessage {
+                bytes: "Hello, Node".to_bytes(),
+                // Node 3 receives the message and it is also delivered by node 1
+                delivered_from: node_1.node_id(),
+            }
+        );
+
+        node_1.shutdown().await.unwrap();
+        node_2.shutdown().await.unwrap();
+        node_3.shutdown().await.unwrap();
+    }
+
+    fn run_node<T: TopicId + Topic + 'static>(node: Network<T>, topic: T) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let (_tx, mut rx, ready) = node.subscribe(topic).await.unwrap();
+
+            // Await the ready signal so we know the gossip overlay has been joined.
+            assert!(ready.await.is_ok());
+
+            // Await at least one message received via sync.
+            loop {
+                let msg = rx.recv().await.unwrap();
+                println!("{msg:?}");
+                match msg {
+                    FromNetwork::SyncMessage { .. } => break,
+                    _ => (),
+                }
+            }
+
+            // Give other nodes enough time to complete sync sessions.
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            node.shutdown().await.unwrap();
+        })
+    }
+    #[tokio::test]
+    async fn multi_hop_topic_discovery_and_sync() {
+        setup_logging();
+
+        let network_id = [1; 32];
+        let topic = TestTopic::new("chat");
+        let sync_config = SyncConfiguration::new(PingPongProtocol {});
+
+        // Create 4 nodes.
+        let node_1 = NetworkBuilder::new(network_id)
+            .sync(sync_config.clone())
+            .build()
+            .await
+            .unwrap();
+        let node_2 = NetworkBuilder::new(network_id)
+            .sync(sync_config.clone())
+            .build()
+            .await
+            .unwrap();
+        let node_3 = NetworkBuilder::new(network_id)
+            .sync(sync_config.clone())
+            .build()
+            .await
+            .unwrap();
+        let node_4 = NetworkBuilder::new(network_id)
+            .sync(sync_config.clone())
+            .build()
+            .await
+            .unwrap();
+
+        let node_1_addr = node_1.endpoint().node_addr().await.unwrap();
+        let node_2_addr = node_2.endpoint().node_addr().await.unwrap();
+        let node_3_addr = node_3.endpoint().node_addr().await.unwrap();
+
+        // All peers know about only one other peer.
+        node_1.add_peer(node_2_addr.clone()).await.unwrap();
+        node_2.add_peer(node_1_addr).await.unwrap();
+        node_3.add_peer(node_2_addr.clone()).await.unwrap();
+        node_4.add_peer(node_3_addr.clone()).await.unwrap();
+
+        // Run all nodes. We are testing that peers gracefully handle starting a sync session
+        // whine not knowing the other peer's address yet. Eventually all peers complete at least
+        // one sync session.
+        let handle1 = run_node(node_1, topic.clone());
+        let handle2 = run_node(node_2, topic.clone());
+        let handle3 = run_node(node_3, topic.clone());
+        let handle4 = run_node(node_4, topic.clone());
+
+        let (result1, result2, result3, result4) = tokio::join!(handle1, handle2, handle3, handle4);
+
+        assert!(result1.is_ok());
+        assert!(result2.is_ok());
+        assert!(result3.is_ok());
+        assert!(result4.is_ok());
     }
 }

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -262,6 +262,7 @@ where
         );
 
         let engine = Engine::new(
+            secret_key.clone(),
             self.network_id,
             endpoint.clone(),
             gossip.clone(),


### PR DESCRIPTION
- [x] add signature and public key to `TopicDiscoveryMessage` 
- [x] attempt to join gossip overlay and sync with the _signing_ peer (rather than the peer which delivered the message)
- [x] don't notify engine of sync error on connection failures (after x retry attempts)   