### PR TITLE
Make log sync protocol bidirectional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Changed
 
+- Make log sync protocol bidirectional [#657](https://github.com/p2panda/p2panda/pull/657)
 - `TopicMap` replaced by `TopicLogMap` [#650](https://github.com/p2panda/p2panda/pull/650)
 - Reset sync and gossip state on major network interface change [#648](https://github.com/p2panda/p2panda/pull/648)
 - Remove `Default`, `Sync` and `Send` from `LogId` supertrait definition [#633](https://github.com/p2panda/p2panda/pull/633)

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.42.0", features = ["sync", "time", "rt"], optional = true
 thiserror = "1.0.63"
 
 [dev-dependencies]
+p2panda-store = { path = "../p2panda-store", version = "0.1.0", features = [ "memory" ] }
 tokio = { version = "1.42.0", features = ["rt", "macros", "net", "io-util"] }
 tokio-stream = { version = "0.1.15" }
 

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -821,7 +821,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn e2e_sync() {
+    async fn e2e_sync_where_one_peer_has_data() {
         let private_key = PrivateKey::new();
         let log_id = 0;
         let topic_query = LogHeightTopic::new("messages");
@@ -1037,5 +1037,197 @@ mod tests {
         let mut peer_b_messages = Vec::new();
         peer_b_app_rx.recv_many(&mut peer_b_messages, 10).await;
         assert_eq!(peer_b_messages, peer_b_expected_messages);
+    }
+
+    #[tokio::test]
+    async fn e2e_sync_two_logs() {
+        // Scenario: peer A holds three operations for log 0 while peer B holds three operations
+        // for log 1. All operations are authored by the same keypair.
+        //
+        // Expectation: peer B receives log 0 operations from peer A and peer A receives log 1
+        // operations from peer B, all in a single sync session.
+
+        let private_key = PrivateKey::new();
+        let log_id_1 = 0;
+        let log_id_2 = 1;
+
+        let body_1 = Body::new("Hello, Sloth!".as_bytes());
+        let body_2 = Body::new("Hello, Panda!".as_bytes());
+
+        // Create a sequence of three operations authored by the same private key.
+        let (hash_0, header_0, header_bytes_1_0) =
+            create_operation(&private_key, &body_1, 0, 0, None);
+        let (hash_1, header_1, header_bytes_1_1) =
+            create_operation(&private_key, &body_1, 1, 100, Some(hash_0));
+        let (hash_2, header_2, header_bytes_1_2) =
+            create_operation(&private_key, &body_1, 2, 200, Some(hash_1));
+
+        // Create a store for peer a and insert the three operations with log_id_1.
+        let mut store_1 = MemoryStore::default();
+        store_1
+            .insert_operation(
+                hash_0,
+                &header_0,
+                Some(&body_1),
+                &header_bytes_1_0,
+                &log_id_1,
+            )
+            .await
+            .unwrap();
+        store_1
+            .insert_operation(
+                hash_1,
+                &header_1,
+                Some(&body_1),
+                &header_bytes_1_1,
+                &log_id_1,
+            )
+            .await
+            .unwrap();
+        store_1
+            .insert_operation(
+                hash_2,
+                &header_2,
+                Some(&body_1),
+                &header_bytes_1_2,
+                &log_id_1,
+            )
+            .await
+            .unwrap();
+
+        // Create a second sequence of three operations authored by the same private key.
+        let (hash_0, header_0, header_bytes_2_0) =
+            create_operation(&private_key, &body_2, 0, 300, None);
+        let (hash_1, header_1, header_bytes_2_1) =
+            create_operation(&private_key, &body_2, 1, 400, Some(hash_0));
+        let (hash_2, header_2, header_bytes_2_2) =
+            create_operation(&private_key, &body_2, 2, 500, Some(hash_1));
+
+        // Create a store for peer b and insert the three operations with log_id_2.
+        let mut store_2 = MemoryStore::default();
+        store_2
+            .insert_operation(
+                hash_0,
+                &header_0,
+                Some(&body_2),
+                &header_bytes_2_0,
+                &log_id_2,
+            )
+            .await
+            .unwrap();
+        store_2
+            .insert_operation(
+                hash_1,
+                &header_1,
+                Some(&body_2),
+                &header_bytes_2_1,
+                &log_id_2,
+            )
+            .await
+            .unwrap();
+        store_2
+            .insert_operation(
+                hash_2,
+                &header_2,
+                Some(&body_2),
+                &header_bytes_2_2,
+                &log_id_2,
+            )
+            .await
+            .unwrap();
+
+        // Define the topic query, logs and topic map.
+        let topic_query = LogHeightTopic::new("messages");
+        let logs = HashMap::from([(private_key.public_key(), vec![log_id_1, log_id_2])]);
+        let mut topic_map = LogHeightTopicMap::new();
+        topic_map.insert(&topic_query, logs);
+
+        // Instantiate the sync protocol for both peers.
+        let peer_a_protocol = Arc::new(LogSyncProtocol::new(topic_map.clone(), store_1.clone()));
+        let peer_b_protocol = Arc::new(LogSyncProtocol::new(topic_map, store_2.clone()));
+
+        // Duplex streams which simulate both ends of a bi-directional network connection
+        let (peer_a, peer_b) = tokio::io::duplex(64 * 1024);
+        let (peer_a_read, peer_a_write) = tokio::io::split(peer_a);
+        let (peer_b_read, peer_b_write) = tokio::io::split(peer_b);
+
+        // Spawn a task which opens a sync session from peer a runs it to completion
+        let peer_a_protocol_clone = peer_a_protocol.clone();
+        let (peer_a_app_tx, mut peer_a_app_rx) = mpsc::channel(128);
+        let mut sink =
+            PollSender::new(peer_a_app_tx).sink_map_err(|err| SyncError::Critical(err.to_string()));
+        let topic_clone = topic_query.clone();
+        let handle_1 = tokio::spawn(async move {
+            peer_a_protocol_clone
+                .initiate(
+                    topic_clone,
+                    Box::new(&mut peer_a_write.compat_write()),
+                    Box::new(&mut peer_a_read.compat()),
+                    Box::new(&mut sink),
+                )
+                .await
+                .unwrap();
+        });
+
+        // Spawn a task which accepts a sync session on peer b runs it to completion
+        let peer_b_protocol_clone = peer_b_protocol.clone();
+        let (peer_b_app_tx, mut peer_b_app_rx) = mpsc::channel(128);
+        let mut sink =
+            PollSender::new(peer_b_app_tx).sink_map_err(|err| SyncError::Critical(err.to_string()));
+        let handle_2 = tokio::spawn(async move {
+            peer_b_protocol_clone
+                .accept(
+                    Box::new(&mut peer_b_write.compat_write()),
+                    Box::new(&mut peer_b_read.compat()),
+                    Box::new(&mut sink),
+                )
+                .await
+                .unwrap();
+        });
+
+        // Wait for both to complete
+        let (_, _) = tokio::join!(handle_1, handle_2);
+
+        // Peer b should receive log_1 data from peer a.
+        let peer_b_expected_messages = vec![
+            FromSync::HandshakeSuccess(topic_query.clone()),
+            FromSync::Data {
+                header: header_bytes_1_0,
+                payload: Some(body_1.to_bytes()),
+            },
+            FromSync::Data {
+                header: header_bytes_1_1,
+                payload: Some(body_1.to_bytes()),
+            },
+            FromSync::Data {
+                header: header_bytes_1_2,
+                payload: Some(body_1.to_bytes()),
+            },
+        ];
+
+        let mut peer_b_messages = Vec::new();
+        peer_b_app_rx.recv_many(&mut peer_b_messages, 10).await;
+        assert_eq!(peer_b_messages, peer_b_expected_messages);
+
+        // Peer a should receive log_2 data from peer b.
+        let peer_a_expected_messages = vec![
+            FromSync::HandshakeSuccess(topic_query.clone()),
+            FromSync::Data {
+                header: header_bytes_2_0,
+                payload: Some(body_2.to_bytes()),
+            },
+            FromSync::Data {
+                header: header_bytes_2_1,
+                payload: Some(body_2.to_bytes()),
+            },
+            FromSync::Data {
+                header: header_bytes_2_2,
+                payload: Some(body_2.to_bytes()),
+            },
+        ];
+
+        let mut peer_a_messages = Vec::new();
+        peer_a_app_rx.recv_many(&mut peer_a_messages, 10).await;
+        assert_eq!(peer_a_messages, peer_a_expected_messages);
     }
 }

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -370,8 +370,8 @@ where
     Ok(messages)
 }
 
-/// Return all messages needed by a remote peer and format them as data messages for transport over
-/// the wire.
+/// Compare the local log heights with the remote log heights for all given logs and return all
+/// messages needed by the remote peer.
 async fn messages_needed_by_remote<T, L, E>(
     store: &impl LogStore<L, E>,
     logs: &Logs<L>,

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -41,7 +41,7 @@ type Logs<T> = HashMap<PublicKey, Vec<T>>;
 ///
 /// Each `SyncProtocol` implementation defines the type of data it is expecting to sync and how
 /// the scope for a particular session should be identified. `LogSyncProtocol` maps a generic
-/// `TopicQuery` to a set of logs, users provide an implementation of the `TopicLogMap` trait in
+/// `TopicQuery` to a set of logs; users provide an implementation of the `TopicLogMap` trait in
 /// order to define how this mapping occurs.
 ///
 /// Since `TopicLogMap` is generic we can use the same mapping across different sync implementations
@@ -308,7 +308,7 @@ where
 /// which match the given topic query.
 async fn local_log_heights<T, L, E>(
     store: &impl LogStore<L, E>,
-    topic_map: &impl TopicMap<T, Logs<L>>,
+    topic_map: &impl TopicLogMap<T, L>,
     topic_query: &T,
 ) -> Result<Vec<(PublicKey, Vec<(L, u64)>)>, SyncError>
 where

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -524,7 +524,7 @@ mod tests {
 
     async fn assert_message_bytes(
         mut rx: ReadHalf<DuplexStream>,
-        messages: Vec<Message<LogHeightTopic>>,
+        messages: Vec<Message<LogHeightTopic, u8>>,
     ) {
         let mut buf = Vec::new();
         rx.read_to_end(&mut buf).await.unwrap();
@@ -718,7 +718,7 @@ mod tests {
             Message::Done,
             Message::Have(
                 topic_query.clone(),
-                vec![(private_key.public_key(), vec![("0".to_string(), 2)])],
+                vec![(private_key.public_key(), vec![(0, 2)])],
             ),
         ];
         assert_message_bytes(peer_b_read, messages).await;

--- a/p2panda-sync/src/log_sync.rs
+++ b/p2panda-sync/src/log_sync.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Efficient sync protocol for append-only log data types.
+//! Efficient bidirectional sync protocol for append-only log data types.
 //!
 //! This implementation is generic over the actual data type implementation, as long as it follows
 //! the form of a numbered, linked list it will be compatible for sync. p2panda provides an own log
@@ -8,13 +8,12 @@
 //!
 //! The protocol checks the current local "log heights", that is the index of the latest known
 //! entry in each log, of the "initiating" peer and sends them in form of a "Have" message to the
-//! remote one. The "accepting", remote peer matches the given log heights with the locally present
+//! remote peer. The "accepting" remote peer matches the given log heights with the locally present
 //! ones, calculates the delta of missing entries and sends them to the initiating peer as part of
-//! "Data" messages.
-//!
-//! In this implementation the "accepting" peer will never receive any new data from the
-//! "initiating" counter-part. Usually this would be handled in a "reverse" sync session which
-//! might run concurrently.
+//! "Data" messages. The accepting peer then sends a "Done" message to signal that data
+//! transmission is complete. The protocol exchange is then repeated with the roles reversed: the
+//! accepting peer sends their "Have" message and the initiating peer responds with the required
+//! "Data" messages, followed by a final "Done" message.
 //!
 //! To find out which logs to send matching the given "topic query" a `TopicLogMap` is provided. This
 //! interface aids the sync protocol in deciding which logs to transfer for each given topic.


### PR DESCRIPTION
Previously, only the sync session acceptor would send messages (based on the `Have` message sent by the initiator). This PR updates log sync to be bidirectional, so that both the acceptor and initiator send `Have` and `Data` messages.

```
// Bidirectional log sync protocol.
//
// Both peers send and receive data during the same session.
//
// [ Initiator ]        [ Acceptor ]
// -------------        ------------
//       have ->        -> have
//       data <-        <- data
//       done <-        <- done
//       have <-        <- have
//       data ->        -> data
//       done ->        -> done
```

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`