### PR TITLE
Unsubscribe on drop for topic sender and receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Highlights are marked with a pancake 🥞
 ### Added
 
 - Partial ordering algorithm for operations [#710](https://github.com/p2panda/p2panda/pull/710)
+- Unsubscribe on drop for topic sender and receiver [#728](https://github.com/p2panda/p2panda/pull/728)
 
 ### Fixed
 

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -23,7 +23,7 @@ use crate::engine::topic_streams::{
 };
 use crate::events::SystemEvent;
 use crate::sync::manager::{SyncActor, ToSyncActor};
-use crate::{from_public_key, to_public_key, NetworkId, NodeAddress, TopicId};
+use crate::{NetworkId, NodeAddress, TopicId, from_public_key, to_public_key};
 
 #[derive(Debug)]
 pub enum ToEngineActor<T> {

--- a/p2panda-net/src/engine/engine.rs
+++ b/p2panda-net/src/engine/engine.rs
@@ -21,7 +21,7 @@ use crate::engine::topic_discovery::TopicDiscovery;
 use crate::engine::topic_streams::{TopicStreamReceiver, TopicStreamSender, TopicStreams};
 use crate::events::SystemEvent;
 use crate::sync::manager::{SyncActor, ToSyncActor};
-use crate::{from_public_key, to_public_key, NetworkId, NodeAddress, TopicId};
+use crate::{NetworkId, NodeAddress, TopicId, from_public_key, to_public_key};
 
 #[derive(Debug)]
 pub enum ToEngineActor<T> {

--- a/p2panda-net/src/engine/gossip.rs
+++ b/p2panda-net/src/engine/gossip.rs
@@ -27,7 +27,6 @@ pub enum ToGossipActor {
         topic_id: [u8; 32],
         peers: Vec<PublicKey>,
     },
-    #[allow(dead_code)]
     Leave {
         topic_id: [u8; 32],
     },

--- a/p2panda-net/src/engine/mod.rs
+++ b/p2panda-net/src/engine/mod.rs
@@ -26,7 +26,7 @@ use tracing::{debug, error};
 pub use crate::engine::address_book::AddressBook;
 use crate::engine::engine::EngineActor;
 use crate::engine::gossip::GossipActor;
-pub use crate::engine::topic_streams::{TopicStreamReceiver, TopicStreamSender};
+pub use crate::engine::topic_streams::{TopicReceiver, TopicReceiverStream, TopicSender};
 use crate::events::SystemEvent;
 use crate::network::JoinErrToStr;
 use crate::sync::manager::SyncActor;
@@ -139,15 +139,15 @@ where
     pub async fn subscribe(
         &self,
         topic: T,
-        topic_stream_sender_tx: oneshot::Sender<TopicStreamSender<T>>,
-        topic_stream_receiver_tx: oneshot::Sender<TopicStreamReceiver<T>>,
+        topic_sender_tx: oneshot::Sender<TopicSender<T>>,
+        topic_receiver_tx: oneshot::Sender<TopicReceiver<T>>,
         gossip_ready_tx: oneshot::Sender<()>,
     ) -> Result<()> {
         self.engine_actor_tx
             .send(ToEngineActor::SubscribeTopic {
                 topic,
-                topic_stream_sender_tx,
-                topic_stream_receiver_tx,
+                topic_sender_tx,
+                topic_receiver_tx,
                 gossip_ready_tx,
             })
             .await?;

--- a/p2panda-net/src/engine/topic_streams.rs
+++ b/p2panda-net/src/engine/topic_streams.rs
@@ -7,16 +7,16 @@ use anyhow::Result;
 use p2panda_core::PublicKey;
 use p2panda_sync::TopicQuery;
 use tokio::sync::mpsc::error::SendError;
-use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::sync::{RwLock, mpsc, oneshot};
 use tracing::{debug, error, warn};
 
+use crate::TopicId;
 use crate::engine::address_book::AddressBook;
 use crate::engine::constants::JOIN_PEERS_SAMPLE_LEN;
 use crate::engine::gossip::ToGossipActor;
 use crate::engine::gossip_buffer::GossipBuffer;
 use crate::network::{FromNetwork, ToNetwork};
 use crate::sync::manager::ToSyncActor;
-use crate::TopicId;
 
 use super::ToEngineActor;
 

--- a/p2panda-net/src/engine/topic_streams/mod.rs
+++ b/p2panda-net/src/engine/topic_streams/mod.rs
@@ -9,10 +9,9 @@ use std::sync::Arc;
 use anyhow::Result;
 use p2panda_core::PublicKey;
 use p2panda_sync::TopicQuery;
-use tokio::sync::{RwLock, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, RwLock};
 use tracing::{debug, error, warn};
 
-use crate::TopicId;
 use crate::engine::address_book::AddressBook;
 use crate::engine::constants::JOIN_PEERS_SAMPLE_LEN;
 use crate::engine::engine::ToEngineActor;
@@ -20,6 +19,7 @@ use crate::engine::gossip::ToGossipActor;
 use crate::engine::gossip_buffer::GossipBuffer;
 use crate::network::{FromNetwork, ToNetwork};
 use crate::sync::manager::ToSyncActor;
+use crate::TopicId;
 
 pub use crate::engine::topic_streams::receiver::TopicStreamReceiver;
 pub use crate::engine::topic_streams::sender::TopicStreamSender;
@@ -51,11 +51,7 @@ impl TopicStreamState {
     }
 
     fn is_active(&self) -> bool {
-        if self.sender || self.receiver {
-            true
-        } else {
-            false
-        }
+        self.sender || self.receiver
     }
 }
 

--- a/p2panda-net/src/engine/topic_streams/mod.rs
+++ b/p2panda-net/src/engine/topic_streams/mod.rs
@@ -146,15 +146,13 @@ where
             stream_id,
             to_network_tx,
             self.engine_actor_tx.clone(),
-        )
-        .await;
+        );
         let topic_rx = TopicReceiver::new(
             topic.clone(),
             stream_id,
             from_network_rx,
             self.engine_actor_tx.clone(),
-        )
-        .await;
+        );
 
         // Send the topic stream channels back to the subscriber.
         if topic_sender_tx.send(topic_tx).is_err() {

--- a/p2panda-net/src/engine/topic_streams/mod.rs
+++ b/p2panda-net/src/engine/topic_streams/mod.rs
@@ -9,9 +9,10 @@ use std::sync::Arc;
 use anyhow::Result;
 use p2panda_core::PublicKey;
 use p2panda_sync::TopicQuery;
-use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::sync::{RwLock, mpsc, oneshot};
 use tracing::{debug, error, warn};
 
+use crate::TopicId;
 use crate::engine::address_book::AddressBook;
 use crate::engine::constants::JOIN_PEERS_SAMPLE_LEN;
 use crate::engine::engine::ToEngineActor;
@@ -19,7 +20,6 @@ use crate::engine::gossip::ToGossipActor;
 use crate::engine::gossip_buffer::GossipBuffer;
 use crate::network::{FromNetwork, ToNetwork};
 use crate::sync::manager::ToSyncActor;
-use crate::TopicId;
 
 pub use crate::engine::topic_streams::receiver::{TopicReceiver, TopicReceiverStream};
 pub use crate::engine::topic_streams::sender::TopicSender;
@@ -710,9 +710,11 @@ mod tests {
 
         assert_eq!(topic_streams.next_stream_id, 2);
         assert!(topic_streams.gossip_pending.contains_key(&topic_id));
-        assert!(topic_streams
-            .active_streams
-            .contains_key(&current_stream_id));
+        assert!(
+            topic_streams
+                .active_streams
+                .contains_key(&current_stream_id)
+        );
 
         let stream_state = topic_streams
             .active_streams
@@ -722,18 +724,22 @@ mod tests {
         assert_eq!(stream_state.receiver, true);
 
         assert!(topic_streams.topic_id_to_stream.contains_key(&topic_id));
-        assert!(topic_streams
-            .topic_id_to_stream
-            .get(&topic_id)
-            .unwrap()
-            .contains(&current_stream_id));
+        assert!(
+            topic_streams
+                .topic_id_to_stream
+                .get(&topic_id)
+                .unwrap()
+                .contains(&current_stream_id)
+        );
 
         assert!(topic_streams.topic_to_stream.contains_key(&topic));
-        assert!(topic_streams
-            .topic_to_stream
-            .get(&topic)
-            .unwrap()
-            .contains(&current_stream_id));
+        assert!(
+            topic_streams
+                .topic_to_stream
+                .get(&topic)
+                .unwrap()
+                .contains(&current_stream_id)
+        );
 
         // Process the joining of the gossip topic:
 
@@ -829,18 +835,22 @@ mod tests {
         assert_eq!(stream_state.receiver, true);
 
         assert!(topic_streams.topic_id_to_stream.contains_key(&topic_id));
-        assert!(topic_streams
-            .topic_id_to_stream
-            .get(&topic_id)
-            .unwrap()
-            .contains(&current_stream_id));
+        assert!(
+            topic_streams
+                .topic_id_to_stream
+                .get(&topic_id)
+                .unwrap()
+                .contains(&current_stream_id)
+        );
 
         assert!(topic_streams.topic_to_stream.contains_key(&topic));
-        assert!(topic_streams
-            .topic_to_stream
-            .get(&topic)
-            .unwrap()
-            .contains(&current_stream_id));
+        assert!(
+            topic_streams
+                .topic_to_stream
+                .get(&topic)
+                .unwrap()
+                .contains(&current_stream_id)
+        );
 
         // Drop receiver.
         drop(from_network_rx);
@@ -864,9 +874,11 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(!topic_streams
-            .active_streams
-            .contains_key(&current_stream_id));
+        assert!(
+            !topic_streams
+                .active_streams
+                .contains_key(&current_stream_id)
+        );
 
         assert!(!topic_streams.topic_id_to_stream.contains_key(&topic_id));
 

--- a/p2panda-net/src/engine/topic_streams/mod.rs
+++ b/p2panda-net/src/engine/topic_streams/mod.rs
@@ -9,9 +9,10 @@ use std::sync::Arc;
 use anyhow::Result;
 use p2panda_core::PublicKey;
 use p2panda_sync::TopicQuery;
-use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::sync::{RwLock, mpsc, oneshot};
 use tracing::{debug, error, warn};
 
+use crate::TopicId;
 use crate::engine::address_book::AddressBook;
 use crate::engine::constants::JOIN_PEERS_SAMPLE_LEN;
 use crate::engine::engine::ToEngineActor;
@@ -19,7 +20,6 @@ use crate::engine::gossip::ToGossipActor;
 use crate::engine::gossip_buffer::GossipBuffer;
 use crate::network::{FromNetwork, ToNetwork};
 use crate::sync::manager::ToSyncActor;
-use crate::TopicId;
 
 pub use crate::engine::topic_streams::receiver::TopicStreamReceiver;
 pub use crate::engine::topic_streams::sender::TopicStreamSender;

--- a/p2panda-net/src/engine/topic_streams/receiver.rs
+++ b/p2panda-net/src/engine/topic_streams/receiver.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use p2panda_sync::TopicQuery;
+use tokio::sync::mpsc;
+
+use crate::engine::engine::ToEngineActor;
+use crate::network::FromNetwork;
+use crate::TopicId;
+
+// @TODO(glyph): Docs.
+#[derive(Debug)]
+pub struct TopicStreamReceiver<T> {
+    topic: T,
+    stream_id: usize,
+    from_network_rx: mpsc::Receiver<FromNetwork>,
+    engine_actor_tx: mpsc::Sender<ToEngineActor<T>>,
+}
+
+impl<T> TopicStreamReceiver<T>
+where
+    T: TopicQuery + TopicId + 'static,
+{
+    pub(crate) async fn new(
+        topic: T,
+        stream_id: usize,
+        from_network_rx: mpsc::Receiver<FromNetwork>,
+        engine_actor_tx: mpsc::Sender<ToEngineActor<T>>,
+    ) -> Self {
+        Self {
+            topic,
+            stream_id,
+            from_network_rx,
+            engine_actor_tx,
+        }
+    }
+
+    // @TODO(glyph): Probably want to implement `recv()`, `recv_many()` and `try_recv()`.
+
+    async fn recv(&mut self) -> Option<FromNetwork> {
+        self.from_network_rx.recv().await
+    }
+}
+
+impl<T> Drop for TopicStreamReceiver<T> {
+    fn drop(&mut self) {
+        todo!()
+
+        // self.engine_actor_tx.send(ToEngineActor::UnsubscribeTopic { .. })
+    }
+}

--- a/p2panda-net/src/engine/topic_streams/receiver.rs
+++ b/p2panda-net/src/engine/topic_streams/receiver.rs
@@ -1,23 +1,28 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::Stream;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
 use tracing::warn;
 
 use crate::engine::engine::ToEngineActor;
-use crate::engine::topic_streams::TopicStreamChannel;
+use crate::engine::topic_streams::TopicChannelType;
 use crate::network::FromNetwork;
 
-// @TODO(glyph): Docs.
+/// A wrapper around [`tokio::sync::mpsc::Receiver`] that invokes unsubscribe behaviour for the
+/// topic when dropped.
 #[derive(Debug)]
-pub struct TopicStreamReceiver<T> {
+pub struct TopicReceiver<T> {
     topic: Option<T>,
     stream_id: usize,
     from_network_rx: mpsc::Receiver<FromNetwork>,
     engine_actor_tx: mpsc::Sender<ToEngineActor<T>>,
 }
 
-impl<T> TopicStreamReceiver<T> {
+impl<T> TopicReceiver<T> {
     pub(crate) async fn new(
         topic: T,
         stream_id: usize,
@@ -51,22 +56,84 @@ impl<T> TopicStreamReceiver<T> {
     pub fn is_closed(&self) -> bool {
         self.from_network_rx.is_closed()
     }
+
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<FromNetwork>> {
+        self.from_network_rx.poll_recv(cx)
+    }
 }
 
-impl<T> Drop for TopicStreamReceiver<T> {
+impl<T> Drop for TopicReceiver<T> {
     fn drop(&mut self) {
         if let Some(topic) = self.topic.take() {
             if self
                 .engine_actor_tx
-                .blocking_send(ToEngineActor::UnsubscribeTopic {
+                .try_send(ToEngineActor::UnsubscribeTopic {
                     topic,
                     stream_id: self.stream_id,
-                    channel_type: TopicStreamChannel::Receiver,
+                    channel_type: TopicChannelType::Receiver,
                 })
                 .is_err()
             {
                 warn!("engine actor receiver dropped before topic unsubscribe event could be sent")
             }
         }
+    }
+}
+
+impl<T> Unpin for TopicReceiver<T> {}
+
+/// A wrapper around [`TopicReceiver`] that implements [`Stream`].
+#[derive(Debug)]
+pub struct TopicReceiverStream<T> {
+    inner: TopicReceiver<T>,
+}
+
+impl<T> TopicReceiverStream<T> {
+    /// Create a new `TopicReceiverStream`.
+    pub fn new(recv: TopicReceiver<T>) -> Self {
+        Self { inner: recv }
+    }
+
+    /// Get back the inner `TopicReceiver`.
+    pub fn into_inner(self) -> TopicReceiver<T> {
+        self.inner
+    }
+
+    /// Closes the receiving half of a channel without dropping it.
+    ///
+    /// This prevents any further messages from being sent on the channel while
+    /// still enabling the receiver to drain messages that are buffered. Any
+    /// outstanding [`Permit`] values will still be able to send messages.
+    ///
+    /// To guarantee no messages are dropped, after calling `close()`, you must
+    /// receive all items from the stream until `None` is returned.
+    pub fn close(&mut self) {
+        self.inner.close();
+    }
+}
+
+impl<T> Stream for TopicReceiverStream<T> {
+    type Item = FromNetwork;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_recv(cx)
+    }
+}
+
+impl<T> AsRef<TopicReceiver<T>> for TopicReceiverStream<T> {
+    fn as_ref(&self) -> &TopicReceiver<T> {
+        &self.inner
+    }
+}
+
+impl<T> AsMut<TopicReceiver<T>> for TopicReceiverStream<T> {
+    fn as_mut(&mut self) -> &mut TopicReceiver<T> {
+        &mut self.inner
+    }
+}
+
+impl<T> From<TopicReceiver<T>> for TopicReceiverStream<T> {
+    fn from(recv: TopicReceiver<T>) -> Self {
+        Self::new(recv)
     }
 }

--- a/p2panda-net/src/engine/topic_streams/receiver.rs
+++ b/p2panda-net/src/engine/topic_streams/receiver.rs
@@ -56,13 +56,14 @@ impl<T> TopicStreamReceiver<T> {
 impl<T> Drop for TopicStreamReceiver<T> {
     fn drop(&mut self) {
         if let Some(topic) = self.topic.take() {
-            if let Err(_) = self
+            if self
                 .engine_actor_tx
                 .blocking_send(ToEngineActor::UnsubscribeTopic {
                     topic,
                     stream_id: self.stream_id,
                     channel_type: TopicStreamChannel::Receiver,
                 })
+                .is_err()
             {
                 warn!("engine actor receiver dropped before topic unsubscribe event could be sent")
             }

--- a/p2panda-net/src/engine/topic_streams/receiver.rs
+++ b/p2panda-net/src/engine/topic_streams/receiver.rs
@@ -33,7 +33,7 @@ pub struct TopicReceiver<T> {
 }
 
 impl<T> TopicReceiver<T> {
-    pub(crate) async fn new(
+    pub(crate) fn new(
         topic: T,
         stream_id: usize,
         from_network_rx: mpsc::Receiver<FromNetwork>,

--- a/p2panda-net/src/engine/topic_streams/receiver.rs
+++ b/p2panda-net/src/engine/topic_streams/receiver.rs
@@ -12,8 +12,12 @@ use crate::engine::engine::ToEngineActor;
 use crate::engine::topic_streams::TopicChannelType;
 use crate::network::FromNetwork;
 
-/// A wrapper around [`tokio::sync::mpsc::Receiver`] that invokes unsubscribe behaviour for the
-/// topic when dropped.
+/// Receive bytes associated with a specific topic from the network.
+///
+/// `TopicReceiver` acts as a thin wrapper around [`tokio::sync::mpsc::Receiver`], only
+/// implementing a limited subset of methods, and invokes unsubscribe behaviour for the topic when
+/// dropped. The state of all senders and receivers for the topic is tracked internally; the topic
+/// is only fully unsubscribed from when all of them have been dropped.
 #[derive(Debug)]
 pub struct TopicReceiver<T> {
     topic: Option<T>,

--- a/p2panda-net/src/engine/topic_streams/receiver.rs
+++ b/p2panda-net/src/engine/topic_streams/receiver.rs
@@ -2,6 +2,7 @@
 
 use p2panda_sync::TopicQuery;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TryRecvError;
 
 use crate::engine::engine::ToEngineActor;
 use crate::network::FromNetwork;
@@ -34,10 +35,24 @@ where
         }
     }
 
-    // @TODO(glyph): Probably want to implement `recv()`, `recv_many()` and `try_recv()`.
-
-    async fn recv(&mut self) -> Option<FromNetwork> {
+    pub async fn recv(&mut self) -> Option<FromNetwork> {
         self.from_network_rx.recv().await
+    }
+
+    pub async fn recv_many(&mut self, buffer: &mut Vec<FromNetwork>, limit: usize) -> usize {
+        self.from_network_rx.recv_many(buffer, limit).await
+    }
+
+    pub fn try_recv(&mut self) -> Result<FromNetwork, TryRecvError> {
+        self.from_network_rx.try_recv()
+    }
+
+    pub fn close(&mut self) {
+        self.from_network_rx.close()
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.from_network_rx.is_closed()
     }
 }
 

--- a/p2panda-net/src/engine/topic_streams/receiver.rs
+++ b/p2panda-net/src/engine/topic_streams/receiver.rs
@@ -14,8 +14,9 @@ use crate::network::FromNetwork;
 
 /// Receive bytes associated with a specific topic from the network.
 ///
-/// `TopicReceiver` acts as a thin wrapper around `tokio::sync::mpsc::Receiver`, only
-/// implementing a limited subset of methods.
+/// `TopicReceiver` acts as a thin wrapper around
+/// [`tokio::sync::mpsc::Receiver`](https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Receiver.html),
+/// only implementing a limited subset of methods.
 ///
 /// Unsubscribe behaviour for the topic is automatically invoked when the receiver is dropped. The
 /// state of all senders and receivers for each subscribed topic is tracked internally. A topic is

--- a/p2panda-net/src/engine/topic_streams/receiver.rs
+++ b/p2panda-net/src/engine/topic_streams/receiver.rs
@@ -1,26 +1,23 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use p2panda_sync::TopicQuery;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
+use tracing::warn;
 
 use crate::engine::engine::ToEngineActor;
+use crate::engine::topic_streams::TopicStreamChannel;
 use crate::network::FromNetwork;
-use crate::TopicId;
 
 // @TODO(glyph): Docs.
 #[derive(Debug)]
 pub struct TopicStreamReceiver<T> {
-    topic: T,
+    topic: Option<T>,
     stream_id: usize,
     from_network_rx: mpsc::Receiver<FromNetwork>,
     engine_actor_tx: mpsc::Sender<ToEngineActor<T>>,
 }
 
-impl<T> TopicStreamReceiver<T>
-where
-    T: TopicQuery + TopicId + 'static,
-{
+impl<T> TopicStreamReceiver<T> {
     pub(crate) async fn new(
         topic: T,
         stream_id: usize,
@@ -28,7 +25,7 @@ where
         engine_actor_tx: mpsc::Sender<ToEngineActor<T>>,
     ) -> Self {
         Self {
-            topic,
+            topic: Some(topic),
             stream_id,
             from_network_rx,
             engine_actor_tx,
@@ -58,8 +55,17 @@ where
 
 impl<T> Drop for TopicStreamReceiver<T> {
     fn drop(&mut self) {
-        todo!()
-
-        // self.engine_actor_tx.send(ToEngineActor::UnsubscribeTopic { .. })
+        if let Some(topic) = self.topic.take() {
+            if let Err(_) = self
+                .engine_actor_tx
+                .blocking_send(ToEngineActor::UnsubscribeTopic {
+                    topic,
+                    stream_id: self.stream_id,
+                    channel_type: TopicStreamChannel::Receiver,
+                })
+            {
+                warn!("engine actor receiver dropped before topic unsubscribe event could be sent")
+            }
+        }
     }
 }

--- a/p2panda-net/src/engine/topic_streams/sender.rs
+++ b/p2panda-net/src/engine/topic_streams/sender.rs
@@ -10,10 +10,15 @@ use crate::network::ToNetwork;
 
 /// Send bytes associated with a specific topic into the network.
 ///
-/// `TopicSender` acts as a thin wrapper around [`tokio::sync::mpsc::Sender`], only
-/// implementing a limited subset of methods, and invokes unsubscribe behaviour for the topic when
-/// dropped. The state of all senders and receivers for the topic is tracked internally; the topic
-/// is only fully unsubscribed from when all of them have been dropped.
+/// `TopicSender` acts as a thin wrapper around `tokio::sync::mpsc::Sender`, only
+/// implementing a limited subset of methods.
+///
+/// Unsubscribe behaviour for the topic is automatically invoked when the sender is dropped. The
+/// state of all senders and receivers for each subscribed topic is tracked internally. A topic is
+/// only fully unsubscribed from when _all_ senders and receivers for that topic have been dropped.
+/// In practice, this means that you can drop a sender or receiver and continue interacting with
+/// the other half of the channel. Or you can subscribe to the same topic twice, drop one
+/// sender-receiver pair and continue to use the other pair.
 #[derive(Debug)]
 pub struct TopicSender<T> {
     topic: Option<T>,

--- a/p2panda-net/src/engine/topic_streams/sender.rs
+++ b/p2panda-net/src/engine/topic_streams/sender.rs
@@ -56,13 +56,14 @@ impl<T> TopicStreamSender<T> {
 impl<T> Drop for TopicStreamSender<T> {
     fn drop(&mut self) {
         if let Some(topic) = self.topic.take() {
-            if let Err(_) = self
+            if self
                 .engine_actor_tx
                 .blocking_send(ToEngineActor::UnsubscribeTopic {
                     topic,
                     stream_id: self.stream_id,
                     channel_type: TopicStreamChannel::Sender,
                 })
+                .is_err()
             {
                 warn!("engine actor receiver dropped before topic unsubscribe event could be sent")
             }

--- a/p2panda-net/src/engine/topic_streams/sender.rs
+++ b/p2panda-net/src/engine/topic_streams/sender.rs
@@ -29,7 +29,7 @@ pub struct TopicSender<T> {
 }
 
 impl<T> TopicSender<T> {
-    pub(crate) async fn new(
+    pub(crate) fn new(
         topic: T,
         stream_id: usize,
         to_network_tx: mpsc::Sender<ToNetwork>,

--- a/p2panda-net/src/engine/topic_streams/sender.rs
+++ b/p2panda-net/src/engine/topic_streams/sender.rs
@@ -8,7 +8,12 @@ use crate::engine::engine::ToEngineActor;
 use crate::engine::topic_streams::TopicChannelType;
 use crate::network::ToNetwork;
 
-// @TODO(glyph): Docs.
+/// Send bytes associated with a specific topic into the network.
+///
+/// `TopicSender` acts as a thin wrapper around [`tokio::sync::mpsc::Sender`], only
+/// implementing a limited subset of methods, and invokes unsubscribe behaviour for the topic when
+/// dropped. The state of all senders and receivers for the topic is tracked internally; the topic
+/// is only fully unsubscribed from when all of them have been dropped.
 #[derive(Debug)]
 pub struct TopicSender<T> {
     topic: Option<T>,

--- a/p2panda-net/src/engine/topic_streams/sender.rs
+++ b/p2panda-net/src/engine/topic_streams/sender.rs
@@ -10,8 +10,9 @@ use crate::network::ToNetwork;
 
 /// Send bytes associated with a specific topic into the network.
 ///
-/// `TopicSender` acts as a thin wrapper around `tokio::sync::mpsc::Sender`, only
-/// implementing a limited subset of methods.
+/// `TopicSender` acts as a thin wrapper around
+/// [`tokio::sync::mpsc::Sender`](https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Sender.html),
+/// only implementing a limited subset of methods.
 ///
 /// Unsubscribe behaviour for the topic is automatically invoked when the sender is dropped. The
 /// state of all senders and receivers for each subscribed topic is tracked internally. A topic is

--- a/p2panda-net/src/engine/topic_streams/sender.rs
+++ b/p2panda-net/src/engine/topic_streams/sender.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use p2panda_sync::TopicQuery;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::SendError;
+
+use crate::engine::engine::ToEngineActor;
+use crate::network::ToNetwork;
+use crate::TopicId;
+
+// @TODO(glyph): the TopicStreams struct is where we keep the reference counters for the stream
+// subscribers.
+
+// @TODO(glyph): Docs.
+#[derive(Debug)]
+pub struct TopicStreamSender<T> {
+    topic: T,
+    stream_id: usize,
+    to_network_tx: mpsc::Sender<ToNetwork>,
+    engine_actor_tx: mpsc::Sender<ToEngineActor<T>>,
+}
+
+impl<T> TopicStreamSender<T>
+where
+    T: TopicQuery + TopicId + 'static,
+{
+    pub(crate) async fn new(
+        topic: T,
+        stream_id: usize,
+        to_network_tx: mpsc::Sender<ToNetwork>,
+        engine_actor_tx: mpsc::Sender<ToEngineActor<T>>,
+    ) -> Self {
+        Self {
+            topic,
+            stream_id,
+            to_network_tx,
+            engine_actor_tx,
+        }
+    }
+
+    async fn send(&mut self, to_network_bytes: ToNetwork) -> Result<(), SendError<ToNetwork>> {
+        self.to_network_tx.send(to_network_bytes).await?;
+
+        Ok(())
+    }
+}
+
+impl<T> Drop for TopicStreamSender<T> {
+    fn drop(&mut self) {
+        todo!()
+
+        // self.engine_actor_tx.send(ToEngineActor::UnsubscribeTopic { .. })
+    }
+}

--- a/p2panda-net/src/engine/topic_streams/sender.rs
+++ b/p2panda-net/src/engine/topic_streams/sender.rs
@@ -2,7 +2,7 @@
 
 use p2panda_sync::TopicQuery;
 use tokio::sync::mpsc;
-use tokio::sync::mpsc::error::SendError;
+use tokio::sync::mpsc::error::{SendError, TrySendError};
 
 use crate::engine::engine::ToEngineActor;
 use crate::network::ToNetwork;
@@ -42,6 +42,20 @@ where
         self.to_network_tx.send(to_network_bytes).await?;
 
         Ok(())
+    }
+
+    fn try_send(&mut self, to_network_bytes: ToNetwork) -> Result<(), TrySendError<ToNetwork>> {
+        self.to_network_tx.try_send(to_network_bytes)?;
+
+        Ok(())
+    }
+
+    async fn closed(&self) {
+        self.to_network_tx.closed().await
+    }
+
+    fn is_closed(&self) -> bool {
+        self.to_network_tx.is_closed()
     }
 }
 

--- a/p2panda-net/src/events.rs
+++ b/p2panda-net/src/events.rs
@@ -13,8 +13,6 @@ pub enum SystemEvent<T> {
     },
 
     /// Left a gossip topic.
-    // @TODO: This requires `unsubscribe()` to be implemented.
-    // https://github.com/p2panda/p2panda/issues/639
     GossipLeft { topic_id: [u8; 32] },
 
     /// Established a connection with a neighbor.

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -151,6 +151,7 @@ mod sync;
 
 pub use addrs::{NodeAddress, RelayUrl};
 pub use config::Config;
+pub use engine::{TopicStreamReceiver, TopicStreamSender};
 pub use events::SystemEvent;
 pub use network::{FromNetwork, Network, NetworkBuilder, RelayMode, ToNetwork};
 pub use protocols::ProtocolHandler;

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -151,7 +151,7 @@ mod sync;
 
 pub use addrs::{NodeAddress, RelayUrl};
 pub use config::Config;
-pub use engine::{TopicStreamReceiver, TopicStreamSender};
+pub use engine::{TopicReceiver, TopicReceiverStream, TopicSender};
 pub use events::SystemEvent;
 pub use network::{FromNetwork, Network, NetworkBuilder, RelayMode, ToNetwork};
 pub use protocols::ProtocolHandler;

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -787,7 +787,7 @@ where
     /// Subscribes to a topic and returns a bi-directional stream that can be read from and written
     /// to, along with a oneshot receiver to be informed when the gossip overlay has been joined.
     ///
-    /// The topic will automatically be unsubscribed from once both the sender and receiver have
+    /// Unsubscription will occur automatically once all senders and receivers for this topic have
     /// been dropped.
     pub async fn subscribe(
         &self,

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -139,7 +139,7 @@ use tracing::{Instrument, debug, error, error_span, warn};
 
 use crate::addrs::{DEFAULT_STUN_PORT, to_node_addr, to_relay_url};
 use crate::config::{Config, DEFAULT_BIND_PORT, GossipConfig};
-use crate::engine::{Engine, TopicStreamReceiver, TopicStreamSender};
+use crate::engine::{Engine, TopicReceiver, TopicSender};
 use crate::events::SystemEvent;
 use crate::protocols::{ProtocolHandler, ProtocolMap};
 use crate::sync::{SYNC_CONNECTION_ALPN, SyncConfiguration};
@@ -792,11 +792,7 @@ where
     pub async fn subscribe(
         &self,
         topic: T,
-    ) -> Result<(
-        TopicStreamSender<T>,
-        TopicStreamReceiver<T>,
-        oneshot::Receiver<()>,
-    )> {
+    ) -> Result<(TopicSender<T>, TopicReceiver<T>, oneshot::Receiver<()>)> {
         let (topic_stream_sender_tx, topic_stream_sender_rx) = oneshot::channel();
         let (topic_stream_receiver_tx, topic_stream_receiver_rx) = oneshot::channel();
         let (gossip_ready_tx, gossip_ready_rx) = oneshot::channel();

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -121,12 +121,12 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use futures_lite::StreamExt;
 use futures_util::future::{MapErr, Shared};
 use futures_util::{FutureExt, TryFutureExt};
 use iroh::{Endpoint, RelayMap, RelayNode};
-use iroh_gossip::net::{Gossip, GOSSIP_ALPN};
+use iroh_gossip::net::{GOSSIP_ALPN, Gossip};
 use iroh_quinn::TransportConfig;
 use p2panda_core::{PrivateKey, PublicKey};
 use p2panda_discovery::{Discovery, DiscoveryMap};
@@ -135,15 +135,15 @@ use tokio::sync::{broadcast, oneshot};
 use tokio::task::{JoinError, JoinSet};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
-use tracing::{debug, error, error_span, warn, Instrument};
+use tracing::{Instrument, debug, error, error_span, warn};
 
-use crate::addrs::{to_node_addr, to_relay_url, DEFAULT_STUN_PORT};
-use crate::config::{Config, GossipConfig, DEFAULT_BIND_PORT};
+use crate::addrs::{DEFAULT_STUN_PORT, to_node_addr, to_relay_url};
+use crate::config::{Config, DEFAULT_BIND_PORT, GossipConfig};
 use crate::engine::{Engine, TopicStreamReceiver, TopicStreamSender};
 use crate::events::SystemEvent;
 use crate::protocols::{ProtocolHandler, ProtocolMap};
-use crate::sync::{SyncConfiguration, SYNC_CONNECTION_ALPN};
-use crate::{from_private_key, NetworkId, NodeAddress, RelayUrl, TopicId};
+use crate::sync::{SYNC_CONNECTION_ALPN, SyncConfiguration};
+use crate::{NetworkId, NodeAddress, RelayUrl, TopicId, from_private_key};
 
 /// Maximum number of streams accepted on a QUIC connection.
 const MAX_STREAMS: u32 = 1024;
@@ -881,19 +881,19 @@ mod tests {
     use p2panda_core::{Body, Extensions, Hash, Header, PrivateKey, PublicKey};
     use p2panda_discovery::mdns::LocalDiscovery;
     use p2panda_store::{MemoryStore, OperationStore};
+    use p2panda_sync::TopicQuery;
     use p2panda_sync::log_sync::{LogSyncProtocol, TopicLogMap};
     use p2panda_sync::test_protocols::{
         FailingProtocol, PingPongProtocol, SyncTestTopic as TestTopic,
     };
-    use p2panda_sync::TopicQuery;
     use tokio::task::JoinHandle;
 
-    use crate::addrs::{to_node_addr, DEFAULT_STUN_PORT};
+    use crate::addrs::{DEFAULT_STUN_PORT, to_node_addr};
     use crate::bytes::ToBytes;
     use crate::config::Config;
     use crate::events::SystemEvent;
     use crate::sync::SyncConfiguration;
-    use crate::{to_public_key, NetworkBuilder, NodeAddress, RelayMode, RelayUrl, TopicId};
+    use crate::{NetworkBuilder, NodeAddress, RelayMode, RelayUrl, TopicId, to_public_key};
 
     use super::{FromNetwork, Network, ToNetwork};
 

--- a/p2panda-net/src/network.rs
+++ b/p2panda-net/src/network.rs
@@ -934,14 +934,11 @@ mod tests {
             // Await at least one message received via sync.
             loop {
                 let msg = rx.recv().await.unwrap();
-                println!("{msg:?}");
                 if let FromNetwork::SyncMessage { .. } = msg {
                     break;
                 }
             }
 
-            // Give other nodes enough time to complete sync sessions.
-            tokio::time::sleep(Duration::from_secs(3)).await;
             node.shutdown().await.unwrap();
         })
     }
@@ -1443,10 +1440,16 @@ mod tests {
         // Run all nodes. We are testing that peers gracefully handle starting a sync session while
         // not knowing the other peer's address yet. Eventually all peers complete at least one
         // sync session.
+        //
+        // We sleep briefly to give nodes enough time to complete sync sessions.
         let handle1 = run_node(node_1, topic.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
         let handle2 = run_node(node_2, topic.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
         let handle3 = run_node(node_3, topic.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
         let handle4 = run_node(node_4, topic.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         let (result1, result2, result3, result4) = tokio::join!(handle1, handle2, handle3, handle4);
 

--- a/p2panda-net/src/sync/manager.rs
+++ b/p2panda-net/src/sync/manager.rs
@@ -9,14 +9,14 @@ use p2panda_core::PublicKey;
 use p2panda_sync::{SyncError, TopicQuery};
 use thiserror::Error;
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tokio::time::{interval, Duration, Instant};
+use tokio::time::{Duration, Instant, interval};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 
 use crate::engine::ToEngineActor;
 use crate::from_public_key;
 use crate::sync::config::FALLBACK_RESYNC_INTERVAL_SEC;
-use crate::sync::{self, SyncConfiguration, SYNC_CONNECTION_ALPN};
+use crate::sync::{self, SYNC_CONNECTION_ALPN, SyncConfiguration};
 
 /// Events sent to the sync manager.
 #[derive(Debug)]
@@ -364,17 +364,17 @@ mod tests {
     use iroh::{Endpoint, RelayMode};
     use iroh_quinn::TransportConfig;
     use p2panda_core::PublicKey;
-    use p2panda_sync::test_protocols::{PingPongProtocol, SyncTestTopic as TestTopic};
     use p2panda_sync::SyncProtocol;
+    use p2panda_sync::test_protocols::{PingPongProtocol, SyncTestTopic as TestTopic};
     use tokio::sync::mpsc;
-    use tokio::time::{sleep, Duration};
+    use tokio::time::{Duration, sleep};
     use tokio_util::sync::CancellationToken;
     use tracing::warn;
 
     use crate::engine::ToEngineActor;
     use crate::protocols::ProtocolMap;
-    use crate::sync::{SyncConnection, SYNC_CONNECTION_ALPN};
-    use crate::{to_public_key, ResyncConfiguration, SyncConfiguration};
+    use crate::sync::{SYNC_CONNECTION_ALPN, SyncConnection};
+    use crate::{ResyncConfiguration, SyncConfiguration, to_public_key};
 
     use super::{SyncActor, ToSyncActor};
 

--- a/p2panda-net/src/sync/manager.rs
+++ b/p2panda-net/src/sync/manager.rs
@@ -243,9 +243,9 @@ where
 
     /// Remove all sessions for the given topic.
     async fn on_forget(&mut self, topic: T) {
-        self.sessions.retain(|scope, _| scope.topic == topic);
-        self.resync_queue.retain(|scope| scope.topic == topic);
-        self.retry_queue.retain(|scope| scope.topic == topic);
+        self.sessions.retain(|scope, _| scope.topic != topic);
+        self.resync_queue.retain(|scope| scope.topic != topic);
+        self.retry_queue.retain(|scope| scope.topic != topic);
     }
 
     /// Reset state for all sessions and schedule new attempts.

--- a/p2panda-net/src/sync/manager.rs
+++ b/p2panda-net/src/sync/manager.rs
@@ -9,14 +9,14 @@ use p2panda_core::PublicKey;
 use p2panda_sync::{SyncError, TopicQuery};
 use thiserror::Error;
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tokio::time::{interval, Duration, Instant};
+use tokio::time::{Duration, Instant, interval};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 
 use crate::engine::ToEngineActor;
 use crate::from_public_key;
 use crate::sync::config::FALLBACK_RESYNC_INTERVAL_SEC;
-use crate::sync::{self, SyncConfiguration, SYNC_CONNECTION_ALPN};
+use crate::sync::{self, SYNC_CONNECTION_ALPN, SyncConfiguration};
 
 /// Events sent to the sync manager.
 #[derive(Debug)]
@@ -376,17 +376,17 @@ mod tests {
     use iroh::{Endpoint, RelayMode};
     use iroh_quinn::TransportConfig;
     use p2panda_core::PublicKey;
-    use p2panda_sync::test_protocols::{PingPongProtocol, SyncTestTopic as TestTopic};
     use p2panda_sync::SyncProtocol;
+    use p2panda_sync::test_protocols::{PingPongProtocol, SyncTestTopic as TestTopic};
     use tokio::sync::mpsc;
-    use tokio::time::{sleep, Duration};
+    use tokio::time::{Duration, sleep};
     use tokio_util::sync::CancellationToken;
     use tracing::warn;
 
     use crate::engine::ToEngineActor;
     use crate::protocols::ProtocolMap;
-    use crate::sync::{SyncConnection, SYNC_CONNECTION_ALPN};
-    use crate::{to_public_key, ResyncConfiguration, SyncConfiguration};
+    use crate::sync::{SYNC_CONNECTION_ALPN, SyncConnection};
+    use crate::{ResyncConfiguration, SyncConfiguration, to_public_key};
 
     use super::{SyncActor, ToSyncActor};
 


### PR DESCRIPTION
## Public API

The main change to the public API is that calls to `Network::subscribe()` now return our own types (`TopicSender` and `TopicReceiver`) instead of the `tokio` equivalents (`mpsc::Sender` and `mpsc::Receiver`). These new types allow us to implement `Drop` to invoke custom unsubscribe behaviour.

We also introduce `TopicReceiverStream`, a thin wrapper around `TopicReceiver` which implements `Stream`. This is effectively a replacement for using the `ReceiverStream` wrapper from `tokio_stream`.

## Internal Implementation

There is quite a lot of state to keep track of and modify internally. One important consideration is that we need to account for a topic having been subscribed to multiple times; in that case, the complete unsubscribe actions should only occur once _all_ senders and receivers for that topic have been dropped. This PR introduces a counter for each topic we've joined (using `topic_id` as key); we only leave the `gossip_joined` state once the counter reaches zero.

Each `TopicSender` and `TopicReceiver` holds some state (such as the `stream_id`) and uses an `mpsc::Sender` to inform the engine actor once it has been dropped. Those events are then passed along to relevant sub-systems: the gossip actor, sync manager and system events stream.

The majority of state regarding the streams is held in the `topic_streams` module. I've moved the `TopicSender` and `TopicReceiver` into separate sub-modules to hopefully keep things clear.

-----

## Open Questions

Should we implement more methods on `TopicSender` and `TopicReceiver` (ie. methods from `tokio::mpsc::Sender` and `tokio::mpsc::Receiver`)? I've implemented the bare minimum for now.

Closes https://github.com/p2panda/p2panda/issues/639

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
