### PR TITLE
Only proceed with sync if handshake topic is of interest

### DIFF
--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -65,7 +65,7 @@ pub enum ToEngineActor<T> {
     SyncHandshakeSuccess {
         topic: T,
         peer: PublicKey,
-        topic_is_known_tx: oneshot::Sender<bool>,
+        topic_is_known_tx: Option<oneshot::Sender<bool>>,
     },
     SyncMessage {
         topic: T,

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -65,6 +65,7 @@ pub enum ToEngineActor<T> {
     SyncHandshakeSuccess {
         topic: T,
         peer: PublicKey,
+        topic_is_known_tx: oneshot::Sender<bool>,
     },
     SyncMessage {
         topic: T,
@@ -300,8 +301,13 @@ where
             ToEngineActor::SyncStart { topic, peer } => {
                 self.on_sync_start(topic, peer).await?;
             }
-            ToEngineActor::SyncHandshakeSuccess { topic, peer } => {
-                self.topic_streams.on_sync_handshake_success(topic, peer);
+            ToEngineActor::SyncHandshakeSuccess {
+                topic,
+                peer,
+                topic_is_known_tx,
+            } => {
+                self.topic_streams
+                    .on_sync_handshake_success(topic, peer, topic_is_known_tx)?;
             }
             ToEngineActor::SyncMessage {
                 topic,

--- a/p2panda-net/src/sync/accept.rs
+++ b/p2panda-net/src/sync/accept.rs
@@ -124,6 +124,9 @@ where
 
                         topic = Some(handshake_topic.clone());
 
+                        // Channel to communicate with the engine actor and ensure that the topic
+                        // for this sync session is known / subscribed to. If it's not, we don't
+                        // want to continue with the session.
                         let (topic_is_known_tx, topic_is_known_rx) = oneshot::channel();
 
                         // Inform the engine that we are expecting sync messages from the peer on
@@ -132,7 +135,7 @@ where
                             .send(ToEngineActor::SyncHandshakeSuccess {
                                 peer,
                                 topic: handshake_topic,
-                                topic_is_known_tx,
+                                topic_is_known_tx: Some(topic_is_known_tx),
                             })
                             .await
                             .map_err(|err| {

--- a/p2panda-net/src/sync/accept.rs
+++ b/p2panda-net/src/sync/accept.rs
@@ -153,7 +153,7 @@ where
                             Ok(true) => (),
                             Ok(false) => {
                                 return Err(SyncError::UnknownTopic(
-                                    "acceptor doesn't know about {topic:?}".into(),
+                                    "acceptor is not subscribed to {topic:?}".into(),
                                 ));
                             }
                             Err(_) => {

--- a/p2panda-net/src/sync/initiate.rs
+++ b/p2panda-net/src/sync/initiate.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use futures_util::{AsyncRead, AsyncWrite, SinkExt};
 use p2panda_core::PublicKey;
 use p2panda_sync::{FromSync, SyncError, SyncProtocol, TopicQuery};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::PollSender;
 use tracing::{debug, error, warn};
@@ -103,15 +103,15 @@ where
                     }
                     sync_handshake_success = true;
 
-                    let (topic_is_known_tx, topic_is_known_rx) = oneshot::channel();
-
                     // Inform the engine that we are expecting sync messages from the peer on this
                     // topic.
                     engine_actor_tx
                         .send(ToEngineActor::SyncHandshakeSuccess {
                             peer,
                             topic: topic.clone(),
-                            topic_is_known_tx,
+                            // There is no need to check if the topic is known,
+                            // since we're acting as the initiator.
+                            topic_is_known_tx: None,
                         })
                         .await
                         .map_err(|err| {
@@ -119,25 +119,6 @@ where
                                 "engine_actor_tx failed sending sync handshake success: {err}"
                             ))
                         })?;
-
-                    // Wait to learn whether the sync topic is known locally.
-                    //
-                    // This should always return `true` in this context, since we are acting as the
-                    // sync protocol initiator and therefore know the topic. By extension, this
-                    // means that we are subscribed to the topic and want to sync over it.
-                    match topic_is_known_rx.await {
-                        Ok(true) => (),
-                        Ok(false) => {
-                            return Err(SyncError::UnknownTopic(
-                                "initiator doesn't know about {topic:?}".into(),
-                            ));
-                        }
-                        Err(_) => {
-                            return Err(SyncError::Critical(
-                                "oneshot sender dropped; failed to learn whether the sync topic is of interest".into(),
-                            ));
-                        }
-                    }
 
                     continue;
                 }

--- a/p2panda-net/src/sync/tests.rs
+++ b/p2panda-net/src/sync/tests.rs
@@ -92,10 +92,21 @@ async fn initiator_fails_critical() {
         Some(ToEngineActor::SyncStart { .. })
     ));
 
-    assert!(matches!(
-        rx_acceptor.recv().await,
-        Some(ToEngineActor::SyncHandshakeSuccess { .. })
-    ));
+    // We expect a `SyncHandshakeSuccess` message and need to respond using the oneshot sender (to
+    // let the `accept` side of the protocol that we're interested in the topic.
+    if let Some(ToEngineActor::SyncHandshakeSuccess {
+        peer: _,
+        topic: _,
+        topic_is_known_tx,
+    }) = rx_acceptor.recv().await
+    {
+        if let Some(tx) = topic_is_known_tx {
+            tx.send(true)
+                .expect("topic_is_known receiver already dropped");
+        }
+    } else {
+        panic!("expected sync handshake success message from acceptor")
+    }
 
     assert!(matches!(
         rx_acceptor.recv().await,
@@ -137,10 +148,21 @@ async fn initiator_fails_unexpected() {
         Some(ToEngineActor::SyncStart { .. })
     ));
 
-    assert!(matches!(
-        rx_acceptor.recv().await,
-        Some(ToEngineActor::SyncHandshakeSuccess { .. })
-    ));
+    // We expect a `SyncHandshakeSuccess` message and need to respond using the oneshot sender (to
+    // let the `accept` side of the protocol that we're interested in the topic.
+    if let Some(ToEngineActor::SyncHandshakeSuccess {
+        peer: _,
+        topic: _,
+        topic_is_known_tx,
+    }) = rx_acceptor.recv().await
+    {
+        if let Some(tx) = topic_is_known_tx {
+            tx.send(true)
+                .expect("topic_is_known receiver already dropped");
+        }
+    } else {
+        panic!("expected sync handshake success message from acceptor")
+    }
 
     assert!(matches!(
         rx_acceptor.recv().await,
@@ -169,10 +191,19 @@ async fn initiator_sends_topic_twice() {
         Some(ToEngineActor::SyncStart { .. })
     ));
 
-    assert!(matches!(
-        rx_initiator.recv().await,
-        Some(ToEngineActor::SyncHandshakeSuccess { .. })
-    ));
+    if let Some(ToEngineActor::SyncHandshakeSuccess {
+        peer: _,
+        topic: _,
+        topic_is_known_tx,
+    }) = rx_initiator.recv().await
+    {
+        if let Some(tx) = topic_is_known_tx {
+            tx.send(true)
+                .expect("topic_is_known receiver already dropped");
+        }
+    } else {
+        panic!("expected sync handshake success message from initiator")
+    }
 
     assert!(matches!(
         rx_initiator.recv().await,
@@ -212,10 +243,21 @@ async fn acceptor_fails_critical() {
         Some(ToEngineActor::SyncStart { .. })
     ));
 
-    assert!(matches!(
-        rx_initiator.recv().await,
-        Some(ToEngineActor::SyncHandshakeSuccess { .. })
-    ));
+    // We expect a `SyncHandshakeSuccess` message and need to respond using the oneshot sender (to
+    // let the `initiate` side of the protocol that we're interested in the topic.
+    if let Some(ToEngineActor::SyncHandshakeSuccess {
+        peer: _,
+        topic: _,
+        topic_is_known_tx,
+    }) = rx_initiator.recv().await
+    {
+        if let Some(tx) = topic_is_known_tx {
+            tx.send(true)
+                .expect("topic_is_known receiver already dropped");
+        }
+    } else {
+        panic!("expected sync handshake success message from initiator")
+    }
 
     assert!(matches!(
         rx_initiator.recv().await,
@@ -256,10 +298,19 @@ async fn acceptor_sends_topic() {
         Some(ToEngineActor::SyncStart { .. })
     ));
 
-    assert!(matches!(
-        rx_initiator.recv().await,
-        Some(ToEngineActor::SyncHandshakeSuccess { .. })
-    ));
+    if let Some(ToEngineActor::SyncHandshakeSuccess {
+        peer: _,
+        topic: _,
+        topic_is_known_tx,
+    }) = rx_initiator.recv().await
+    {
+        if let Some(tx) = topic_is_known_tx {
+            tx.send(true)
+                .expect("topic_is_known receiver already dropped");
+        }
+    } else {
+        panic!("expected sync handshake success message from initiator")
+    }
 
     // Note: "SyncFailed" message is handled by manager for initiators.
     assert!(rx_initiator.recv().now_or_never().unwrap().is_none());
@@ -270,10 +321,19 @@ async fn acceptor_sends_topic() {
         Some(ToEngineActor::SyncStart { .. })
     ));
 
-    assert!(matches!(
-        rx_acceptor.recv().await,
-        Some(ToEngineActor::SyncHandshakeSuccess { .. })
-    ));
+    if let Some(ToEngineActor::SyncHandshakeSuccess {
+        peer: _,
+        topic: _,
+        topic_is_known_tx,
+    }) = rx_acceptor.recv().await
+    {
+        if let Some(tx) = topic_is_known_tx {
+            tx.send(true)
+                .expect("topic_is_known receiver already dropped");
+        }
+    } else {
+        panic!("expected sync handshake success message from acceptor")
+    }
 
     assert!(matches!(
         rx_acceptor.recv().await,
@@ -303,7 +363,11 @@ async fn run_sync_without_error() {
 
     assert!(matches!(
         rx_initiator.recv().await,
-        Some(ToEngineActor::SyncHandshakeSuccess { .. })
+        Some(ToEngineActor::SyncHandshakeSuccess {
+            peer: _,
+            topic: _,
+            topic_is_known_tx: None,
+        })
     ));
 
     assert!(matches!(
@@ -317,10 +381,19 @@ async fn run_sync_without_error() {
         Some(ToEngineActor::SyncStart { .. })
     ));
 
-    assert!(matches!(
-        rx_acceptor.recv().await,
-        Some(ToEngineActor::SyncHandshakeSuccess { .. })
-    ));
+    if let Some(ToEngineActor::SyncHandshakeSuccess {
+        peer: _,
+        topic: _,
+        topic_is_known_tx,
+    }) = rx_acceptor.recv().await
+    {
+        if let Some(tx) = topic_is_known_tx {
+            tx.send(true)
+                .expect("topic_is_known receiver already dropped");
+        }
+    } else {
+        panic!("expected sync handshake success message from acceptor")
+    }
 
     assert!(matches!(
         rx_acceptor.recv().await,


### PR DESCRIPTION
## Problem

In an application context with many topics, a peer may attempt to initiate a sync session with one who is not interested in that topic. In other words: the session acceptor is not subscribed to the topic. A panic then occurs when the accepting peer tries to retrieve the stream for the received topic (because the stream doesn't exist; it was never created because no topic subscription occurred).

## Solution

We need a way for the sync session acceptor to query whether the topic is of interest. If not: return an error. If so, continue to phase II and begin processing data messages from the initiator.

## Implementation

After receiving the handshake message from the initiator (which includes the topic), we create a oneshot channel and include the sender as part of the `SyncHandshakeSuccess` message. The message is sent to the actor, allowing the `topic_streams` module to report-back concerning whether or not it is subscribed to the given topic. We listen on the oneshot receiver and exit the sync session before any data messages are exchanged (in "phase II" of the sync protocol) if the topic is not known.

A new error variant has been introduced to signal this failure scenario: `SyncError::UnknownTopic`.

Addresses: https://github.com/p2panda/p2panda/issues/717

-----

## Open Questions

Do we want to introduce an error wire message in `LogSyncProtocol`? Right now we only have `Message::Have(_, _)`, `Message::Data(_, _)` and `Message::Done`. What if there was a `Message::Denied(_)` variant (or similar) which is used to communicate: "nothing went wrong but I don't want to sync with you". This would be useful in the case of two peers not sharing mutual topic interests; the acceptor can then clearly communicate that they're ending the session early because they're not interested in the topic of the initiator (and not simply end the session without any context). 

Right now we simply return an `UnexpectedBehaviour` error when the topic query sent by the initiator is not in the topic map of the acceptor: https://github.com/p2panda/p2panda/blob/main/p2panda-sync/src/log_sync.rs#L253-L258

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
