### PR TITLE
Set test timeout to 30 minutes in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Changes our timeout from six hours (which seems to be the default) to 30 minutes.

This means that a blocked test will timeout in 30 minutes and we'll be alerted to the outcome much sooner.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
