### PR TITLE
Update to Rust version `1.85.0` in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: push
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: 1.83.0
+  RUST_TOOLCHAIN: 1.85.0
 
 jobs:
   test:


### PR DESCRIPTION
One of our dependencies (`base64ct v1.7.0`) requires Rust 1.85. This is causing failures in our CI.

Here we update the Rust toolchain to `1.85.0` in CI.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
