### PR TITLE
Documentation for modules and types in `p2panda-discovery`

### DIFF
--- a/p2panda-discovery/src/lib.rs
+++ b/p2panda-discovery/src/lib.rs
@@ -22,7 +22,7 @@ pub type BoxedStream<T> = Pin<Box<dyn Stream<Item = T> + Send + 'static>>;
 /// A collection of discovery services.
 ///
 /// `DiscoveryMap` implements the `Discovery` trait to provide a convenient means of subscribing to
-/// a single stream comprising all discovery events. This also allows updating the address
+/// a single stream comprising all events from multiple discovery strategies. This also allows updating the address
 /// information of the local node for all discovery services with a single call to
 /// `update_local_address`.
 #[derive(Debug, Default)]
@@ -31,7 +31,7 @@ pub struct DiscoveryMap {
 }
 
 impl DiscoveryMap {
-    /// Instantiate a `DiscoveryMap` from a vector of services.
+    /// Instantiate a `DiscoveryMap` from a list of services.
     pub fn from_services(services: Vec<Box<dyn Discovery>>) -> Self {
         Self { services }
     }

--- a/p2panda-discovery/src/lib.rs
+++ b/p2panda-discovery/src/lib.rs
@@ -1,5 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//! Peer discovery traits and services.
+//!
+//! This crate currently provides a single discovery service implementation: mDNS. It is disabled
+//! by default and can be selected by enabling the `mdns` feature flag.
+//!
+//! Generic traits are provided to facitilate the creation of other peer discovery implementations.
+
 #[cfg(feature = "mdns")]
 pub mod mdns;
 
@@ -66,6 +73,8 @@ pub struct DiscoveryEvent {
     pub node_addr: NodeAddr,
 }
 
+/// An interface for announcing and discovering network peers.
+///
 /// The `Discovery` trait provides a generic interface for discovering the identities and
 /// addressing information of peers on a network, as well as sharing that same information for the
 /// local node.

--- a/p2panda-discovery/src/lib.rs
+++ b/p2panda-discovery/src/lib.rs
@@ -6,7 +6,6 @@
 //! by default and can be selected by enabling the `mdns` feature flag.
 //!
 //! Generic traits are provided to facitilate the creation of other peer discovery implementations.
-
 #[cfg(feature = "mdns")]
 pub mod mdns;
 
@@ -69,6 +68,7 @@ impl Discovery for DiscoveryMap {
 pub struct DiscoveryEvent {
     /// Identifier of the discovery service from which this event originated from.
     pub provenance: &'static str,
+
     /// Addressing information of a discovered peer.
     pub node_addr: NodeAddr,
 }

--- a/p2panda-discovery/src/mdns/mod.rs
+++ b/p2panda-discovery/src/mdns/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+//! Local peer discovery via mDNS over IPv4.
+
 mod dns;
 mod socket;
 

--- a/p2panda-discovery/src/mdns/mod.rs
+++ b/p2panda-discovery/src/mdns/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 //! Local peer discovery via mDNS over IPv4.
-
 mod dns;
 mod socket;
 


### PR DESCRIPTION
Crate docs, module docs and doc-strings for public types and methods.