### PR TITLE
Fix re-attempt logic for out-of-order buffer in `Ingest` stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Highlights are marked with a pancake 🥞
 - Reset sync and gossip state on major network interface change [#648](https://github.com/p2panda/p2panda/pull/648)
 - Remove `Default`, `Sync` and `Send` from `LogId` supertrait definition [#633](https://github.com/p2panda/p2panda/pull/633)
 
+### Fixed
+
+- Fix re-attempt logic for out-of-order buffer in `Ingest` stream [#666](https://github.com/p2panda/p2panda/pull/666)
+
 ## [0.1.0]
 
 Version `v0.1.0` represents the first release of the new p2panda stack! You can find out more details by reading our [blog](https://p2panda.org/2024/12/06/p2panda-release.html).

--- a/p2panda-stream/Cargo.toml
+++ b/p2panda-stream/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0.63"
 async-stream = "0.3.5"
 serde = { version = "1.0.215", features = ["derive"] }
 tokio = { version = "1.42.0", features = ["rt", "macros"] }
-tokio-stream = { version = "0.1.17", features = ["sync"] }
+tokio-stream = "0.1.17"
 
 [lints]
 workspace = true

--- a/p2panda-stream/Cargo.toml
+++ b/p2panda-stream/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0.63"
 async-stream = "0.3.5"
 serde = { version = "1.0.215", features = ["derive"] }
 tokio = { version = "1.42.0", features = ["rt", "macros"] }
+tokio-stream = { version = "0.1.17", features = ["sync"] }
 
 [lints]
 workspace = true

--- a/p2panda-stream/src/stream/ingest.rs
+++ b/p2panda-stream/src/stream/ingest.rs
@@ -123,13 +123,13 @@ where
                             Some(IngestAttempt(header, body, header_bytes, 1))
                         }
                         Poll::Pending => {
-                            // If we're getting back to the buffer queue after an failed ingest
-                            // attempt, we should park here instead and allow the runtime to try
+                            // If we're getting back to the buffer queue after a failed ingest
+                            // attempt, we should "park" here instead and allow the runtime to try
                             // polling the stream again next time.
                             //
-                            // Otherwise we run into an loop where the runtime will never have the
-                            // chance again to take in new operations and we end up with exhausting
-                            // our re-attempt counter.
+                            // Otherwise we run into a loop where the runtime will never have the
+                            // chance again to take in new operations and we end up exhausting our
+                            // re-attempt counter for no reason.
                             if park_buffer {
                                 return Poll::Pending;
                             }

--- a/p2panda-stream/src/stream/ingest.rs
+++ b/p2panda-stream/src/stream/ingest.rs
@@ -310,14 +310,14 @@ mod tests {
 
     #[tokio::test]
     async fn exhaust_re_attempts_too_early_bug() {
-        let items_num = 10;
+        // Related issue: https://github.com/p2panda/p2panda/issues/665
         let store = MemoryStore::<StreamName, Extensions>::new();
-        let (tx, rx) = mpsc::channel::<RawOperation>(items_num);
+        let (tx, rx) = mpsc::channel::<RawOperation>(10);
 
         // Incoming operations in order: 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 (<-- first operation in log
         // comes last in).
         let mut items: Vec<RawOperation> = {
-            let operations: Vec<RawOperation> = mock_stream().take(items_num).collect().await;
+            let operations: Vec<RawOperation> = mock_stream().take(10).collect().await;
             let first_operation = operations[0].clone();
             let mut result = operations[1..10].to_vec();
             result.push(first_operation);
@@ -347,6 +347,6 @@ mod tests {
             .ingest(store, 128); // out-of-order buffer is large enough
 
         let res: Vec<Operation<Extensions>> = stream.try_collect().await.expect("not fail");
-        assert_eq!(res.len(), items_num);
+        assert_eq!(res.len(), 10);
     }
 }

--- a/p2panda-stream/src/stream/ingest.rs
+++ b/p2panda-stream/src/stream/ingest.rs
@@ -316,18 +316,13 @@ mod tests {
 
         // Incoming operations in order: 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 (<-- first operation in log
         // comes last in).
-        let mut items: Vec<RawOperation> = {
-            let operations: Vec<RawOperation> = mock_stream().take(10).collect().await;
-            let first_operation = operations[0].clone();
-            let mut result = operations[1..10].to_vec();
-            result.push(first_operation);
-            result
-        };
+        let mut operations: Vec<RawOperation> = mock_stream().take(10).collect().await;
+        operations.rotate_left(1);
 
         tokio::spawn(async move {
             // Reverse operations and pop one after another from the back to ingest.
-            items.reverse();
-            while let Some(operation) = items.pop() {
+            operations.reverse();
+            while let Some(operation) = operations.pop() {
                 let _ = tx.send(operation).await;
 
                 // Waiting here is crucial to cause the bug: The polling logic will not receive a


### PR DESCRIPTION
Closes: https://github.com/p2panda/p2panda/issues/665

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
