### PR TITLE
Introduce concrete error type for `SqliteStore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
-- Introduce a concrete error type for `SqliteStore` [#698](https://github.com/p2panda/p2panda/pull/698)
+- Introduce concrete error types for `MemoryStore` and `SqliteStore` [#698](https://github.com/p2panda/p2panda/pull/698)
 - Implement SQLite `OperationStore` & `LogStore` [#680](https://github.com/p2panda/p2panda/pull/680)
 - Introduce network system events API [#669](https://github.com/p2panda/p2panda/pull/669)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
+- Introduce a concrete error type for `SqliteStore` [#698](https://github.com/p2panda/p2panda/pull/698)
 - Implement SQLite `OperationStore` & `LogStore` [#680](https://github.com/p2panda/p2panda/pull/680)
 - Introduce network system events API [#669](https://github.com/p2panda/p2panda/pull/669)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
-- Introduce concrete error types for `MemoryStore` and `SqliteStore` [#698](https://github.com/p2panda/p2panda/pull/698)
+- Introduce concrete error type for `SqliteStore` [#698](https://github.com/p2panda/p2panda/pull/698)
 - Implement SQLite `OperationStore` & `LogStore` [#680](https://github.com/p2panda/p2panda/pull/680)
 - Introduce network system events API [#669](https://github.com/p2panda/p2panda/pull/669)
 

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -21,7 +21,6 @@ memory = []
 sqlite = ["dep:ciborium", "dep:sqlx", "dep:hex"]
 
 [dependencies]
-anyhow = { version = "1.0.86" }
 ciborium = { version = "0.2.2", optional = true }
 hex = { version = "0.4.3", optional = true }
 p2panda-core = { path = "../p2panda-core", version = "0.2.0" }

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -27,6 +27,7 @@ hex = { version = "0.4.3", optional = true }
 p2panda-core = { path = "../p2panda-core", version = "0.2.0" }
 sqlx = { version = "0.8.3", optional = true, features = ["sqlite",
 "runtime-tokio"] }
+thiserror = "2.0.11"
 trait-variant = "0.1.2"
 
 [dev-dependencies]

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -20,6 +20,10 @@
 //! An in-memory storage solution is provided in the form of a `MemoryStore` which implements both
 //! `OperationStore` and `LogStore`. The store is gated by the `memory` feature flag and is enabled
 //! by default.
+//!
+//! A SQLite storage solution is provided in the form of a `SqliteStore` which implements both
+//! `OperationStore` and `LogStore`. The store is gated by the `sqlite` feature flag and is
+//! disabled by default.
 #[cfg(feature = "memory")]
 pub mod memory;
 #[cfg(feature = "sqlite")]
@@ -27,6 +31,8 @@ pub mod sqlite;
 
 #[cfg(feature = "memory")]
 pub use memory::MemoryStore;
+#[cfg(feature = "sqlite")]
+pub use sqlite::store::{SqliteStore, SqliteStoreError};
 
 use std::fmt::{Debug, Display};
 

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -30,7 +30,7 @@ pub mod memory;
 pub mod sqlite;
 
 #[cfg(feature = "memory")]
-pub use memory::MemoryStore;
+pub use memory::{MemoryStore, MemoryStoreError};
 #[cfg(feature = "sqlite")]
 pub use sqlite::store::{SqliteStore, SqliteStoreError};
 

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -30,7 +30,7 @@ pub mod memory;
 pub mod sqlite;
 
 #[cfg(feature = "memory")]
-pub use memory::{MemoryStore, MemoryStoreError};
+pub use memory::MemoryStore;
 #[cfg(feature = "sqlite")]
 pub use sqlite::store::{SqliteStore, SqliteStoreError};
 

--- a/p2panda-store/src/memory.rs
+++ b/p2panda-store/src/memory.rs
@@ -413,31 +413,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn insert_operation_with_unsigned_header() {
-        let mut store = MemoryStore::default();
-        let private_key = PrivateKey::new();
-
-        // Create the first operation.
-        let body = Body::new("hello!".as_bytes());
-        let (hash, mut header, header_bytes) = create_operation(&private_key, &body, 0, 0, None);
-
-        // Set signature to `None` for the sake of the test.
-        header.signature = None;
-
-        // Only insert the first operation into the store.
-        let inserted = store
-            .insert_operation(hash, &header, Some(&body), &header_bytes, &0)
-            .await;
-
-        // Ensure that the lack of a header signature returns an error.
-        assert!(inserted.is_err());
-        assert_eq!(
-            format!("{}", inserted.unwrap_err()),
-            "operation header must be signed prior to insertion"
-        );
-    }
-
-    #[tokio::test]
     async fn insert_get_operation() {
         let mut store = MemoryStore::default();
         let private_key = PrivateKey::new();

--- a/p2panda-store/src/sqlite/models.rs
+++ b/p2panda-store/src/sqlite/models.rs
@@ -3,10 +3,9 @@
 use std::convert::From;
 use std::str::FromStr;
 
+use p2panda_core::cbor::decode_cbor;
 use p2panda_core::{Extensions, Hash, Header, PublicKey, RawOperation, Signature};
 use sqlx::FromRow;
-
-use crate::sqlite::store::deserialize_extensions;
 
 /// A single "raw" operation row as it is inserted in the database.
 #[derive(FromRow, Debug, Clone, PartialEq, Eq)]
@@ -61,7 +60,7 @@ where
             previous,
             extensions: row
                 .extensions
-                .map(|extensions| deserialize_extensions(extensions).unwrap()),
+                .map(|extensions| decode_cbor(&extensions[..]).unwrap()),
         }
     }
 }

--- a/p2panda-store/src/sqlite/store.rs
+++ b/p2panda-store/src/sqlite/store.rs
@@ -18,9 +18,6 @@ use crate::{LogId, LogStore, OperationStore};
 
 #[derive(Debug, Error)]
 pub enum SqliteStoreError {
-    #[error("operation header must be signed prior to insertion")]
-    MissingHeaderSignature,
-
     #[error("failed to encode operation extensions: {0}")]
     EncodingFailed(#[from] EncodeError),
 
@@ -117,10 +114,6 @@ where
         header_bytes: &[u8],
         log_id: &L,
     ) -> Result<bool, Self::Error> {
-        if header.signature.is_none() {
-            return Err(SqliteStoreError::MissingHeaderSignature);
-        }
-
         query(
             "
             INSERT INTO
@@ -664,7 +657,7 @@ mod tests {
         assert!(inserted.is_err());
         assert_eq!(
             format!("{}", inserted.unwrap_err()),
-            "operation header must be signed prior to insertion"
+            "an error occurred with the sqlite database: error returned from database: (code: 1299) NOT NULL constraint failed: operations_v1.signature"
         );
     }
 

--- a/p2panda-store/src/sqlite/store.rs
+++ b/p2panda-store/src/sqlite/store.rs
@@ -4,16 +4,38 @@
 use std::hash::{DefaultHasher, Hash as StdHash, Hasher};
 use std::marker::PhantomData;
 
-use anyhow::{anyhow, Error, Result};
 use sqlx::migrate;
-use sqlx::migrate::MigrateDatabase;
+use sqlx::migrate::{MigrateDatabase, MigrateError};
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
-use sqlx::{query, query_as, Sqlite};
+use sqlx::{query, query_as, Error as SqlxError, Sqlite};
+use thiserror::Error;
 
+use p2panda_core::cbor::{encode_cbor, DecodeError, EncodeError};
 use p2panda_core::{Body, Extensions, Hash, Header, PublicKey, RawOperation};
 
 use crate::sqlite::models::{LogHeightRow, OperationRow, RawOperationRow};
 use crate::{LogId, LogStore, OperationStore};
+
+#[derive(Debug, Error)]
+pub enum SqliteStoreError {
+    #[error("operation header must be signed prior to insertion")]
+    MissingHeaderSignature,
+
+    #[error("failed to encode operation extensions: {0}")]
+    EncodingFailed(#[from] EncodeError),
+
+    #[error("failed to decode operation extensions: {0}")]
+    DecodingFailed(#[from] DecodeError),
+
+    #[error("an error occurred with the sqlite database: {0}")]
+    Database(#[from] SqlxError),
+}
+
+impl From<MigrateError> for SqliteStoreError {
+    fn from(error: MigrateError) -> Self {
+        Self::Database(SqlxError::Migrate(Box::new(error)))
+    }
+}
 
 /// Re-export of SQLite connection pool type.
 pub type Pool = SqlitePool;
@@ -40,25 +62,25 @@ where
 }
 
 /// Create the database if it doesn't already exist.
-pub async fn create_database(url: &str) -> Result<()> {
+pub async fn create_database(url: &str) -> Result<(), SqliteStoreError> {
     if !Sqlite::database_exists(url).await? {
-        Sqlite::create_database(url).await?;
+        Sqlite::create_database(url).await?
     }
 
     Ok(())
 }
 
 /// Drop the database if it exists.
-pub async fn drop_database(url: &str) -> Result<()> {
+pub async fn drop_database(url: &str) -> Result<(), SqliteStoreError> {
     if Sqlite::database_exists(url).await? {
-        Sqlite::drop_database(url).await?;
+        Sqlite::drop_database(url).await?
     }
 
     Ok(())
 }
 
 /// Create a connection pool.
-pub async fn connection_pool(url: &str, max_connections: u32) -> Result<Pool, Error> {
+pub async fn connection_pool(url: &str, max_connections: u32) -> Result<Pool, SqliteStoreError> {
     let pool: Pool = SqlitePoolOptions::new()
         .max_connections(max_connections)
         .connect(url)
@@ -68,8 +90,9 @@ pub async fn connection_pool(url: &str, max_connections: u32) -> Result<Pool, Er
 }
 
 /// Run any pending database migrations from inside the application.
-pub async fn run_pending_migrations(pool: &Pool) -> Result<()> {
+pub async fn run_pending_migrations(pool: &Pool) -> Result<(), SqliteStoreError> {
     migrate!().run(pool).await?;
+
     Ok(())
 }
 
@@ -79,28 +102,12 @@ fn calculate_hash<T: StdHash>(t: &T) -> u64 {
     s.finish()
 }
 
-fn serialize_extensions<T: Extensions>(extensions: &T) -> Result<Vec<u8>> {
-    let mut bytes: Vec<u8> = Vec::new();
-    ciborium::ser::into_writer(extensions, &mut bytes)?;
-
-    Ok(bytes)
-}
-
-pub(crate) fn deserialize_extensions<T>(bytes: Vec<u8>) -> Result<T>
-where
-    T: Extensions,
-{
-    let extensions = ciborium::de::from_reader(&bytes[..])?;
-
-    Ok(extensions)
-}
-
 impl<L, E> OperationStore<L, E> for SqliteStore<L, E>
 where
     L: LogId + Send + Sync,
     E: Extensions + Send + Sync,
 {
-    type Error = Error;
+    type Error = SqliteStoreError;
 
     async fn insert_operation(
         &mut self,
@@ -111,9 +118,7 @@ where
         log_id: &L,
     ) -> Result<bool, Self::Error> {
         if header.signature.is_none() {
-            return Err(anyhow!(
-                "store error: operation header must be signed prior to insertion"
-            ));
+            return Err(SqliteStoreError::MissingHeaderSignature);
         }
 
         query(
@@ -157,9 +162,12 @@ where
                 .collect::<Vec<String>>()
                 .concat(),
         )
-        .bind(header.extensions.as_ref().map(|extensions| {
-            serialize_extensions(extensions).expect("extenions are serializable")
-        }))
+        .bind(
+            header
+                .extensions
+                .as_ref()
+                .map(|extensions| encode_cbor(extensions).expect("extenions are serializable")),
+        )
         .bind(body.map(|body| body.to_bytes()))
         .bind(header_bytes)
         .execute(&self.pool)
@@ -292,7 +300,7 @@ where
     L: LogId + Send + Sync,
     E: Extensions + Send + Sync,
 {
-    type Error = Error;
+    type Error = SqliteStoreError;
 
     async fn get_log(
         &self,
@@ -656,7 +664,7 @@ mod tests {
         assert!(inserted.is_err());
         assert_eq!(
             format!("{}", inserted.unwrap_err()),
-            "store error: operation header must be signed prior to insertion"
+            "operation header must be signed prior to insertion"
         );
     }
 


### PR DESCRIPTION
Replaces the current `anyhow` errors and result type with a custom error type: `SqliteStoreError`.

The sqlite error has variants to account for extension encoding, extension decoding and all other errors stemming from `sqlx` (basically anything relating to SQL or the SQLite database).  

Addresses https://github.com/p2panda/p2panda/issues/692

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes