### PR TITLE
Fix CBOR decoder when buffer contains less than a full frame

### DIFF
--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use p2panda_core::{PrivateKey, PublicKey, Signature};
+use p2panda_core::{Hash, PrivateKey, PublicKey, Signature};
 use p2panda_discovery::mdns::LocalDiscovery;
 use p2panda_net::network::{FromNetwork, ToNetwork};
 use p2panda_net::{NetworkBuilder, TopicId};
@@ -23,7 +23,7 @@ pub struct ChatTopic(String, [u8; 32]);
 
 impl ChatTopic {
     pub fn new(name: &str) -> Self {
-        Self(name.to_owned(), [0; 32])
+        Self(name.to_owned(), *Hash::new(name).as_bytes())
     }
 }
 

--- a/p2panda-sync/src/cbor.rs
+++ b/p2panda-sync/src/cbor.rs
@@ -78,6 +78,8 @@ where
         let starting = bytes.len();
 
         // Attempt decoding the buffer and remember how many bytes we've advanced it doing that.
+        //
+        // This will succeed in case 2. and 3.
         let result: Result<Self::Item, _> = decode_cbor(&mut bytes);
         let ending = bytes.len();
 
@@ -96,6 +98,8 @@ where
                         // EOF errors indicate that our buffer doesn't contain enough data to
                         // decode a whole CBOR frame. We're yielding no data item and re-try
                         // decoding in the next iteration.
+                        //
+                        // This is handling case 1.
                         Ok(None)
                     } else {
                         // An I/O error during decoding usually indicates something wrong with our

--- a/p2panda-sync/src/cbor.rs
+++ b/p2panda-sync/src/cbor.rs
@@ -46,7 +46,7 @@ where
 {
     type Error = SyncError;
 
-    /// Encodes an serializable item into CBOR bytes and adds them to the buffer.
+    /// Encodes a serializable item into CBOR bytes and adds them to the buffer.
     fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let bytes = encode_cbor(&item).map_err(|err| {
             // When we've failed encoding our _own_ messages something seriously went wrong.
@@ -66,8 +66,8 @@ where
     type Item = T;
     type Error = SyncError;
 
-    /// CBOR decoder method taking as an argument the bytes that has been read so far, and when it
-    /// is called, it will be in one of the following situations:
+    /// CBOR decoder method taking as an argument the bytes that have been read so far; when called,
+    /// it will be in one of the following situations:
     ///
     /// 1. The buffer contains less than a full frame.
     /// 2. The buffer contains exactly a full frame.
@@ -85,7 +85,7 @@ where
 
         match result {
             Ok(item) => {
-                // We've successfully could read one full frame from the buffer. We're finally
+                // We've successfully read one full frame from the buffer. We're finally
                 // advancing it for the next decode iteration and yield the resulting data item to
                 // the stream.
                 src.advance(starting - ending);

--- a/p2panda-sync/src/cbor.rs
+++ b/p2panda-sync/src/cbor.rs
@@ -13,6 +13,14 @@ use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
 use crate::SyncError;
 
+/// Implementation of the tokio codec traits to encode- and decode CBOR data as a stream.
+///
+/// CBOR allows message framing based on initial "headers" for each "data item", which indicate the
+/// type of data and the expected "body" length to be followed. A stream-based decoder can attempt
+/// parsing these headers and then reason about if it has enough information to proceed.
+///
+/// Read more on CBOR in streaming applications here:
+/// https://www.rfc-editor.org/rfc/rfc8949.html#section-5.1
 #[derive(Clone, Debug)]
 pub struct CborCodec<T> {
     _phantom: PhantomData<T>,
@@ -38,10 +46,14 @@ where
 {
     type Error = SyncError;
 
+    /// Encodes an serializable item into CBOR bytes and adds them to the buffer.
     fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let bytes = encode_cbor(&item).map_err(|err| {
+            // When we've failed encoding our _own_ messages something seriously went wrong.
             SyncError::Critical(format!("CBOR codec failed encoding message, {err}"))
         })?;
+        // Append the encoded CBOR bytes to the buffer instead of replacing it, we might already
+        // have previously encoded items in it.
         dst.extend_from_slice(&bytes);
         Ok(())
     }
@@ -54,17 +66,40 @@ where
     type Item = T;
     type Error = SyncError;
 
+    /// CBOR decoder method taking as an argument the bytes that has been read so far, and when it
+    /// is called, it will be in one of the following situations:
+    ///
+    /// 1. The buffer contains less than a full frame.
+    /// 2. The buffer contains exactly a full frame.
+    /// 3. The buffer contains more than a full frame.
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        let reader = src.reader();
-        let result: Result<Self::Item, _> = decode_cbor(reader);
+        // Keep a reference of the buffer to not advance the main buffer itself (yet).
+        let mut bytes: &[u8] = src.as_ref();
+        let starting = bytes.len();
+
+        // Attempt decoding the buffer and remember how many bytes we've advanced it doing that.
+        let result: Result<Self::Item, _> = decode_cbor(&mut bytes);
+        let ending = bytes.len();
+
         match result {
-            Ok(item) => Ok(Some(item)),
+            Ok(item) => {
+                // We've successfully could read one full frame from the buffer. We're finally
+                // advancing it for the next decode iteration and yield the resulting data item to
+                // the stream.
+                src.advance(starting - ending);
+                Ok(Some(item))
+            }
+            // Note that the buffer is not further advanced in case of an error.
             Err(ref error) => match error {
                 DecodeError::Io(err) => {
-                    // Sometimes the EOF is signalled as IO error.
                     if err.kind() == std::io::ErrorKind::UnexpectedEof {
+                        // EOF errors indicate that our buffer doesn't contain enough data to
+                        // decode a whole CBOR frame. We're yielding no data item and re-try
+                        // decoding in the next iteration.
                         Ok(None)
                     } else {
+                        // An I/O error during decoding usually indicates something wrong with our
+                        // system (lack of system memory etc.).
                         Err(SyncError::Critical(format!(
                             "CBOR codec failed decoding message due to i/o error, {err}"
                         )))
@@ -76,6 +111,16 @@ where
     }
 }
 
+/// Returns a reader for your data type, receiving CBOR encoded byte-streams of it and handling the
+/// framing of them automatically.
+///
+/// This can be used in various sync protocol implementations where we need to receive data via a
+/// wire protocol between two peers.
+///
+/// This is a convenience method if you want to use CBOR encoding and serde to handle your wire
+/// protocol message encoding and framing without implementing it yourself. If you're interested in
+/// your own approach you can either implement your own `FramedRead` or `Sink` (if you're not
+/// interested in the tokio codec traits).
 pub fn into_cbor_stream<'a, M>(
     rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
 ) -> impl Stream<Item = Result<M, SyncError>> + Send + Unpin + 'a
@@ -85,6 +130,15 @@ where
     FramedRead::new(rx.compat(), CborCodec::<M>::new())
 }
 
+/// Returns a writer for your data type, sending CBOR encoded byte-streams of it.
+///
+/// This can be used in various sync protocol implementations where we need to send data via a wire
+/// protocol between two peers.
+///
+/// This is a convenience method if you want to use CBOR encoding and serde to handle your wire
+/// protocol message encoding and framing without implementing it yourself. If you're interested in
+/// your own approach you can either implement your own `FramedWrite` or `Stream` (if you're not
+/// interested in the tokio codec traits).
 pub fn into_cbor_sink<'a, M>(
     tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
 ) -> impl Sink<M, Error = SyncError> + Send + Unpin + 'a


### PR DESCRIPTION
This PR fixes an bug in the CBOR decoder where it always advanced the buffer, even when it only contained an incomplete message frame.