### PR TITLE
Introduce offline-first capability for `LocalDiscovery` mDNS service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Changed
 
+- Introduce offline-first capability for `LocalDiscovery` mDNS service [#660](https://github.com/p2panda/p2panda/pull/660)
 - Update to iroh `v0.28.1` [#661](https://github.com/p2panda/p2panda/pull/661)
 - Make log sync protocol bidirectional [#657](https://github.com/p2panda/p2panda/pull/657)
 - `TopicMap` replaced by `TopicLogMap` [#650](https://github.com/p2panda/p2panda/pull/650)

--- a/p2panda-discovery/Cargo.toml
+++ b/p2panda-discovery/Cargo.toml
@@ -25,6 +25,7 @@ futures-lite = "2.3.0"
 hickory-proto = { version = "0.24.1", optional = true }
 iroh-base = "0.28.0"
 iroh-net = "0.28.1"
+netwatch = "0.2.0"
 socket2 = { version = "0.5.7", optional = true }
 tokio = { version = "1.42.0", features = ["net", "sync"] }
 tokio-util = { version = "0.7.11", features = ["codec", "io-util", "io"] }

--- a/p2panda-discovery/src/mdns/mod.rs
+++ b/p2panda-discovery/src/mdns/mod.rs
@@ -5,7 +5,6 @@ mod dns;
 mod socket;
 
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -15,17 +14,18 @@ use futures_lite::{FutureExt, StreamExt};
 use hickory_proto::rr::Name;
 use iroh_base::base32;
 use iroh_net::NodeAddr;
-use netwatch::netmon::{CallbackToken, Monitor};
+use netwatch::netmon::Monitor;
 use tokio::sync::mpsc::{self, Receiver};
 use tokio_util::task::AbortOnDropHandle;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::mdns::dns::{make_query, make_response, parse_message, MulticastDNSMessage};
-use crate::mdns::socket::{send, socket_v4, MDNS_IPV4};
+use crate::mdns::socket::{send, socket_v4, socket_v4_unbound};
 use crate::{BoxedStream, Discovery, DiscoveryEvent};
 
 const MDNS_PROVENANCE: &str = "mdns";
 const MDNS_QUERY_INTERVAL: Duration = Duration::from_millis(1000);
+const SOCKET_REBIND_INTERVAL: Duration = Duration::from_millis(5000);
 
 pub type ServiceName = Name;
 
@@ -44,10 +44,10 @@ pub struct LocalDiscovery {
 }
 
 /// Create a new network monitor and subscribe to major interface changes.
-async fn network_monitor() -> Result<(Monitor, CallbackToken, Receiver<bool>)> {
+async fn network_monitor() -> Result<Receiver<bool>> {
     let network_monitor = Monitor::new().await?;
     let (interface_change_tx, interface_change_rx) = mpsc::channel(8);
-    let token = network_monitor
+    let _token = network_monitor
         .subscribe(move |is_major| {
             debug!("detected major network interface change");
             let interface_change_tx = interface_change_tx.clone();
@@ -58,49 +58,48 @@ async fn network_monitor() -> Result<(Monitor, CallbackToken, Receiver<bool>)> {
         })
         .await?;
 
-    Ok((network_monitor, token, interface_change_rx))
+    Ok(interface_change_rx)
+}
+
+impl Default for LocalDiscovery {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl LocalDiscovery {
-    pub fn new() -> Result<Self> {
+    pub fn new() -> Self {
         let (tx, rx) = flume::bounded(64);
 
-        let socket = socket_v4()?;
+        let mut socket_is_bound = false;
+        let mut socket = match socket_v4() {
+            Ok(socket) => {
+                socket_is_bound = true;
+                socket
+            }
+            Err(err) => {
+                warn!("failed to create udp socket for mdns discovery: {}", err);
+                socket_v4_unbound().expect("create udp socket")
+            }
+        };
 
         let mut subscribers: HashMap<ServiceName, Vec<SubscribeSender>> = HashMap::new();
         let mut my_node_addr: Option<NodeAddr> = None;
 
         let handle = tokio::task::spawn(async move {
-            // Instantiate a network monitor.
-            let (network_monitor, token, mut interface_change_rx) =
-                network_monitor().await.expect("start network monitor");
-
-            // Attempt to join multicast on the socket. If this fails, we wait for a major network
-            // interface change and try again.
-            while socket
-                .join_multicast_v4(MDNS_IPV4, Ipv4Addr::UNSPECIFIED)
-                .is_err()
-            {
-                debug!("failed to join ipv4 multicast for mdns discovery; waiting for major network interface change");
-                if let Some(true) = interface_change_rx.recv().await {
-                    debug!("detected major network interface change");
-                }
-            }
-
-            // Clean-up the network monitor.
-            network_monitor
-                .unsubscribe(token)
-                .await
-                .expect("unsubscribe from network interface changes");
-            drop(interface_change_rx);
-
+            let mut interface_change_rx = network_monitor().await.expect("start network monitor");
+            let mut socket_interval = tokio::time::interval(SOCKET_REBIND_INTERVAL);
             let mut interval = tokio::time::interval(MDNS_QUERY_INTERVAL);
             let mut buf = [0; 1472];
 
             loop {
                 tokio::select! {
                     biased;
-                    Ok(len) = socket.recv(&mut buf) => {
+                    Some(true) = interface_change_rx.recv() => {
+                        // Force a recreation of the socket on the next tick.
+                        socket_is_bound = false;
+                    }
+                    Ok(len) = socket.recv(&mut buf), if socket_is_bound => {
                         let Some(msg) = parse_message(&buf[..len]) else {
                             continue;
                         };
@@ -143,12 +142,12 @@ impl LocalDiscovery {
                             }
                         }
                     },
-                    _ = interval.tick() => {
+                    _ = interval.tick(), if socket_is_bound => {
                         for service_name in subscribers.keys() {
                             send(&socket, make_query(service_name)).await;
                         }
                     },
-                    Ok(msg) = rx.recv_async() => {
+                    Ok(msg) = rx.recv_async(), if socket_is_bound => {
                         match msg {
                             Message::Subscribe(service_name, subscribe_tx) => {
                                 if let Some(subscriber) = subscribers.get_mut(&service_name) {
@@ -162,15 +161,27 @@ impl LocalDiscovery {
                             }
                         }
                     },
+                    _ = socket_interval.tick() => {
+                        if !socket_is_bound {
+                            match socket_v4() {
+                                Ok(bound_socket) => {
+                                    socket = bound_socket;
+                                    debug!("bound udp socket for mdns discovery");
+                                    socket_is_bound = true;
+                                }
+                                Err(err) => warn!("failed to rebind socket: {}", err)
+                            }
+                        }
+                    }
                     else => break,
                 }
             }
         });
 
-        Ok(Self {
+        Self {
             handle: AbortOnDropHandle::new(handle),
             tx,
-        })
+        }
     }
 }
 

--- a/p2panda-discovery/src/mdns/socket.rs
+++ b/p2panda-discovery/src/mdns/socket.rs
@@ -9,7 +9,7 @@ use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::UdpSocket;
 use tracing::error;
 
-pub const MDNS_IPV4: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
+const MDNS_IPV4: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
 const MDNS_PORT: u16 = 5353;
 
 pub fn socket_v4_unbound() -> Result<UdpSocket> {

--- a/p2panda-discovery/src/mdns/socket.rs
+++ b/p2panda-discovery/src/mdns/socket.rs
@@ -9,7 +9,7 @@ use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::UdpSocket;
 use tracing::error;
 
-const MDNS_IPV4: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
+pub const MDNS_IPV4: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
 const MDNS_PORT: u16 = 5353;
 
 pub fn socket_v4() -> Result<UdpSocket> {
@@ -26,9 +26,6 @@ pub fn socket_v4() -> Result<UdpSocket> {
     socket
         .set_multicast_loop_v4(true)
         .context("set_multicast_loop_v4")?;
-    socket
-        .join_multicast_v4(&MDNS_IPV4, &Ipv4Addr::UNSPECIFIED)
-        .context("join_multicast_v4")?;
     socket
         .set_multicast_ttl_v4(16)
         .context("set_multicast_ttl_v4")?;

--- a/p2panda-discovery/src/mdns/socket.rs
+++ b/p2panda-discovery/src/mdns/socket.rs
@@ -12,6 +12,12 @@ use tracing::error;
 pub const MDNS_IPV4: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
 const MDNS_PORT: u16 = 5353;
 
+pub fn socket_v4_unbound() -> Result<UdpSocket> {
+    let socket =
+        Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).context("Socket::new")?;
+    UdpSocket::from_std(std::net::UdpSocket::from(socket)).context("from_std")
+}
+
 pub fn socket_v4() -> Result<UdpSocket> {
     let socket =
         Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).context("Socket::new")?;
@@ -23,6 +29,7 @@ pub fn socket_v4() -> Result<UdpSocket> {
     socket
         .bind(&SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, MDNS_PORT).into())
         .context("bind")?;
+    socket.join_multicast_v4(&MDNS_IPV4, &Ipv4Addr::UNSPECIFIED)?;
     socket
         .set_multicast_loop_v4(true)
         .context("set_multicast_loop_v4")?;

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
     let private_key = PrivateKey::new();
 
     let network = NetworkBuilder::new(network_id)
-        .discovery(LocalDiscovery::new()?)
+        .discovery(LocalDiscovery::new())
         .build()
         .await?;
 

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -208,20 +208,18 @@ where
                 },
                 // Inform the topic discovery process and sync actor about a major network
                 // interface change.
-                Some(is_major) = interface_change_rx.recv() => {
+                Some(true) = interface_change_rx.recv() => {
                     // In the event of a disconnection, we will drop out of the topic and
                     // network-wide gossip overlays and may fall out of sync with peers with whom we
                     // had previously synced. Here we inform the sync actor (if one exists) of the
                     // interface change and reset the state of the topic discovery process. This
                     // should result in us reentering the network-wide gossip overlay and resyncing
                     // with our peers before entering "live mode" again.
-                    if is_major {
-                        debug!("detected major network interface change");
-                        self.topic_discovery.reset_status().await;
-                        self.topic_streams.move_joined_to_pending().await;
-                        if let Some(sync_actor_tx) = &self.sync_actor_tx {
-                            sync_actor_tx.send(ToSyncActor::Reset).await?;
-                        }
+                    debug!("detected major network interface change");
+                    self.topic_discovery.reset_status().await;
+                    self.topic_streams.move_joined_to_pending().await;
+                    if let Some(sync_actor_tx) = &self.sync_actor_tx {
+                        sync_actor_tx.send(ToSyncActor::Reset).await?;
                     }
                 }
                 // Attempt to start topic discovery if it didn't happen yet.

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -120,7 +120,7 @@
 //! let private_key = PrivateKey::new();
 //!
 //! // Use mDNS to discover other peers on the local network.
-//! let mdns_discovery = LocalDiscovery::new()?;
+//! let mdns_discovery = LocalDiscovery::new();
 //!
 //! // Establish the p2p network which will automatically connect you to any discovered peers.
 //! let network = NetworkBuilder::new(network_id)


### PR DESCRIPTION
This PR introduces offline-first capability for our `LocalDiscovery` mDNS service.

If the initial attempt to fully configure and bind the UDP socket fails, we create an unbound socket as a fallback and periodically attempt to configure and bind a new socket. The socket is also recreated when a major network interface change is detected.

A minor API change is introduced: the `LocalDiscovery::new()` no longer returns a `Result`.

Addresses: https://github.com/p2panda/p2panda/issues/654

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes