### PR TITLE
Wait for relay connection initialisation and first direct address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Fixed
 
+- Wait for relay connection initialisation and first direct address [#725](https://github.com/p2panda/p2panda/pull/725)
 - Only decrement the gossip buffer counter if it exists and is greater than zero [#722](https://github.com/p2panda/p2panda/pull/722)
 
 ## [0.3.0] - 11/03/2025

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -556,31 +556,50 @@ where
 
         let mut join_set = JoinSet::<Result<()>>::new();
 
-        // Spawn a task that updates the gossip endpoints and discovery services.
+        // Spawn a task that updates discovery services as our local addresses change.
         {
             let inner = self.clone();
             join_set.spawn(async move {
-                let mut addrs_stream = inner.endpoint.direct_addresses().stream();
-                let mut my_node_addr = iroh::NodeAddr::from(inner.endpoint.node_id());
+                // Wait for the first set of local direct addresses to be discovered.
+                let local_direct_addresses =
+                    inner.endpoint.direct_addresses().initialized().await?;
+
+                // Build the local address from these parts:
+                //
+                // - Public key
+                // - Relay URL
+                // - Direct addresses (IP & port)
+                let mut local_address = iroh::NodeAddr::from(inner.endpoint.node_id());
                 if let Some(relay) = &inner.relay {
-                    my_node_addr = my_node_addr.with_relay_url(relay.url.clone());
+                    local_address = local_address.with_relay_url(relay.url.clone());
+                }
+                let direct_addresses: Vec<SocketAddr> = local_direct_addresses
+                    .iter()
+                    .map(|endpoint| endpoint.addr)
+                    .collect();
+                local_address = local_address.with_direct_addresses(direct_addresses);
+
+                // Update the discovery service with the local address.
+                if let Err(err) = inner.discovery.update_local_address(&local_address) {
+                    warn!("failed to update direct addresses for discovery: {err:?}");
                 }
 
-                loop {
-                    // Wait until we've learned about first direct address.
-                    let Some(endpoints) = addrs_stream.next().await else {
-                        continue;
-                    };
+                // Now we can subscribe to a stream of direct address updates for our endpoint.
+                let mut direct_addresses_stream = inner.endpoint.direct_addresses().stream();
 
+                // Update the discovery service as we learn of address changes.
+                while let Some(endpoints) = direct_addresses_stream.next().await {
                     let direct_addresses: Option<Vec<SocketAddr>> = endpoints
                         .map(|endpoints| endpoints.iter().map(|endpoint| endpoint.addr).collect());
                     if let Some(addresses) = direct_addresses {
-                        my_node_addr = my_node_addr.with_direct_addresses(addresses);
-                        if let Err(err) = inner.discovery.update_local_address(&my_node_addr) {
+                        local_address = local_address.with_direct_addresses(addresses);
+                        if let Err(err) = inner.discovery.update_local_address(&local_address) {
                             warn!("failed to update direct addresses for discovery: {err:?}");
                         }
                     }
                 }
+
+                Ok(())
             });
         }
 


### PR DESCRIPTION
## Changes

- As the final step in the builder, wait for a connection to be established with the relay (if one has been configured)
  - This helps to prevent possible race conditions affecting gossip
- Wait for the first direct addresses to be initialised before listening to the stream of updates
  - This is used to update discovery services of our local address changes

Fixes https://github.com/p2panda/p2panda/issues/723.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
