### PR TITLE
Refactor sync manager and introduce tests

### DIFF
--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -655,7 +655,7 @@ pub(crate) type JoinErrToStr =
     Box<dyn Fn(tokio::task::JoinError) -> String + Send + Sync + 'static>;
 
 #[cfg(test)]
-mod sync_protocols {
+pub(crate) mod sync_protocols {
     use std::sync::Arc;
 
     use async_trait::async_trait;
@@ -866,7 +866,7 @@ mod sync_protocols {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::time::Duration;

--- a/p2panda-net/src/sync/manager.rs
+++ b/p2panda-net/src/sync/manager.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::collections::hash_map::Entry as HashMapEntry;
 use std::collections::{HashMap, VecDeque};
 
 use anyhow::{Context, Error, Result};
@@ -199,9 +200,9 @@ where
 
                     // Only schedule an attempt if we're not already tracking sessions for this
                     // scope.
-                    if !self.sessions.contains_key(&scope) {
-                        let attempt = Attempt::new(scope.clone());
-                        self.sessions.insert(scope, attempt.clone());
+                    if let HashMapEntry::Vacant(entry) = self.sessions.entry(scope.clone()) {
+                        let attempt = Attempt::new(scope);
+                        entry.insert(attempt.clone());
 
                         if let Err(err) = self.schedule_attempt(attempt).await {
                             // The attempt will fail if the sync queue is full, indicating that a high

--- a/p2panda-net/src/sync/manager.rs
+++ b/p2panda-net/src/sync/manager.rs
@@ -352,7 +352,7 @@ mod tests {
     use crate::network::tests::TestTopic;
     use crate::protocols::ProtocolMap;
     use crate::sync::{SyncConnection, SYNC_CONNECTION_ALPN};
-    use crate::SyncConfiguration;
+    use crate::{ResyncConfiguration, SyncConfiguration};
 
     use super::{SyncActor, ToSyncActor};
 
@@ -496,6 +496,137 @@ mod tests {
         assert_eq!(topic, Some(test_topic.to_owned()));
         assert_eq!(peer, peer_b);
 
+        // Receive `SyncHandshakeSuccess`.
+        let Some(ToEngineActor::SyncHandshakeSuccess { topic: _, peer: _ }) =
+            engine_actor_rx_a.recv().await
+        else {
+            panic!("expected to receive SyncHandshakeSuccess on engine actor receiver for peer a")
+        };
+
+        // Receive `SyncMessage`.
+        let Some(ToEngineActor::SyncMessage {
+            topic: _,
+            header: _,
+            payload: _,
+            delivered_from: _,
+        }) = engine_actor_rx_a.recv().await
+        else {
+            panic!("expected to receive SyncMessage on engine actor receiver for peer a")
+        };
+
+        // Receive `SyncDone`.
+        let Some(ToEngineActor::SyncDone { topic: _, peer: _ }) = engine_actor_rx_a.recv().await
+        else {
+            panic!("expected to receive SyncDone on engine actor receiver for peer a")
+        };
+
+        /* --- PEER B SYNC EVENTS --- */
+        /* --- role: acceptor     --- */
+
+        // Receive `SyncStart`.
+        let Some(ToEngineActor::SyncStart { topic, peer }) = engine_actor_rx_b.recv().await else {
+            panic!("expected to receive SyncStart on engine actor receiver for peer a")
+        };
+        assert_eq!(topic, None);
+        assert_eq!(peer, peer_a);
+
+        // @TODO(glyph): Match on the remaining events.
+    }
+
+    #[tokio::test]
+    async fn resync() {
+        setup_logging();
+
+        let test_topic = TestTopic::new("ping_pong");
+        let ping_pong = PingPongProtocol {};
+        let resync_config = ResyncConfiguration::new().interval(1).poll_interval(1);
+        let config_a = SyncConfiguration::new(ping_pong.clone()).resync(resync_config);
+        let config_b = config_a.clone();
+
+        let (engine_actor_tx_a, mut engine_actor_rx_a) = mpsc::channel(64);
+        let (engine_actor_tx_b, mut engine_actor_rx_b) = mpsc::channel(64);
+
+        let endpoint_a = build_endpoint(2022).await;
+        let endpoint_b = build_endpoint(2024).await;
+
+        let mut protocols_a = ProtocolMap::default();
+        let sync_handler_a =
+            SyncConnection::new(Arc::new(ping_pong.clone()), engine_actor_tx_a.clone());
+        protocols_a.insert(SYNC_CONNECTION_ALPN, Arc::new(sync_handler_a));
+        let alpns_a = protocols_a.alpns();
+        endpoint_a.set_alpns(alpns_a).unwrap();
+
+        let mut protocols_b = ProtocolMap::default();
+        let sync_handler_b = SyncConnection::new(Arc::new(ping_pong), engine_actor_tx_b.clone());
+        protocols_b.insert(SYNC_CONNECTION_ALPN, Arc::new(sync_handler_b));
+        let alpns_b = protocols_b.alpns();
+        endpoint_b.set_alpns(alpns_b).unwrap();
+
+        let peer_a = endpoint_a.node_id();
+        let peer_b = endpoint_b.node_id();
+
+        let peer_addr_a = endpoint_a.node_addr().await.unwrap();
+        let peer_addr_b = endpoint_b.node_addr().await.unwrap();
+
+        endpoint_a.add_node_addr(peer_addr_b).unwrap();
+        endpoint_b.add_node_addr(peer_addr_a).unwrap();
+
+        let (sync_actor_a, sync_actor_tx_a) =
+            SyncActor::new(config_a, endpoint_a.clone(), engine_actor_tx_a);
+        let (sync_actor_b, _sync_actor_tx_b) =
+            SyncActor::new(config_b, endpoint_b.clone(), engine_actor_tx_b);
+
+        let shutdown_token_a = CancellationToken::new();
+        let shutdown_token_b = CancellationToken::new();
+
+        // Spawn the sync actor for peer a.
+        tokio::task::spawn(async move { sync_actor_a.run(shutdown_token_a).await.unwrap() });
+
+        // Spawn the inbound connection handler for peer a.
+        tokio::task::spawn(async move {
+            if let Some(incoming) = endpoint_a.accept().await {
+                if let Ok(connecting) = incoming.accept() {
+                    tokio::task::spawn(async move {
+                        handle_connection(connecting, Arc::new(protocols_a)).await
+                    });
+                }
+            }
+        });
+
+        // Spawn the sync actor for peer b.
+        tokio::task::spawn(async move { sync_actor_b.run(shutdown_token_b).await.unwrap() });
+
+        // Spawn the inbound connection handler for peer b.
+        tokio::task::spawn(async move {
+            if let Some(incoming) = endpoint_b.accept().await {
+                if let Ok(connecting) = incoming.accept() {
+                    tokio::task::spawn(async move {
+                        handle_connection(connecting, Arc::new(protocols_b)).await
+                    });
+                }
+            }
+        });
+
+        // Trigger sync session initiation by peer a.
+        sync_actor_tx_a
+            .send(ToSyncActor {
+                peer: peer_b,
+                topic: test_topic.clone(),
+            })
+            .await
+            .unwrap();
+
+        /* --- PEER A SYNC EVENTS --- */
+        /* --- role: initiator    --- */
+        /* --- initial session    --- */
+
+        // Receive `SyncStart`.
+        let Some(ToEngineActor::SyncStart { topic, peer }) = engine_actor_rx_a.recv().await else {
+            panic!("expected to receive SyncStart on engine actor receiver for peer a")
+        };
+        assert_eq!(topic, Some(test_topic.to_owned()));
+        assert_eq!(peer, peer_b);
+
         // Receive `SyncStart`.
         let Some(ToEngineActor::SyncStart { topic, peer }) = engine_actor_rx_b.recv().await else {
             panic!("expected to receive SyncStart on engine actor receiver for peer a")
@@ -521,8 +652,47 @@ mod tests {
             panic!("expected to receive SyncMessage on engine actor receiver for peer a")
         };
 
-        /* --- PEER B SYNC EVENTS --- */
-        /* --- role: acceptor     --- */
+        // Receive `SyncDone`.
+        let Some(ToEngineActor::SyncDone { topic: _, peer: _ }) = engine_actor_rx_a.recv().await
+        else {
+            panic!("expected to receive SyncDone on engine actor receiver for peer a")
+        };
+
+        /* --- PEER A SYNC EVENTS --- */
+        /* --- role: initiator    --- */
+        /* --- resync session     --- */
+
+        // Receive `SyncStart`.
+        let Some(ToEngineActor::SyncStart { topic, peer }) = engine_actor_rx_a.recv().await else {
+            panic!("expected to receive SyncStart on engine actor receiver for peer a")
+        };
+        assert_eq!(topic, Some(test_topic.to_owned()));
+        assert_eq!(peer, peer_b);
+
+        // Receive `SyncStart`.
+        let Some(ToEngineActor::SyncStart { topic, peer }) = engine_actor_rx_b.recv().await else {
+            panic!("expected to receive SyncStart on engine actor receiver for peer a")
+        };
+        assert_eq!(topic, None);
+        assert_eq!(peer, peer_a);
+
+        // Receive `SyncHandshakeSuccess`.
+        let Some(ToEngineActor::SyncHandshakeSuccess { topic: _, peer: _ }) =
+            engine_actor_rx_a.recv().await
+        else {
+            panic!("expected to receive SyncHandshakeSuccess on engine actor receiver for peer a")
+        };
+
+        // Receive `SyncMessage`.
+        let Some(ToEngineActor::SyncMessage {
+            topic: _,
+            header: _,
+            payload: _,
+            delivered_from: _,
+        }) = engine_actor_rx_a.recv().await
+        else {
+            panic!("expected to receive SyncMessage on engine actor receiver for peer a")
+        };
 
         // Receive `SyncDone`.
         let Some(ToEngineActor::SyncDone { topic: _, peer: _ }) = engine_actor_rx_a.recv().await


### PR DESCRIPTION
Here we introduce improvements to the sync manager for more precise state tracking.

Instead of having a separate `HashMap` to track sync attempts belonging to each status (pending, active etc.), we maintain a single map of sessions and update the status for each session as required.

We also introduce three test scenarios:

- A single successful sync session when one peer-topic announcement is received
- No second sync session when two of the same peer-topic announcements are received and resync is not configured
- Two successful sync sessions when one peer-topic announcement is received and resync is configured