### PR TITLE
Refactoring: Declutter and fix ingest logic

### DIFF
--- a/p2panda-stream/src/ooo/buffer.rs
+++ b/p2panda-stream/src/ooo/buffer.rs
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::{self, Pin};
+use std::task::{Context, Poll, Waker};
+
+use futures_util::{ready, FutureExt};
+use p2panda_core::{Body, Extensions, Header, Operation};
+use p2panda_store::LogStore;
+use pin_utils::pin_mut;
+use thiserror::Error;
+
+use crate::ooo::validation::{validate_operation_retry, ValidationError, ValidationResult};
+
+/// Optimized validation logic for incoming operations with some tolerance for "out of order"
+/// behavior.
+///
+/// p2panda's append-only logs are totally ordered per author, with the exception of potential
+/// forks. Due to race conditions or buggy implementations it is not always possible to assume that
+/// operations really arrive in the order which is required, this is why we accept a certain amount
+/// of unordered operations before we bail.
+///
+/// The internal buffer size determines the maximum number of out-of-order operations in a row this
+/// method can handle. This means that given a buffer size of for example 100, we can handle a
+/// worst-case unordered, fully reversed log with 100 items without problem.
+#[derive(Debug)]
+pub struct ValidationBuffer<S, L, E>
+where
+    S: LogStore<L, E> + Clone,
+    E: Extensions,
+{
+    store: S,
+    ooo_buffer_size: usize,
+    ooo_buffer_queue: RefCell<VecDeque<ValidationAttempt<L, E>>>,
+    waker: RefCell<Option<Waker>>,
+    _marker: PhantomData<L>,
+}
+
+impl<S, L, E> ValidationBuffer<S, L, E>
+where
+    S: LogStore<L, E> + Clone,
+    E: Extensions,
+{
+    pub fn new(store: S, ooo_buffer_size: usize) -> Self {
+        Self {
+            store,
+            ooo_buffer_size,
+            // @TODO(adz): We can optimize for the internal out-of-order buffer even more as it's
+            // FIFO nature is not optimal. A sorted list (by seq num, maybe even grouped by public
+            // key) might be more efficient, though I'm not sure about optimal implementations yet,
+            // so benchmarks and more real-world experience might make sense before we attempt any
+            // of this.
+            ooo_buffer_queue: RefCell::new(VecDeque::with_capacity(ooo_buffer_size)),
+            waker: RefCell::new(None),
+            _marker: PhantomData,
+        }
+    }
+
+    pub async fn process(
+        &self,
+        header: Header<E>,
+        body: Option<Body>,
+        header_bytes: Vec<u8>,
+        log_id: L,
+        prune_flag: bool,
+    ) -> Result<Option<Operation<E>>, ValidationBufferError> {
+        self.validate(header, body, header_bytes, log_id, prune_flag, 1)
+            .await
+    }
+
+    pub fn process_queue(
+        &self,
+        header: Header<E>,
+        body: Option<Body>,
+        header_bytes: Vec<u8>,
+        log_id: L,
+        prune_flag: bool,
+    ) -> Result<(), ValidationBufferError> {
+        self.queue(ValidationAttempt {
+            header,
+            body,
+            header_bytes,
+            log_id,
+            prune_flag,
+            attempts_counter: 1,
+        })?;
+        Ok(())
+    }
+
+    pub async fn retry(&self) -> Result<Option<Operation<E>>, ValidationBufferError> {
+        let stuff = {
+            let mut queue = self.ooo_buffer_queue.borrow_mut();
+            queue.pop_front()
+        };
+
+        let Some(attempt) = stuff else {
+            return Ok(None);
+        };
+
+        self.validate(
+            attempt.header,
+            attempt.body,
+            attempt.header_bytes,
+            attempt.log_id,
+            attempt.prune_flag,
+            attempt.attempts_counter + 1,
+        )
+        .await
+    }
+
+    pub fn len(&self) -> usize {
+        self.ooo_buffer_queue.borrow().len()
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.len() > self.ooo_buffer_size
+    }
+
+    async fn validate(
+        &self,
+        header: Header<E>,
+        body: Option<Body>,
+        header_bytes: Vec<u8>,
+        log_id: L,
+        prune_flag: bool,
+        attempts_counter: usize,
+    ) -> Result<Option<Operation<E>>, ValidationBufferError> {
+        let result = {
+            let mut store = self.store.clone();
+            validate_operation_retry(&mut store, header, body, header_bytes, &log_id, prune_flag)
+                .await
+        };
+
+        self.waker.take().map(Waker::wake);
+
+        // If the operation arrived out-of-order we can push it back into the internal buffer and
+        // try again later (attempted for a configured number of times), otherwise forward the
+        // result of ingest to the consumer.
+        match result {
+            Ok(ValidationResult::Valid(operation)) => Ok(Some(operation)),
+            Ok(ValidationResult::Retry(header, body, header_bytes, num_missing)) => {
+                // The number of max. reattempts is equal the size of the buffer. As long as the
+                // buffer is just a FIFO queue it doesn't make sense to optimize over different
+                // parameters as in a worst-case distribution of items (exact reverse) this will be
+                // the max. and min. required bound.
+                if attempts_counter > self.ooo_buffer_size {
+                    return Err(ValidationBufferError::MaxAttemptsReached(num_missing));
+                }
+
+                self.queue(ValidationAttempt {
+                    header,
+                    body,
+                    header_bytes,
+                    log_id,
+                    prune_flag,
+                    attempts_counter,
+                })?;
+
+                Ok(None)
+            }
+            Err(err) => Err(ValidationBufferError::Validation(err)),
+        }
+    }
+
+    fn queue(&self, attempt: ValidationAttempt<L, E>) -> Result<(), ValidationBufferError> {
+        if self.is_full() {
+            return Err(ValidationBufferError::FullBuffer);
+        }
+
+        {
+            let mut queue = self.ooo_buffer_queue.borrow_mut();
+            queue.push_back(attempt);
+        }
+
+        Ok(())
+    }
+}
+
+impl<S, L, E> Future for ValidationBuffer<S, L, E>
+where
+    S: LogStore<L, E> + Clone,
+    E: Extensions,
+{
+    type Output = Result<Option<Operation<E>>, ValidationBufferError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        {
+            let mut inner = self.waker.borrow_mut();
+            if let Some(waker) = inner.as_mut() {
+                waker.clone_from(cx.waker());
+            } else {
+                inner.replace(cx.waker().clone());
+            }
+        }
+
+        let fut = async { self.retry().await };
+        pin_mut!(fut);
+
+        let result = ready!(fut.poll_unpin(cx));
+        Poll::Ready(result)
+    }
+}
+
+#[derive(Debug)]
+struct ValidationAttempt<L, E> {
+    header: Header<E>,
+    body: Option<Body>,
+    header_bytes: Vec<u8>,
+    log_id: L,
+    prune_flag: bool,
+    attempts_counter: usize,
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum ValidationBufferError {
+    /// Errors which can occur due to invalid operations or critical storage failures.
+    #[error(transparent)]
+    Validation(#[from] ValidationError),
+
+    /// Given number of attempts to validate have been exhausted.
+    #[error("too many attempts to ingest out-of-order operation ({0} behind in log)")]
+    MaxAttemptsReached(u64),
+
+    #[error("out-of-order buffer is full")]
+    FullBuffer,
+}
+
+#[cfg(test)]
+mod tests {
+    use p2panda_core::Operation;
+    use p2panda_store::MemoryStore;
+
+    use crate::test_utils::{generate_operations, Extensions, Log, StreamName};
+
+    use super::{ValidationBuffer, ValidationBufferError};
+
+    #[tokio::test]
+    #[allow(unused_variables)]
+    async fn return_directly_on_success() {
+        let store = MemoryStore::<StreamName, Extensions>::new();
+        let mut buffer = ValidationBuffer::new(store, 8);
+
+        let mut log = Log::new();
+        let (header, body) = log.create_operation();
+        let hash = header.hash();
+
+        let result = {
+            let log_id: StreamName = header.extension().unwrap();
+            let header_bytes = header.to_bytes();
+            buffer
+                .process(header.clone(), body.clone(), header_bytes, log_id, false)
+                .await
+        };
+
+        assert!(
+            matches!(result, Ok(Some(Operation { hash, header, body }))),
+            "method should return operation directly"
+        );
+        assert_eq!(buffer.len(), 0, "buffer should be empty");
+    }
+
+    #[tokio::test]
+    #[allow(unused_variables)]
+    async fn max_attempts_reached() {
+        let store = MemoryStore::<StreamName, Extensions>::new();
+        let mut buffer = ValidationBuffer::new(store, 2);
+
+        let operations = generate_operations(4);
+
+        let (header, body) = operations.get(3).unwrap();
+        let hash = header.hash();
+        let log_id: StreamName = header.extension().unwrap();
+        let header_bytes = header.to_bytes();
+
+        let result = buffer
+            .process(header.clone(), body.clone(), header_bytes, log_id, false)
+            .await;
+        assert!(
+            matches!(result, Ok(None)),
+            "should not return anything on attempt 1"
+        );
+        assert_eq!(buffer.len(), 1, "buffer should contain one operation");
+
+        let result = buffer.retry().await;
+        assert!(
+            matches!(result, Ok(None)),
+            "should not return anything on attempt 2"
+        );
+        assert_eq!(buffer.len(), 1, "buffer should contain one operation");
+
+        let result = buffer.retry().await;
+        assert!(
+            matches!(result, Err(ValidationBufferError::MaxAttemptsReached(3))),
+            "should return error on attempt 3 with correct seq num"
+        );
+        assert_eq!(buffer.len(), 0, "buffer should be empty");
+    }
+}

--- a/p2panda-stream/src/ooo/mod.rs
+++ b/p2panda-stream/src/ooo/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+mod buffer;
+mod validation;
+
+pub use buffer::{ValidationBuffer, ValidationBufferError};

--- a/p2panda-stream/src/ooo/validation.rs
+++ b/p2panda-stream/src/ooo/validation.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use p2panda_core::{
+    validate_backlink, validate_operation, Body, Extensions, Header, Operation, OperationError,
+};
+use p2panda_store::LogStore;
+use thiserror::Error;
+
+pub async fn validate_operation_retry<S, L, E>(
+    store: &mut S,
+    header: Header<E>,
+    body: Option<Body>,
+    header_bytes: Vec<u8>,
+    log_id: &L,
+    prune_flag: bool,
+) -> Result<ValidationResult<E>, ValidationError>
+where
+    S: LogStore<L, E>,
+    E: Extensions,
+{
+    let operation = Operation {
+        hash: header.hash(),
+        header,
+        body,
+    };
+
+    if let Err(err) = validate_operation(&operation) {
+        return Err(ValidationError::InvalidOperation(err));
+    }
+
+    // If no pruning flag is set, we expect the log to have integrity with the previously given
+    // operation.
+    if !prune_flag && operation.header.seq_num > 0 {
+        let latest_operation = store
+            .latest_operation(&operation.header.public_key, log_id)
+            .await
+            .map_err(|err| ValidationError::StoreError(err.to_string()))?;
+
+        match latest_operation {
+            Some(latest_operation) => {
+                if let Err(err) = validate_backlink(&latest_operation.0, &operation.header) {
+                    match err {
+                        // These errors signify that the sequence number is monotonic incrementing
+                        // and correct, however the backlink does not match.
+                        OperationError::BacklinkMismatch
+                        | OperationError::BacklinkMissing
+                        // Log can only contain operations from one author.
+                        | OperationError::TooManyAuthors => {
+                            return Err(ValidationError::InvalidOperation(err))
+                        }
+                        // We observe a gap in the log and therefore can't validate the backlink
+                        // yet.
+                        OperationError::SeqNumNonIncremental(expected, given) => {
+                            return Ok(ValidationResult::Retry(operation.header, operation.body, header_bytes, given - expected))
+                        }
+                        _ => unreachable!("other error cases have been handled before"),
+                    }
+                }
+            }
+            // We're missing the whole log so far.
+            None => {
+                return Ok(ValidationResult::Retry(
+                    operation.header.clone(),
+                    operation.body.clone(),
+                    header_bytes,
+                    operation.header.seq_num,
+                ))
+            }
+        }
+    }
+
+    Ok(ValidationResult::Valid(operation))
+}
+
+/// Operations can be validated directly or need to be re-tried if they arrived out-of-order.
+#[derive(Debug)]
+pub enum ValidationResult<E> {
+    /// Operation has been successfully validated.
+    Valid(Operation<E>),
+
+    /// We're missing previous operations before we can try validating the backlink of this
+    /// operation.
+    ///
+    /// The number indicates how many operations we are lacking before we can attempt validation
+    /// again.
+    Retry(Header<E>, Option<Body>, Vec<u8>, u64),
+}
+
+/// Errors which can occur due to invalid operations or critical storage failure.
+#[derive(Clone, Debug, Error)]
+pub enum ValidationError {
+    /// Operation can not be authenticated, has broken log- or payload integrity or doesn't follow
+    /// the p2panda specification.
+    #[error("operation validation failed: {0}")]
+    InvalidOperation(OperationError),
+
+    /// Critical storage failure occurred. This is usually a reason to panic.
+    #[error("critical storage failure: {0}")]
+    StoreError(String),
+}


### PR DESCRIPTION
Separate current `ingest` stream into multiple implementations:

* `deduplicate`
* `validate` (incl. out-of-order buffering)
* `persist`
* `prune` (?, tbc)

The main logic for buffered out-of-order validation etc. is realized in standalone structs which are then again used by the `Stream` impls.

All of this together clarifies the API hopefully, allows for more flexible use in apps and makes our code less buggy.

Closes: #696 and #694 

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
