### PR TITLE
Fuzz-testing Two-Party protocol (2SM)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,10 +10,18 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 p2panda-core = { path = "../p2panda-core", features = ["arbitrary"] }
+p2panda-group = { path = "../p2panda-group", features = ["test_utils"] }
 
 [[bin]]
 name = "header_e2e"
 path = "fuzz_targets/header_e2e.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "groups_2sm"
+path = "fuzz_targets/groups_2sm.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/groups_2sm.rs
+++ b/fuzz/fuzz_targets/groups_2sm.rs
@@ -9,6 +9,10 @@ use p2panda_group::test_utils::SecretKey;
 use p2panda_group::traits::PreKeyManager;
 use p2panda_group::{KeyManager, Lifetime, OneTimeTwoParty, Rng, TwoPartyMessage};
 
+/// Max. number of messages in a member's inbox.
+const INBOX_CAPACITY: usize = 128;
+
+/// Assertable 2SM message.
 struct Message {
     /// Expected message in plaintext.
     expected: Vec<u8>,
@@ -46,14 +50,14 @@ fuzz_target!(|args: ([u8; 32], &[u8])| {
     let mut alice_2sm = OneTimeTwoParty::init(bob_prekey_bundle.clone());
     let mut bob_2sm = OneTimeTwoParty::init(alice_prekey_bundle.clone());
 
-    let mut to_alice_inbox = VecDeque::<Message>::new();
-    let mut to_bob_inbox = VecDeque::<Message>::new();
+    let mut to_alice_inbox = VecDeque::<Message>::with_capacity(INBOX_CAPACITY);
+    let mut to_bob_inbox = VecDeque::<Message>::with_capacity(INBOX_CAPACITY);
 
     for action in actions {
         match action % 4 {
             0 => {
                 // Only send to Bob if their inbox is not too full.
-                if to_bob_inbox.len() > 128 {
+                if to_bob_inbox.len() >= INBOX_CAPACITY {
                     continue;
                 }
 
@@ -72,7 +76,7 @@ fuzz_target!(|args: ([u8; 32], &[u8])| {
             }
             1 => {
                 // Only send to Alice if their inbox is not too full.
-                if to_alice_inbox.len() > 128 {
+                if to_alice_inbox.len() >= INBOX_CAPACITY {
                     continue;
                 }
 

--- a/fuzz/fuzz_targets/groups_2sm.rs
+++ b/fuzz/fuzz_targets/groups_2sm.rs
@@ -1,0 +1,65 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use p2panda_group::test_utils::SecretKey;
+use p2panda_group::traits::PreKeyManager;
+use p2panda_group::{KeyManager, Lifetime, OneTimeTwoParty, Rng};
+
+fuzz_target!(|args: ([u8; 32], &[u8])| {
+    let (seed, actions) = args;
+
+    let rng = Rng::from_seed(seed);
+
+    // Alice generates their long-term key material.
+
+    let alice_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
+    let alice_manager =
+        KeyManager::init(&alice_identity_secret, Lifetime::default(), &rng).unwrap();
+
+    let (mut alice_manager, alice_prekey_bundle) =
+        KeyManager::generate_onetime_bundle(alice_manager, &rng).unwrap();
+
+    // Bob generates their long-term key material.
+
+    let bob_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
+    let bob_manager = KeyManager::init(&bob_identity_secret, Lifetime::default(), &rng).unwrap();
+
+    let (mut bob_manager, bob_prekey_bundle) =
+        KeyManager::generate_onetime_bundle(bob_manager, &rng).unwrap();
+
+    // Alice and Bob set up the 2SM protocol handlers for each other.
+
+    let mut alice_2sm = OneTimeTwoParty::init(bob_prekey_bundle.clone());
+    let mut bob_2sm = OneTimeTwoParty::init(alice_prekey_bundle.clone());
+
+    for action in actions {
+        // Generate a random message with 128 characters.
+        let expected: Vec<u8> = rng.random_vec(128).unwrap();
+
+        // Randomly decide if Alice sends a message to Bob or vice versa.
+        if action & 1 == 0 {
+            let (alice_2sm_i, message) =
+                OneTimeTwoParty::send(alice_2sm, &alice_manager, &expected, &rng).unwrap();
+            let (bob_2sm_i, bob_manager_i, received) =
+                OneTimeTwoParty::receive(bob_2sm, bob_manager, message).unwrap();
+
+            alice_2sm = alice_2sm_i;
+            bob_2sm = bob_2sm_i;
+            bob_manager = bob_manager_i;
+
+            assert_eq!(expected, received);
+        } else {
+            let (bob_2sm_i, message) =
+                OneTimeTwoParty::send(bob_2sm, &bob_manager, &expected, &rng).unwrap();
+            let (alice_2sm_i, alice_manager_i, received) =
+                OneTimeTwoParty::receive(alice_2sm, alice_manager, message).unwrap();
+
+            bob_2sm = bob_2sm_i;
+            alice_2sm = alice_2sm_i;
+            alice_manager = alice_manager_i;
+
+            assert_eq!(expected, received);
+        };
+    }
+});

--- a/fuzz/fuzz_targets/groups_2sm.rs
+++ b/fuzz/fuzz_targets/groups_2sm.rs
@@ -94,7 +94,7 @@ fuzz_target!(|args: ([u8; 32], &[u8])| {
                 });
             }
             2 => {
-                // Alice reads their messages in the inbox if there is anything.
+                // Alice reads one message in their inbox if there is anything.
                 let Some(message) = to_alice_inbox.pop_front() else {
                     break;
                 };
@@ -108,7 +108,7 @@ fuzz_target!(|args: ([u8; 32], &[u8])| {
                 assert_eq!(message.expected, received);
             }
             3 => {
-                // Bob reads their messages in the inbox if there is anything.
+                // Bob reads one message in their inbox if there is anything.
                 let Some(message) = to_bob_inbox.pop_front() else {
                     break;
                 };

--- a/fuzz/fuzz_targets/header_e2e.rs
+++ b/fuzz/fuzz_targets/header_e2e.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;

--- a/p2panda-group/Cargo.toml
+++ b/p2panda-group/Cargo.toml
@@ -15,6 +15,10 @@ all-features = true
 [lints]
 workspace = true
 
+[features]
+default = []
+test_utils = []
+
 [dependencies]
 chacha20poly1305 = { version = "0.10.1", features = ["alloc"], default-features = false }
 curve25519-dalek = "4.1.3"

--- a/p2panda-group/src/crypto/rng.rs
+++ b/p2panda-group/src/crypto/rng.rs
@@ -18,7 +18,7 @@ impl Default for Rng {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test_utils"))]
 impl Rng {
     pub fn from_seed(seed: [u8; 32]) -> Self {
         Self {

--- a/p2panda-group/src/crypto/x25519.rs
+++ b/p2panda-group/src/crypto/x25519.rs
@@ -27,6 +27,11 @@ impl SecretKey {
         SecretKey(Secret::from_bytes(clamp_integer(bytes)))
     }
 
+    #[cfg(feature = "test_utils")]
+    pub fn from_bytes(bytes: [u8; SECRET_KEY_SIZE]) -> Self {
+        SecretKey(Secret::from_bytes(clamp_integer(bytes)))
+    }
+
     pub(crate) fn as_bytes(&self) -> &[u8; SECRET_KEY_SIZE] {
         self.0.as_bytes()
     }

--- a/p2panda-group/src/crypto/x25519.rs
+++ b/p2panda-group/src/crypto/x25519.rs
@@ -23,6 +23,7 @@ pub const SHARED_SECRET_SIZE: usize = 32;
 pub struct SecretKey(Secret<SECRET_KEY_SIZE>);
 
 impl SecretKey {
+    #[cfg(not(feature = "test_utils"))]
     pub(crate) fn from_bytes(bytes: [u8; SECRET_KEY_SIZE]) -> Self {
         SecretKey(Secret::from_bytes(clamp_integer(bytes)))
     }

--- a/p2panda-group/src/lib.rs
+++ b/p2panda-group/src/lib.rs
@@ -13,7 +13,9 @@ pub use key_bundle::{
     Lifetime, LifetimeError, LongTermKeyBundle, OneTimeKeyBundle, OneTimePreKey, OneTimePreKeyId,
 };
 pub use key_manager::{KeyManager, KeyManagerError, KeyManagerState};
-pub use two_party::{LongTermTwoParty, OneTimeTwoParty, TwoParty, TwoPartyError};
+pub use two_party::{
+    LongTermTwoParty, OneTimeTwoParty, TwoParty, TwoPartyCiphertext, TwoPartyError, TwoPartyMessage,
+};
 
 #[cfg(feature = "test_utils")]
 pub mod test_utils {

--- a/p2panda-group/src/lib.rs
+++ b/p2panda-group/src/lib.rs
@@ -8,7 +8,14 @@ mod key_manager;
 pub mod traits;
 mod two_party;
 
+pub use crypto::{Rng, RngError};
 pub use key_bundle::{
     Lifetime, LifetimeError, LongTermKeyBundle, OneTimeKeyBundle, OneTimePreKey, OneTimePreKeyId,
 };
 pub use key_manager::{KeyManager, KeyManagerError, KeyManagerState};
+pub use two_party::{LongTermTwoParty, OneTimeTwoParty, TwoParty, TwoPartyError};
+
+#[cfg(feature = "test_utils")]
+pub mod test_utils {
+    pub use crate::crypto::x25519::SecretKey;
+}


### PR DESCRIPTION
> Related to https://github.com/p2panda/p2panda/pull/732

This PR introduces a fuzz-test for testing the two party key-agreement protocol (2SM). The test randomly generates an "action" sequence, while each action can either send a message from Alice to Bob's inbox, or Bob to Alice's inbox, or Alice reads a message from the inbox or Bob reads a message from the inbox.

Additionally this PR adds a `test_utils` feature flag to the crate, so other crates can get access to more "hazardous" APIs. This will be re-fined in subsequent PRs (currently the public APIs do not make much sense).

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] New files contain a SPDX license header
