### PR TITLE
Expand chat example with relay, mdns and bootstrap options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Highlights are marked with a pancake 🥞
 
 ### Changed
 
+- Expand chat example with relay, mdns and bootstrap options [#690](https://github.com/p2panda/p2panda/pull/690) 
 - Remove logging from network tests [#693](https://github.com/p2panda/p2panda/pull/693)
 - Give access to header in `Extension::extract` method [#670](https://github.com/p2panda/p2panda/pull/670)
 - Update to iroh `v0.31.0` [#672](https://github.com/p2panda/p2panda/pull/672)

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -44,5 +44,6 @@ tokio-util = { version = "0.7.11", features = ["compat", "codec", "io-util", "io
 tracing = "0.1.40"
 
 [dev-dependencies]
+clap = { version = "4.5.29", features = ["derive"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 p2panda-store = { path = "../p2panda-store", version = "0.2.0" }

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -1,4 +1,30 @@
+//! Example chat program using `p2panda-net`.
+//!
+//! `cargo run --example chat -- --help`
+//!
+//! Arguments are exposed to control the networking setup, including local discovery over mDNS,
+//! relay connectivity and the specification of a bootstrap peer.
+//!
+//! # Scenario 1: Local Connectivity
+//!
+//! Run the example with the `--use-mdns` flag if you wish to enable local network discovery.
+//! Run the same command in a second terminal to chat over the local network.
+//!
+//! `cargo run --example chat -- --use-mdns`
+//!
+//! # Scenario 2: Internet Connectivity
+//!
+//! Run the example with the `--use-relay` flag; take note of the `node id` in the terminal output.
+//!
+//! `cargo run --example chat -- --use-relay`
+//!
+//! Run the example on a second computer or in a second terminal with the `--use-relay` and
+//! `--bootstrap <PUBLIC_KEY>` flags (passing in the `node id` from the first computer or
+//! terminal as `PUBLIC_KEY`.
+//!
+//! `cargo run --example chat -- --use-relay --bootstrap <PUBLIC_KEY>`
 use anyhow::{bail, Result};
+use clap::Parser;
 use p2panda_core::{Hash, PrivateKey, PublicKey, Signature};
 use p2panda_discovery::mdns::LocalDiscovery;
 use p2panda_net::network::{FromNetwork, ToNetwork};
@@ -10,12 +36,32 @@ use tokio::sync::mpsc;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
+pub const GOSSIP_ALPN: &[u8] = b"/iroh-gossip/0";
+
+// Relay server operated by p2panda team (may not be running the latest iroh release version).
+const RELAY_URL: &str = "https://wasser.liebechaos.org/";
+
 pub fn setup_logging() {
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
         .with(EnvFilter::from_default_env())
         .try_init()
         .ok();
+}
+
+#[derive(Parser)]
+struct Args {
+    /// Enable local discovery using mDNS.
+    #[arg(short = 'm', long)]
+    use_mdns: bool,
+
+    /// Enable relay server connectivity.
+    #[arg(short = 'r', long)]
+    use_relay: bool,
+
+    /// Supply the public key of a bootstrap peer for discovery over the internet.
+    #[arg(short = 'b', long, value_name = "PUBLIC_KEY")]
+    bootstrap: Option<PublicKey>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
@@ -39,25 +85,85 @@ impl TopicId for ChatTopic {
 async fn main() -> Result<()> {
     setup_logging();
 
-    let network_id = [0; 32];
+    let args = Args::parse();
+
+    let network_id = Hash::new(b"p2panda_chat_example");
     let topic = ChatTopic::new("my_chat");
 
     let private_key = PrivateKey::new();
+    let public_key = private_key.public_key();
 
-    let network = NetworkBuilder::new(network_id)
-        .discovery(LocalDiscovery::new())
-        .build()
-        .await?;
+    // Configure the network.
+    let mut network_builder =
+        NetworkBuilder::<ChatTopic>::new(network_id.into()).private_key(private_key.clone());
 
+    if args.use_mdns {
+        network_builder = network_builder.discovery(LocalDiscovery::new());
+    }
+
+    if args.use_relay {
+        network_builder = network_builder.relay(RELAY_URL.parse()?, false, 3478);
+    }
+
+    if let Some(node_id) = args.bootstrap {
+        network_builder = network_builder.direct_address(node_id, vec![], None);
+    }
+
+    let network = network_builder.build().await?;
+
+    // Print network info to the terminal.
+    println!("node id:");
+    println!("\t{}", public_key);
+    println!("network id:");
+    println!("\t{}", network_id);
+    println!("node listening addresses:");
+    for local_endpoint in network
+        .endpoint()
+        .direct_addresses()
+        .initialized()
+        .await
+        .unwrap()
+    {
+        println!("\t{}", local_endpoint.addr)
+    }
+    println!("local discovery via mdns:");
+    if args.use_mdns {
+        println!("\tactive");
+    } else {
+        println!("\tinactive");
+    }
+    println!("node relay server url:");
+    if args.use_relay {
+        let relay_url = network
+            .endpoint()
+            .home_relay()
+            .get()
+            .unwrap()
+            .expect("should be connected to a relay server");
+        println!("\t{relay_url}");
+    } else {
+        println!("\tnot specified");
+    }
+    println!("bootstrap peer:");
+    if let Some(node_id) = args.bootstrap {
+        println!("\t{node_id}");
+    } else {
+        println!("\tnot specified");
+    }
+    println!();
+
+    // Subscribe to the chat topic.
     let (tx, mut rx, ready) = network.subscribe(topic).await?;
 
+    // Receive topic messages from the network;
+    // decode and verify their integrity before printing them to the terminal.
     tokio::task::spawn(async move {
         while let Some(event) = rx.recv().await {
             match event {
                 FromNetwork::GossipMessage { bytes, .. } => {
                     match Message::decode_and_verify(&bytes) {
                         Ok(message) => {
-                            print!("{}: {}", message.public_key, message.text);
+                            print!("{}: {}", &message.public_key.to_string()[..5], message.text);
                         }
                         Err(err) => {
                             eprintln!("invalid gossip message: {err}");
@@ -73,16 +179,18 @@ async fn main() -> Result<()> {
     let _ = ready.await;
     println!("found other peers, you're ready to chat!");
 
+    // Listen for text input via the terminal.
     let (line_tx, mut line_rx) = mpsc::channel(1);
     std::thread::spawn(move || input_loop(line_tx));
 
+    // Sign and encode each line of text input and broadcast it on the chat topic.
     while let Some(text) = line_rx.recv().await {
         let bytes = Message::sign_and_encode(&private_key, &text)?;
         tx.send(ToNetwork::Message { bytes }).await.ok();
     }
 
+    // Listen for `Ctrl+c` and shutdown the node.
     tokio::signal::ctrl_c().await?;
-
     network.shutdown().await?;
 
     Ok(())
@@ -98,14 +206,14 @@ struct Message {
 
 impl Message {
     pub fn sign_and_encode(private_key: &PrivateKey, text: &str) -> Result<Vec<u8>> {
-        // Sign text content
+        // Sign text content.
         let mut text_bytes: Vec<u8> = Vec::new();
         ciborium::ser::into_writer(text, &mut text_bytes)?;
         let signature = private_key.sign(&text_bytes);
 
-        // Encode message
+        // Encode message.
         let message = Message {
-            // Make every message unique, as duplicates get ignored during gossip broadcast
+            // Make every message unique, as duplicates get ignored during gossip broadcast.
             id: random(),
             signature,
             public_key: private_key.public_key(),
@@ -118,10 +226,10 @@ impl Message {
     }
 
     fn decode_and_verify(bytes: &[u8]) -> Result<Self> {
-        // Decode message
+        // Decode message.
         let message: Self = ciborium::de::from_reader(bytes)?;
 
-        // Verify signature
+        // Verify signature.
         let mut text_bytes: Vec<u8> = Vec::new();
         ciborium::ser::into_writer(&message.text, &mut text_bytes)?;
         if !message.public_key.verify(&text_bytes, &message.signature) {

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -36,8 +36,6 @@ use tokio::sync::mpsc;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
-pub const GOSSIP_ALPN: &[u8] = b"/iroh-gossip/0";
-
 // Relay server operated by p2panda team (may not be running the latest iroh release version).
 const RELAY_URL: &str = "https://wasser.liebechaos.org/";
 


### PR DESCRIPTION
Here we introduce a few improvements to the network chat example. CLI arguments are exposed to control the networking setup, including local discovery over mDNS, relay connectivity and the specification of a bootstrap peer.

We also print more information to the terminal and truncate the public keys of peers when displaying chat messages.

- [x] Add this PR to the Unreleased section in CHANGELOG.md