### PR TITLE
Schedule sync re-attempt after any error occurred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Highlights are marked with a pancake 🥞
 
 ### Changed
 
+- Schedule sync re-attempt after any error occurred [#702](https://github.com/p2panda/p2panda/pull/702) 
 - Expose bootstrap mode setting for network chat example via CLI arg [#709](https://github.com/p2panda/p2panda/pull/709) 
 - Expand chat example with relay, mdns and bootstrap options [#690](https://github.com/p2panda/p2panda/pull/690) 
 - Remove logging from network tests [#693](https://github.com/p2panda/p2panda/pull/693)

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -49,4 +49,5 @@ tracing = "0.1.40"
 [dev-dependencies]
 clap = { version = "4.5.29", features = ["derive"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+p2panda-sync = { path = "../p2panda-sync", version = "0.2.0", features = ["log-sync", "test-protocols"] }
 p2panda-store = { path = "../p2panda-store", version = "0.2.0" }

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -121,12 +121,12 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use futures_lite::StreamExt;
 use futures_util::future::{MapErr, Shared};
 use futures_util::{FutureExt, TryFutureExt};
 use iroh::{Endpoint, RelayMap, RelayNode};
-use iroh_gossip::net::{Gossip, GOSSIP_ALPN};
+use iroh_gossip::net::{GOSSIP_ALPN, Gossip};
 use iroh_quinn::TransportConfig;
 use p2panda_core::{PrivateKey, PublicKey};
 use p2panda_discovery::{Discovery, DiscoveryMap};
@@ -135,15 +135,15 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::task::{JoinError, JoinSet};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tracing::{debug, error, error_span, warn, Instrument};
+use tracing::{Instrument, debug, error, error_span, warn};
 
-use crate::addrs::{to_node_addr, to_relay_url, DEFAULT_STUN_PORT};
-use crate::config::{Config, GossipConfig, DEFAULT_BIND_PORT};
+use crate::addrs::{DEFAULT_STUN_PORT, to_node_addr, to_relay_url};
+use crate::config::{Config, DEFAULT_BIND_PORT, GossipConfig};
 use crate::engine::Engine;
 use crate::events::SystemEvent;
 use crate::protocols::{ProtocolHandler, ProtocolMap};
-use crate::sync::{SyncConfiguration, SYNC_CONNECTION_ALPN};
-use crate::{from_private_key, NetworkId, NodeAddress, RelayUrl, TopicId};
+use crate::sync::{SYNC_CONNECTION_ALPN, SyncConfiguration};
+use crate::{NetworkId, NodeAddress, RelayUrl, TopicId, from_private_key};
 
 /// Maximum number of streams accepted on a QUIC connection.
 const MAX_STREAMS: u32 = 1024;
@@ -842,19 +842,19 @@ mod tests {
     use p2panda_core::{Body, Extensions, Hash, Header, PrivateKey, PublicKey};
     use p2panda_discovery::mdns::LocalDiscovery;
     use p2panda_store::{MemoryStore, OperationStore};
+    use p2panda_sync::TopicQuery;
     use p2panda_sync::log_sync::{LogSyncProtocol, TopicLogMap};
     use p2panda_sync::test_protocols::{
         FailingProtocol, PingPongProtocol, SyncTestTopic as TestTopic,
     };
-    use p2panda_sync::TopicQuery;
     use tokio::task::JoinHandle;
 
-    use crate::addrs::{to_node_addr, DEFAULT_STUN_PORT};
+    use crate::addrs::{DEFAULT_STUN_PORT, to_node_addr};
     use crate::bytes::ToBytes;
     use crate::config::Config;
     use crate::events::SystemEvent;
     use crate::sync::SyncConfiguration;
-    use crate::{to_public_key, NetworkBuilder, NodeAddress, RelayMode, RelayUrl, TopicId};
+    use crate::{NetworkBuilder, NodeAddress, RelayMode, RelayUrl, TopicId, to_public_key};
 
     use super::{FromNetwork, Network, ToNetwork};
 

--- a/p2panda-net/src/sync/manager.rs
+++ b/p2panda-net/src/sync/manager.rs
@@ -395,8 +395,8 @@ mod tests {
     use iroh::{Endpoint, RelayMode};
     use iroh_quinn::TransportConfig;
     use p2panda_core::PublicKey;
-    use p2panda_sync::test_protocols::{PingPongProtocol, SyncTestTopic as TestTopic};
     use p2panda_sync::SyncProtocol;
+    use p2panda_sync::test_protocols::{PingPongProtocol, SyncTestTopic as TestTopic};
     use tokio::sync::mpsc;
     use tokio::time::{Duration, sleep};
     use tokio_util::sync::CancellationToken;

--- a/p2panda-net/src/sync/tests.rs
+++ b/p2panda-net/src/sync/tests.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use futures_util::FutureExt;
 use p2panda_core::PrivateKey;
-use p2panda_sync::test_protocols::{FailingProtocol, SyncTestTopic};
 use p2panda_sync::SyncError;
+use p2panda_sync::test_protocols::{FailingProtocol, SyncTestTopic};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};

--- a/p2panda-net/src/sync/tests.rs
+++ b/p2panda-net/src/sync/tests.rs
@@ -1,157 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-mod sync_protocols {
-    use std::sync::Arc;
-
-    use async_trait::async_trait;
-    use futures_lite::{AsyncRead, AsyncWrite, StreamExt};
-    use futures_util::{Sink, SinkExt};
-    use p2panda_sync::cbor::{into_cbor_sink, into_cbor_stream};
-    use p2panda_sync::{FromSync, SyncError, SyncProtocol};
-    use serde::{Deserialize, Serialize};
-
-    use super::TestTopic;
-
-    #[derive(Debug, Serialize, Deserialize)]
-    enum ProtocolMessage {
-        TopicQuery(TestTopic),
-        Done,
-    }
-
-    /// A sync implementation which returns a mocked error.
-    #[derive(Debug)]
-    pub enum FailingProtocol {
-        /// A critical error is triggered inside `accept()` after sync messages have been
-        /// exchanged.
-        AcceptorFailsCritical,
-
-        /// A critical error is triggered inside `initiate()` after the handshake is complete.
-        InitiatorFailsCritical,
-
-        /// An unexpected behaviour error is triggered inside `accept()` by sending the topic twice
-        /// from `initiate()`.
-        InitiatorSendsTopicTwice,
-
-        /// An unexpected behaviour error is triggered inside `initiate()` by sending a topic from
-        /// `accept()`.
-        AcceptorSendsTopic,
-
-        /// No errors are explicitly triggered; used for "happy path" test.
-        NoError,
-    }
-
-    #[async_trait]
-    impl<'a> SyncProtocol<'a, TestTopic> for FailingProtocol {
-        fn name(&self) -> &'static str {
-            "failing-protocol"
-        }
-
-        async fn initiate(
-            self: Arc<Self>,
-            topic: TestTopic,
-            tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
-            rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
-            mut app_tx: Box<
-                &'a mut (dyn Sink<FromSync<TestTopic>, Error = SyncError> + Send + Unpin),
-            >,
-        ) -> Result<(), SyncError> {
-            let mut sink = into_cbor_sink(tx);
-            let mut stream = into_cbor_stream(rx);
-
-            sink.send(ProtocolMessage::TopicQuery(topic.clone()))
-                .await?;
-
-            // Simulate critical sync implementation bug by sending the topic a second time.
-            if let FailingProtocol::InitiatorSendsTopicTwice = *self {
-                sink.send(ProtocolMessage::TopicQuery(topic.clone()))
-                    .await?;
-            }
-
-            // Simulate some critical error which occurred inside the sync session.
-            if let FailingProtocol::InitiatorFailsCritical = *self {
-                return Err(SyncError::Critical(
-                    "something really bad happened in the initiator".to_string(),
-                ));
-            }
-
-            sink.send(ProtocolMessage::Done).await?;
-
-            app_tx.send(FromSync::HandshakeSuccess(topic)).await?;
-
-            while let Some(result) = stream.next().await {
-                let message: ProtocolMessage = result?;
-                match &message {
-                    ProtocolMessage::TopicQuery(_) => {
-                        return Err(SyncError::UnexpectedBehaviour(
-                            "unexpected message received from acceptor".to_string(),
-                        ));
-                    }
-                    ProtocolMessage::Done => break,
-                }
-            }
-
-            Ok(())
-        }
-
-        async fn accept(
-            self: Arc<Self>,
-            tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
-            rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
-            mut app_tx: Box<
-                &'a mut (dyn Sink<FromSync<TestTopic>, Error = SyncError> + Send + Unpin),
-            >,
-        ) -> Result<(), SyncError> {
-            // Simulate some critical error which occurred inside the sync session.
-            if let FailingProtocol::AcceptorFailsCritical = *self {
-                return Err(SyncError::Critical(
-                    "something really bad happened in the acceptor".to_string(),
-                ));
-            }
-
-            let mut sink = into_cbor_sink(tx);
-            let mut stream = into_cbor_stream(rx);
-
-            // Simulate critical sync implementation bug by sending the topic from the acceptor (it
-            // _never_ sends any topics).
-            if let FailingProtocol::AcceptorSendsTopic = *self {
-                let topic = TestTopic::new("unexpected behaviour test");
-                sink.send(ProtocolMessage::TopicQuery(topic)).await?;
-            }
-
-            let mut received_topic = false;
-
-            while let Some(result) = stream.next().await {
-                let message: ProtocolMessage = result?;
-                match &message {
-                    ProtocolMessage::TopicQuery(topic) => {
-                        if !received_topic {
-                            app_tx
-                                .send(FromSync::HandshakeSuccess(topic.clone()))
-                                .await?;
-                            received_topic = true;
-                        } else {
-                            return Err(SyncError::UnexpectedBehaviour(
-                                "received topic too often".to_string(),
-                            ));
-                        }
-                    }
-                    ProtocolMessage::Done => break,
-                }
-            }
-
-            sink.send(ProtocolMessage::Done).await?;
-
-            Ok(())
-        }
-    }
-}
-
 use std::sync::Arc;
 
 use futures_util::FutureExt;
-use p2panda_core::{Hash, PrivateKey};
-use p2panda_sync::{SyncError, TopicQuery};
-use serde::{Deserialize, Serialize};
+use p2panda_core::PrivateKey;
+use p2panda_sync::test_protocols::{FailingProtocol, SyncTestTopic};
+use p2panda_sync::SyncError;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -159,29 +13,16 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use crate::engine::ToEngineActor;
 use crate::sync;
 
-use sync_protocols::FailingProtocol;
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
-pub struct TestTopic(String, [u8; 32]);
-
-impl TestTopic {
-    pub fn new(name: &str) -> Self {
-        Self(name.to_owned(), *Hash::new(&name).as_bytes())
-    }
-}
-
-impl TopicQuery for TestTopic {}
-
 /// Helper method to establish a sync session between the initiator and acceptor.
 async fn run_sync_impl(
     protocol: FailingProtocol,
 ) -> (
-    mpsc::Receiver<ToEngineActor<TestTopic>>,
-    mpsc::Receiver<ToEngineActor<TestTopic>>,
+    mpsc::Receiver<ToEngineActor<SyncTestTopic>>,
+    mpsc::Receiver<ToEngineActor<SyncTestTopic>>,
     JoinHandle<Result<(), SyncError>>,
     JoinHandle<Result<(), SyncError>>,
 ) {
-    let topic = TestTopic::new("run test protocol impl");
+    let topic = SyncTestTopic::new("run test protocol impl");
 
     let initiator_node_id = PrivateKey::new().public_key();
     let acceptor_node_id = PrivateKey::new().public_key();

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -22,10 +22,14 @@ workspace = true
 [features]
 cbor = ["dep:tokio", "dep:tokio-util"]
 log-sync = ["dep:p2panda-core", "dep:p2panda-store", "cbor"]
+test-protocols = ["dep:p2panda-core", "serde/derive", "cbor", "dep:tracing",
+"dep:futures-lite", "dep:futures-util"]
 
 [dependencies]
 async-trait = "0.1.82"
 futures = "0.3.30"
+futures-lite = { version = "2.3.0", optional = true }
+futures-util = { version = "0.3.30", optional = true }
 p2panda-core = { path = "../p2panda-core", version = "0.2.0", optional = true }
 p2panda-store = { path = "../p2panda-store", version = "0.2.0", optional = true, default-features = false }
 serde = { version = "1.0.215" }
@@ -35,6 +39,7 @@ tokio-util = { version = "0.7.11", features = [
 ], optional = true }
 tokio = { version = "1.42.0", features = ["sync", "time", "rt"], optional = true }
 thiserror = "1.0.63"
+tracing = { version = "0.1.40", optional = true }
 
 [dev-dependencies]
 p2panda-store = { path = "../p2panda-store", version = "0.2.0", features = [ "memory" ] }

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -20,6 +20,8 @@
 pub mod cbor;
 #[cfg(feature = "log-sync")]
 pub mod log_sync;
+#[cfg(feature = "test-protocols")]
+pub mod test_protocols;
 
 use std::fmt::Debug;
 use std::hash::Hash;

--- a/p2panda-sync/src/test_protocols.rs
+++ b/p2panda-sync/src/test_protocols.rs
@@ -1,0 +1,367 @@
+//! Sync protocol implementations for testing purposes.
+//!
+//! - `DummyProtocol`
+//! - `PingPongProtocol`
+//! - `FailingProtocol`
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures_lite::{AsyncRead, AsyncWrite, StreamExt};
+use futures_util::{Sink, SinkExt};
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::cbor::{into_cbor_sink, into_cbor_stream};
+use crate::{FromSync, SyncError, SyncProtocol, TopicQuery};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct SyncTestTopic(String, pub [u8; 32]);
+
+impl SyncTestTopic {
+    pub fn new(name: &str) -> Self {
+        Self(name.to_owned(), [0; 32])
+    }
+}
+
+impl TopicQuery for SyncTestTopic {}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum DummyProtocolMessage {
+    TopicQuery(SyncTestTopic),
+    Done,
+}
+
+/// A sync implementation which fulfills basic protocol requirements but nothing more
+#[derive(Debug)]
+pub struct DummyProtocol {}
+
+#[async_trait]
+impl<'a> SyncProtocol<'a, SyncTestTopic> for DummyProtocol {
+    fn name(&self) -> &'static str {
+        static DUMMY_PROTOCOL_NAME: &str = "dummy_protocol";
+        DUMMY_PROTOCOL_NAME
+    }
+
+    async fn initiate(
+        self: Arc<Self>,
+        topic_query: SyncTestTopic,
+        tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
+        rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
+        mut app_tx: Box<
+            &'a mut (dyn Sink<FromSync<SyncTestTopic>, Error = SyncError> + Send + Unpin),
+        >,
+    ) -> Result<(), SyncError> {
+        debug!("DummyProtocol: initiate sync session");
+
+        let mut sink = into_cbor_sink(tx);
+        let mut stream = into_cbor_stream(rx);
+
+        sink.send(DummyProtocolMessage::TopicQuery(topic_query.clone()))
+            .await?;
+        sink.send(DummyProtocolMessage::Done).await?;
+        app_tx.send(FromSync::HandshakeSuccess(topic_query)).await?;
+
+        while let Some(result) = stream.next().await {
+            let message: DummyProtocolMessage = result?;
+            debug!("message received: {:?}", message);
+
+            match &message {
+                DummyProtocolMessage::TopicQuery(_) => panic!(),
+                DummyProtocolMessage::Done => break,
+            }
+        }
+
+        sink.flush().await?;
+        app_tx.flush().await?;
+
+        Ok(())
+    }
+
+    async fn accept(
+        self: Arc<Self>,
+        tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
+        rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
+        mut app_tx: Box<
+            &'a mut (dyn Sink<FromSync<SyncTestTopic>, Error = SyncError> + Send + Unpin),
+        >,
+    ) -> Result<(), SyncError> {
+        debug!("DummyProtocol: accept sync session");
+
+        let mut sink = into_cbor_sink(tx);
+        let mut stream = into_cbor_stream(rx);
+
+        while let Some(result) = stream.next().await {
+            let message: DummyProtocolMessage = result?;
+            debug!("message received: {:?}", message);
+
+            match &message {
+                DummyProtocolMessage::TopicQuery(topic_query) => {
+                    app_tx
+                        .send(FromSync::HandshakeSuccess(topic_query.clone()))
+                        .await?
+                }
+                DummyProtocolMessage::Done => break,
+            }
+        }
+
+        sink.send(DummyProtocolMessage::Done).await?;
+
+        sink.flush().await?;
+        app_tx.flush().await?;
+
+        Ok(())
+    }
+}
+
+// The protocol message types.
+#[derive(Serialize, Deserialize)]
+enum PingPongProtocolMessage {
+    TopicQuery(SyncTestTopic),
+    Ping,
+    Pong,
+}
+
+/// A sync implementation where the initiator sends a `ping` message and the acceptor responds with
+/// a `pong` message.
+#[derive(Debug, Clone)]
+pub struct PingPongProtocol {}
+
+#[async_trait]
+impl<'a> SyncProtocol<'a, SyncTestTopic> for PingPongProtocol {
+    fn name(&self) -> &'static str {
+        static SIMPLE_PROTOCOL_NAME: &str = "simple_protocol";
+        SIMPLE_PROTOCOL_NAME
+    }
+
+    async fn initiate(
+        self: Arc<Self>,
+        topic_query: SyncTestTopic,
+        tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
+        rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
+        mut app_tx: Box<
+            &'a mut (dyn Sink<FromSync<SyncTestTopic>, Error = SyncError> + Send + Unpin),
+        >,
+    ) -> Result<(), SyncError> {
+        debug!("initiate sync session");
+        let mut sink = into_cbor_sink(tx);
+        let mut stream = into_cbor_stream(rx);
+
+        sink.send(PingPongProtocolMessage::TopicQuery(topic_query.clone()))
+            .await?;
+        sink.send(PingPongProtocolMessage::Ping).await?;
+        debug!("ping message sent");
+
+        app_tx.send(FromSync::HandshakeSuccess(topic_query)).await?;
+
+        while let Some(result) = stream.next().await {
+            let message = result?;
+
+            match message {
+                PingPongProtocolMessage::TopicQuery(_) => panic!(),
+                PingPongProtocolMessage::Ping => {
+                    return Err(SyncError::UnexpectedBehaviour(
+                        "unexpected Ping message received".to_string(),
+                    ));
+                }
+                PingPongProtocolMessage::Pong => {
+                    debug!("pong message received");
+                    app_tx
+                        .send(FromSync::Data {
+                            header: "PONG".as_bytes().to_owned(),
+                            payload: None,
+                        })
+                        .await
+                        .unwrap();
+                    break;
+                }
+            }
+        }
+
+        // Flush all bytes so that no messages are lost.
+        sink.flush().await?;
+        app_tx.flush().await?;
+
+        Ok(())
+    }
+
+    async fn accept(
+        self: Arc<Self>,
+        tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
+        rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
+        mut app_tx: Box<
+            &'a mut (dyn Sink<FromSync<SyncTestTopic>, Error = SyncError> + Send + Unpin),
+        >,
+    ) -> Result<(), SyncError> {
+        debug!("accept sync session");
+        let mut sink = into_cbor_sink(tx);
+        let mut stream = into_cbor_stream(rx);
+
+        while let Some(result) = stream.next().await {
+            let message = result?;
+
+            match message {
+                PingPongProtocolMessage::TopicQuery(topic_query) => {
+                    app_tx.send(FromSync::HandshakeSuccess(topic_query)).await?
+                }
+                PingPongProtocolMessage::Ping => {
+                    debug!("ping message received");
+                    app_tx
+                        .send(FromSync::Data {
+                            header: "PING".as_bytes().to_owned(),
+                            payload: None,
+                        })
+                        .await
+                        .unwrap();
+
+                    sink.send(PingPongProtocolMessage::Pong).await?;
+                    debug!("pong message sent");
+                    break;
+                }
+                PingPongProtocolMessage::Pong => {
+                    return Err(SyncError::UnexpectedBehaviour(
+                        "unexpected Pong message received".to_string(),
+                    ));
+                }
+            }
+        }
+
+        sink.flush().await?;
+        app_tx.flush().await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum FailingProtocolMessage {
+    TopicQuery(SyncTestTopic),
+    Done,
+}
+
+/// A sync implementation which returns a mocked error.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum FailingProtocol {
+    /// A critical error is triggered inside `accept()` after sync messages have been
+    /// exchanged.
+    AcceptorFailsCritical,
+
+    /// A critical error is triggered inside `initiate()` after the handshake is complete.
+    InitiatorFailsCritical,
+
+    /// An unexpected behaviour error is triggered inside `accept()` by sending the topic twice
+    /// from `initiate()`.
+    InitiatorSendsTopicTwice,
+
+    /// An unexpected behaviour error is triggered inside `initiate()` by sending a topic from
+    /// `accept()`.
+    AcceptorSendsTopic,
+
+    /// No errors are explicitly triggered; used for "happy path" test.
+    NoError,
+}
+
+#[async_trait]
+impl<'a> SyncProtocol<'a, SyncTestTopic> for FailingProtocol {
+    fn name(&self) -> &'static str {
+        "failing-protocol"
+    }
+
+    async fn initiate(
+        self: Arc<Self>,
+        topic: SyncTestTopic,
+        tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
+        rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
+        mut app_tx: Box<
+            &'a mut (dyn Sink<FromSync<SyncTestTopic>, Error = SyncError> + Send + Unpin),
+        >,
+    ) -> Result<(), SyncError> {
+        let mut sink = into_cbor_sink(tx);
+        let mut stream = into_cbor_stream(rx);
+
+        sink.send(FailingProtocolMessage::TopicQuery(topic.clone()))
+            .await?;
+
+        // Simulate critical sync implementation bug by sending the topic a second time.
+        if let FailingProtocol::InitiatorSendsTopicTwice = *self {
+            sink.send(FailingProtocolMessage::TopicQuery(topic.clone()))
+                .await?;
+        }
+
+        // Simulate some critical error which occurred inside the sync session.
+        if let FailingProtocol::InitiatorFailsCritical = *self {
+            return Err(SyncError::Critical(
+                "something really bad happened in the initiator".to_string(),
+            ));
+        }
+
+        sink.send(FailingProtocolMessage::Done).await?;
+
+        app_tx.send(FromSync::HandshakeSuccess(topic)).await?;
+
+        while let Some(result) = stream.next().await {
+            let message: FailingProtocolMessage = result?;
+            match &message {
+                FailingProtocolMessage::TopicQuery(_) => {
+                    return Err(SyncError::UnexpectedBehaviour(
+                        "unexpected message received from acceptor".to_string(),
+                    ));
+                }
+                FailingProtocolMessage::Done => break,
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn accept(
+        self: Arc<Self>,
+        tx: Box<&'a mut (dyn AsyncWrite + Send + Unpin)>,
+        rx: Box<&'a mut (dyn AsyncRead + Send + Unpin)>,
+        mut app_tx: Box<
+            &'a mut (dyn Sink<FromSync<SyncTestTopic>, Error = SyncError> + Send + Unpin),
+        >,
+    ) -> Result<(), SyncError> {
+        // Simulate some critical error which occurred inside the sync session.
+        if let FailingProtocol::AcceptorFailsCritical = *self {
+            return Err(SyncError::Critical(
+                "something really bad happened in the acceptor".to_string(),
+            ));
+        }
+
+        let mut sink = into_cbor_sink(tx);
+        let mut stream = into_cbor_stream(rx);
+
+        // Simulate critical sync implementation bug by sending the topic from the acceptor (it
+        // _never_ sends any topics).
+        if let FailingProtocol::AcceptorSendsTopic = *self {
+            let topic = SyncTestTopic::new("unexpected behaviour test");
+            sink.send(FailingProtocolMessage::TopicQuery(topic)).await?;
+        }
+
+        let mut received_topic = false;
+
+        while let Some(result) = stream.next().await {
+            let message: FailingProtocolMessage = result?;
+            match &message {
+                FailingProtocolMessage::TopicQuery(topic) => {
+                    if !received_topic {
+                        app_tx
+                            .send(FromSync::HandshakeSuccess(topic.clone()))
+                            .await?;
+                        received_topic = true;
+                    } else {
+                        return Err(SyncError::UnexpectedBehaviour(
+                            "received topic too often".to_string(),
+                        ));
+                    }
+                }
+                FailingProtocolMessage::Done => break,
+            }
+        }
+
+        sink.send(FailingProtocolMessage::Done).await?;
+
+        Ok(())
+    }
+}

--- a/p2panda-sync/src/test_protocols.rs
+++ b/p2panda-sync/src/test_protocols.rs
@@ -249,6 +249,10 @@ pub enum FailingProtocol {
     /// A critical error is triggered inside `initiate()` after the handshake is complete.
     InitiatorFailsCritical,
 
+    /// An unexpected behaviour error is triggered inside `initiate()` after the topic query has
+    /// been sent.
+    InitiatorFailsUnexpected,
+
     /// An unexpected behaviour error is triggered inside `accept()` by sending the topic twice
     /// from `initiate()`.
     InitiatorSendsTopicTwice,
@@ -293,6 +297,11 @@ impl<'a> SyncProtocol<'a, SyncTestTopic> for FailingProtocol {
             return Err(SyncError::Critical(
                 "something really bad happened in the initiator".to_string(),
             ));
+        }
+
+        // Simulate unexpected behaviour (such as a broken pipe due to disconnection).
+        if let FailingProtocol::InitiatorFailsUnexpected = *self {
+            return Err(SyncError::UnexpectedBehaviour("bang!".to_string()));
         }
 
         sink.send(FailingProtocolMessage::Done).await?;


### PR DESCRIPTION
Currently we only schedule a sync attempt retry if a session failed because of a connection error. We want to retry after any error occurred.

This PR also does some cleanup by moving our test protocols into `p2panda_sync`.

Issue details: https://github.com/p2panda/p2panda/issues/701

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
