### PR TITLE
Update dependencies (including iroh to `0.34.1`) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Highlights are marked with a pancake 🥞
 - Wait for relay connection initialisation and first direct address [#725](https://github.com/p2panda/p2panda/pull/725)
 - Only decrement the gossip buffer counter if it exists and is greater than zero [#722](https://github.com/p2panda/p2panda/pull/722)
 
+### Changed
+
+-  Update dependencies (including iroh to `0.34.1`) [#738](https://github.com/p2panda/p2panda/pull/738)
+
 ## [0.3.0] - 11/03/2025
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@ Highlights are marked with a pancake 🥞
 
 - Partial ordering algorithm for operations [#710](https://github.com/p2panda/p2panda/pull/710)
 
+### Changed
+
+- Update dependencies (including iroh `v0.34.1`) [#738](https://github.com/p2panda/p2panda/pull/738)
+
 ### Fixed
 
 - Wait for relay connection initialisation and first direct address [#725](https://github.com/p2panda/p2panda/pull/725)
 - Only decrement the gossip buffer counter if it exists and is greater than zero [#722](https://github.com/p2panda/p2panda/pull/722)
-
-### Changed
-
--  Update dependencies (including iroh to `0.34.1`) [#738](https://github.com/p2panda/p2panda/pull/738)
 
 ## [0.3.0] - 11/03/2025
 

--- a/p2panda-blobs/Cargo.toml
+++ b/p2panda-blobs/Cargo.toml
@@ -20,12 +20,12 @@ all-features = true
 workspace = true
 
 [dependencies]
-anyhow = "1.0.86"
+anyhow = "1.0.97"
 async-channel = "2.3.1"
-bytes = "1.7.1"
-futures-buffered = "0.2.8"
-futures-lite = "2.3.0"
-futures-util = "0.3.30"
+bytes = "1.10.1"
+futures-buffered = "0.2.11"
+futures-lite = "2.6.0"
+futures-util = "0.3.31"
 iroh = { version = "0.34.1", default-features = false }
 iroh-base = "0.34.1"
 iroh-blobs = { version = "0.34.1", features = ["downloader", "fs-store"], default-features = false }
@@ -33,7 +33,7 @@ iroh-io = "0.6.1"
 p2panda-core = { path = "../p2panda-core", version = "0.3.0" }
 p2panda-net = { path = "../p2panda-net", version = "0.3.0" }
 p2panda-sync = { path = "../p2panda-sync", version = "0.3.0" }
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive"] }
 serde-error = "0.1.3"
-tokio = { version = "1.42.0", features = ["fs"] }
-tracing = "0.1.40"
+tokio = { version = "1.44.2", features = ["fs"] }
+tracing = "0.1.41"

--- a/p2panda-blobs/Cargo.toml
+++ b/p2panda-blobs/Cargo.toml
@@ -26,9 +26,9 @@ bytes = "1.7.1"
 futures-buffered = "0.2.8"
 futures-lite = "2.3.0"
 futures-util = "0.3.30"
-iroh = { version = "0.33.0", default-features = false }
-iroh-base = "0.33.0"
-iroh-blobs = { version = "0.33.0", features = ["downloader", "fs-store"], default-features = false }
+iroh = { version = "0.34.1", default-features = false }
+iroh-base = "0.34.1"
+iroh-blobs = { version = "0.34.1", features = ["downloader", "fs-store"], default-features = false }
 iroh-io = "0.6.1"
 p2panda-core = { path = "../p2panda-core", version = "0.3.0" }
 p2panda-net = { path = "../p2panda-net", version = "0.3.0" }

--- a/p2panda-core/Cargo.toml
+++ b/p2panda-core/Cargo.toml
@@ -24,15 +24,15 @@ default = ["prune"]
 prune = []
 
 [dependencies]
-arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
-blake3 = "1.5.1"
+arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
+blake3 = "1.8.1"
 ciborium = "0.2.2"
-ed25519-dalek = { version = "2.1.0", features = ["rand_core"] }
+ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 hex = { version = "0.4.3", features = ["serde"] }
 rand = "0.8.5"
-serde = { version = "1.0.215", features = ["derive"] }
-serde_bytes = { version = "0.11.15" }
-thiserror = "1.0.63"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_bytes = { version = "0.11.17" }
+thiserror = "2.0.12"
 
 [dev-dependencies]
-serde_json = "1.0.120"
+serde_json = "1.0.140"

--- a/p2panda-discovery/Cargo.toml
+++ b/p2panda-discovery/Cargo.toml
@@ -30,8 +30,8 @@ flume = "0.11.0"
 futures-buffered = "0.2.8"
 futures-lite = "2.3.0"
 hickory-proto = { version = "0.24.1", optional = true }
-iroh = { version = "0.33.0", default-features = false }
-iroh-base = "0.33.0"
+iroh = { version = "0.34.1", default-features = false }
+iroh-base = "0.34.1"
 netwatch = "0.2.0"
 socket2 = { version = "0.5.7", optional = true }
 tokio = { version = "1.42.0", features = ["net", "sync"] }

--- a/p2panda-discovery/Cargo.toml
+++ b/p2panda-discovery/Cargo.toml
@@ -24,16 +24,16 @@ default = []
 mdns = ["dep:hickory-proto", "dep:socket2", "dep:base32"]
 
 [dependencies]
-anyhow = "1.0.86"
+anyhow = "1.0.97"
 base32 = { version = "0.5.1", optional = true }
-flume = "0.11.0"
-futures-buffered = "0.2.8"
-futures-lite = "2.3.0"
-hickory-proto = { version = "0.24.1", optional = true }
+flume = "0.11.1"
+futures-buffered = "0.2.11"
+futures-lite = "2.6.0"
+hickory-proto = { version = "0.25.1", optional = true }
 iroh = { version = "0.34.1", default-features = false }
 iroh-base = "0.34.1"
-netwatch = "0.2.0"
-socket2 = { version = "0.5.7", optional = true }
-tokio = { version = "1.42.0", features = ["net", "sync"] }
-tokio-util = { version = "0.7.11", features = ["codec", "io-util", "io"] }
-tracing = "0.1.40"
+netwatch = "0.4.0"
+socket2 = { version = "0.5.9", optional = true }
+tokio = { version = "1.44.2", features = ["net", "sync"] }
+tokio-util = { version = "0.7.14", features = ["codec", "io-util", "io"] }
+tracing = "0.1.41"

--- a/p2panda-discovery/src/mdns/dns.rs
+++ b/p2panda-discovery/src/mdns/dns.rs
@@ -6,7 +6,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
 use hickory_proto::op::{Message, MessageType, Query};
-use hickory_proto::rr::{DNSClass, Name, RData, Record, RecordType, rdata};
+use hickory_proto::rr::{rdata, DNSClass, Name, RData, Record, RecordType};
 use iroh::{NodeAddr, NodeId};
 use tracing::{debug, trace};
 
@@ -179,7 +179,7 @@ fn parse_response(message: &Message) -> Option<MulticastDNSMessage> {
             };
             node_id
         };
-        let Some(RData::SRV(srv)) = answer.data() else {
+        let RData::SRV(srv) = answer.data() else {
             trace!("received mdns response with wrong data {:?}", answer.data());
             continue;
         };
@@ -206,8 +206,8 @@ fn parse_response(message: &Message) -> Option<MulticastDNSMessage> {
         }
         trace!("received mdns additional for {}", name);
         let ip: IpAddr = match additional.data() {
-            Some(RData::A(addr)) => addr.0.into(),
-            Some(RData::AAAA(addr)) => addr.0.into(),
+            RData::A(addr) => addr.0.into(),
+            RData::AAAA(addr) => addr.0.into(),
             _ => {
                 debug!(
                     "received mdns additional with wrong data {:?}",

--- a/p2panda-discovery/src/mdns/dns.rs
+++ b/p2panda-discovery/src/mdns/dns.rs
@@ -6,7 +6,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
 use hickory_proto::op::{Message, MessageType, Query};
-use hickory_proto::rr::{rdata, DNSClass, Name, RData, Record, RecordType};
+use hickory_proto::rr::{DNSClass, Name, RData, Record, RecordType, rdata};
 use iroh::{NodeAddr, NodeId};
 use tracing::{debug, trace};
 

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -30,9 +30,9 @@ async-trait = "0.1.82"
 ciborium = "0.2.2"
 futures-lite = "2.3.0"
 futures-util = "0.3.30"
-iroh = { version = "0.33.0", default-features = false }
-iroh-base = "0.33.0"
-iroh-gossip = "0.33.0"
+iroh = { version = "0.34.1", default-features = false }
+iroh-base = "0.34.1"
+iroh-gossip = "0.34.1"
 iroh-quinn = { version = "0.13.0", features = ["futures-io"] }
 netwatch = "0.2.0"
 p2panda-core = { path = "../p2panda-core", version = "0.3.0" }

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -25,29 +25,29 @@ log-sync = []
 mdns-discovery = ["p2panda-discovery/mdns"]
 
 [dependencies]
-anyhow = "1.0.86"
-async-trait = "0.1.82"
+anyhow = "1.0.97"
+async-trait = "0.1.88"
 ciborium = "0.2.2"
-futures-lite = "2.3.0"
-futures-util = "0.3.30"
+futures-lite = "2.6.0"
+futures-util = "0.3.31"
 iroh = { version = "0.34.1", default-features = false }
 iroh-base = "0.34.1"
 iroh-gossip = "0.34.1"
 iroh-quinn = { version = "0.13.0", features = ["futures-io"] }
-netwatch = "0.2.0"
+netwatch = "0.4.0"
 p2panda-core = { path = "../p2panda-core", version = "0.3.0" }
 p2panda-discovery = { path = "../p2panda-discovery", version = "0.3.0" }
 p2panda-sync = { path = "../p2panda-sync", version = "0.3.0", features = ["log-sync"] }
 rand = "0.8.5"
-serde = { version = "1.0.215", features = ["derive"] }
-thiserror = "1.0.63"
-tokio = { version = "1.42.0", features = ["rt", "sync", "time"] }
-tokio-stream = { version = "0.1.15", features = ["sync"] }
-tokio-util = { version = "0.7.11", features = ["compat", "codec", "io-util", "io"] }
-tracing = "0.1.40"
+serde = { version = "1.0.219", features = ["derive"] }
+thiserror = "2.0.12"
+tokio = { version = "1.44.2", features = ["rt", "sync", "time"] }
+tokio-stream = { version = "0.1.17", features = ["sync"] }
+tokio-util = { version = "0.7.14", features = ["compat", "codec", "io-util", "io"] }
+tracing = "0.1.41"
 
 [dev-dependencies]
-clap = { version = "4.5.29", features = ["derive"] }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+clap = { version = "4.5.35", features = ["derive"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 p2panda-sync = { path = "../p2panda-sync", version = "0.3.0", features = ["log-sync", "test-protocols"] }
 p2panda-store = { path = "../p2panda-store", version = "0.3.0" }

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -31,10 +31,10 @@ hex = { version = "0.4.3", optional = true }
 p2panda-core = { path = "../p2panda-core", version = "0.3.0" }
 rand = { version = "0.8.5", optional = true }
 sqlx = { version = "0.8.3", optional = true, features = ["sqlite", "runtime-tokio"] }
-thiserror = "2.0.11"
+thiserror = "2.0.12"
 trait-variant = "0.1.2"
 
 [dev-dependencies]
 rand = "0.8.5"
-serde = "1.0.215"
-tokio = { version = "1.42.0", features = ["rt", "macros"] }
+serde = "1.0.219"
+tokio = { version = "1.44.2", features = ["rt", "macros"] }

--- a/p2panda-stream/Cargo.toml
+++ b/p2panda-stream/Cargo.toml
@@ -21,17 +21,17 @@ workspace = true
 
 [dependencies]
 ciborium = "0.2.2"
-futures-channel = "0.3.30"
-futures-util = { version = "0.3.30", features = ["sink"] }
+futures-channel = "0.3.31"
+futures-util = { version = "0.3.31", features = ["sink"] }
 p2panda-core = { path = "../p2panda-core", version = "0.3.0", features = ["prune"] }
 p2panda-store = { path = "../p2panda-store", version = "0.3.0" }
-pin-project = "1.1.5"
+pin-project = "1.1.10"
 pin-utils = "0.1.0"
-thiserror = "1.0.63"
+thiserror = "2.0.12"
 
 [dev-dependencies]
-async-stream = "0.3.5"
+async-stream = "0.3.6"
 p2panda-store = { path = "../p2panda-store", version = "0.3.0", features = ["sqlite", "test_utils"] }
-serde = { version = "1.0.215", features = ["derive"] }
-tokio = { version = "1.42.0", features = ["rt", "macros"] }
+serde = { version = "1.0.219", features = ["derive"] }
+tokio = { version = "1.44.2", features = ["rt", "macros"] }
 tokio-stream = "0.1.17"

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -26,22 +26,22 @@ test-protocols = ["dep:p2panda-core", "serde/derive", "cbor", "dep:tracing",
 "dep:futures-lite", "dep:futures-util"]
 
 [dependencies]
-async-trait = "0.1.82"
-futures = "0.3.30"
-futures-lite = { version = "2.3.0", optional = true }
-futures-util = { version = "0.3.30", optional = true }
+async-trait = "0.1.88"
+futures = "0.3.31"
+futures-lite = { version = "2.6.0", optional = true }
+futures-util = { version = "0.3.31", optional = true }
 p2panda-core = { path = "../p2panda-core", version = "0.3.0", optional = true }
 p2panda-store = { path = "../p2panda-store", version = "0.3.0", optional = true, default-features = false }
-serde = { version = "1.0.215" }
-tokio-util = { version = "0.7.11", features = [
+serde = { version = "1.0.219" }
+tokio-util = { version = "0.7.14", features = [
     "codec",
     "compat",
 ], optional = true }
-tokio = { version = "1.42.0", features = ["sync", "time", "rt"], optional = true }
-thiserror = "1.0.63"
-tracing = { version = "0.1.40", optional = true }
+tokio = { version = "1.44.2", features = ["sync", "time", "rt"], optional = true }
+thiserror = "2.0.12"
+tracing = { version = "0.1.41", optional = true }
 
 [dev-dependencies]
 p2panda-store = { path = "../p2panda-store", version = "0.3.0", features = [ "memory" ] }
-tokio = { version = "1.42.0", features = ["rt", "macros", "net", "io-util"] }
-tokio-stream = { version = "0.1.15" }
+tokio = { version = "1.44.2", features = ["rt", "macros", "net", "io-util"] }
+tokio-stream = { version = "0.1.17" }


### PR DESCRIPTION
Dependency maintenance.

iroh -> `0.34.1` : no breaking changes

Updating `hickory-proto` introduced a small change.

I couldn't update to the latest version of `rand` (`0.9.0`) because `ed25519-dalek` relies on an incompatible version of `rand_core`.

Fixes https://github.com/p2panda/p2panda/issues/695

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes