### PR TITLE
Replace channel from network with mpsc instead of lagging broadcast

### DIFF
--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
     let (tx, mut rx, ready) = network.subscribe(topic).await?;
 
     tokio::task::spawn(async move {
-        while let Ok(event) = rx.recv().await {
+        while let Some(event) = rx.recv().await {
             match event {
                 FromNetwork::GossipMessage {
                     bytes,

--- a/p2panda-net/src/engine/mod.rs
+++ b/p2panda-net/src/engine/mod.rs
@@ -17,7 +17,7 @@ use futures_util::{FutureExt, TryFutureExt};
 use iroh_gossip::net::Gossip;
 use iroh_net::{Endpoint, NodeAddr};
 use p2panda_sync::Topic;
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinError;
 use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error};
@@ -121,7 +121,7 @@ where
     pub async fn subscribe(
         &self,
         topic: T,
-        from_network_tx: broadcast::Sender<FromNetwork>,
+        from_network_tx: mpsc::Sender<FromNetwork>,
         to_network_rx: mpsc::Receiver<ToNetwork>,
         gossip_ready_tx: oneshot::Sender<()>,
     ) -> Result<()> {

--- a/p2panda-net/src/engine/topic_streams.rs
+++ b/p2panda-net/src/engine/topic_streams.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use iroh_net::NodeId;
 use p2panda_sync::Topic;
-use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
+use tokio::sync::{mpsc, oneshot, RwLock};
 use tracing::{debug, error, warn};
 
 use crate::engine::address_book::AddressBook;
@@ -18,7 +18,7 @@ use crate::sync::manager::ToSyncActor;
 use crate::{to_public_key, TopicId};
 
 /// Managed data stream over an application-defined topic.
-type TopicStream<T> = (T, broadcast::Sender<FromNetwork>);
+type TopicStream<T> = (T, mpsc::Sender<FromNetwork>);
 
 /// Every stream has a unique identifier.
 type TopicStreamId = usize;
@@ -85,7 +85,7 @@ where
     pub async fn subscribe(
         &mut self,
         topic: T,
-        from_network_tx: broadcast::Sender<FromNetwork>,
+        from_network_tx: mpsc::Sender<FromNetwork>,
         mut to_network_rx: mpsc::Receiver<ToNetwork>,
         gossip_ready_tx: oneshot::Sender<()>,
     ) -> Result<()> {
@@ -251,10 +251,12 @@ where
             .expect("consistent topic id to stream id mapping");
         for stream_id in stream_ids {
             let (_, from_network_tx) = self.subscribed.get(stream_id).expect("stream should exist");
-            from_network_tx.send(FromNetwork::GossipMessage {
-                bytes: bytes.clone(),
-                delivered_from: to_public_key(delivered_from),
-            })?;
+            from_network_tx
+                .send(FromNetwork::GossipMessage {
+                    bytes: bytes.clone(),
+                    delivered_from: to_public_key(delivered_from),
+                })
+                .await?;
         }
 
         Ok(())
@@ -313,7 +315,7 @@ where
     }
 
     /// Process application-data message resulting from the sync session.
-    pub fn on_sync_message(
+    pub async fn on_sync_message(
         &mut self,
         topic: T,
         header: Vec<u8>,
@@ -327,11 +329,13 @@ where
 
         for stream_id in stream_ids {
             let (_, from_network_tx) = self.subscribed.get(stream_id).expect("stream should exist");
-            from_network_tx.send(FromNetwork::SyncMessage {
-                header: header.clone(),
-                payload: payload.clone(),
-                delivered_from: to_public_key(delivered_from),
-            })?;
+            from_network_tx
+                .send(FromNetwork::SyncMessage {
+                    header: header.clone(),
+                    payload: payload.clone(),
+                    delivered_from: to_public_key(delivered_from),
+                })
+                .await?;
         }
 
         Ok(())
@@ -387,8 +391,8 @@ mod tests {
     use p2panda_core::PrivateKey;
     use p2panda_sync::Topic;
     use serde::{Deserialize, Serialize};
-    use tokio::sync::{broadcast, mpsc, oneshot};
-    use tokio_stream::wrappers::BroadcastStream;
+    use tokio::sync::{mpsc, oneshot};
+    use tokio_stream::wrappers::ReceiverStream;
 
     use crate::engine::AddressBook;
     use crate::network::FromNetwork;
@@ -421,10 +425,10 @@ mod tests {
     async fn ooo_gossip_buffering() {
         let (gossip_actor_tx, _gossip_actor_rx) = mpsc::channel(128);
         let (sync_actor_tx, _sync_actor_rx) = mpsc::channel(128);
-        let (from_network_tx, from_network_rx) = broadcast::channel(128);
+        let (from_network_tx, from_network_rx) = mpsc::channel(128);
         let (_to_network_tx, to_network_rx) = mpsc::channel(128);
         let (gossip_ready_tx, _) = oneshot::channel();
-        let mut from_network_rx_stream = BroadcastStream::new(from_network_rx);
+        let mut from_network_rx_stream = ReceiverStream::new(from_network_rx);
 
         let topic = TestTopic::Primary;
         let topic_id = topic.id();
@@ -473,14 +477,14 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            from_network_rx_stream.next().await.unwrap().unwrap(),
+            from_network_rx_stream.next().await.unwrap(),
             FromNetwork::GossipMessage {
                 bytes: b"a new cmos battery".to_vec(),
                 delivered_from: to_public_key(peer_1.node_id),
             }
         );
         assert_eq!(
-            from_network_rx_stream.next().await.unwrap().unwrap(),
+            from_network_rx_stream.next().await.unwrap(),
             FromNetwork::GossipMessage {
                 bytes: b"and icecream".to_vec(),
                 delivered_from: to_public_key(peer_1.node_id),

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -18,7 +18,7 @@ use iroh_net::{Endpoint, NodeAddr, NodeId};
 use p2panda_core::{PrivateKey, PublicKey};
 use p2panda_discovery::{Discovery, DiscoveryMap};
 use p2panda_sync::Topic;
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::{JoinError, JoinSet};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
@@ -588,11 +588,11 @@ where
         topic: T,
     ) -> Result<(
         mpsc::Sender<ToNetwork>,
-        broadcast::Receiver<FromNetwork>,
+        mpsc::Receiver<FromNetwork>,
         oneshot::Receiver<()>,
     )> {
         let (to_network_tx, to_network_rx) = mpsc::channel::<ToNetwork>(128);
-        let (from_network_tx, from_network_rx) = broadcast::channel::<FromNetwork>(128);
+        let (from_network_tx, from_network_rx) = mpsc::channel::<FromNetwork>(128);
         let (gossip_ready_tx, gossip_ready_rx) = oneshot::channel();
 
         self.inner
@@ -1162,7 +1162,7 @@ mod tests {
             assert!(ready.await.is_ok());
 
             let mut from_sync_messages = Vec::new();
-            while let Ok(message) = from_sync_rx.recv().await {
+            while let Some(message) = from_sync_rx.recv().await {
                 from_sync_messages.push(message);
                 if from_sync_messages.len() == 3 {
                     break;


### PR DESCRIPTION
We're running into "lagged behind" errors when using the `tokio::sync::broadcast` mpmc channel implementation when there's a lot of messages to process, coming from the network. Unfortunately this means that messages will simply get lost.

We can easily replace it with an `tokio:sync::mpsc` channel to avoid this behaviour and apply backpressure instead of dropping messages. The downside is that users will not be able to easily clone (subscribe) to the stream, but so far (from our experiences at least) it was never used and if people would like to do that, they can easily pipe the mpsc receiver into another, more flexible solution.

This changes the public's API `from_network_rx` type, kinda a breaking change (we're not released yet though).