### PR TITLE
Reset sync and gossip state on major network interface change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Highlights are marked with a pancake 🥞
 ### Changed
 
 - `TopicMap` replaced by `TopicLogMap` [#650](https://github.com/p2panda/p2panda/pull/650)
+- Reset sync and gossip state on major network interface change [#648](https://github.com/p2panda/p2panda/pull/648)
 - Remove `Default`, `Sync` and `Send` from `LogId` supertrait definition [#633](https://github.com/p2panda/p2panda/pull/633)
 
 ## [0.1.0]

--- a/p2panda-blobs/Cargo.toml
+++ b/p2panda-blobs/Cargo.toml
@@ -20,10 +20,10 @@ bytes = "1.7.1"
 futures-buffered = "0.2.8"
 futures-lite = "2.3.0"
 futures-util = "0.3.30"
-iroh-base = "0.25.0"
-iroh-blobs = { version = "0.25.0", features = ["downloader", "fs-store"], default-features = false }
+iroh-base = "0.26.0"
+iroh-blobs = { version = "0.26.0", features = ["downloader", "fs-store"], default-features = false }
 iroh-io = "0.6.1"
-iroh-net = "0.25.0"
+iroh-net = "0.26.0"
 p2panda-core = { path = "../p2panda-core", version = "0.1.0" }
 p2panda-net = { path = "../p2panda-net", version = "0.1.0" }
 p2panda-sync = { path = "../p2panda-sync", version = "0.1.0" }

--- a/p2panda-discovery/Cargo.toml
+++ b/p2panda-discovery/Cargo.toml
@@ -23,8 +23,8 @@ flume = "0.11.0"
 futures-buffered = "0.2.8"
 futures-lite = "2.3.0"
 hickory-proto = { version = "0.24.1", optional = true }
-iroh-base = "0.25.0"
-iroh-net = "0.25.0"
+iroh-base = "0.26.0"
+iroh-net = "0.26.0"
 socket2 = { version = "0.5.7", optional = true }
 tokio = { version = "1.42.0", features = ["net", "sync"] }
 tokio-util = { version = "0.7.11", features = ["codec", "io-util", "io"] }

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -27,10 +27,11 @@ async-trait = "0.1.82"
 ciborium = "0.2.2"
 futures-lite = "2.3.0"
 futures-util = "0.3.30"
-iroh-base = "0.25.0"
-iroh-gossip = "0.25.0"
-iroh-net = "0.25.0"
+iroh-base = "0.26.0"
+iroh-gossip = "0.26.0"
+iroh-net = "0.26.0"
 iroh-quinn = { version = "0.11.3", features = ["futures-io"] }
+netwatch = "0.2.0"
 p2panda-core = { path = "../p2panda-core", version = "0.1.0" }
 p2panda-discovery = { path = "../p2panda-discovery", version = "0.1.0" }
 p2panda-sync = { path = "../p2panda-sync", version = "0.1.0", features = ["log-sync"] }

--- a/p2panda-net/src/engine/topic_discovery.rs
+++ b/p2panda-net/src/engine/topic_discovery.rs
@@ -77,6 +77,14 @@ impl TopicDiscovery {
         Ok(())
     }
 
+    /// Reset the topic discovery status to idle.
+    ///
+    /// Resetting the status allows the network-wide gossip overlay to be rejoined after a loss of
+    /// network connectivity.
+    pub async fn reset_status(&mut self) {
+        self.status = Status::Idle;
+    }
+
     pub fn on_gossip_joined(&mut self) {
         if self.status == Status::Active {
             return;

--- a/p2panda-net/src/engine/topic_streams.rs
+++ b/p2panda-net/src/engine/topic_streams.rs
@@ -281,7 +281,7 @@ where
             for (topic, _) in self.subscribed.values() {
                 if their_topic_ids.contains(&topic.id()) {
                     found_common_topic = true;
-                    let peer_topic = ToSyncActor::new(peer, topic.clone());
+                    let peer_topic = ToSyncActor::new_discovery(peer, topic.clone());
                     sync_actor_tx.send(peer_topic).await?
                 }
             }

--- a/p2panda-net/src/engine/topic_streams.rs
+++ b/p2panda-net/src/engine/topic_streams.rs
@@ -167,6 +167,20 @@ where
             .collect()
     }
 
+    /// Moves all gossip topics which were previously joined into the set of pending joins.
+    ///
+    /// This is useful for rejoining gossip topic overlays after an extended loss of network
+    /// connectivity. One important consideration is that the ready receiver is immediately
+    /// dropped, meaning that the application layer is never made aware when the topic has been
+    /// rejoined.
+    pub async fn move_joined_to_pending(&mut self) {
+        let mut gossip_joined = self.gossip_joined.write().await;
+        for topic in gossip_joined.drain() {
+            let (ready_tx, _ready_rx) = oneshot::channel();
+            self.gossip_pending.insert(topic, ready_tx);
+        }
+    }
+
     /// Re-attempts joining pending gossip overlays for topic id's we haven't succeeded joining yet
     /// (for example because we lacked knowledge of other peers also being interested in them).
     ///


### PR DESCRIPTION
## Expectation

Peers should resync and reenter network-wide and topic gossip overlays following an extended loss of connectivity.

## Problem

Network disconnections > 30 seconds result in gossip connections dropping. This means that we "fall out" of the network-wide and topic gossip overlays. In addition to gossip issues, peers who had previously synced will not sync again if the resync flag is not enabled.

## Solution

We listen for major network interface changes and use them as a trigger to reset sync and gossip state. This takes place on the node that lost connection.

This alone is not enough for a full recovery of the system once a connection is reestablished, since sync is currently unidirectional and the peer that stayed online will not necessary attempt to resync. Bidirectional sync is introduced in https://github.com/p2panda/p2panda/pull/657

Closes https://github.com/p2panda/p2panda/issues/630

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [ ] ~~New files contain a SPDX license header~~
