### PR TITLE
Rename: `Topic` => `TopicQuery`

### DIFF
--- a/p2panda-blobs/src/blobs.rs
+++ b/p2panda-blobs/src/blobs.rs
@@ -12,7 +12,7 @@ use iroh_blobs::store::{Map, Store};
 use iroh_blobs::util::local_pool::{Config as LocalPoolConfig, LocalPool};
 use p2panda_core::Hash;
 use p2panda_net::{Network, NetworkBuilder, TopicId};
-use p2panda_sync::Topic;
+use p2panda_sync::TopicQuery;
 
 use crate::config::Config;
 use crate::download::download_blob;
@@ -35,7 +35,7 @@ where
 
 impl<T, S> Blobs<T, S>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + TopicId + 'static,
     S: Store,
 {
     /// Returns a new instance of `Blobs` using the given `NetworkBuilder` and store

--- a/p2panda-blobs/src/download.rs
+++ b/p2panda-blobs/src/download.rs
@@ -11,7 +11,7 @@ use iroh_blobs::util::progress::{AsyncChannelProgressSender, ProgressSender};
 use iroh_blobs::{BlobFormat, Hash as IrohHash, HashAndFormat};
 use p2panda_core::Hash;
 use p2panda_net::{Network, TopicId};
-use p2panda_sync::Topic;
+use p2panda_sync::TopicQuery;
 use serde::{Deserialize, Serialize};
 
 /// Status of a blob download attempt.
@@ -21,7 +21,7 @@ pub enum DownloadBlobEvent {
     Abort(RpcError),
 }
 
-pub(crate) async fn download_blob<T: Topic + TopicId + 'static>(
+pub(crate) async fn download_blob<T: TopicQuery + TopicId + 'static>(
     network: Network<T>,
     downloader: Downloader,
     pool_handle: LocalPoolHandle,
@@ -59,7 +59,7 @@ pub(crate) async fn download_blob<T: Topic + TopicId + 'static>(
     })
 }
 
-async fn download_queued<T: Topic + TopicId + 'static>(
+async fn download_queued<T: TopicQuery + TopicId + 'static>(
     network: Network<T>,
     downloader: &Downloader,
     hash_and_format: HashAndFormat,

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -3,7 +3,7 @@ use p2panda_core::{Hash, PrivateKey, PublicKey, Signature};
 use p2panda_discovery::mdns::LocalDiscovery;
 use p2panda_net::network::{FromNetwork, ToNetwork};
 use p2panda_net::{NetworkBuilder, TopicId};
-use p2panda_sync::Topic;
+use p2panda_sync::TopicQuery;
 use rand::random;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -27,7 +27,7 @@ impl ChatTopic {
     }
 }
 
-impl Topic for ChatTopic {}
+impl TopicQuery for ChatTopic {}
 
 impl TopicId for ChatTopic {
     fn id(&self) -> [u8; 32] {

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use iroh_net::key::{PublicKey, SecretKey};
 use iroh_net::{Endpoint, NodeAddr, NodeId};
-use p2panda_sync::Topic;
+use p2panda_sync::TopicQuery;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
@@ -87,7 +87,7 @@ pub struct EngineActor<T> {
 
 impl<T> EngineActor<T>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + TopicId + 'static,
 {
     pub fn new(
         secret_key: SecretKey,

--- a/p2panda-net/src/engine/gossip.rs
+++ b/p2panda-net/src/engine/gossip.rs
@@ -7,7 +7,7 @@ use futures_lite::StreamExt;
 use futures_util::FutureExt;
 use iroh_gossip::net::{Event, Gossip, GossipEvent, GossipReceiver, GossipSender, GossipTopic};
 use iroh_net::key::PublicKey;
-use p2panda_sync::Topic;
+use p2panda_sync::TopicQuery;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_stream::StreamMap;
@@ -47,7 +47,7 @@ pub struct GossipActor<T> {
 
 impl<T> GossipActor<T>
 where
-    T: Topic + 'static,
+    T: TopicQuery + 'static,
 {
     pub fn new(
         inbox: mpsc::Receiver<ToGossipActor>,

--- a/p2panda-net/src/engine/mod.rs
+++ b/p2panda-net/src/engine/mod.rs
@@ -17,7 +17,7 @@ use futures_util::{FutureExt, TryFutureExt};
 use iroh_gossip::net::Gossip;
 use iroh_net::key::SecretKey;
 use iroh_net::{Endpoint, NodeAddr};
-use p2panda_sync::Topic;
+use p2panda_sync::TopicQuery;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinError;
 use tokio_util::task::AbortOnDropHandle;
@@ -44,7 +44,7 @@ pub struct Engine<T> {
 
 impl<T> Engine<T>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + TopicId + 'static,
 {
     pub fn new(
         secret_key: SecretKey,

--- a/p2panda-net/src/engine/topic_streams.rs
+++ b/p2panda-net/src/engine/topic_streams.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use iroh_net::key::PublicKey;
 use iroh_net::NodeId;
-use p2panda_sync::Topic;
+use p2panda_sync::TopicQuery;
 use tokio::sync::{mpsc, oneshot, RwLock};
 use tracing::{debug, error, warn};
 
@@ -52,7 +52,7 @@ pub struct TopicStreams<T> {
 
 impl<T> TopicStreams<T>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + TopicId + 'static,
 {
     pub fn new(
         gossip_actor_tx: mpsc::Sender<ToGossipActor>,
@@ -387,7 +387,7 @@ mod tests {
     use futures_util::{FutureExt, StreamExt};
     use iroh_net::NodeAddr;
     use p2panda_core::PrivateKey;
-    use p2panda_sync::Topic;
+    use p2panda_sync::TopicQuery;
     use serde::{Deserialize, Serialize};
     use tokio::sync::{mpsc, oneshot};
     use tokio_stream::wrappers::ReceiverStream;
@@ -404,7 +404,7 @@ mod tests {
         Secondary,
     }
 
-    impl Topic for TestTopic {}
+    impl TopicQuery for TestTopic {}
 
     impl TopicId for TestTopic {
         fn id(&self) -> [u8; 32] {

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -85,7 +85,7 @@
 //! use p2panda_core::{PrivateKey, Hash};
 //! use p2panda_discovery::mdns::LocalDiscovery;
 //! use p2panda_net::{NetworkBuilder, TopicId};
-//! use p2panda_sync::Topic;
+//! use p2panda_sync::TopicQuery;
 //! use serde::{Serialize, Deserialize};
 //! # #[tokio::main]
 //! # async fn main() -> Result<()> {
@@ -108,7 +108,7 @@
 //!     }
 //! }
 //!
-//! impl Topic for ChatGroup {}
+//! impl TopicQuery for ChatGroup {}
 //!
 //! impl TopicId for ChatGroup {
 //!     fn id(&self) -> [u8; 32] {
@@ -185,15 +185,15 @@ pub type NetworkId = [u8; 32];
 /// each chat group. Now peers can announce their interest in a specific chat group and only sync
 /// that particular data.
 ///
-/// ## `Topic` vs. `TopicId`
+/// ## `TopicQuery` vs. `TopicId`
 ///
-/// Next to topic identifiers p2panda offers a `Topic` trait which allows for even more
+/// Next to topic identifiers p2panda offers a `TopicQuery` trait which allows for even more
 /// sophisticated "network queries".
 ///
 /// `TopicId` is a tool for general topic discovery and establishing gossip network overlays.
-/// `Topic` is a query for sync protocols to ask for a specific piece of information.
+/// `TopicQuery` is a query for sync protocols to ask for a specific piece of information.
 ///
-/// Consult the `Topic` documentation in `p2panda-sync` for further information.
+/// Consult the `TopicQuery` documentation in `p2panda-sync` for further information.
 pub trait TopicId {
     fn id(&self) -> [u8; 32];
 }

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -133,7 +133,7 @@ use iroh_net::relay::{RelayMap, RelayNode};
 use iroh_net::{Endpoint, NodeAddr, NodeId};
 use p2panda_core::{PrivateKey, PublicKey};
 use p2panda_discovery::{Discovery, DiscoveryMap};
-use p2panda_sync::Topic;
+use p2panda_sync::TopicQuery;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::{JoinError, JoinSet};
 use tokio_util::sync::CancellationToken;
@@ -192,7 +192,7 @@ pub struct NetworkBuilder<T> {
 
 impl<T> NetworkBuilder<T>
 where
-    T: Topic,
+    T: TopicQuery,
 {
     /// Returns a new instance of `NetworkBuilder` using the given network identifier.
     ///
@@ -333,7 +333,7 @@ where
     /// error is returned.
     pub async fn build(mut self) -> Result<Network<T>>
     where
-        T: Topic + TopicId + 'static,
+        T: TopicQuery + TopicId + 'static,
     {
         let secret_key = self.secret_key.unwrap_or(SecretKey::generate());
 
@@ -479,7 +479,7 @@ struct NetworkInner<T> {
 
 impl<T> NetworkInner<T>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + TopicId + 'static,
 {
     /// Spawns a network.
     ///
@@ -648,7 +648,7 @@ pub struct Network<T> {
 
 impl<T> Network<T>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + TopicId + 'static,
 {
     /// Adds a peer to the address book.
     pub async fn add_peer(&self, node_addr: NodeAddr) -> Result<()> {
@@ -786,7 +786,7 @@ pub(crate) mod sync_protocols {
 
     #[derive(Debug, Serialize, Deserialize)]
     enum DummyProtocolMessage {
-        Topic(TestTopic),
+        TopicQuery(TestTopic),
         Done,
     }
 
@@ -814,7 +814,7 @@ pub(crate) mod sync_protocols {
             let mut sink = into_cbor_sink(tx);
             let mut stream = into_cbor_stream(rx);
 
-            sink.send(DummyProtocolMessage::Topic(topic.clone()))
+            sink.send(DummyProtocolMessage::TopicQuery(topic.clone()))
                 .await?;
             sink.send(DummyProtocolMessage::Done).await?;
             app_tx.send(FromSync::HandshakeSuccess(topic)).await?;
@@ -824,7 +824,7 @@ pub(crate) mod sync_protocols {
                 debug!("message received: {:?}", message);
 
                 match &message {
-                    DummyProtocolMessage::Topic(_) => panic!(),
+                    DummyProtocolMessage::TopicQuery(_) => panic!(),
                     DummyProtocolMessage::Done => break,
                 }
             }
@@ -853,7 +853,7 @@ pub(crate) mod sync_protocols {
                 debug!("message received: {:?}", message);
 
                 match &message {
-                    DummyProtocolMessage::Topic(topic) => {
+                    DummyProtocolMessage::TopicQuery(topic) => {
                         app_tx
                             .send(FromSync::HandshakeSuccess(topic.clone()))
                             .await?
@@ -874,7 +874,7 @@ pub(crate) mod sync_protocols {
     // The protocol message types.
     #[derive(Serialize, Deserialize)]
     enum Message {
-        Topic(TestTopic),
+        TopicQuery(TestTopic),
         Ping,
         Pong,
     }
@@ -903,7 +903,7 @@ pub(crate) mod sync_protocols {
             let mut sink = into_cbor_sink(tx);
             let mut stream = into_cbor_stream(rx);
 
-            sink.send(Message::Topic(topic.clone())).await?;
+            sink.send(Message::TopicQuery(topic.clone())).await?;
             sink.send(Message::Ping).await?;
             debug!("ping message sent");
 
@@ -913,7 +913,7 @@ pub(crate) mod sync_protocols {
                 let message = result?;
 
                 match message {
-                    Message::Topic(_) => panic!(),
+                    Message::TopicQuery(_) => panic!(),
                     Message::Ping => {
                         return Err(SyncError::UnexpectedBehaviour(
                             "unexpected Ping message received".to_string(),
@@ -956,7 +956,7 @@ pub(crate) mod sync_protocols {
                 let message = result?;
 
                 match message {
-                    Message::Topic(topic) => app_tx.send(FromSync::HandshakeSuccess(topic)).await?,
+                    Message::TopicQuery(topic) => app_tx.send(FromSync::HandshakeSuccess(topic)).await?,
                     Message::Ping => {
                         debug!("ping message received");
                         app_tx
@@ -998,7 +998,7 @@ pub(crate) mod tests {
     use p2panda_core::{Body, Extensions, Hash, Header, PrivateKey, PublicKey};
     use p2panda_store::{MemoryStore, OperationStore};
     use p2panda_sync::log_sync::LogSyncProtocol;
-    use p2panda_sync::{Topic, TopicMap};
+    use p2panda_sync::{TopicQuery, TopicMap};
     use serde::{Deserialize, Serialize};
     use tokio::task::JoinHandle;
     use tracing_subscriber::layer::SubscriberExt;
@@ -1056,7 +1056,7 @@ pub(crate) mod tests {
         }
     }
 
-    impl Topic for TestTopic {}
+    impl TopicQuery for TestTopic {}
 
     impl TopicId for TestTopic {
         fn id(&self) -> [u8; 32] {
@@ -1190,7 +1190,7 @@ pub(crate) mod tests {
 
     impl<T> LogIdTopicMap<T>
     where
-        T: Topic,
+        T: TopicQuery,
     {
         pub fn new() -> Self {
             LogIdTopicMap(HashMap::new())
@@ -1204,7 +1204,7 @@ pub(crate) mod tests {
     #[async_trait]
     impl<T> TopicMap<T, Logs<u64>> for LogIdTopicMap<T>
     where
-        T: Topic,
+        T: TopicQuery,
     {
         async fn get(&self, topic: &T) -> Option<Logs<u64>> {
             self.0.get(topic).cloned()
@@ -1403,7 +1403,7 @@ pub(crate) mod tests {
         node_3.shutdown().await.unwrap();
     }
 
-    fn run_node<T: TopicId + Topic + 'static>(node: Network<T>, topic: T) -> JoinHandle<()> {
+    fn run_node<T: TopicId + TopicQuery + 'static>(node: Network<T>, topic: T) -> JoinHandle<()> {
         tokio::spawn(async move {
             let (_tx, mut rx, ready) = node.subscribe(topic).await.unwrap();
 

--- a/p2panda-net/src/sync/accept.rs
+++ b/p2panda-net/src/sync/accept.rs
@@ -5,14 +5,13 @@ use std::sync::Arc;
 use anyhow::Result;
 use futures_util::{AsyncRead, AsyncWrite, SinkExt};
 use iroh_net::key::PublicKey;
-use p2panda_sync::{FromSync, SyncError, SyncProtocol, Topic};
+use p2panda_sync::{FromSync, SyncError, SyncProtocol, TopicQuery};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::PollSender;
 use tracing::{debug, error};
 
 use crate::engine::ToEngineActor;
-use crate::TopicId;
 
 /// Accept a sync protocol session over the provided bi-directional stream for the given peer and
 /// topic.
@@ -46,7 +45,7 @@ pub async fn accept_sync<T, S, R>(
     engine_actor_tx: mpsc::Sender<ToEngineActor<T>>,
 ) -> Result<(), SyncError>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + 'static,
     S: AsyncWrite + Send + Unpin,
     R: AsyncRead + Send + Unpin,
 {

--- a/p2panda-net/src/sync/config.rs
+++ b/p2panda-net/src/sync/config.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use tokio::time::Duration;
 
-use p2panda_sync::{SyncProtocol, Topic};
+use p2panda_sync::{SyncProtocol, TopicQuery};
 
 const MAX_CONCURRENT_SYNC_SESSIONS: usize = 128;
 const MAX_RETRY_ATTEMPTS: u8 = 5;
@@ -81,7 +81,7 @@ pub struct SyncConfiguration<T> {
 
 impl<T> SyncConfiguration<T>
 where
-    T: Topic,
+    T: TopicQuery,
 {
     /// Return a default instance of `SyncConfiguration`.
     pub fn new(protocol: impl for<'a> SyncProtocol<'a, T> + 'static) -> Self {

--- a/p2panda-net/src/sync/handler.rs
+++ b/p2panda-net/src/sync/handler.rs
@@ -5,13 +5,13 @@ use std::sync::Arc;
 use anyhow::Result;
 use futures_lite::future::Boxed as BoxedFuture;
 use iroh_net::endpoint::{self, Connecting, Connection};
-use p2panda_sync::{SyncProtocol, Topic};
+use p2panda_sync::{SyncProtocol, TopicQuery};
 use tokio::sync::mpsc;
 use tracing::{debug, debug_span};
 
 use crate::engine::ToEngineActor;
 use crate::protocols::ProtocolHandler;
-use crate::{sync, TopicId};
+use crate::sync;
 
 pub const SYNC_CONNECTION_ALPN: &[u8] = b"/p2panda-net-sync/0";
 
@@ -23,7 +23,7 @@ pub struct SyncConnection<T> {
 
 impl<T> SyncConnection<T>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + 'static,
 {
     pub fn new(
         sync_protocol: Arc<dyn for<'a> SyncProtocol<'a, T> + 'static>,
@@ -73,7 +73,7 @@ where
 
 impl<T> ProtocolHandler for SyncConnection<T>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + 'static,
 {
     fn accept(self: Arc<Self>, connecting: Connecting) -> BoxedFuture<Result<()>> {
         Box::pin(async move { self.handle_connection(connecting.await?).await })

--- a/p2panda-net/src/sync/initiate.rs
+++ b/p2panda-net/src/sync/initiate.rs
@@ -5,14 +5,13 @@ use std::sync::Arc;
 use anyhow::Result;
 use futures_util::{AsyncRead, AsyncWrite, SinkExt};
 use iroh_net::key::PublicKey;
-use p2panda_sync::{FromSync, SyncError, SyncProtocol, Topic};
+use p2panda_sync::{FromSync, SyncError, SyncProtocol, TopicQuery};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::PollSender;
 use tracing::{debug, error, warn};
 
 use crate::engine::ToEngineActor;
-use crate::TopicId;
 
 /// Initiate a sync protocol session over the provided bi-directional stream for the given peer and
 /// topic.
@@ -21,7 +20,7 @@ use crate::TopicId;
 /// Protocol Flow" required for the engine to work efficiently. We're expecting the following
 /// messages from this "initiator" flow:
 ///
-/// 1. `SyncStart`: The sync session just began, we already know the Topic since we're the
+/// 1. `SyncStart`: The sync session just began, we already know the TopicQuery since we're the
 ///    initiators.
 /// 2. `SyncHandshakeSuccess`: We've successfully completed the I. "Handshake" phase, transmitting
 ///    the topic to the acceptor.
@@ -48,7 +47,7 @@ pub async fn initiate_sync<T, S, R>(
     engine_actor_tx: mpsc::Sender<ToEngineActor<T>>,
 ) -> Result<(), SyncError>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + 'static,
     S: AsyncWrite + Send + Unpin,
     R: AsyncRead + Send + Unpin,
 {

--- a/p2panda-net/src/sync/manager.rs
+++ b/p2panda-net/src/sync/manager.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use anyhow::{Context, Error, Result};
 use iroh_net::{Endpoint, NodeId};
-use p2panda_sync::{SyncError, Topic};
+use p2panda_sync::{SyncError, TopicQuery};
 use thiserror::Error;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::time::{interval, Duration, Instant};
@@ -13,7 +13,6 @@ use tracing::{debug, error, trace, warn};
 
 use crate::engine::ToEngineActor;
 use crate::sync::{self, SYNC_CONNECTION_ALPN};
-use crate::TopicId;
 
 use super::SyncConfiguration;
 
@@ -80,7 +79,7 @@ pub(crate) struct SyncActor<T> {
 
 impl<T> SyncActor<T>
 where
-    T: Topic + TopicId + 'static,
+    T: TopicQuery + 'static,
 {
     /// Create a new instance of the `SyncActor` and return it along with a channel sender.
     pub(crate) fn new(

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -40,8 +40,8 @@ use thiserror::Error;
 /// They are designed as a two-party protocol featuring an "initiator" and an "acceptor" role.
 ///
 /// Each protocol usually follows two phases: 1) The "Handshake" phase, during which the
-/// "initiator" sends the "topic" and any access control data to the "acceptor", and 2) The "Sync"
-/// phase, where the requested application data is finally exchanged and validated.
+/// "initiator" sends the "topic query" and any access control data to the "acceptor", and 2) The 
+/// "Sync" phase, where the requested application data is finally exchanged and validated.
 ///
 /// ## Privacy and Security
 ///
@@ -68,10 +68,10 @@ use thiserror::Error;
 /// specific "search queries", for example "give me all documents containing the word 'billy'."
 ///
 /// With the help of the `TopicMap` trait we can keep sync implementations agnostic to specific
-/// topic implementations. The sync protocol only needs to feed the "topic" into the "map" which
-/// will answer with the actual to-be-synced data entities (for example coming from a store). This
-/// allows application developers to re-use your `SyncProtocol` implementation for their custom
-/// `Topic` requirements.
+/// topic implementations. The sync protocol only needs to feed the "topic query" into the "map"
+/// which will answer with the actual to-be-synced data entities (for example coming from a
+/// store). This allows application developers to re-use your `SyncProtocol` implementation for
+/// their custom `TopicQuery` requirements.
 ///
 /// ## Validation
 ///
@@ -93,7 +93,7 @@ use thiserror::Error;
 pub trait SyncProtocol<T, 'a>
 where
     Self: Send + Sync + Debug,
-    T: Topic,
+    T: TopicQuery,
 {
     /// Custom identifier for this sync protocol implementation.
     ///
@@ -104,7 +104,7 @@ where
     /// topic.
     ///
     /// During the "Handshake" phase the "initiator" usually requests access and informs the remote
-    /// peer about the "topic" they are interested in exchanging. Implementations for `p2panda-net`
+    /// peer about the "topic query" they are interested in. Implementations for `p2panda-net`
     /// are required to send a `SyncFrom::HandshakeSuccess` message to the application layer (via
     /// `app_tx`) during this phase to inform the backend that we've successfully requested access,
     /// exchanged the topic with the remote peer and are about to begin sync.
@@ -119,7 +119,7 @@ where
     /// behaviour from the remote peer) a `SyncError` is returned.
     async fn initiate(
         self: Arc<Self>,
-        topic: T,
+        topic_query: T,
         tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
         rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
         app_tx: Box<&'a mut (dyn Sink<FromSync<T>, Error = SyncError> + Send + Unpin)>,
@@ -128,10 +128,10 @@ where
     /// Accept a sync protocol session over the provided bi-directional stream.
     ///
     /// During the "Handshake" phase the "acceptor" usually responds to the access request and
-    /// learns about the "topic" from the remote peer. Implementations for `p2panda-net` are
+    /// learns about the "topic query" from the remote peer. Implementations for `p2panda-net` are
     /// required to send a `SyncFrom::HandshakeSuccess` message to the application layer (via
-    /// `app_tx`) during this phase to inform the backend that the topic has been successfully
-    /// received from the remote peer and that data exchange is about to begin.
+    /// `app_tx`) during this phase to inform the backend that the topic query has been
+    /// successfully received from the remote peer and that data exchange is about to begin.
     ///
     /// After the "Handshake" is complete the protocol enters the "Sync" phase, during which
     /// the actual application data is exchanged with the remote peer. It's left up to each
@@ -154,10 +154,10 @@ where
 #[derive(Debug, PartialEq)]
 pub enum FromSync<T>
 where
-    T: Topic,
+    T: TopicQuery,
 {
     /// During the "Handshake" phase both peers usually manage access control and negotiate the
-    /// "topic" they want to exchange over. This message indicates that this phase has ended.
+    /// "topic query" they want to exchange over. This message indicates that this phase has ended.
     ///
     /// Implementations for `p2panda-net` are required to send this message to the underlying
     /// transport layer to inform the "backend" that we've successfully requested access, exchanged
@@ -251,24 +251,24 @@ impl From<std::io::Error> for SyncError {
 /// access-control checks can be performed. Once this "handshake" is complete both peers will
 /// proceed with the designated sync protocol.
 ///
-/// ## `TopicId` vs `Topic`
+/// ## `TopicId` vs `TopicQuery`
 ///
 /// While `TopicId` is merely a 32-byte identifier which can't hold much information other than
-/// being a distinct identifier of a single data item or collection of them, we can use `Topic` to
+/// being a distinct identifier of a single data item or collection of them, we can use `TopicQuery` to
 /// implement custom data types representing "queries" for very specific data items. Peers can for
 /// example announce that they'd like "all events from the 27th of September 23 until today" with
-/// `Topic`.
+/// `TopicQuery`.
 ///
 /// Consult the `TopicId` documentation in `p2panda-net` for more information.
-pub trait Topic:
-    // Data types implementing `Topic` also need to implement `Eq` and `Hash` in order to allow 
+pub trait TopicQuery:
+    // Data types implementing `TopicQuery` also need to implement `Eq` and `Hash` in order to allow 
     // backends to organise sync sessions per topic and peer, along with `Serialize` and 
     // `Deserialize` to allow sending topics over the wire.
     Clone + Debug + Eq + Hash + Send + Sync + Serialize + for<'a> Deserialize<'a>
 {
 }
 
-/// Maps a `Topic` to the related data being sent over the wire during sync.
+/// Maps a `TopicQuery` to the related data being sent over the wire during sync.
 ///
 /// Each `SyncProtocol` implementation defines the type of data it is expecting to sync and how the
 /// scope for a particular session should be identified. Sync protocol users can provide an
@@ -299,13 +299,13 @@ pub trait Topic:
 /// - Log C2
 /// ```
 ///
-/// If we implement `Topic` to express that we're interested in syncing over a specific chat group,
+/// If we implement `TopicQuery` to express that we're interested in syncing over a specific chat group,
 /// for example "Chat Group 2" we would implement `TopicMap` to give us all append-only logs of all
 /// members inside this group, that is the entries inside logs `A2`, `B2` and `C2`.
 #[async_trait]
 pub trait TopicMap<T, S>: Debug + Send + Sync
 where
-    T: Topic,
+    T: TopicQuery,
 {
     async fn get(&self, topic: &T) -> Option<S>;
 }


### PR DESCRIPTION
Rename trait `Topic` to `TopicQuery` and update arg names and documentation.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
