### PR TITLE
Expose bootstrap mode setting for network chat example via CLI arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Highlights are marked with a pancake 🥞
 
 ### Changed
 
+- Expose bootstrap mode setting for network chat example via CLI arg [#709](https://github.com/p2panda/p2panda/pull/709) 
 - Expand chat example with relay, mdns and bootstrap options [#690](https://github.com/p2panda/p2panda/pull/690) 
 - Remove logging from network tests [#693](https://github.com/p2panda/p2panda/pull/693)
 - Give access to header in `Extension::extract` method [#670](https://github.com/p2panda/p2panda/pull/670)


### PR DESCRIPTION
We need to be able to configure a node as a bootstrap node in the `chat.rs` example of `p2panda-net`.

Here we add the `--is-bootstrap` flag (enable bootstrap mode) and change the `--bootstrap` argument to `--bootstrap-peer`.

## Example output:

### Bootstrap peer:

```
cargo run --example chat -- --use-relay --is-bootstrap
   Compiling p2panda-net v0.2.0 (/home/glyph/Projects/p2panda/p2panda/p2panda-net)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.87s
     Running `/home/glyph/Projects/p2panda/p2panda/target/debug/examples/chat --use-relay --is-bootstrap`
node id:
	2221fa93981012aa9efdb829bd63a7535c76cc6654fde876bf72d089bfaf29c4
network id:
	d7579661388c5b49796800a847329a9d4ca4f53e718fb53a987b1bb083696a28
node listening addresses:
	[omitted]
local discovery via mdns:
	inactive
node relay server url:
	https://wasser.liebechaos.org./
bootstrap mode:
	enabled
bootstrap peer:
	not specified

.. waiting for peers to join ..
found other peers, you're ready to chat!
```

### Bootstrapped peer:

```
cargo run --example chat -- --use-relay --bootstrap-peer 2221fa93981012aa9efdb829bd63a7535c76cc6654fde876bf72d089bfaf29c4
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running `/home/glyph/Projects/p2panda/p2panda/target/debug/examples/chat --use-relay --bootstrap-peer 2221fa93981012aa9efdb829bd63a7535c76cc6654fde876bf72d089bfaf29c4`
node id:
	21c2b91db1bca4b16ab04124ec83b779717978226e4d81fb0242baf531325d93
network id:
	d7579661388c5b49796800a847329a9d4ca4f53e718fb53a987b1bb083696a28
node listening addresses:
	[omitted]
local discovery via mdns:
	inactive
node relay server url:
	https://wasser.liebechaos.org./
bootstrap mode:
	disabled
bootstrap peer:
	2221fa93981012aa9efdb829bd63a7535c76cc6654fde876bf72d089bfaf29c4

.. waiting for peers to join ..
found other peers, you're ready to chat!
```

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`