### PR TITLE
Reset gossip state to rejoin after major interface change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Fixed
 
+- Reset gossip state to rejoin after major interface change [#726](https://github.com/p2panda/p2panda/pull/726)
 - Wait for relay connection initialisation and first direct address [#725](https://github.com/p2panda/p2panda/pull/725)
 - Only decrement the gossip buffer counter if it exists and is greater than zero [#722](https://github.com/p2panda/p2panda/pull/722)
 

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -239,6 +239,7 @@ where
                     if let Some(sync_actor_tx) = &self.sync_actor_tx {
                         sync_actor_tx.send(ToSyncActor::Reset).await?;
                     }
+                    self.gossip_actor_tx.send(ToGossipActor::Reset).await?;
                 }
                 // Attempt to start topic discovery if it didn't happen yet.
                 _ = join_network_interval.tick() => {

--- a/p2panda-net/src/engine/gossip.rs
+++ b/p2panda-net/src/engine/gossip.rs
@@ -31,6 +31,7 @@ pub enum ToGossipActor {
     Leave {
         topic_id: [u8; 32],
     },
+    Reset,
     Shutdown,
 }
 
@@ -143,6 +144,7 @@ where
                 self.joined.remove(&topic_id);
                 self.want_join.remove(&topic_id);
             }
+            ToGossipActor::Reset => self.want_join.clear(),
             ToGossipActor::Shutdown => {
                 for topic_id in self.joined.iter() {
                     let _handle = self.gossip_events.remove(topic_id);


### PR DESCRIPTION
## Scenario

- Peer A and B connect on the same WiFi; everything works fine
- Peer A switches to a different WiFi network; gossip stops working (as expected)
- Peer A reconnects to the same WiFi as peer B; gossip still not working (should work)

## Problem

- The `want_join` set in the gossip actor wasn't being cleared
- This meant that we were returning early from the call to `ToGossipActor::Join`
- So we never rejoined the gossip overlay for the topic 

## Solution

- Send a `Reset` event to the gossip actor on major interface change and clear the `want_join` set

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
