### PR TITLE
Introduce sync manager tests

### DIFF
--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -655,7 +655,7 @@ pub(crate) type JoinErrToStr =
     Box<dyn Fn(tokio::task::JoinError) -> String + Send + Sync + 'static>;
 
 #[cfg(test)]
-mod sync_protocols {
+pub(crate) mod sync_protocols {
     use std::sync::Arc;
 
     use async_trait::async_trait;
@@ -866,7 +866,7 @@ mod sync_protocols {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::time::Duration;


### PR DESCRIPTION
This PR introduces three tests for (re)sync behaviour in the sync manager:

- A single successful sync session when one peer-topic announcement is received
- No (second) sync session when a peer-topic announcement is received after a session has already been completed for that combination and resync is not configured
- Two successful sync sessions, one after the other, when one peer-topic announcement is received and resync is configured