### PR TITLE
Remove `Default` from `LogId` supertrait definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
+### [Changed]
+
+- Remove `Default` from `LogId` supertrait definition [#633](https://github.com/p2panda/p2panda/pull/633)
+
 ## [0.1.0]
 
 Version `v0.1.0` represents the first release of the new p2panda stack! You can find out more details by reading our [blog](https://p2panda.org/2024/12/06/p2panda-release.html).

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -55,9 +55,9 @@ use p2panda_core::{Body, Hash, Header, PublicKey, RawOperation};
 /// Finally, please note that implementers of `LogId` must take steps to ensure their log design is
 /// fit for purpose and that all operations have been thoroughly validated before being persisted.
 /// No such validation checks are provided by `p2panda-store`.
-pub trait LogId: Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash {}
+pub trait LogId: Clone + Debug + Eq + std::hash::Hash {}
 
-impl<T> LogId for T where T: Clone + Default + Debug + Eq + Send + Sync + std::hash::Hash {}
+impl<T> LogId for T where T: Clone + Debug + Eq + std::hash::Hash {}
 
 /// Interface for storing, deleting and querying operations.
 ///

--- a/p2panda-store/src/memory_store.rs
+++ b/p2panda-store/src/memory_store.rs
@@ -72,7 +72,7 @@ impl<T, E> MemoryStore<T, E> {
 
 impl<L, E> OperationStore<L, E> for MemoryStore<L, E>
 where
-    L: LogId,
+    L: LogId + Send + Sync,
     E: Extensions + Send + Sync,
 {
     type Error = Infallible;
@@ -165,7 +165,7 @@ where
 
 impl<L, E> LogStore<L, E> for MemoryStore<L, E>
 where
-    L: LogId,
+    L: LogId + Send + Sync,
     E: Extensions + Send + Sync,
 {
     type Error = Infallible;

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -78,7 +78,7 @@ impl<'a, T, TM, L, E, S> SyncProtocol<T, 'a> for LogSyncProtocol<TM, L, E, S>
 where
     T: TopicQuery,
     TM: TopicMap<T, Logs<L>>,
-    L: LogId + for<'de> Deserialize<'de> + Serialize + 'a,
+    L: LogId + Send + Sync + for<'de> Deserialize<'de> + Serialize + 'a,
     E: Extensions + Send + Sync + 'a,
     S: Debug + Sync + LogStore<L, E>,
 {


### PR DESCRIPTION
This PR removes `Default` as a bound in the `LogId` supertrait definition as it is not required and makes the API unnecessarily cumbersome. Additionally I took decision to move `Send` and `Sync` out of the supertrait and instead require them in the place where they are needed, for now only in the `MemoryStore` implementation. This was to have a consistent approach as we took with `Extensions`.

closes: #626 

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
