### PR TITLE
Documentation for modules and types in `p2panda-net` and `p2panda-sync`

### DIFF
--- a/p2panda-core/src/hash.rs
+++ b/p2panda-core/src/hash.rs
@@ -86,6 +86,12 @@ impl TryFrom<&[u8]> for Hash {
     }
 }
 
+impl From<&Hash> for [u8; 32] {
+    fn from(value: &Hash) -> Self {
+        *value.as_bytes()
+    }
+}
+
 impl FromStr for Hash {
     type Err = HashError;
 

--- a/p2panda-net/src/config.rs
+++ b/p2panda-net/src/config.rs
@@ -10,7 +10,10 @@ use crate::{NetworkId, NodeAddress, RelayUrl};
 pub const DEFAULT_BIND_PORT: u16 = 2022;
 
 /// Default network id.
-pub const DEFAULT_NETWORK_ID: NetworkId = [0; 32];
+pub const DEFAULT_NETWORK_ID: NetworkId = [
+    247, 69, 248, 242, 132, 120, 159, 230, 98, 100, 214, 200, 78, 40, 79, 94, 174, 8, 12, 27, 84,
+    195, 246, 159, 132, 240, 79, 208, 1, 43, 132, 118,
+];
 
 /// Configuration parameters for the local network node.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -18,17 +21,19 @@ pub struct Config {
     /// Bind port for the IPv4 socket. The IPv6 socket will be bound to `bind_port` + 1.
     pub bind_port: u16,
 
-    /// Direct node addresses for the local node (e.g. "0.0.0.0:2026").
+    /// Node addresses of remote peers which are directly reachable (no STUN or relay required).
+    /// These will be added to the address book.
     pub direct_node_addresses: Vec<NodeAddress>,
 
     /// Identifier of the network to be joined.
     pub network_id: NetworkId,
 
-    /// Path to the local private key. If not provided, a random keypair will be generated.
+    /// Path to the local private key. If not provided, a random keypair will be generated and kept
+    /// in memory.
     pub private_key: Option<PathBuf>,
 
-    /// Relay URL to help in establishing a peer-to-peer connection if one or both peers are behind
-    /// a NAT.
+    /// URL to relay server to help in establishing a peer-to-peer connection if one or both peers
+    /// are behind a NAT or firewall.
     pub relay: Option<RelayUrl>,
 }
 

--- a/p2panda-net/src/config.rs
+++ b/p2panda-net/src/config.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//! Alternative configuration API which can be passed into `Network::from_config` constructor
+//! instead of using `NetworkBuilder`.
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};

--- a/p2panda-net/src/config.rs
+++ b/p2panda-net/src/config.rs
@@ -34,7 +34,7 @@ pub struct Config {
     /// in memory.
     pub private_key: Option<PathBuf>,
 
-    /// URL to relay server to help in establishing a peer-to-peer connection if one or both peers
+    /// URL of a relay server to help in establishing a peer-to-peer connection if one or both peers
     /// are behind a NAT or firewall.
     pub relay: Option<RelayUrl>,
 }

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -19,8 +19,8 @@
 //! for relay fallbacks, PlumTree and HyParView for broadcast-based gossip overlays.
 //!
 //! p2panda adds crucial functionality on top of iroh for peer-to-peer application development,
-//! without tying developers too closely to any pre-defined data types and allowing plenty of space for
-//! customisation:
+//! without tying developers too closely to any pre-defined data types and allowing plenty of space
+//! for customisation:
 //!
 //! 1. Data of any kind can be exchanged efficiently via gossip broadcast ("live mode") or via sync
 //!    protocols between two peers ("catching up on past state")
@@ -154,9 +154,9 @@ pub use p2panda_sync::log_sync::LogSyncProtocol;
 
 /// Unique 32 byte identifier for a network.
 ///
-/// Peers using the same network identifier will eventually discover each other. This is the most
-/// global identifier to group peers into networks. Different applications may choose to share the 
-/// same underlying network infrastructure by using the same network identifier.
+/// Peers operating on the same network identifier will eventually discover each other. This is the
+/// most global identifier to group peers into networks. Different applications may choose to share
+/// the same underlying network infrastructure by using the same network identifier.
 ///
 /// Please note that the network identifier should _never_ be the same as any other topic
 /// identifier.

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -205,6 +205,7 @@ pub(crate) fn to_public_key(key: iroh_base::key::PublicKey) -> p2panda_core::Pub
 }
 
 /// Converts an `p2panda-core` public key to the "iroh" type.
+#[allow(dead_code)]
 pub(crate) fn from_public_key(key: p2panda_core::PublicKey) -> iroh_base::key::PublicKey {
     iroh_base::key::PublicKey::from_bytes(key.as_bytes()).expect("already validated public key")
 }

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -3,13 +3,12 @@
 //! `p2panda-net` is a data-type-agnostic p2p networking layer offering robust, direct
 //! communication to any device, no matter where they are.
 //!
-//! It provides a stream-based API for higher application layers: Applications subscribe to any
-//! "topic" they are interested in and `p2panda-net` will automatically discover similar peers and
-//! transport raw bytes between them.
+//! It provides a stream-based API for higher layers: Applications subscribe to any "topic" they
+//! are interested in and `p2panda-net` will automatically discover similar peers and transport raw
+//! bytes between them.
 //!
-//! Additionally `p2panda-net` can be extended with custom sync protocol implementations for all
-//! data types, allowing applications to "catch up on past data", eventually converging to the same
-//! state.
+//! Additionally `p2panda-net` can be extended with custom sync protocols for all data types,
+//! allowing applications to "catch up on past data", eventually converging to the same state.
 //!
 //! ## Features
 //!
@@ -25,7 +24,7 @@
 //!
 //! 1. Data of any kind can be exchanged efficiently via gossip broadcast ("live mode") or via sync
 //!    protocols between two peers ("catching up on past state")
-//! 2. Custom queries to express interest in certain data of applications
+//! 2. Custom network-wide queries to express interest in certain data of applications
 //! 3. Ambient peer discovery: Learning about new, previously unknown peers in the network
 //! 4. Ambient topic discovery: Learning what peers are interested in, automatically forming
 //!    overlay networks per topic
@@ -55,11 +54,11 @@
 //!
 //! * Custom Data types exchanged over the network
 //! * Optional relay nodes to aid connection establishment when peers are behind firewalls etc.
-//! * Fine-tune gossipping behaviour
 //! * Custom sync protocol for any data types, with managed re-attempts on connection failures and
 //! optional re-sync schedules
 //! * Custom peer discovery strategies (multiple approaches can be used at the same time)
 //! * Sync and storage of (very) large blobs
+//! * Fine-tune gossipping behaviour
 //! * Additional custom protocol handlers
 //!
 //! ## Integration with other p2panda solutions

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -15,9 +15,9 @@
 //!
 //! Most of the lower-level networking of `p2panda-net` is made possible by the work of
 //! [iroh](https://github.com/n0-computer/iroh/) utilising well-established and known standards,
-//! like QUIC for transport, STUN for establishing direct connections between devices, Tailscale's
-//! DERP (Designated Encrypted Relay for Packets) for relay fallbacks, PlumTree and HyParView for
-//! broadcast-based gossip overlays.
+//! like QUIC for transport, (self-certified) TLS for transport encryption, STUN for establishing
+//! direct connections between devices, Tailscale's DERP (Designated Encrypted Relay for Packets)
+//! for relay fallbacks, PlumTree and HyParView for broadcast-based gossip overlays.
 //!
 //! p2panda adds crucial functionality on top of iroh for peer-to-peer application development,
 //! without tying developers too close to any pre-defined data types and allowing plenty space for
@@ -192,7 +192,7 @@ pub type NetworkId = [u8; 32];
 /// sophisticated "network queries".
 ///
 /// `TopicId` is a tool for general topic discovery and establishing gossip network overlays and
-/// `Topic` a query for sync protocols to ask for a specific piece of information. 
+/// `Topic` a query for sync protocols to ask for a specific piece of information.
 ///
 /// Consult the `Topic` documentation in `p2panda-sync` for further information.
 pub trait TopicId {

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -3,27 +3,37 @@
 //! `p2panda-net` is a data-type-agnostic p2p networking layer which offers robust, direct
 //! communication to any device, no matter where they are.
 //!
-//! It offers gossip overlays for message broadcast, peer identities and stream-based interfaces
-//! for your higher application layers. Additionally it comes with modular extensions, for peer and
-//! topic discovery, access control or sync protocols with eventual-consistency guarantees.
+//! It offers a stream-based API for your higher application layers: Subscribe to any "topic" your
+//! application is interested in and `p2panda-net` will automatically discover peers who are
+//! interested in the same data.
+//!
+//! Additionally `p2panda-net` can be extended with custom peer discovery techniques or sync
+//! protocols, allowing your applications to "catch up on past data", so they can eventually
+//! converge on the same state.
 //!
 //! ## Features
 //!
 //! Most of the lower-level networking of `p2panda-net` is made possible by the work of
-//! [Iroh](https://github.com/n0-computer/iroh/) utilising well-established and known standards,
+//! [iroh](https://github.com/n0-computer/iroh/) utilising well-established and known standards,
 //! like QUIC for transport, STUN for holepunching, Tailscale's DERP (Designated Encrypted Relay
 //! for Packets) for relay fallbacks, PlumTree and HyParView for gossipping.
 //!
-//! `p2panda-net` adds all functionality on top of Iroh we believe is crucial for p2p application
-//! development, without tying ourselves too close to any data types or strategies:
+//! p2panda adds all functionality on top of iroh we believe is crucial for peer-to-peer
+//! application development, without tying ourselves too close to any pre-defined data types and
+//! allowing plenty space for customisation:
 //!
-//! * Subscription API to topics, independent of if they arrived via gossip ("fast message
-//! delivery") or a sync session ("catching up on past state")
+//! * Data of any kind can be exchanged efficiently via gossip broadcast ("live mode") or via a
+//! sync protocol between two peers
+//! * Custom queries to express interest in certain data of your application
 //! * Ambient peer discovery, learning about new peers you might not know about
-//! * Ambient topic discovery, learning what they are interested in
-//! * Sync interfaces, providing the eventual-consistency guarantee that
-//! your peers will converge on the same state over time
-//! * Queries to ask about specific data in the network
+//! * Ambient topic discovery, learning what peers are interested in
+//! * Sync protocol API, providing the eventual-consistency guarantee that your peers will converge
+//! on the same state over time
+//! * Manages connections, automatically syncs with discovered peers and re-tries on faults
+//! * Extension to handle [sync of large files](https://docs.rs/p2panda-blobs)
+//!
+//! `p2panda-net` is designed to run on top of bi-directional connections on the IP layer (aka "The
+//! Internet"). For use-
 //!
 //! ## Example
 //!

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -172,7 +172,7 @@ pub type NetworkId = [u8; 32];
 ///
 /// ## Designing topic identifiers for applications
 ///
-/// Networked applications, such as p2p systems, usually want to converge to the same state over 
+/// Networked applications, such as p2p systems, usually want to converge to the same state over
 /// time so that all users eventually see the same data.
 ///
 /// If we're considering the totality of "all data" the application can create as the "global

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -1,39 +1,66 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `p2panda-net` is a data-type-agnostic p2p networking layer which offers robust, direct
+//! `p2panda-net` is a data-type-agnostic p2p networking layer offering robust, direct
 //! communication to any device, no matter where they are.
 //!
-//! It offers a stream-based API for your higher application layers: Subscribe to any "topic" your
-//! application is interested in and `p2panda-net` will automatically discover peers who are
-//! interested in the same data.
+//! It provides a stream-based API for higher application layers: Applications subscribe to any
+//! "topic" they are interested in and `p2panda-net` will automatically discover similar peers and
+//! transport raw bytes between them.
 //!
-//! Additionally `p2panda-net` can be extended with custom peer discovery techniques or sync
-//! protocols, allowing your applications to "catch up on past data", so they can eventually
-//! converge on the same state.
+//! Additionally `p2panda-net` can be extended with custom sync protocol implementations for all
+//! data types, allowing applications to "catch up on past data", eventually converging to the same
+//! state.
 //!
 //! ## Features
 //!
 //! Most of the lower-level networking of `p2panda-net` is made possible by the work of
 //! [iroh](https://github.com/n0-computer/iroh/) utilising well-established and known standards,
-//! like QUIC for transport, STUN for holepunching, Tailscale's DERP (Designated Encrypted Relay
-//! for Packets) for relay fallbacks, PlumTree and HyParView for gossipping.
+//! like QUIC for transport, STUN for establishing direct connections between devices, Tailscale's
+//! DERP (Designated Encrypted Relay for Packets) for relay fallbacks, PlumTree and HyParView for
+//! broadcast-based gossip overlays.
 //!
-//! p2panda adds all functionality on top of iroh we believe is crucial for peer-to-peer
-//! application development, without tying ourselves too close to any pre-defined data types and
-//! allowing plenty space for customisation:
+//! p2panda adds crucial functionality on top of iroh for peer-to-peer application development,
+//! without tying developers too close to any pre-defined data types and allowing plenty space for
+//! customisation:
 //!
-//! * Data of any kind can be exchanged efficiently via gossip broadcast ("live mode") or via a
-//! sync protocol between two peers
-//! * Custom queries to express interest in certain data of your application
-//! * Ambient peer discovery, learning about new peers you might not know about
-//! * Ambient topic discovery, learning what peers are interested in
-//! * Sync protocol API, providing the eventual-consistency guarantee that your peers will converge
-//! on the same state over time
-//! * Manages connections, automatically syncs with discovered peers and re-tries on faults
-//! * Extension to handle [sync of large files](https://docs.rs/p2panda-blobs)
+//! 1. Data of any kind can be exchanged efficiently via gossip broadcast ("live mode") or via sync
+//!    protocols between two peers ("catching up on past state")
+//! 2. Custom queries to express interest in certain data of applications
+//! 3. Ambient peer discovery: Learning about new, previously unknown peers in the network
+//! 4. Ambient topic discovery: Learning what peers are interested in, automatically forming
+//!    overlay networks per topic
+//! 5. Sync protocol API, providing an eventual-consistency guarantee that peers will converge on
+//!    the same state over time
+//! 6. Manages connections, automatically syncs with discovered peers and re-tries on faults
+//! 7. Extension for networks to handle efficient [sync of large
+//!    files](https://docs.rs/p2panda-blobs)
 //!
-//! `p2panda-net` is designed to run on top of bi-directional connections on the IP layer (aka "The
-//! Internet"). For use-
+//! ## Offline-First
+//!
+//! This networking crate is designed to run on top of bi-directional, ordered connections on the
+//! IP layer (aka "The Internet"), with robustness to work in environments with instable
+//! connectivity or offline time-periods.
+//!
+//! While this IP-based networking implementation should provide for many "modern" use-cases,
+//! p2panda data-types are designed for more extreme scenarios where connectivity can _never_ be
+//! assumed and data transmission is highly "delay tolerant": For example "broadcast-only"
+//! topologies on top of BLE (Bluetooth Low Energy), LoRa or even Digital Radio Communication
+//! infrastructure.
+//!
+//! ## Extensions
+//!
+//! `p2panda-net` is agnostic to any data type (sending and receiving raw byte streams) and can
+//! seamlessly be extended with external or official p2panda implementations. We provide p2panda's
+//! fork-tolerant and prunable append-only logs in `p2panda-core`, offering single-writer and
+//! multi-writer streams, authentication, deletion, ordering and much more. It can be further
+//! extended with an efficient sync implementation in `p2panda-sync` and validation and fast
+//! stream-based ingest solutions in `p2panda-streams`. Lastly we maintain persistance layer APIs
+//! in `p2panda-store` for in-memory storage or embeddable, SQL-based databases. In the future we
+//! will provide additional implementations for managing access control and group encryption.
+//!
+//! For discovery of peers on the local network, we currently provide an mDNS-based implementation
+//! in `p2panda-discovery`, later additional techniques like "rendesvouz" nodes and random walk
+//! algorithms.
 //!
 //! ## Example
 //!

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -43,24 +43,41 @@
 //!
 //! While this IP-based networking implementation should provide for many "modern" use-cases,
 //! p2panda data-types are designed for more extreme scenarios where connectivity can _never_ be
-//! assumed and data transmission is highly "delay tolerant": For example "broadcast-only"
+//! assumed and data transmission needs to be highly "delay tolerant": For example "broadcast-only"
 //! topologies on top of BLE (Bluetooth Low Energy), LoRa or even Digital Radio Communication
 //! infrastructure.
 //!
 //! ## Extensions
 //!
 //! `p2panda-net` is agnostic to any data type (sending and receiving raw byte streams) and can
-//! seamlessly be extended with external or official p2panda implementations. We provide p2panda's
-//! fork-tolerant and prunable append-only logs in `p2panda-core`, offering single-writer and
-//! multi-writer streams, authentication, deletion, ordering and much more. It can be further
-//! extended with an efficient sync implementation in `p2panda-sync` and validation and fast
-//! stream-based ingest solutions in `p2panda-streams`. Lastly we maintain persistance layer APIs
-//! in `p2panda-store` for in-memory storage or embeddable, SQL-based databases. In the future we
-//! will provide additional implementations for managing access control and group encryption.
+//! seamlessly be extended with external or official p2panda implementations for different parts of
+//! the application:
 //!
-//! For discovery of peers on the local network, we currently provide an mDNS-based implementation
-//! in `p2panda-discovery`, later additional techniques like "rendesvouz" nodes and random walk
-//! algorithms.
+//! * Custom Data types exchanged over the network
+//! * Optional relay nodes to aid connection establishment when peers are behind firewalls etc.
+//! * Fine-tune gossipping behaviour
+//! * Custom sync protocol for any data types, with managed re-attempts on connection failures and
+//! optional re-sync schedules
+//! * Custom peer discovery strategies (multiple approaches can be used at the same time)
+//! * Sync and storage of (very) large blobs
+//! * Additional custom protocol handlers
+//!
+//! ## Integration with other p2panda solutions
+//!
+//! We provide p2panda's fork-tolerant and prunable append-only logs in `p2panda-core`, offering
+//! single-writer and multi-writer streams, authentication, deletion, ordering and more. This can
+//! be further extended with an efficient sync implementation in `p2panda-sync` and validation and
+//! fast stream-based ingest solutions in `p2panda-streams`.
+//!
+//! For discovery of peers on the local network, we provide a mDNS-based implementation in
+//! `p2panda-discovery`, planned next are additional techniques like "rendesvouz" nodes and random
+//! walk algorithms.
+//!
+//! Lastly we maintain persistance layer APIs in `p2panda-store` for in-memory storage or
+//! embeddable, SQL-based databases.
+//! 
+//! In the future we will provide additional implementations for managing access control and group
+//! encryption.
 //!
 //! ## Example
 //!
@@ -71,7 +88,6 @@
 //! use p2panda_net::{NetworkBuilder, TopicId};
 //! use p2panda_sync::Topic;
 //! use serde::{Serialize, Deserialize};
-//!
 //! # #[tokio::main]
 //! # async fn main() -> Result<()> {
 //!
@@ -117,7 +133,6 @@
 //! // From now on we can send and receive bytes to any peer interested in the same chat.
 //! let my_friends_group = ChatGroup::new("me-and-my-friends");
 //! let (tx, mut rx, ready) = network.subscribe(my_friends_group).await?;
-//!
 //! # Ok(())
 //! # }
 //! ```

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -1,5 +1,82 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//! `p2panda-net` is a data-type-agnostic p2p networking layer which offers robust, direct
+//! communication to any device, no matter where they are.
+//!
+//! It offers gossip overlays for message broadcast, peer identities and stream-based interfaces
+//! for your higher application layers. Additionally it comes with modular extensions, for peer and
+//! topic discovery, access control or sync protocols with eventual-consistency guarantees.
+//!
+//! ## Features
+//!
+//! Most of the lower-level networking of `p2panda-net` is made possible by the work of
+//! [Iroh](https://github.com/n0-computer/iroh/) utilising well-established and known standards,
+//! like QUIC for transport, STUN for holepunching, Tailscale's DERP (Designated Encrypted Relay
+//! for Packets) for relay fallbacks, PlumTree and HyParView for gossipping.
+//!
+//! `p2panda-net` adds all functionality on top of Iroh we believe is crucial for p2p application
+//! development, without tying ourselves too close to any data types or strategies:
+//!
+//! * Subscription API to topics, independent of if they arrived via gossip ("fast message
+//! delivery") or a sync session ("catching up on past state")
+//! * Ambient peer discovery, learning about new peers you might not know about
+//! * Ambient topic discovery, learning what they are interested in
+//! * Sync interfaces, providing the eventual-consistency guarantee that
+//! your peers will converge on the same state over time
+//! * Queries to ask about specific data in the network
+//!
+//! ## Example
+//!
+//! ```
+//! use p2panda_core::{PrivateKey, Hash};
+//! use p2panda_net::{NetworkBuilder, Topic, TopicId};
+//! use p2panda_discovery::LocalDiscovery;
+//! use serde::{Serialize, Deserialize};
+//!
+//! // All peers knowing the same "network id" will eventually find each other. Use this as the most
+//! // global identifier to group peers into multiple networks when necessary. This can be useful if
+//! // you're planning to run different applications on top of the same infrastructure.
+//! let network_id = b"my-chat-network";
+//!
+//! // We can use the network now to automatically find and ask other peers about any data we are
+//! // interested in. For this we're defining our own "queries" with topics.
+//! //
+//! // In this example we would like to be able to query messages from each chat, identified by
+//! // a BLAKE3 hash.
+//! #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+//! struct ChatChannel(Hash);
+//!
+//! impl ChatChannel {
+//!     pub fn new(name: &str) -> Self {
+//!         Self(Hash::new(name.to_bytes()))
+//!     }
+//! }
+//!
+//! impl Topic for ChatChannel {}
+//!
+//! impl TopicId for ChatChannel {
+//!     fn id(&self) -> [u8; 32] {
+//!         *self.1.as_bytes()
+//!     }
+//! }
+//!
+//! // Generate an Ed25519 private key which will be used to identifiy your peer towards others.
+//! let private_key = PrivateKey::new();
+//!
+//! // Use mDNS to discover other peers on the local network.
+//! let mdns_discovery = LocalDiscovery::new()?;
+//!
+//! // Establish the p2p network which will automatically connect you to any peers.
+//! let network = NetworkBuilder::new(network_id)
+//!     .private_key(private_key)
+//!     .discovery(mdns_discovery)
+//!     .build()
+//!     .await?;
+//!
+//! // From now on we can send and receive bytes to any peer interested in the same chat channel.
+//! let friends_channel = ChatChannel::new("me-and-my-friends");
+//! let (tx, mut rx, ready) = network.subscribe(friends_channel).await?;
+//! ```
 mod addrs;
 mod bytes;
 pub mod config;

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -52,14 +52,14 @@
 //! seamlessly be extended with external or official p2panda implementations for different parts of
 //! the application:
 //!
-//! * Custom Data types exchanged over the network
-//! * Optional relay nodes to aid connection establishment when peers are behind firewalls etc.
-//! * Custom sync protocol for any data types, with managed re-attempts on connection failures and
-//! optional re-sync schedules
-//! * Custom peer discovery strategies (multiple approaches can be used at the same time)
-//! * Sync and storage of (very) large blobs
-//! * Fine-tune gossipping behaviour
-//! * Additional custom protocol handlers
+//! 1. Custom Data types exchanged over the network
+//! 2. Optional relay nodes to aid connection establishment when peers are behind firewalls etc.
+//! 3. Custom sync protocol for any data types, with managed re-attempts on connection failures and
+//!    optional re-sync schedules
+//! 4. Custom peer discovery strategies (multiple approaches can be used at the same time)
+//! 5. Sync and storage of (very) large blobs
+//! 6. Fine-tune gossipping behaviour
+//! 7. Additional custom protocol handlers
 //!
 //! ## Integration with other p2panda solutions
 //!

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -19,7 +19,7 @@
 //! for relay fallbacks, PlumTree and HyParView for broadcast-based gossip overlays.
 //!
 //! p2panda adds crucial functionality on top of iroh for peer-to-peer application development,
-//! without tying developers too close to any pre-defined data types and allowing plenty space for
+//! without tying developers too closely to any pre-defined data types and allowing plenty of space for
 //! customisation:
 //!
 //! 1. Data of any kind can be exchanged efficiently via gossip broadcast ("live mode") or via sync
@@ -37,7 +37,7 @@
 //! ## Offline-First
 //!
 //! This networking crate is designed to run on top of bi-directional, ordered connections on the
-//! IP layer (aka "The Internet"), with robustness to work in environments with instable
+//! IP layer (aka "The Internet"), with robustness to work in environments with unstable
 //! connectivity or offline time-periods.
 //!
 //! While this IP-based networking implementation should provide for many "modern" use-cases,
@@ -90,7 +90,7 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<()> {
 //!
-//! // Peers knowing the same "network id" will eventually find each other. This is the most global
+//! // Peers using the same "network id" will eventually find each other. This is the most global
 //! // identifier to group peers into multiple networks when necessary.
 //! let network_id = [1; 32];
 //!
@@ -122,7 +122,7 @@
 //! // Use mDNS to discover other peers on the local network.
 //! let mdns_discovery = LocalDiscovery::new()?;
 //!
-//! // Establish the p2p network which will automatically connect you to any peers.
+//! // Establish the p2p network which will automatically connect you to any discovered peers.
 //! let network = NetworkBuilder::new(network_id)
 //!     .private_key(private_key)
 //!     .discovery(mdns_discovery)
@@ -154,9 +154,9 @@ pub use p2panda_sync::log_sync::LogSyncProtocol;
 
 /// Unique 32 byte identifier for a network.
 ///
-/// Peers knowing the same network identifier will eventually discover each other. This is the most
-/// global identifier to group peers into networks and becomes necessary if different applications
-/// share the same underlying network infrastructure.
+/// Peers using the same network identifier will eventually discover each other. This is the most
+/// global identifier to group peers into networks. Different applications may choose to share the 
+/// same underlying network infrastructure by using the same network identifier.
 ///
 /// Please note that the network identifier should _never_ be the same as any other topic
 /// identifier.
@@ -167,13 +167,13 @@ pub type NetworkId = [u8; 32];
 /// Once other peers are discovered who are interested in the same topic id, the application will
 /// join the gossip overlay under that identifier.
 ///
-/// If an optional sync protocol has been provided, the application will attempt to synchronize
+/// If an optional sync protocol has been provided, the application will attempt to synchronise
 /// past state before entering the gossip overlay.
 ///
 /// ## Designing topic identifiers for applications
 ///
-/// Networked applications, like p2p systems, usually want to converge to the same state over time,
-/// so that all users will see the same data at some point.
+/// Networked applications, such as p2p systems, usually want to converge to the same state over 
+/// time so that all users eventually see the same data.
 ///
 /// If we're considering the totality of "all data" the application can create as the "global
 /// state", we might want to categorise it into logical "sub-sections", especially when the
@@ -190,8 +190,8 @@ pub type NetworkId = [u8; 32];
 /// Next to topic identifiers p2panda offers a `Topic` trait which allows for even more
 /// sophisticated "network queries".
 ///
-/// `TopicId` is a tool for general topic discovery and establishing gossip network overlays and
-/// `Topic` a query for sync protocols to ask for a specific piece of information.
+/// `TopicId` is a tool for general topic discovery and establishing gossip network overlays.
+/// `Topic` is a query for sync protocols to ask for a specific piece of information.
 ///
 /// Consult the `Topic` documentation in `p2panda-sync` for further information.
 pub trait TopicId {

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -69,7 +69,7 @@
 //! be further extended with an efficient sync implementation in `p2panda-sync` and validation and
 //! fast stream-based ingest solutions in `p2panda-streams`.
 //!
-//! For discovery of peers on the local network, we provide a mDNS-based implementation in
+//! For discovery of peers on the local network, we provide an mDNS-based implementation in
 //! `p2panda-discovery`, planned next are additional techniques like "rendesvouz" nodes and random
 //! walk algorithms.
 //!
@@ -95,7 +95,7 @@
 //! // identifier to group peers into multiple networks when necessary.
 //! let network_id = [1; 32];
 //!
-//! // The network can be used to automatically find and ask other peers about any data we the
+//! // The network can be used to automatically find and ask other peers about any data the
 //! // application is interested in. This is expressed through "network-wide queries" over topics.
 //! //
 //! // In this example we would like to be able to query messages from each chat group, identified
@@ -176,7 +176,7 @@ pub type NetworkId = [u8; 32];
 /// Networked applications, like p2p systems, usually want to converge to the same state over time,
 /// so that all users will see the same data at some point.
 ///
-/// If we're considering that the totality of "all data" the application can create as the "global
+/// If we're considering the totality of "all data" the application can create as the "global
 /// state", we might want to categorise it into logical "sub-sections", especially when the
 /// application gets complex. In an example chat application we might not want to sync _all_ chat
 /// group data which has ever been created by all peers, but only a subset of the ones our peer is
@@ -204,7 +204,7 @@ pub(crate) fn to_public_key(key: iroh_base::key::PublicKey) -> p2panda_core::Pub
     p2panda_core::PublicKey::from_bytes(key.as_bytes()).expect("already validated public key")
 }
 
-/// Converts an `p2panda-core` public key to the "iroh" type.
+/// Converts a `p2panda-core` public key to the "iroh" type.
 #[allow(dead_code)]
 pub(crate) fn from_public_key(key: p2panda_core::PublicKey) -> iroh_base::key::PublicKey {
     iroh_base::key::PublicKey::from_bytes(key.as_bytes()).expect("already validated public key")

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -806,7 +806,10 @@ mod sync_protocols {
                     Message::Pong => {
                         debug!("pong message received");
                         app_tx
-                            .send(FromSync::Data("PONG".as_bytes().to_owned(), None))
+                            .send(FromSync::Data {
+                                header: "PONG".as_bytes().to_owned(),
+                                payload: None,
+                            })
                             .await
                             .unwrap();
                         break;
@@ -841,7 +844,10 @@ mod sync_protocols {
                     Message::Ping => {
                         debug!("ping message received");
                         app_tx
-                            .send(FromSync::Data("PING".as_bytes().to_owned(), None))
+                            .send(FromSync::Data {
+                                header: "PING".as_bytes().to_owned(),
+                                payload: None,
+                            })
                             .await
                             .unwrap();
 

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -1111,12 +1111,12 @@ mod tests {
         let mut topic_map = LogIdTopicMap::new();
         topic_map.insert(topic.clone(), logs);
 
-        // Construct a store and log height protocol for peer a
+        // Construct a store and log height protocol for peer a.
         let store_a = MemoryStore::default();
         let protocol_a = LogSyncProtocol::new(topic_map.clone(), store_a);
         let sync_config_a = SyncConfiguration::new(protocol_a);
 
-        // Create some operations
+        // Create some operations.
         let body = Body::new("Hello, Sloth!".as_bytes());
         let (hash_0, header_0, header_bytes_0) =
             create_operation(&peer_a_private_key, &body, 0, 0, None, None);
@@ -1125,7 +1125,7 @@ mod tests {
         let (hash_2, header_2, header_bytes_2) =
             create_operation(&peer_a_private_key, &body, 2, 200, Some(hash_1), None);
 
-        // Create store for peer b and populate with operations
+        // Create store for peer b and populate with operations.
         let mut store_b = MemoryStore::default();
         store_b
             .insert_operation(hash_0, &header_0, Some(&body), &header_bytes_0, &log_id)
@@ -1140,7 +1140,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Construct log height protocol for peer b
+        // Construct log height protocol for peer b.
         let protocol_b = LogSyncProtocol::new(topic_map, store_b);
         let sync_config_b = SyncConfiguration::new(protocol_b);
 
@@ -1166,12 +1166,12 @@ mod tests {
         node_a.add_peer(node_b_addr).await.unwrap();
         node_b.add_peer(node_a_addr).await.unwrap();
 
-        // Subscribe to the same topic from both nodes which should kick off sync
+        // Subscribe to the same topic from both nodes which should kick off sync.
         let topic_clone = topic.clone();
         let handle1 = tokio::spawn(async move {
             let (_tx, mut from_sync_rx, ready) = node_a.subscribe(topic_clone).await.unwrap();
 
-            // Wait until the gossip overlay has been joined for TOPIC_ID
+            // Wait until the gossip overlay has been joined for TOPIC_ID.
             assert!(ready.await.is_ok());
 
             let mut from_sync_messages = Vec::new();

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -879,9 +879,9 @@ mod tests {
 
     use async_trait::async_trait;
     use iroh_net::relay::{RelayNode, RelayUrl as IrohRelayUrl};
-    use p2panda_core::{Body, Hash, Header, PrivateKey};
+    use p2panda_core::{Body, Hash, Header, PrivateKey, PublicKey};
     use p2panda_store::{MemoryStore, OperationStore};
-    use p2panda_sync::log_sync::{LogSyncProtocol, Logs};
+    use p2panda_sync::log_sync::LogSyncProtocol;
     use p2panda_sync::{Topic, TopicMap};
     use serde::{Deserialize, Serialize};
     use tokio::task::JoinHandle;
@@ -1066,6 +1066,8 @@ mod tests {
         assert!(result1.is_ok());
         assert!(result2.is_ok());
     }
+
+    type Logs<T> = HashMap<PublicKey, Vec<T>>;
 
     #[derive(Clone, Debug)]
     struct LogIdTopicMap<T>(HashMap<T, Logs<u64>>);

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -1465,9 +1465,9 @@ mod tests {
         node_3.add_peer(node_2_addr.clone()).await.unwrap();
         node_4.add_peer(node_3_addr.clone()).await.unwrap();
 
-        // Run all nodes. We are testing that peers gracefully handle starting a sync session
-        // whine not knowing the other peer's address yet. Eventually all peers complete at least
-        // one sync session.
+        // Run all nodes. We are testing that peers gracefully handle starting a sync session while
+        // not knowing the other peer's address yet. Eventually all peers complete at least one
+        // sync session.
         let handle1 = run_node(node_1, topic.clone());
         let handle2 = run_node(node_2, topic.clone());
         let handle3 = run_node(node_3, topic.clone());

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -1111,10 +1111,7 @@ mod tests {
 
         // Construct a store and log height protocol for peer a
         let store_a = MemoryStore::default();
-        let protocol_a = LogSyncProtocol {
-            topic_map: topic_map.clone(),
-            store: store_a,
-        };
+        let protocol_a = LogSyncProtocol::new(topic_map.clone(), store_a);
         let sync_config_a = SyncConfiguration::new(protocol_a);
 
         // Create some operations
@@ -1142,10 +1139,7 @@ mod tests {
             .unwrap();
 
         // Construct log height protocol for peer b
-        let protocol_b = LogSyncProtocol {
-            topic_map,
-            store: store_b,
-        };
+        let protocol_b = LogSyncProtocol::new(topic_map, store_b);
         let sync_config_b = SyncConfiguration::new(protocol_b);
 
         // Build peer a's node

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -1,5 +1,121 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//! Node implementation for p2p networking and data streaming, extensible with discovery
+//! strategies, sync protocols, blob sync and more.
+//!
+//! As soon as the local node is launched it roughly attempts the following goal:
+//!
+//! 1. Find as many peers as possible who are interested in the same topic
+//! 2. Connect with as many peers as possible to exchange data with, eventually converging to the
+//!    same state
+//!
+//! To achieve this goal, multiple systems are in play:
+//!
+//! ## Bootstrap
+//!
+//! Establishing a peer-to-peer network suffers from the "chicken and egg" problem where we need to
+//! start _somewhere_ before we can begin to discover more and become "discoverable" for other,
+//! possibly previously unknown peers.
+//!
+//! This process of the "first step" into a network is called "bootstrap" and can be realised with
+//! different strategies:
+//!
+//! 1. Supply your node with a hard-coded list of well-known node addresses which are directly
+//!    reachable. The node will attempt connecting them on start.
+//! 2. Use techniques like mDNS or rendesvouz servers to learn about other nodes to connect to.
+//!
+//! The latter approach is very similar to "peer discovery" with one important difference: While
+//! peer discovery helps us to learn about _more peers_ we use these discovery techniques during
+//! bootstrap to find _the first_ peer to connect to.
+//!
+//! ## Peer Discovery
+//!
+//! Like "Bootstrap" we can apply similar algorithms to find more peers in the network. In
+//! `p2panda-net` this is an "ambient" process, meaning that it constantly takes place in the
+//! background, as soon as the node is running.
+//!
+//! To find more peers which potentially might be interested in the same data as the local node,
+//! one or more discovery techniques can be added when creating the network, for example mDNS for
+//! finding peers in the local network or a "Rendesvouz" server for finding peers on the internet.
+//!
+//! Additionally `p2panda-net` might find new peers through joining any gossip overlay. If another
+//! peer becomes a direct neighbor in the gossip tree, we register it in our address book.
+//!
+//! ## Topic Discovery
+//!
+//! Next to "Peer Discovery" we additionally find out what peers are interested in and announce our
+//! own topics of interest in the network. With this design it is possible to have peers in the
+//! network being interested in different data, potentially using other applications, at the same
+//! time.
+//!
+//! By default `p2panda-net` always enters at least one network-wide gossip overlay where peers
+//! exchange information over this information. In the future we might use a random-walk traversal
+//! algorithm instead to "explore" the network.
+//!
+//! As soon as we've identified a common interest in the same topic, we're joining the gossip
+//! overlay for this topic with them and earmark this peer for a future sync session.
+//!
+//! ## Connectivity
+//!
+//! With the help of iroh, we can connect to any device whereever they are. There is a multi-step
+//! process requiring additional strategies depending on the situation to connect to a peer:
+//!
+//! 1. If we know a peer's directly reachable address, we can just connect to them
+//! 2. If this peer's direct address is not known (because they are behind a NAT or we only know
+//!    their public key) we use a STUN server to find out the address
+//! 3. If this peer is still not reachable (for example because they are behind a Firewall), we use
+//!    a Relay (TURN-like) server to handle the connection through it
+//!
+//! In the last case we can't establish a direct connection and rely on additional infrastructure.
+//!
+//! Read the `iroh-relay` documentation to learn about how to run your own STUN and Relay server:
+//! <https://github.com/n0-computer/iroh/tree/main/iroh-relay>.
+//!
+//! This implementation aims at being robust in situations where bad or no connectivity is
+//! (temporarily) given. `p2panda-net` will automatically re-connect to peers as soon as they are
+//! reachable again which, from the application perspective, shouldn't make any difference.
+//!
+//! ## "Live Mode"
+//!
+//! To send newly created messages fastly to other peers, `p2panda-net` uses broadcast gossip
+//! overlays for each topic. With this "live mode" messages arrive almost instantly.
+//!
+//! ## Sync
+//!
+//! By learning about other peers who are interested in the same topic we keep track of them in an
+//! internal "address book". A sync session mananger process will eventually kick in a sync session
+//! with one of these peers and try to exchange _all_ data we're so far missing on that topic with
+//! them.
+//!
+//! Sync is disabled by default and can be enabled by adding a `SyncProtocol` implementation to the
+//! node.
+//!
+//! Sync sessions are only running once per peer per topic but can optionally be re-attempted after
+//! a certain duration if a `ResyncConfiguration` was given.
+//!
+//! ## Gossip Buffer
+//!
+//! Since a node receives potentially older data from another node during a sync session,
+//! `p2panda-net` uses a "gossip buffer" to make sure that we're buffering new messages which were
+//! received at the same time during the gossip overlay.
+//!
+//! The buffer is released after the sync session has ended. Through this trick we can make sure
+//! that messages are arriving "in order" (based on their timestamp or partial ordering for
+//! example) to higher application layers.
+//!
+//! Please note that this implementation can never fully be sure that messages will arrive "out of
+//! order" to the application. It is recommended to apply additional buffering if this is required.
+//! In `p2panda-streams` we offer a solution which will take care of that.
+//!
+//! ## Blobs
+//!
+//! With the help of the `p2panda-blobs` crate it is possible to extend the node to support
+//! efficient sync of large binary data (images, files etc.) with various storage backends.
+//!
+//! ## Custom Protocols
+//!
+//! Next to blob sync, data sync or discovery protocols it is also possible to register any other
+//! low-level bi-directional communication protocol to the node when necessary.
 use std::fmt::Debug;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::sync::Arc;
@@ -50,7 +166,8 @@ pub enum RelayMode {
     ///
     /// Relays are used to help establishing a connection in case the direct address is not known
     /// yet (via STUN). In case this process fails (for example due to a firewall), the relay is
-    /// used as a fallback to tunnel traffic from one peer to another (via DERP).
+    /// used as a fallback to tunnel traffic from one peer to another (via DERP, which is similar
+    /// to TURN).
     ///
     /// Important: Peers need to use the _same_ relay address to be able to connect to each other.
     Custom(RelayNode),
@@ -79,8 +196,8 @@ where
 {
     /// Returns a new instance of `NetworkBuilder` using the given network identifier.
     ///
-    /// The identifier is used during handshake and discovery protocols. Networks must use the
-    /// same identifier if they wish to successfully connect and share gossip.
+    /// Networks must use the same identifier if they wish to successfully connect and share
+    /// data.
     pub fn new(network_id: NetworkId) -> Self {
         Self {
             bind_port: None,
@@ -131,9 +248,10 @@ where
     /// Sets the relay used by the local network to facilitate the establishment of direct
     /// connections.
     ///
-    /// Relay nodes are STUN servers which help in establishing a peer-to-peer connection if one
-    /// or both of the peers are behind a NAT. The relay node might offer proxy functionality if
-    /// the connection attempt fails, which will serve to relay the data in that case.
+    /// Relay nodes are STUN servers which help in establishing a peer-to-peer connection if one or
+    /// both of the peers are behind a NAT. The relay node might offer proxy functionality on top
+    /// (via the Tailscale DERP protocol which is very similar to TURN) if the connection attempt
+    /// fails, which will serve to relay the data in that case.
     pub fn relay(mut self, url: RelayUrl, stun_only: bool, stun_port: u16) -> Self {
         self.relay_mode = RelayMode::Custom(RelayNode {
             url: url.into(),
@@ -145,9 +263,10 @@ where
 
     /// Sets the direct address of a peer, identified by their public key (node id).
     ///
-    /// The direct address should be reachable without the aid of a STUN / relay node. However, if
-    /// the direct connection attempt might fail (for example, because of a NAT or Firewall), the
-    /// relay node of that peer can be supplied to allow a connection re-attempt.
+    /// The direct address should be reachable without the aid of a STUN or TURN-based relay node.
+    /// However, if the direct connection attempt might fail (for example, because of a NAT or
+    /// Firewall), the relay node of that peer can be supplied to allow connecting to it via a
+    /// fallback connection.
     ///
     /// If no relay address is given but turns out to be required, we optimistically try to use our
     /// own relay node instead (if specified). This might still fail, as we can't know if the peer
@@ -175,7 +294,8 @@ where
 
     /// Sets the sync protocol and configuration.
     ///
-    /// Sync sessions will be completed with any known peers with whom we share topics of interest.
+    /// Sync sessions will be automatically initiated with any known peers with whom we share
+    /// topics of interest.
     pub fn sync(mut self, config: SyncConfiguration<T>) -> Self {
         self.sync_config = Some(config);
         self
@@ -203,14 +323,14 @@ where
     /// Returns a handle to a newly-spawned instance of `Network`.
     ///
     /// A peer-to-peer endpoint is created and bound to a QUIC socket, after which the gossip,
-    /// engine and handshake handlers are instantiated. A sync handler is also instantiated if a
-    /// sync protolc is provided. Direct addresses for network peers are added to the engine from
+    /// engine and connection handlers are instantiated. A sync handler is also instantiated if a
+    /// sync protocol is provided. Direct addresses for network peers are added to the engine from
     /// the address book and core protocols are registered.
     ///
     /// After configuration and registration processes are complete, the network is spawned and an
-    /// attempt is made to retrieve a direct address for a network peer so that a connection
-    /// attempt may be made. If no address is retrieved within the timeout limit, the network is
-    /// shut down and an error is returned.
+    /// attempt is made to retrieve a direct address for a network peer so that a connection may be
+    /// made. If no address is retrieved within the timeout limit, the network is shut down and an
+    /// error is returned.
     pub async fn build(mut self) -> Result<Network<T>>
     where
         T: Topic + TopicId + 'static,
@@ -424,8 +544,8 @@ where
                 },
                 // Handle incoming p2p connections.
                 Some(incoming) = self.endpoint.accept() => {
-                    // @TODO: This is the point at which we can reject the connection if
-                    // limits have been reached.
+                    // @TODO: This is the point at which we can reject the connection if limits
+                    // have been reached.
                     let connecting = match incoming.accept() {
                         Ok(connecting) => connecting,
                         Err(err) => {
@@ -502,7 +622,7 @@ where
     }
 }
 
-/// An API for interacting with the p2panda networking stack.
+/// Running peer-to-peer node.
 ///
 /// The primary feature of the `Network` is the ability to subscribe to one or more topics and
 /// exchange messages over those topics with remote peers. Replication can be conducted exclusively
@@ -530,7 +650,7 @@ impl<T> Network<T>
 where
     T: Topic + TopicId + 'static,
 {
-    /// Adds a peer to the local network address book.
+    /// Adds a peer to the address book.
     pub async fn add_peer(&self, node_addr: NodeAddr) -> Result<()> {
         self.inner.engine.add_peer(node_addr).await
     }
@@ -540,7 +660,7 @@ where
         self.inner.engine.known_peers().await
     }
 
-    /// Returns the direct addresses of the local network.
+    /// Returns the direct addresses of this node.
     pub async fn direct_addresses(&self) -> Option<Vec<SocketAddr>> {
         self.inner
             .endpoint
@@ -561,13 +681,13 @@ where
         &self.inner.endpoint
     }
 
-    /// Returns the public key of the local network.
+    /// Returns the public key of the node.
     pub fn node_id(&self) -> PublicKey {
         PublicKey::from_bytes(self.inner.endpoint.node_id().as_bytes())
             .expect("public key already checked")
     }
 
-    /// Terminates the main network task and shuts down the network.
+    /// Terminates all internal tasks and shuts down the node.
     pub async fn shutdown(self) -> Result<()> {
         // Trigger shutdown of the main run task by activating the cancel token.
         self.inner.cancel_token.cancel();
@@ -580,10 +700,6 @@ where
 
     /// Subscribes to a topic and returns a bi-directional stream that can be read from and written
     /// to, along with a oneshot receiver to be informed when the gossip overlay has been joined.
-    ///
-    /// Peers subscribed to a topic can be discovered by others via the gossip overlay ("neighbor
-    /// up event"). They'll sync data initially, if a sync protocol has been provided, and then
-    /// start "live-mode" via gossip broadcast.
     pub async fn subscribe(
         &self,
         topic: T,

--- a/p2panda-net/src/protocols.rs
+++ b/p2panda-net/src/protocols.rs
@@ -13,12 +13,10 @@ use futures_util::future::join_all;
 use iroh_net::endpoint::Connecting;
 use tracing::debug;
 
-/// Handler for incoming connections.
+/// Interface to accept incoming connections for custom protocol implementations.
 ///
-/// An iroh node can accept connections for arbitrary ALPN protocols. By default, the iroh node
-/// only accepts connections for the ALPNs of the core iroh protocols (blobs, gossip, docs).
-///
-/// With this trait, you can handle incoming connections for custom protocols.
+/// An node can accept connections for custom protocols. By default, the node only accepts
+/// connections for the core protocols (gossip and optionally sync or blobs).
 pub trait ProtocolHandler: Send + Sync + IntoArcAny + fmt::Debug + 'static {
     /// Handle an incoming connection.
     ///
@@ -31,7 +29,7 @@ pub trait ProtocolHandler: Send + Sync + IntoArcAny + fmt::Debug + 'static {
     }
 }
 
-/// Helper trait to facilite casting from `Arc<dyn T>` to `Arc<dyn Any>`.
+/// Helper trait to facilitate casting from `Arc<dyn T>` to `Arc<dyn Any>`.
 ///
 /// This trait has a blanket implementation so there is no need to implement this yourself.
 pub trait IntoArcAny {

--- a/p2panda-net/src/protocols.rs
+++ b/p2panda-net/src/protocols.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 
 /// Interface to accept incoming connections for custom protocol implementations.
 ///
-/// An node can accept connections for custom protocols. By default, the node only accepts
+/// A node can accept connections for custom protocols. By default, the node only accepts
 /// connections for the core protocols (gossip and optionally sync or blobs).
 pub trait ProtocolHandler: Send + Sync + IntoArcAny + fmt::Debug + 'static {
     /// Handle an incoming connection.

--- a/p2panda-net/src/sync/accept.rs
+++ b/p2panda-net/src/sync/accept.rs
@@ -166,7 +166,7 @@ where
 
                     // From this point on we are only expecting "data" messages from the sync
                     // session.
-                    let FromSync::Data(header, payload) = message else {
+                    let FromSync::Data { header, payload } = message else {
                         return Err(
                             SyncError::Critical(
                                 "expected only data messages from sync session in data sync phase"

--- a/p2panda-net/src/sync/initiate.rs
+++ b/p2panda-net/src/sync/initiate.rs
@@ -123,7 +123,7 @@ where
 
                 // 2. Data Sync Phase.
                 // ~~~~~~~~~~~~~~~~~~~
-                let FromSync::Data(header, payload) = message else {
+                let FromSync::Data { header, payload } = message else {
                     return Err(SyncError::Critical("expected to receive only data messages from sync session in data sync phase".into()));
                 };
 

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -11,7 +11,7 @@ log-sync = ["dep:p2panda-core", "dep:p2panda-store", "cbor"]
 async-trait = "0.1.82"
 futures = "0.3.30"
 p2panda-core = { path = "../p2panda-core", optional = true }
-p2panda-store = { path = "../p2panda-store", optional = true }
+p2panda-store = { path = "../p2panda-store", optional = true, default-features = false }
 serde = { version = "1.0.208" }
 tokio-stream = { version = "0.1.15", optional = true }
 tokio-util = { version = "0.7.11", features = [

--- a/p2panda-sync/src/cbor.rs
+++ b/p2panda-sync/src/cbor.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//! Utility methods to encode or decode wire protocol messages in [CBOR] format.
+//!
+//! [CBOR]: https://cbor.io/
 use std::marker::PhantomData;
 
 use futures::{AsyncRead, AsyncWrite, Sink, Stream};

--- a/p2panda-sync/src/cbor.rs
+++ b/p2panda-sync/src/cbor.rs
@@ -20,7 +20,7 @@ use crate::SyncError;
 /// parsing these headers and then reason about if it has enough information to proceed.
 ///
 /// Read more on CBOR in streaming applications here:
-/// https://www.rfc-editor.org/rfc/rfc8949.html#section-5.1
+/// <https://www.rfc-editor.org/rfc/rfc8949.html#section-5.1>
 #[derive(Clone, Debug)]
 pub struct CborCodec<T> {
     _phantom: PhantomData<T>,

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -1,5 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//! Data- and transport-agnostic interface to implement custom sync protocols, compatible with
+//! `p2panda-net` or other peer-to-peer networking solutions.
+//!
+//! Sync or "synchronisation" protocols (also known as "replication protocols") are used to
+//! efficiently exchange data between peers.
+//!
+//! Unlike gossip protocols, sync protocols are better solutions to "catch up on past state". Peers
+//! can negotiate scope and access in a sync protocol for any type of data the remote peer
+//! currently knows about.
+//!
+//! While `p2panda-sync` is merely a generic definition of the `Sync` trait interface, compatible
+//! with all sorts of data types, it also comes with optional implementations, optimized for
+//! efficient sync over append-only log-based data types and helpers to encode wire messages in
+//! CBOR.
 #[cfg(feature = "cbor")]
 pub mod cbor;
 #[cfg(feature = "log-sync")]
@@ -14,48 +28,95 @@ use futures::{AsyncRead, AsyncWrite, Sink};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// Identify the particular data-set a peer is interested in syncing.
+/// Data- and transport-agnostic interface to implement a custom sync protocol, compatible with
+/// `p2panda-net` or other peer-to-peer networking solutions.
 ///
-/// Exactly how this is expressed is left up to the user to decide. During sync the "initiator"
-/// sends their topic to a remote peer where it is be mapped to their local data-set and
-/// access-control checks can be performed. Once this "handshake" is complete both peers will
-/// proceed with the designated sync protocol.
+/// Implementing a `SyncProtocol` trait needs extra care but is only required when designing custom
+/// low-level peer-to-peer protocols and data types. p2panda comes already with solutions which can
+/// be used "out of the box", providing implementations for most applications and usecases.
 ///
-/// ## Designing topics for applications
+/// ## Design
 ///
-/// While `TopicId` is merely a 32-byte identifier which can't hold much information other than
-/// being a distinct identifier of a single data item or subset of them, we can use `Topic` to
-/// implement custom data types which can "query" very specific data items. Peers can for example
-/// announce that they'd like "all events from the 27th of September 23 until today" with `Topic`.
+/// Sync sessions are designed as a two-party protocol, where an "initiator" starts the session
+/// over a "topic" and an "acceptor" learning about the topic to finally exchange the actual data
+/// of interest with each other.
 ///
-/// Consult the `TopicId` documentation in `p2panda-net` for more information.
-pub trait Topic:
-    Clone + Debug + Eq + Hash + Send + Sync + Serialize + for<'a> Deserialize<'a>
-{
-}
-
-/// Maps a topic to the related data being sent over the wire during sync.
+/// Each protocol is usually following two phases: A "Handshake" phase, used to exchange the
+/// "topic" and access control and a "Sync" phase where the requested application data is exchanged
+/// and validated.
 ///
-/// Each `SyncProtocol` implementation defines the type of data it is expecting to sync and how the
-/// scope for a particular session should be identified. Sync protocol users can provide an
-/// implementation of `TopicMap` so that a scope `S` can be retrieved for a specific topic `T` when
-/// a peer initiates or accepts a sync session.
-#[async_trait]
-pub trait TopicMap<T, S>: Debug + Send + Sync
-where
-    T: Topic,
-{
-    async fn get(&self, topic: &T) -> Option<S>;
-}
-
+/// ## Privacy and Security
+///
+/// The `SyncProtocol` trait has been designed to allow privacy-respecting implementations where
+/// data (via access control) and the topic itself (for example via Diffie Hellmann) is securely
+/// exchanged without revealing any information unnecessarily. This usually takes place inside the
+/// "Handshake" phase of the regarding protocol.
+///
+/// The underlying transport layer should provide automatic authentication of the remote peer, a
+/// reliable connection and transport encryption, as in `p2panda-net`.
+///
+/// ## Streams
+///
+/// Three distinct data channels are provided by the underlying transport layer to each
+/// `SyncProtocol` implementation: `tx` for sending data to the remote peer, `rx` to receive data
+/// from the remote peer and `app_tx` to send received data to the higher-level application,
+/// validation and persistance layers.
+///
+/// ## Topics
+///
+/// Topics are generic data types which can be used to express the interest in a particular subset
+/// of the data we want to sync over, for example chat group identifiers or very specific "search
+/// queries" for example "give me all documents containing the word 'billy'."
+///
+/// With the help of the `TopicMap` trait we can keep sync implementations agnostic to specific
+/// topic implementations. The sync protocol only needs to feed the "topic" into the "map" which
+/// will answer with the actual to-be-synced data entities (for example coming from a store). This
+/// allows application developers to use your `SyncProtocol` implementation for their custom
+/// `Topic` requirements.
+///
+/// ## Validation
+///
+/// Basic data-format and -encoding validation usually takes place during the "Sync" phase of the
+/// protocol.
+///
+/// Further validation which might require more knowledge of the application state or can only be
+/// applied after decrypting the payload should be handled _outside_ the sync protocol, by sending
+/// it upstream to higher application layers.
+///
+/// ## Errors
+///
+/// Protocol implementations operate on multiple layers at the same time, expressed in distinct
+/// error categories:
+///
+/// 1. Unexpected behaviour of the remote peer not following the implemented protocol
+/// 2. Handling (rare) critical system failures
 #[async_trait]
 pub trait SyncProtocol<T, 'a>
 where
     Self: Send + Sync + Debug,
     T: Topic,
 {
+    /// Custom identifier for this sync protocol implementation.
+    ///
+    /// This is currently only used for debugging or logging purposes.
     fn name(&self) -> &'static str;
 
+    /// Initiate a sync protocol session over the provided bi-directional stream for the given
+    /// topic.
+    ///
+    /// During the "Handshake" phase the "initiator" usually requests access and informs the remote
+    /// peer about the "topic" they are interested in exchanging. Implementations for `p2panda-net`
+    /// are required to send a `SyncFrom::HandshakeSuccess` message to the application layer (via
+    /// `app_tx`) during this phase to inform the backend that we've successfully requested access,
+    /// exchanged the topic with the remote peer and are about to begin sync.
+    ///
+    /// Afterwards it enters the "Sync" phase where the actual application data is exchanged with
+    /// the remote peer. If the protocol exchanges data in both directions or not is up to the
+    /// regarding implementation. Synced data is forwarded to the application layers via the
+    /// `SyncFrom::Data` message (via `app_tx`).
+    ///
+    /// In case of a detected failure (either through an critical error on our end or an unexpected
+    /// behaviour from the remote peer) a `SyncError` is returned.
     async fn initiate(
         self: Arc<Self>,
         topic: T,
@@ -64,6 +125,22 @@ where
         app_tx: Box<&'a mut (dyn Sink<FromSync<T>, Error = SyncError> + Send + Unpin)>,
     ) -> Result<(), SyncError>;
 
+    /// Accept a sync protocol session over the provided bi-directional stream.
+    ///
+    /// During the "Handshake" phase the "acceptor" usually responds to the access request and
+    /// informs the learns about the "topic" from the remote peer they are interested in
+    /// exchanging. Implementations for `p2panda-net` are required to send a
+    /// `SyncFrom::HandshakeSuccess` message to the application layer (via `app_tx`) during this
+    /// phase to inform the backend that we've successfully learned the topic with the remote peer
+    /// and are about to begin sync.
+    ///
+    /// Afterwards it enters the "Sync" phase where the actual application data is exchanged with
+    /// the remote peer. If the protocol exchanges data in both directions or not is up to the
+    /// regarding implementation. Synced data is forwarded to the application layers via the
+    /// `SyncFrom::Data` message (via `app_tx`).
+    ///
+    /// In case of a detected failure (either through an critical error on our end or an unexpected
+    /// behaviour from the remote peer) a `SyncError` is returned.
     async fn accept(
         self: Arc<Self>,
         tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
@@ -72,6 +149,46 @@ where
     ) -> Result<(), SyncError>;
 }
 
+/// Messages which can be sent to the higher application layers for further validation or
+/// persistance and the underlying transport layer for managing the sync session.
+#[derive(PartialEq, Debug)]
+pub enum FromSync<T>
+where
+    T: Topic,
+{
+    /// During the "Handshake" phase both peers usually manage access control and negotiate the
+    /// "topic" they want to exchange over. This messages indicates that this phase has ended.
+    ///
+    /// Implementations for `p2panda-net` are required to send this message to the underlying
+    /// transport layer to inform the "backend" that we've successfully requested access, exchanged
+    /// the topic with the remote peer and are about to begin sync.
+    ///
+    /// With this information backends can optionally apply optimizations, which might for example
+    /// be required to keep application messages in-order (as there might be other channels the
+    /// backend might exchange similar data over at the same time).
+    HandshakeSuccess(T),
+
+    /// Application data we've received during the sync session from the remote peer and we want to
+    /// forward to higher application layers.
+    ///
+    /// These "frontends" might further process, decrypt payloads, sort messages or apply more
+    /// validation before they get finally persisted or rendered to the user. At this point the
+    /// sync protocol is merely "forwarding" it without any more knowledge how the data is used.
+    ///
+    /// Some data-types might be designed with "off-chain" use in mind, where a "header" is crucial
+    /// for integrity and authenticity but the actual payload is optional or requested lazily in a
+    /// later process. This is why the main data can be expressed as bytes but the second field is
+    /// optional. Implementations without this distinction will leave the second field always
+    /// `None`.
+    Data(Vec<u8>, Option<Vec<u8>>),
+}
+
+/// Errors which can occur during sync sessions.
+///
+/// 1. Critical system failures (bug in p2panda code or sync implementation, sync implementation
+///    did not follow "2. Phase Flow" requirements, lack of system resources, etc.)
+/// 2. Unexpected Behaviour (remote peer abruptly disconnected, error which got correctly handled
+///    in sync implementation, etc.)
 #[derive(Debug, Error, PartialEq)]
 pub enum SyncError {
     /// Error due to unexpected (buggy or malicious) behaviour of the remote peer.
@@ -119,11 +236,64 @@ impl From<std::io::Error> for SyncError {
     }
 }
 
-#[derive(PartialEq, Debug)]
-pub enum FromSync<T>
+/// Identify the particular data-set a peer is interested in syncing.
+///
+/// Exactly how this is expressed is left up to the user to decide. During sync the "initiator"
+/// sends their topic to a remote peer where it is be mapped to their local data-set. Additionally
+/// access-control checks can be performed. Once this "handshake" is complete both peers will
+/// proceed with the designated sync protocol.
+///
+/// ## `TopicId` vs `Topic`
+///
+/// While `TopicId` is merely a 32-byte identifier which can't hold much information other than
+/// being a distinct identifier of a single data item or subset of them, we can use `Topic` to
+/// implement custom data types which can "query" very specific data items. Peers can for example
+/// announce that they'd like "all events from the 27th of September 23 until today" with `Topic`.
+///
+/// Consult the `TopicId` documentation in `p2panda-net` for more information.
+pub trait Topic:
+    Clone + Debug + Eq + Hash + Send + Sync + Serialize + for<'a> Deserialize<'a>
+{
+}
+
+/// Maps a `Topic` to the related data being sent over the wire during sync.
+///
+/// Each `SyncProtocol` implementation defines the type of data it is expecting to sync and how the
+/// scope for a particular session should be identified. Sync protocol users can provide an
+/// implementation of `TopicMap` so that scope `S` for data can be retrieved for a specific topic
+/// `T` when a peer initiates or accepts a sync session.
+///
+/// Since `TopicMap` is generic we can use the same mapping across different sync implementations
+/// for the same data type when necessary.
+///
+/// ## Designing `TopicMap` for applications
+///
+/// Considering an example chat application which is based on append-only log data types, we
+/// probably want to organise messages from an author for a certain chat group into one log each.
+/// Like this, a chat group can be expressed as a collection of one to potentially many logs (one
+/// per member of the group):
+///
+/// ```text
+/// All authors: A, B and C
+/// All chat groups: 1 and 2
+///
+/// "Chat group 1 with members A and B"
+/// - Log A1
+/// - Log B1
+///
+/// "Chat group 2 with members A, B and C"
+/// - Log A2
+/// - Log B2
+/// - Log C2
+/// ```
+///
+/// If we implement `Topic` to express that we're interested in syncing over a specific chat group,
+/// for example "Chat Group 2" we would implement `TopicMap` to give us all append-only logs of all
+/// members inside this group, that is the entries inside logs `A2`, `B2` and `C2`.
+#[async_trait]
+pub trait TopicMap<T, S>: Debug + Send + Sync
 where
     T: Topic,
 {
-    HandshakeSuccess(T),
-    Data(Vec<u8>, Option<Vec<u8>>),
+    async fn get(&self, topic: &T) -> Option<S>;
 }

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -37,13 +37,10 @@ use thiserror::Error;
 ///
 /// ## Design
 ///
-/// Sync sessions are designed as a two-party protocol, where an "initiator" starts the session
-/// over a "topic" and an "acceptor" learning about the topic to finally exchange the actual data
-/// of interest with each other.
-///
-/// Each protocol is usually following two phases: A "Handshake" phase, used to exchange the
-/// "topic" and access control and a "Sync" phase where the requested application data is exchanged
-/// and validated.
+/// Sync sessions are designed as a two-party protocol featuring an "initiator" and an "acceptor".
+/// Each protocol usually follows two phases: 1) The "Handshake" phase, during which the "initiator" 
+/// sends the sync "topic" and any access control data to the "acceptor", and 2) The "Sync" phase, 
+/// where the requested application data is exchanged and validated.
 ///
 /// ## Privacy and Security
 ///
@@ -64,7 +61,7 @@ use thiserror::Error;
 ///
 /// ## Topics
 ///
-/// Topics are generic data types which can be used to express the interest in a particular subset
+/// Topics are generic data types which can be used to express interest in a particular subset
 /// of the data we want to sync over, for example chat group identifiers or very specific "search
 /// queries" for example "give me all documents containing the word 'billy'."
 ///
@@ -115,7 +112,7 @@ where
     /// regarding implementation. Synced data is forwarded to the application layers via the
     /// `SyncFrom::Data` message (via `app_tx`).
     ///
-    /// In case of a detected failure (either through an critical error on our end or an unexpected
+    /// In case of a detected failure (either through a critical error on our end or an unexpected
     /// behaviour from the remote peer) a `SyncError` is returned.
     async fn initiate(
         self: Arc<Self>,
@@ -128,18 +125,18 @@ where
     /// Accept a sync protocol session over the provided bi-directional stream.
     ///
     /// During the "Handshake" phase the "acceptor" usually responds to the access request and
-    /// informs the learns about the "topic" from the remote peer they are interested in
-    /// exchanging. Implementations for `p2panda-net` are required to send a
+    /// learns about the "topic" from the remote peer.
+    /// Implementations for `p2panda-net` are required to send a
     /// `SyncFrom::HandshakeSuccess` message to the application layer (via `app_tx`) during this
-    /// phase to inform the backend that we've successfully learned the topic with the remote peer
-    /// and are about to begin sync.
+/// phase to inform the backend that the topic has been successfully received from the remote peer
+/// and that data exchange is about to begin.
     ///
     /// Afterwards it enters the "Sync" phase where the actual application data is exchanged with
     /// the remote peer. If the protocol exchanges data in both directions or not is up to the
     /// regarding implementation. Synced data is forwarded to the application layers via the
     /// `SyncFrom::Data` message (via `app_tx`).
     ///
-    /// In case of a detected failure (either through an critical error on our end or an unexpected
+    /// In case of a detected failure (either through a critical error on our end or an unexpected
     /// behaviour from the remote peer) a `SyncError` is returned.
     async fn accept(
         self: Arc<Self>,
@@ -157,7 +154,7 @@ where
     T: Topic,
 {
     /// During the "Handshake" phase both peers usually manage access control and negotiate the
-    /// "topic" they want to exchange over. This messages indicates that this phase has ended.
+    /// "topic" they want to exchange over. This message indicates that this phase has ended.
     ///
     /// Implementations for `p2panda-net` are required to send this message to the underlying
     /// transport layer to inform the "backend" that we've successfully requested access, exchanged
@@ -168,7 +165,7 @@ where
     /// backend might exchange similar data over at the same time).
     HandshakeSuccess(T),
 
-    /// Application data we've received during the sync session from the remote peer and we want to
+    /// Application data we've received during the sync session from the remote peer and want to
     /// forward to higher application layers.
     ///
     /// These "frontends" might further process, decrypt payloads, sort messages or apply more
@@ -247,7 +244,7 @@ impl From<std::io::Error> for SyncError {
 /// Identify the particular data-set a peer is interested in syncing.
 ///
 /// Exactly how this is expressed is left up to the user to decide. During sync the "initiator"
-/// sends their topic to a remote peer where it is be mapped to their local data-set. Additionally
+/// sends their topic to a remote peer where it is be mapped to their local data-set. Additional
 /// access-control checks can be performed. Once this "handshake" is complete both peers will
 /// proceed with the designated sync protocol.
 ///

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -10,9 +10,10 @@
 //! can negotiate scope and access in a sync protocol for any type of data the remote peer
 //! currently knows about.
 //!
-//! Next to `p2panda-sync` containing the generic definition of the `SyncProtocol` trait interface,
-//! it also comes with optional implementations behind feature flags, optimized for efficient sync
-//! of append-only log-based data types plus helpers to encode wire messages in CBOR.
+//! In addition to the generic definition of the `SyncProtocol` trait, `p2panda-sync` includes 
+//! optional implementations for efficient sync of append-only log-based data types. These optional 
+//! implementations may be activated via feature flags. Finally, `p2panda-sync` provides helpers 
+//! to encode wire messages in CBOR.
 #[cfg(feature = "cbor")]
 pub mod cbor;
 #[cfg(feature = "log-sync")]
@@ -30,7 +31,7 @@ use thiserror::Error;
 /// Traits to implement a custom sync protocol.
 ///
 /// Implementing a `SyncProtocol` trait needs extra care and is only required when designing custom
-/// low-level peer-to-peer protocols and data types. p2panda comes already with solutions which can
+/// low-level peer-to-peer protocols and data types. p2panda already comes with solutions which can
 /// be used "out of the box", providing implementations for most applications and usecases.
 ///
 /// ## Design
@@ -47,11 +48,11 @@ use thiserror::Error;
 /// The `SyncProtocol` trait has been designed to allow privacy-respecting implementations where
 /// application data (via access control) and the topic itself (for example via Diffie Hellmann) is
 /// securely exchanged without revealing any information to unknown peers unnecessarily. This
-/// usually takes place during the "Handshake" phase of the regarding protocol.
+/// usually takes place during the "Handshake" phase of the protocol.
 ///
 /// The underlying transport layer should provide automatic authentication of the remote peer, a
-/// reliable connection and transport encryption, for example self-certified TLS 1.3 over QUIC as
-/// in `p2panda-net`.
+/// reliable connection and transport encryption. `p2panda-net`, for example, uses self-certified 
+/// TLS 1.3 over QUIC.
 ///
 /// ## Streams
 ///
@@ -108,10 +109,11 @@ where
     /// `app_tx`) during this phase to inform the backend that we've successfully requested access,
     /// exchanged the topic with the remote peer and are about to begin sync.
     ///
-    /// Afterwards it enters the "Sync" phase where the actual application data is exchanged with
-    /// the remote peer. If the protocol exchanges data in both directions or not is up to the
-    /// regarding implementation. Synced data is forwarded to the application layers via the
-    /// `SyncFrom::Data` message (via `app_tx`).
+    /// After the "Handshake" is complete the protocol enters the "Sync" phase, during which 
+    /// the actual application data is exchanged with the remote peer. It's left up to each 
+    /// protocol implementation to decide whether data is exchanged in one or both directions. 
+    /// Synced data is forwarded to the application layers via the `SyncFrom::Data` message 
+    /// (via `app_tx`).
     ///
     /// In case of a detected failure (either through a critical error on our end or an unexpected
     /// behaviour from the remote peer) a `SyncError` is returned.
@@ -131,10 +133,11 @@ where
     /// `app_tx`) during this phase to inform the backend that the topic has been successfully
     /// received from the remote peer and that data exchange is about to begin.
     ///
-    /// Afterwards it enters the "Sync" phase where the actual application data is exchanged with
-    /// the remote peer. If the protocol exchanges data in both directions or not is up to the
-    /// regarding implementation. Synced data is forwarded to the application layers via the
-    /// `SyncFrom::Data` message (via `app_tx`).
+    /// After the "Handshake" is complete the protocol enters the "Sync" phase, during which 
+    /// the actual application data is exchanged with the remote peer. It's left up to each 
+    /// protocol implementation to decide whether data is exchanged in one or both directions. 
+    /// Synced data is forwarded to the application layers via the `SyncFrom::Data` message 
+    /// (via `app_tx`).
     ///
     /// In case of a detected failure (either through a critical error on our end or an unexpected
     /// behaviour from the remote peer) a `SyncError` is returned.
@@ -160,7 +163,7 @@ where
     /// transport layer to inform the "backend" that we've successfully requested access, exchanged
     /// the topic with the remote peer and are about to begin sync.
     ///
-    /// With this information backends can optionally apply optimizations, which might for example
+    /// With this information backends can optionally apply optimisations, which might for example
     /// be required to keep application messages in-order (as there might exist other channels the
     /// backend exchanges similar data over at the same time).
     HandshakeSuccess(T),
@@ -170,7 +173,7 @@ where
     ///
     /// These "frontends" might further process, decrypt payloads, sort messages or apply more
     /// validation before they get finally persisted or rendered to the user. At this point the
-    /// sync protocol is merely "forwarding" it without any more knowledge how the data is used.
+    /// sync protocol is merely "forwarding" it without any knowledge of how the data is used.
     Data {
         /// Exchanged data from sync session.
         ///
@@ -181,8 +184,8 @@ where
 
         /// Optional "body" which can represent "off-chain" application data.
         ///
-        /// This is useful for realizing "off-chain" compatible data types. Implementations without
-        /// this distinction will leave this field always to `None` and only encode their data
+        /// This is useful for realising "off-chain" compatible data types. Implementations without
+        /// this distinction will always leave this field as `None` and only encode their data
         /// types in the `header` field.
         payload: Option<Vec<u8>>,
     },
@@ -258,9 +261,9 @@ impl From<std::io::Error> for SyncError {
 ///
 /// Consult the `TopicId` documentation in `p2panda-net` for more information.
 pub trait Topic:
-    // Data types implementing `Topic` need to also implement `Eq` and `Hash` to allow backends to
-    // organise sync sessions per topic and peer and `Serialize` and `Deserialize` to allow sending
-    // topics over the wire.
+    // Data types implementing `Topic` also need to implement `Eq` and `Hash` in order to allow 
+    // backends to organise sync sessions per topic and peer, along with `Serialize` and 
+    // `Deserialize` to allow sending topics over the wire.
     Clone + Debug + Eq + Hash + Send + Sync + Serialize + for<'a> Deserialize<'a>
 {
 }

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -10,10 +10,10 @@
 //! can negotiate scope and access in a sync protocol for any type of data the remote peer
 //! currently knows about.
 //!
-//! In addition to the generic definition of the `SyncProtocol` trait, `p2panda-sync` includes 
-//! optional implementations for efficient sync of append-only log-based data types. These optional 
-//! implementations may be activated via feature flags. Finally, `p2panda-sync` provides helpers 
-//! to encode wire messages in CBOR.
+//! In addition to the generic definition of the `SyncProtocol` trait, `p2panda-sync` includes
+//! optional implementations for efficient sync of append-only log-based data types. These optional
+//! implementations may be activated via feature flags. Finally, `p2panda-sync` provides helpers to
+//! encode wire messages in CBOR.
 #[cfg(feature = "cbor")]
 pub mod cbor;
 #[cfg(feature = "log-sync")]
@@ -51,7 +51,7 @@ use thiserror::Error;
 /// usually takes place during the "Handshake" phase of the protocol.
 ///
 /// The underlying transport layer should provide automatic authentication of the remote peer, a
-/// reliable connection and transport encryption. `p2panda-net`, for example, uses self-certified 
+/// reliable connection and transport encryption. `p2panda-net`, for example, uses self-certified
 /// TLS 1.3 over QUIC.
 ///
 /// ## Streams
@@ -63,9 +63,9 @@ use thiserror::Error;
 ///
 /// ## Topics
 ///
-/// Topics are generic data types which can be used to express interest in a particular subset of
-/// the data we want to sync over, like chat group identifiers or very specific "search queries",
-/// for example "give me all documents containing the word 'billy'."
+/// Topics are generic data types which can be used to subjectively express interest in a
+/// particular subset of the data we want to sync over, like chat group identifiers or very
+/// specific "search queries", for example "give me all documents containing the word 'billy'."
 ///
 /// With the help of the `TopicMap` trait we can keep sync implementations agnostic to specific
 /// topic implementations. The sync protocol only needs to feed the "topic" into the "map" which

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -174,13 +174,21 @@ where
     /// These "frontends" might further process, decrypt payloads, sort messages or apply more
     /// validation before they get finally persisted or rendered to the user. At this point the
     /// sync protocol is merely "forwarding" it without any more knowledge how the data is used.
-    ///
-    /// Some data-types might be designed with "off-chain" use in mind, where a "header" is crucial
-    /// for integrity and authenticity but the actual payload is optional or requested lazily in a
-    /// later process. This is why the main data can be expressed as bytes but the second field is
-    /// optional. Implementations without this distinction will leave the second field always
-    /// `None`.
-    Data(Vec<u8>, Option<Vec<u8>>),
+    Data {
+        /// Exchanged data from sync session.
+        ///
+        /// Some data-types might be designed with "off-chain" use in mind, where a "header" is
+        /// crucial for integrity and authenticity but the actual "payload" is optional or
+        /// requested lazily in a later process.
+        header: Vec<u8>,
+
+        /// Optional "body" which can represent the application data.
+        ///
+        /// This is useful for realizing "off-chain" compatible data types. Implementations without
+        /// this distinction will leave this field always to `None` and only encode their data
+        /// types in the `header` field.
+        payload: Option<Vec<u8>>,
+    },
 }
 
 /// Errors which can occur during sync sessions.

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -20,6 +20,15 @@ use thiserror::Error;
 /// sends their topic to a remote peer where it is be mapped to their local data-set and
 /// access-control checks can be performed. Once this "handshake" is complete both peers will
 /// proceed with the designated sync protocol.
+///
+/// ## Designing topics for applications
+///
+/// While `TopicId` is merely a 32-byte identifier which can't hold much information other than
+/// being a distinct identifier of a single data item or subset of them, we can use `Topic` to
+/// implement custom data types which can "query" very specific data items. Peers can for example
+/// announce that they'd like "all events from the 27th of September 23 until today" with `Topic`.
+///
+/// Consult the `TopicId` documentation in `p2panda-net` for more information.
 pub trait Topic:
     Clone + Debug + Eq + Hash + Send + Sync + Serialize + for<'a> Deserialize<'a>
 {

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -10,9 +10,9 @@
 //! can negotiate scope and access in a sync protocol for any type of data the remote peer
 //! currently knows about.
 //!
-//! While `p2panda-sync` is merely a generic definition of the `Sync` trait interface, compatible
-//! with all sorts of data types, it also comes with optional implementations, optimized for
-//! efficient sync over append-only log-based data types and helpers to encode wire messages in
+//! While `p2panda-sync` is merely a generic definition of the `SyncProtocol` trait interface,
+//! compatible with all sorts of data types, it also comes with optional implementations, optimized
+//! for efficient sync over append-only log-based data types and helpers to encode wire messages in
 //! CBOR.
 #[cfg(feature = "cbor")]
 pub mod cbor;

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -260,6 +260,9 @@ impl From<std::io::Error> for SyncError {
 ///
 /// Consult the `TopicId` documentation in `p2panda-net` for more information.
 pub trait Topic:
+    // Data types implementing `Topic` need to also implement `Eq` and `Hash` to allow backends to
+    // organise sync sessions per topic and peer and `Serialize` and `Deserialize` to allow sending
+    // topics over the wire.
     Clone + Debug + Eq + Hash + Send + Sync + Serialize + for<'a> Deserialize<'a>
 {
 }

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -109,10 +109,10 @@ where
     /// `app_tx`) during this phase to inform the backend that we've successfully requested access,
     /// exchanged the topic with the remote peer and are about to begin sync.
     ///
-    /// After the "Handshake" is complete the protocol enters the "Sync" phase, during which 
-    /// the actual application data is exchanged with the remote peer. It's left up to each 
-    /// protocol implementation to decide whether data is exchanged in one or both directions. 
-    /// Synced data is forwarded to the application layers via the `SyncFrom::Data` message 
+    /// After the "Handshake" is complete the protocol enters the "Sync" phase, during which
+    /// the actual application data is exchanged with the remote peer. It's left up to each
+    /// protocol implementation to decide whether data is exchanged in one or both directions.
+    /// Synced data is forwarded to the application layers via the `SyncFrom::Data` message
     /// (via `app_tx`).
     ///
     /// In case of a detected failure (either through a critical error on our end or an unexpected
@@ -133,10 +133,10 @@ where
     /// `app_tx`) during this phase to inform the backend that the topic has been successfully
     /// received from the remote peer and that data exchange is about to begin.
     ///
-    /// After the "Handshake" is complete the protocol enters the "Sync" phase, during which 
-    /// the actual application data is exchanged with the remote peer. It's left up to each 
-    /// protocol implementation to decide whether data is exchanged in one or both directions. 
-    /// Synced data is forwarded to the application layers via the `SyncFrom::Data` message 
+    /// After the "Handshake" is complete the protocol enters the "Sync" phase, during which
+    /// the actual application data is exchanged with the remote peer. It's left up to each
+    /// protocol implementation to decide whether data is exchanged in one or both directions.
+    /// Synced data is forwarded to the application layers via the `SyncFrom::Data` message
     /// (via `app_tx`).
     ///
     /// In case of a detected failure (either through a critical error on our end or an unexpected

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -148,7 +148,7 @@ where
 
 /// Messages which can be sent to the higher application layers (for further validation or
 /// persistance) and the underlying transport layer (for managing the sync session).
-#[derive(PartialEq, Debug)]
+#[derive(Debug, PartialEq)]
 pub enum FromSync<T>
 where
     T: Topic,
@@ -194,7 +194,7 @@ where
 ///    implementation did not follow "2. Phase Flow" requirements, lack of system resources, etc.)
 /// 2. Unexpected Behaviour (ie. remote peer abruptly disconnected, error which got correctly
 ///    caught in sync implementation, etc.)
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, PartialEq, Error)]
 pub enum SyncError {
     /// Error due to unexpected (buggy or malicious) behaviour of the remote peer.
     ///

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -228,7 +228,7 @@ pub enum SyncError {
 /// on the user's machine.
 ///
 /// See `Encoder` or `Decoder` `Error` trait type in tokio's codec for more information:
-/// https://docs.rs/tokio-util/latest/tokio_util/codec/trait.Decoder.html#associatedtype.Error
+/// <https://docs.rs/tokio-util/latest/tokio_util/codec/trait.Decoder.html#associatedtype.Error>
 impl From<std::io::Error> for SyncError {
     fn from(err: std::io::Error) -> Self {
         match err.kind() {

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -11,7 +11,6 @@ use futures::{stream, AsyncRead, AsyncWrite, Sink, SinkExt, StreamExt};
 use p2panda_core::{Extensions, PublicKey};
 use p2panda_store::{LogId, LogStore};
 use serde::{Deserialize, Serialize};
-use tracing::debug;
 
 use crate::cbor::{into_cbor_sink, into_cbor_stream};
 use crate::{FromSync, SyncError, SyncProtocol, Topic, TopicMap};
@@ -32,6 +31,26 @@ pub enum Message<T, L = String> {
     Done,
 }
 
+/// Efficient sync protocol for append-only log data types.
+///
+/// This implementation is generic over the actual data type implementation, as long as it follows
+/// the form of a numbered, linked list it will be compatible for sync. p2panda provides an own log
+/// implementation in `p2panda-core` which can be easily combined with this sync protocol.
+///
+/// The protocol checks the current local "log heights", that is the index of the latest known
+/// entry in each log, of the "initiating" peer and sends them in form of a "Have" message to the
+/// remote one. The "accepting", remote peer matches the given log heights with the locally present
+/// ones, calculates the delta of missing entries and sends them to the initiating peer as part of
+/// "Data" messages.
+///
+/// In this implementation the "accepting" peer will never receive any new data from the
+/// "initiating" counter-part. Usually this would be handled in a "reverse" sync session which
+/// might run concurrently.
+///
+/// To find out which logs to send matching the given "topic" a `TopicMap` is provided. This
+/// interface aids the sync protocol in deciding which logs to transfer for each given topic. Due
+/// to the generic nature of `TopicMap` it's possible to realize very different applications on top
+/// of the same sync implementation.
 #[derive(Clone, Debug)]
 pub struct LogSyncProtocol<TM, L, E, S: LogStore<L, E>> {
     topic_map: TM,
@@ -82,7 +101,7 @@ where
             return Err(SyncError::Critical(format!("unknown {topic:?} topic")));
         };
 
-        // Get local log heights for all authors who have published under the requested log ids
+        // Get local log heights for all authors who have published under the requested log ids.
         let mut local_log_heights = Vec::new();
         for (public_key, log_ids) in logs {
             let mut log_heights = Vec::new();
@@ -118,7 +137,6 @@ where
         // Consume messages arriving on the receive stream.
         while let Some(result) = stream.next().await {
             let message: Message<L> = result?;
-            debug!("message received: {:?}", message);
 
             match message {
                 Message::Have(_, _) => {
@@ -144,8 +162,6 @@ where
         sink.flush().await?;
         app_tx.flush().await?;
 
-        debug!("sync session finished");
-
         Ok(())
     }
 
@@ -163,8 +179,6 @@ where
 
         while let Some(result) = stream.next().await {
             let message: Message<T, L> = result?;
-            debug!("message received: {:?}", message);
-
             match &message {
                 Message::Have(topic, remote_log_heights) => {
                     // Signal that the "handshake" phase of this protocol is complete as we
@@ -185,7 +199,9 @@ where
 
                     // Now that the topic has been translated into a collection of logs we want to
                     // compare our own local log heights with what the remote sent for this topic.
-                    // If our logs are more advanced for any log we should send the missing operations.
+                    //
+                    // If our logs are more advanced for any log we should send the missing
+                    // entries.
                     for (public_key, log_ids) in logs {
                         for log_id in log_ids {
                             // For all logs in this topic scope get the local height.
@@ -217,7 +233,7 @@ where
                                         None => 0,
                                     }
                                 }
-                                // The author is not known, they need from seq num 0
+                                // The author is not known, they need from seq num 0.
                                 None => 0,
                             };
 
@@ -260,14 +276,12 @@ where
         sink.flush().await?;
         app_tx.flush().await?;
 
-        debug!("sync session finished");
-
         Ok(())
     }
 }
 
-// Helper method for getting only the operations a peer needs from a log and composing them into
-// the expected message format.
+/// Helper method for getting only the operations a peer needs from a log and composing them into
+/// the expected message format.
 async fn remote_needs<T, L, E>(
     store: &impl LogStore<L, E>,
     log_id: &L,

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -120,7 +120,7 @@ where
                 }
                 Message::Operation(header, payload) => {
                     // Forward data received from the remote to the app layer.
-                    app_tx.send(FromSync::Data(header, payload)).await?;
+                    app_tx.send(FromSync::Data { header, payload }).await?;
                 }
                 Message::SyncDone => {
                     sync_done_received = true;
@@ -631,9 +631,18 @@ mod tests {
             messages,
             [
                 FromSync::HandshakeSuccess(topic),
-                FromSync::Data(header_bytes_0, Some(body.to_bytes())),
-                FromSync::Data(header_bytes_1, Some(body.to_bytes())),
-                FromSync::Data(header_bytes_2, Some(body.to_bytes())),
+                FromSync::Data {
+                    header: header_bytes_0,
+                    payload: Some(body.to_bytes())
+                },
+                FromSync::Data {
+                    header: header_bytes_1,
+                    payload: Some(body.to_bytes())
+                },
+                FromSync::Data {
+                    header: header_bytes_2,
+                    payload: Some(body.to_bytes())
+                },
             ]
         );
     }
@@ -730,9 +739,18 @@ mod tests {
 
         let peer_a_expected_messages = vec![
             FromSync::HandshakeSuccess(topic.clone()),
-            FromSync::Data(header_bytes_0, Some(body.to_bytes())),
-            FromSync::Data(header_bytes_1, Some(body.to_bytes())),
-            FromSync::Data(header_bytes_2, Some(body.to_bytes())),
+            FromSync::Data {
+                header: header_bytes_0,
+                payload: Some(body.to_bytes()),
+            },
+            FromSync::Data {
+                header: header_bytes_1,
+                payload: Some(body.to_bytes()),
+            },
+            FromSync::Data {
+                header: header_bytes_2,
+                payload: Some(body.to_bytes()),
+            },
         ];
 
         let mut peer_a_messages = Vec::new();
@@ -843,8 +861,14 @@ mod tests {
 
         let peer_a_expected_messages = vec![
             FromSync::HandshakeSuccess(topic.clone()),
-            FromSync::Data(header_bytes_1, Some(body.to_bytes())),
-            FromSync::Data(header_bytes_2, Some(body.to_bytes())),
+            FromSync::Data {
+                header: header_bytes_1,
+                payload: Some(body.to_bytes()),
+            },
+            FromSync::Data {
+                header: header_bytes_2,
+                payload: Some(body.to_bytes()),
+            },
         ];
 
         let mut peer_a_messages = Vec::new();

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -28,17 +28,6 @@ pub enum Message<T, L = String> {
     Done,
 }
 
-#[cfg(test)]
-impl<T, L> Message<T, L>
-where
-    T: Serialize,
-    L: Serialize,
-{
-    pub fn to_bytes(&self) -> Vec<u8> {
-        p2panda_core::cbor::encode_cbor(&self).expect("type can be serialized")
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct LogSyncProtocol<TM, L, E> {
     pub topic_map: TM,
@@ -302,6 +291,16 @@ mod tests {
     use crate::{FromSync, SyncError, SyncProtocol, Topic};
 
     use super::{LogSyncProtocol, Logs, Message, TopicMap};
+
+    impl<T, L> Message<T, L>
+    where
+        T: Serialize,
+        L: Serialize,
+    {
+        pub fn to_bytes(&self) -> Vec<u8> {
+            p2panda_core::cbor::encode_cbor(&self).expect("type can be serialized")
+        }
+    }
 
     fn create_operation<E: Clone + Serialize>(
         private_key: &PrivateKey,

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -44,12 +44,13 @@ type Logs<T> = HashMap<PublicKey, Vec<T>>;
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type", content = "value")]
-pub enum Message<T, L = String> {
+enum Message<T, L = String> {
     Have(T, Vec<(PublicKey, LogHeights<L>)>),
     Data(Vec<u8>, Option<Vec<u8>>),
     Done,
 }
 
+/// Efficient sync protocol for append-only log data types.
 #[derive(Clone, Debug)]
 pub struct LogSyncProtocol<TM, L, E, S: LogStore<L, E>> {
     topic_map: TM,
@@ -61,6 +62,8 @@ impl<TM, L, E, S> LogSyncProtocol<TM, L, E, S>
 where
     S: LogStore<L, E>,
 {
+    /// Returns a new sync protocol instance, configured with a store and `TopicMap` implementation
+    /// which associates the to-be-synced logs with a given topic.
     pub fn new(topic_map: TM, store: S) -> Self {
         Self {
             topic_map,


### PR DESCRIPTION
Writing a whole bunch of doc-strings and examples for crates, modules and types across the p2panda stack.