### PR TITLE
DCGKA and group secret bundles for data encryption scheme

### DIFF
--- a/p2panda-group/src/crypto/sha2.rs
+++ b/p2panda-group/src/crypto/sha2.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! SHA2 hashing functions.
-use sha2::{Digest, Sha512};
+use sha2::{Digest, Sha256, Sha512};
 
 pub const SHA512_DIGEST_SIZE: usize = 64;
+
+pub const SHA256_DIGEST_SIZE: usize = 32;
 
 /// SHA2-512 hashing function.
 pub fn sha2_512(messages: &[&[u8]]) -> [u8; SHA512_DIGEST_SIZE] {
@@ -13,4 +15,14 @@ pub fn sha2_512(messages: &[&[u8]]) -> [u8; SHA512_DIGEST_SIZE] {
     }
     let result = hasher.finalize();
     result[..].try_into().expect("sha512 digest size")
+}
+
+/// SHA2-256 hashing function.
+pub fn sha2_256(messages: &[&[u8]]) -> [u8; SHA256_DIGEST_SIZE] {
+    let mut hasher = Sha256::new();
+    for message in messages {
+        hasher.update(message);
+    }
+    let result = hasher.finalize();
+    result[..].try_into().expect("sha256 digest size")
 }

--- a/p2panda-group/src/data_scheme/data.rs
+++ b/p2panda-group/src/data_scheme/data.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::crypto::xchacha20::{XAeadError, XAeadNonce, x_aead_decrypt, x_aead_encrypt};
+use crate::data_scheme::group_secret::GroupSecret;
+
+pub fn encrypt_data(
+    plaintext: &[u8],
+    group_secret: &GroupSecret,
+    nonce: XAeadNonce,
+) -> Result<Vec<u8>, XAeadError> {
+    let ciphertext = x_aead_encrypt(group_secret.as_bytes(), plaintext, nonce, None)?;
+    Ok(ciphertext)
+}
+
+pub fn decrypt_data(
+    ciphertext: &[u8],
+    group_secret: &GroupSecret,
+    nonce: XAeadNonce,
+) -> Result<Vec<u8>, XAeadError> {
+    let plaintext = x_aead_decrypt(group_secret.as_bytes(), ciphertext, nonce, None)?;
+    Ok(plaintext)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Rng;
+    use crate::crypto::xchacha20::XAeadNonce;
+    use crate::data_scheme::GroupSecret;
+
+    use super::{decrypt_data, encrypt_data};
+
+    #[test]
+    fn encrypt_decrypt() {
+        let rng = Rng::from_seed([1; 32]);
+
+        let group_secret = GroupSecret::from_rng(&rng).unwrap();
+        let nonce: XAeadNonce = rng.random_array().unwrap();
+
+        let message = encrypt_data(b"Service! Service!", &group_secret, nonce).unwrap();
+        let receive = decrypt_data(&message, &group_secret, nonce).unwrap();
+        assert_eq!(receive, b"Service! Service!");
+    }
+}

--- a/p2panda-group/src/data_scheme/dcgka.rs
+++ b/p2panda-group/src/data_scheme/dcgka.rs
@@ -1,0 +1,621 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::{Debug, Display};
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::crypto::hkdf::HkdfError;
+use crate::crypto::{Rng, RngError};
+use crate::data_scheme::{GroupSecret, GroupSecretBundle, GroupSecretError};
+use crate::key_bundle::LongTermKeyBundle;
+use crate::traits::{
+    GroupMembership, IdentityHandle, IdentityManager, IdentityRegistry, OperationId, PreKeyManager,
+    PreKeyRegistry,
+};
+use crate::two_party::{TwoParty, TwoPartyError, TwoPartyMessage, TwoPartyState};
+
+/// A decentralized continuous group key agreement protocol (DCGKA) for p2panda's "data
+/// encryption" scheme with strong forward-secrecy and post-compromise security.
+pub struct Dcgka<ID, OP, PKI, DGM, KMG> {
+    _marker: PhantomData<(ID, OP, PKI, DGM, KMG)>,
+}
+
+/// Serializable state of DCGKA (for persistence).
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
+pub struct DcgkaState<ID, OP, PKI, DGM, KMG>
+where
+    ID: IdentityHandle,
+    OP: OperationId,
+    PKI: IdentityRegistry<ID, PKI::State> + PreKeyRegistry<ID, LongTermKeyBundle>,
+    DGM: GroupMembership<ID, OP>,
+    KMG: IdentityManager<KMG::State> + PreKeyManager,
+{
+    pub(crate) pki: PKI::State,
+    pub(crate) my_keys: KMG::State,
+    pub(crate) my_id: ID,
+    pub(crate) two_party: HashMap<ID, TwoPartyState<LongTermKeyBundle>>,
+    pub(crate) dgm: DGM::State,
+}
+
+impl<ID, OP, PKI, DGM, KMG> Dcgka<ID, OP, PKI, DGM, KMG>
+where
+    ID: IdentityHandle,
+    OP: OperationId,
+    PKI: IdentityRegistry<ID, PKI::State> + PreKeyRegistry<ID, LongTermKeyBundle>,
+    DGM: GroupMembership<ID, OP>,
+    KMG: IdentityManager<KMG::State> + PreKeyManager,
+{
+    /// Returns new DCGKA state with our own identity and key managers.
+    ///
+    /// Use this when creating a new group or before accepting an invitation to an existing one.
+    pub fn init(
+        my_id: ID,
+        my_keys: KMG::State,
+        pki: PKI::State,
+        dgm: DGM::State,
+    ) -> DcgkaState<ID, OP, PKI, DGM, KMG> {
+        DcgkaState {
+            pki,
+            my_id,
+            my_keys,
+            two_party: HashMap::new(),
+            dgm,
+        }
+    }
+
+    /// Handler for when a "remote" control message is received from the network.
+    ///
+    /// It takes the user ID of the message sender, a control message, and a direct message (or
+    /// none if there is no associated direct message).
+    ///
+    /// Control messages are expected to be authenticated and causally ordered.
+    pub fn process_remote(
+        y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        sender: ID,
+        message: ProcessMessage<ID>,
+    ) -> DcgkaProcessResult<ID, OP, PKI, DGM, KMG> {
+        let (y_i, output) = match message {
+            ProcessMessage::Create(CreateMessage { initial_members }, direct_message) => {
+                Self::process_create(y, &sender, initial_members, direct_message)?
+            }
+            ProcessMessage::Update(_, direct_message) => {
+                Self::process_update(y, &sender, direct_message)?
+            }
+            ProcessMessage::Remove(RemoveMessage { removed }, direct_message) => {
+                Self::process_remove(y, sender, &removed, direct_message)?
+            }
+            ProcessMessage::Add(AddMessage { added }, direct_message) => {
+                Self::process_add(y, sender, added, direct_message)?
+            }
+        };
+        Ok((y_i, output))
+    }
+
+    pub fn create(
+        y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        initial_members: Vec<ID>,
+        rng: &Rng,
+    ) -> DcgkaOperationResult<ID, OP, PKI, DGM, KMG> {
+        // De-duplicate members.
+        let mut initial_members: Vec<ID> =
+            initial_members.into_iter().fold(Vec::new(), |mut acc, id| {
+                if !acc.contains(&id) {
+                    acc.push(id);
+                }
+                acc
+            });
+
+        // Add ourselves if the user hasn't done it yet.
+        if !initial_members.contains(&y.my_id) {
+            initial_members.push(y.my_id);
+        }
+
+        // The "create" function constructs the "create" control message.
+        let control_message = ControlMessage {
+            message_type: ControlMessageType::Create(CreateMessage {
+                initial_members: initial_members.clone(),
+            }),
+        };
+
+        // Generate the set of direct messages to send.
+        let (y_ii, direct_messages, group_secret) =
+            Self::generate_secret(y, &initial_members, rng)?;
+
+        Ok((
+            y_ii,
+            OperationOutput {
+                control_message,
+                direct_messages,
+                group_secret: Some(group_secret),
+            },
+        ))
+    }
+
+    fn process_create(
+        mut y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        sender: &ID,
+        initial_members: Vec<ID>,
+        direct_message: DirectMessage<ID>,
+    ) -> DcgkaProcessResult<ID, OP, PKI, DGM, KMG> {
+        y.dgm =
+            DGM::create(y.my_id, &initial_members).map_err(|err| DcgkaError::DgmOperation(err))?;
+        Self::process_secret(y, sender, direct_message)
+    }
+
+    pub fn update(
+        y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        rng: &Rng,
+    ) -> DcgkaOperationResult<ID, OP, PKI, DGM, KMG> {
+        let control_message = ControlMessage {
+            message_type: ControlMessageType::Update(UpdateMessage),
+        };
+
+        let recipient_ids: Vec<ID> = Self::members(&y)?
+            .into_iter()
+            .filter(|member| member != &y.my_id)
+            .collect();
+
+        let (y_i, direct_messages, group_secret) = Self::generate_secret(y, &recipient_ids, rng)?;
+
+        Ok((
+            y_i,
+            OperationOutput {
+                control_message,
+                direct_messages,
+                group_secret: Some(group_secret),
+            },
+        ))
+    }
+
+    fn process_update(
+        y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        sender: &ID,
+        direct_message: DirectMessage<ID>,
+    ) -> DcgkaProcessResult<ID, OP, PKI, DGM, KMG> {
+        Self::process_secret(y, sender, direct_message)
+    }
+
+    pub fn remove(
+        y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        removed: ID,
+        rng: &Rng,
+    ) -> DcgkaOperationResult<ID, OP, PKI, DGM, KMG> {
+        let control_message = ControlMessage {
+            message_type: ControlMessageType::Remove(RemoveMessage { removed }),
+        };
+
+        let recipient_ids: Vec<ID> = Self::members(&y)?
+            .into_iter()
+            .filter(|member| member != &y.my_id && member != &removed)
+            .collect();
+
+        let (y_i, direct_messages, group_secret) = Self::generate_secret(y, &recipient_ids, rng)?;
+
+        Ok((
+            y_i,
+            OperationOutput {
+                control_message,
+                direct_messages,
+                group_secret: Some(group_secret),
+            },
+        ))
+    }
+
+    fn process_remove(
+        mut y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        sender: ID,
+        removed: &ID,
+        direct_message: DirectMessage<ID>,
+    ) -> DcgkaProcessResult<ID, OP, PKI, DGM, KMG> {
+        y.dgm = DGM::remove(y.dgm, sender, removed).map_err(|err| DcgkaError::DgmOperation(err))?;
+        Self::process_secret(y, &sender, direct_message)
+    }
+
+    pub fn add(
+        y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        added: ID,
+        bundle: &GroupSecretBundle,
+        rng: &Rng,
+    ) -> DcgkaOperationResult<ID, OP, PKI, DGM, KMG> {
+        // Construct a control message of type "add" to broadcast to the group
+        let control_message = ControlMessage {
+            message_type: ControlMessageType::Add(AddMessage { added }),
+        };
+
+        // Construct a welcome message that is sent to the new member as a direct message.
+        let (y_i, ciphertext) = {
+            let bundle_bytes = bundle.to_bytes()?;
+            Self::encrypt_to(y, &added, &bundle_bytes, rng)?
+        };
+        let direct_message = DirectMessage {
+            recipient: added,
+            content: DirectMessageContent::Welcome { ciphertext },
+        };
+
+        Ok((
+            y_i,
+            OperationOutput {
+                control_message,
+                direct_messages: vec![direct_message],
+                group_secret: None,
+            },
+        ))
+    }
+
+    fn process_add(
+        mut y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        sender: ID,
+        added: ID,
+        direct_message: Option<DirectMessage<ID>>,
+    ) -> DcgkaProcessResult<ID, OP, PKI, DGM, KMG> {
+        y.dgm = DGM::add(y.dgm, sender, added).map_err(|err| DcgkaError::DgmOperation(err))?;
+
+        if added == y.my_id {
+            let Some(DirectMessage {
+                recipient,
+                content: DirectMessageContent::Welcome { ciphertext },
+                ..
+            }) = direct_message
+            else {
+                return match direct_message {
+                    Some(direct_message) => Err(DcgkaError::UnexpectedDirectMessageType(
+                        DirectMessageType::Welcome,
+                        direct_message.message_type(),
+                    )),
+                    None => Err(DcgkaError::MissingDirectMessage(DirectMessageType::Welcome)),
+                };
+            };
+
+            if recipient != y.my_id {
+                return Err(DcgkaError::NotOurDirectMessage(y.my_id, recipient));
+            }
+
+            return Self::process_welcome(y, sender, ciphertext);
+        }
+
+        Ok((
+            y,
+            ProcessOutput {
+                control_message: None,
+                direct_messages: vec![],
+                group_secret: GroupSecretOutput::None,
+            },
+        ))
+    }
+
+    fn process_welcome(
+        y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        sender: ID,
+        ciphertext: TwoPartyMessage,
+    ) -> DcgkaProcessResult<ID, OP, PKI, DGM, KMG> {
+        let (y_i, bundle) = {
+            let (y_i, plaintext) = Self::decrypt_from(y, &sender, ciphertext)?;
+            let bundle = GroupSecretBundle::try_from_bytes(&plaintext)?;
+            (y_i, bundle)
+        };
+
+        Ok((
+            y_i,
+            ProcessOutput {
+                control_message: None,
+                direct_messages: vec![],
+                group_secret: GroupSecretOutput::Bundle(bundle),
+            },
+        ))
+    }
+
+    fn generate_secret(
+        y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        recipients: &[ID],
+        rng: &Rng,
+    ) -> GenerateSecretResult<ID, OP, PKI, DGM, KMG> {
+        let mut direct_messages: Vec<DirectMessage<ID>> = Vec::with_capacity(recipients.len());
+
+        let group_secret = GroupSecret::from_rng(rng)?;
+
+        let y_i = {
+            let mut y_loop = y;
+            for recipient in recipients {
+                // Skip ourselves.
+                if recipient == &y_loop.my_id {
+                    continue;
+                }
+
+                // Encrypt to every recipient.
+                let (y_next, ciphertext) =
+                    Self::encrypt_to(y_loop, recipient, group_secret.as_bytes(), rng)?;
+                y_loop = y_next;
+
+                direct_messages.push(DirectMessage {
+                    recipient: *recipient,
+                    content: DirectMessageContent::TwoParty { ciphertext },
+                });
+            }
+            y_loop
+        };
+
+        Ok((y_i, direct_messages, group_secret))
+    }
+
+    fn process_secret(
+        y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        sender: &ID,
+        direct_message: DirectMessage<ID>,
+    ) -> DcgkaProcessResult<ID, OP, PKI, DGM, KMG> {
+        let DirectMessage {
+            recipient,
+            content: DirectMessageContent::TwoParty { ciphertext },
+            ..
+        } = direct_message
+        else {
+            return Err(DcgkaError::UnexpectedDirectMessageType(
+                DirectMessageType::TwoParty,
+                direct_message.message_type(),
+            ));
+        };
+
+        if recipient != y.my_id {
+            return Err(DcgkaError::NotOurDirectMessage(y.my_id, recipient));
+        }
+
+        let (y_i, plaintext) = Self::decrypt_from(y, sender, ciphertext)?;
+        let group_secret = GroupSecret::try_from_bytes(&plaintext)?;
+
+        Ok((
+            y_i,
+            ProcessOutput {
+                control_message: None,
+                direct_messages: vec![],
+                group_secret: GroupSecretOutput::Secret(group_secret),
+            },
+        ))
+    }
+
+    fn encrypt_to(
+        mut y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        recipient: &ID,
+        plaintext: &[u8],
+        rng: &Rng,
+    ) -> DcgkaResult<ID, OP, PKI, DGM, KMG, TwoPartyMessage> {
+        let y_2sm = match y.two_party.remove(recipient) {
+            Some(y_2sm) => y_2sm,
+            None => {
+                let (pki_i, prekey_bundle) = PKI::key_bundle(y.pki, recipient)
+                    .map_err(|err| DcgkaError::PreKeyRegistry(err))?;
+                y.pki = pki_i;
+                let prekey_bundle = prekey_bundle.ok_or(DcgkaError::MissingPreKeys(*recipient))?;
+                TwoParty::<KMG, LongTermKeyBundle>::init(prekey_bundle)
+            }
+        };
+        let (y_2sm_i, ciphertext) =
+            TwoParty::<KMG, LongTermKeyBundle>::send(y_2sm, &y.my_keys, plaintext, rng)?;
+        y.two_party.insert(*recipient, y_2sm_i);
+        Ok((y, ciphertext))
+    }
+
+    fn decrypt_from(
+        mut y: DcgkaState<ID, OP, PKI, DGM, KMG>,
+        sender: &ID,
+        ciphertext: TwoPartyMessage,
+    ) -> DcgkaResult<ID, OP, PKI, DGM, KMG, Vec<u8>> {
+        let y_2sm = match y.two_party.remove(sender) {
+            Some(y_2sm) => y_2sm,
+            None => {
+                let (pki_i, prekey_bundle) = PKI::key_bundle(y.pki, sender)
+                    .map_err(|err| DcgkaError::PreKeyRegistry(err))?;
+                y.pki = pki_i;
+                let prekey_bundle = prekey_bundle.ok_or(DcgkaError::MissingPreKeys(*sender))?;
+                TwoParty::<KMG, LongTermKeyBundle>::init(prekey_bundle)
+            }
+        };
+        let (y_2sm_i, y_my_keys_i, plaintext) =
+            TwoParty::<KMG, LongTermKeyBundle>::receive(y_2sm, y.my_keys, ciphertext)?;
+        y.my_keys = y_my_keys_i;
+        y.two_party.insert(*sender, y_2sm_i);
+        Ok((y, plaintext))
+    }
+
+    fn members(
+        y: &DcgkaState<ID, OP, PKI, DGM, KMG>,
+    ) -> Result<HashSet<ID>, DcgkaError<ID, OP, PKI, DGM, KMG>> {
+        let members = DGM::members(&y.dgm).map_err(|err| DcgkaError::GroupMembership(err))?;
+        Ok(members)
+    }
+}
+
+pub type GenerateSecretResult<ID, OP, PKI, DGM, KMG> = Result<
+    (
+        DcgkaState<ID, OP, PKI, DGM, KMG>,
+        Vec<DirectMessage<ID>>,
+        GroupSecret,
+    ),
+    DcgkaError<ID, OP, PKI, DGM, KMG>,
+>;
+
+pub type DcgkaResult<ID, OP, PKI, DGM, KMG, T> =
+    Result<(DcgkaState<ID, OP, PKI, DGM, KMG>, T), DcgkaError<ID, OP, PKI, DGM, KMG>>;
+
+pub type DcgkaProcessResult<ID, OP, PKI, DGM, KMG> =
+    DcgkaResult<ID, OP, PKI, DGM, KMG, ProcessOutput<ID>>;
+
+pub type DcgkaOperationResult<ID, OP, PKI, DGM, KMG> =
+    DcgkaResult<ID, OP, PKI, DGM, KMG, OperationOutput<ID>>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ControlMessage<ID> {
+    pub message_type: ControlMessageType<ID>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ControlMessageType<ID> {
+    Create(CreateMessage<ID>),
+    Update(UpdateMessage),
+    Remove(RemoveMessage<ID>),
+    Add(AddMessage<ID>),
+}
+
+impl<ID> Display for ControlMessageType<ID> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                ControlMessageType::Create(_) => "create",
+                ControlMessageType::Update(_) => "update",
+                ControlMessageType::Remove(_) => "remove",
+                ControlMessageType::Add(_) => "add",
+            }
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreateMessage<ID> {
+    pub initial_members: Vec<ID>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateMessage;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoveMessage<ID> {
+    pub removed: ID,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AddMessage<ID> {
+    pub added: ID,
+}
+
+#[derive(Clone, Debug)]
+pub enum ProcessMessage<ID> {
+    Create(CreateMessage<ID>, DirectMessage<ID>),
+    Update(UpdateMessage, DirectMessage<ID>),
+    Remove(RemoveMessage<ID>, DirectMessage<ID>),
+    Add(AddMessage<ID>, Option<DirectMessage<ID>>),
+}
+
+#[derive(Debug)]
+pub struct ProcessOutput<ID> {
+    pub control_message: Option<ControlMessage<ID>>,
+    pub direct_messages: Vec<DirectMessage<ID>>,
+    pub group_secret: GroupSecretOutput,
+}
+
+impl<ID> Default for ProcessOutput<ID> {
+    fn default() -> Self {
+        Self {
+            control_message: None,
+            direct_messages: Vec::new(),
+            group_secret: GroupSecretOutput::None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum GroupSecretOutput {
+    None,
+    Secret(GroupSecret),
+    Bundle(GroupSecretBundle),
+}
+
+#[derive(Debug)]
+pub struct OperationOutput<ID> {
+    pub control_message: ControlMessage<ID>,
+    pub direct_messages: Vec<DirectMessage<ID>>,
+    pub group_secret: Option<GroupSecret>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DirectMessage<ID> {
+    pub recipient: ID,
+    pub content: DirectMessageContent,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DirectMessageType {
+    Welcome,
+    TwoParty,
+}
+
+impl Display for DirectMessageType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                DirectMessageType::Welcome => "welcome",
+                DirectMessageType::TwoParty => "2sm",
+            }
+        )
+    }
+}
+
+impl<ID> DirectMessage<ID> {
+    pub fn message_type(&self) -> DirectMessageType {
+        match self.content {
+            DirectMessageContent::Welcome { .. } => DirectMessageType::Welcome,
+            DirectMessageContent::TwoParty { .. } => DirectMessageType::TwoParty,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum DirectMessageContent {
+    Welcome { ciphertext: TwoPartyMessage },
+    TwoParty { ciphertext: TwoPartyMessage },
+}
+
+#[derive(Debug, Error)]
+pub enum DcgkaError<ID, OP, PKI, DGM, KMG>
+where
+    PKI: IdentityRegistry<ID, PKI::State> + PreKeyRegistry<ID, LongTermKeyBundle>,
+    DGM: GroupMembership<ID, OP>,
+    KMG: PreKeyManager,
+{
+    #[error("the given key does not match the required 32 byte length")]
+    InvalidKeySize,
+
+    #[error("expected direct message of type \"{0}\" but got nothing instead")]
+    MissingDirectMessage(DirectMessageType),
+
+    #[error("expected direct message of type \"{0}\" but got message of type \"{1}\" instead")]
+    UnexpectedDirectMessageType(DirectMessageType, DirectMessageType),
+
+    #[error("direct message recipient mismatch, expected recipient: {1}, actual recipient: {0}")]
+    NotOurDirectMessage(ID, ID),
+
+    #[error("computing members view from dgm failed: {0}")]
+    GroupMembership(DGM::Error),
+
+    #[error("dgm operation failed: {0}")]
+    DgmOperation(DGM::Error),
+
+    #[error("failed retrieving bundle from pre key registry: {0}")]
+    PreKeyRegistry(<PKI as PreKeyRegistry<ID, LongTermKeyBundle>>::Error),
+
+    #[error("failed retrieving identity from registry: {0}")]
+    IdentityRegistry(<PKI as IdentityRegistry<ID, PKI::State>>::Error),
+
+    #[error("missing key bundle for member {0}")]
+    MissingPreKeys(ID),
+
+    #[error(transparent)]
+    GroupSecret(#[from] GroupSecretError),
+
+    #[error(transparent)]
+    Rng(#[from] RngError),
+
+    #[error(transparent)]
+    KeyManager(KMG::Error),
+
+    #[error(transparent)]
+    TwoParty(#[from] TwoPartyError),
+
+    #[error(transparent)]
+    Hdkf(#[from] HkdfError),
+}

--- a/p2panda-group/src/data_scheme/dcgka.rs
+++ b/p2panda-group/src/data_scheme/dcgka.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use crate::crypto::hkdf::HkdfError;
 use crate::crypto::{Rng, RngError};
-use crate::data_scheme::{GroupSecret, GroupSecretBundle, GroupSecretError};
+use crate::data_scheme::{GroupSecret, GroupSecretError, SecretBundle, SecretBundleState};
 use crate::key_bundle::LongTermKeyBundle;
 use crate::traits::{
     GroupMembership, IdentityHandle, IdentityManager, IdentityRegistry, OperationId, PreKeyManager,
@@ -218,7 +218,7 @@ where
     pub fn add(
         y: DcgkaState<ID, OP, PKI, DGM, KMG>,
         added: ID,
-        bundle: &GroupSecretBundle,
+        bundle: &SecretBundleState,
         rng: &Rng,
     ) -> DcgkaOperationResult<ID, OP, PKI, DGM, KMG> {
         // Construct a control message of type "add" to broadcast to the group
@@ -296,7 +296,7 @@ where
 
         let (y_i, bundle) = {
             let (y_i, plaintext) = Self::decrypt_from(y, &sender, ciphertext)?;
-            let bundle = GroupSecretBundle::try_from_bytes(&plaintext)?;
+            let bundle = SecretBundle::try_from_bytes(&plaintext)?;
             (y_i, bundle)
         };
 
@@ -524,7 +524,7 @@ where
 pub enum GroupSecretOutput {
     None,
     Secret(GroupSecret),
-    Bundle(GroupSecretBundle),
+    Bundle(SecretBundleState),
 }
 
 #[derive(Debug)]

--- a/p2panda-group/src/data_scheme/dcgka.rs
+++ b/p2panda-group/src/data_scheme/dcgka.rs
@@ -221,7 +221,7 @@ where
         bundle: &SecretBundleState,
         rng: &Rng,
     ) -> DcgkaOperationResult<ID, OP, PKI, DGM, KMG> {
-        // Construct a control message of type "add" to broadcast to the group
+        // Construct a control message of type "add" to broadcast to the group.
         let control_message = ControlMessage::Add { added };
 
         // Construct a welcome message that is sent to the new member as a direct message.

--- a/p2panda-group/src/data_scheme/dgm.rs
+++ b/p2panda-group/src/data_scheme/dgm.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cfg(any(test, feature = "test_utils"))]
+pub mod test_utils {
+    use std::collections::HashSet;
+    use std::convert::Infallible;
+    use std::marker::PhantomData;
+
+    use serde::{Deserialize, Serialize};
+
+    use crate::traits::{GroupMembership, IdentityHandle, OperationId};
+
+    #[derive(Clone, Debug)]
+    pub struct TestDgm<ID, OP> {
+        _marker: PhantomData<(ID, OP)>,
+    }
+
+    impl<ID, OP> TestDgm<ID, OP>
+    where
+        ID: IdentityHandle + Serialize + for<'a> Deserialize<'a>,
+    {
+        pub fn init(my_id: ID) -> TestDgmState<ID, OP> {
+            TestDgmState {
+                my_id,
+                members: HashSet::new(),
+                _marker: PhantomData,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct TestDgmState<ID, OP>
+    where
+        ID: IdentityHandle,
+    {
+        my_id: ID,
+        members: HashSet<ID>,
+        _marker: PhantomData<OP>,
+    }
+
+    impl<ID, OP> GroupMembership<ID, OP> for TestDgm<ID, OP>
+    where
+        ID: IdentityHandle + Serialize + for<'a> Deserialize<'a>,
+        OP: OperationId + Serialize + for<'a> Deserialize<'a>,
+    {
+        type State = TestDgmState<ID, OP>;
+
+        type Error = Infallible;
+
+        fn create(my_id: ID, initial_members: &[ID]) -> Result<Self::State, Self::Error> {
+            Ok(TestDgmState {
+                my_id,
+                members: HashSet::from_iter(initial_members.iter().cloned()),
+                _marker: PhantomData,
+            })
+        }
+
+        fn from_welcome(my_id: ID, y: Self::State) -> Result<Self::State, Self::Error> {
+            Ok(TestDgmState {
+                my_id,
+                members: y.members,
+                _marker: PhantomData,
+            })
+        }
+
+        fn add(mut y: Self::State, _adder: ID, added: ID) -> Result<Self::State, Self::Error> {
+            y.members.insert(added);
+            Ok(y)
+        }
+
+        fn remove(
+            mut y: Self::State,
+            _remover: ID,
+            removed: &ID,
+        ) -> Result<Self::State, Self::Error> {
+            y.members.remove(removed);
+            Ok(y)
+        }
+
+        fn members(y: &Self::State) -> Result<HashSet<ID>, Self::Error> {
+            Ok(y.members.clone())
+        }
+    }
+}

--- a/p2panda-group/src/data_scheme/dgm.rs
+++ b/p2panda-group/src/data_scheme/dgm.rs
@@ -63,7 +63,12 @@ pub mod test_utils {
             })
         }
 
-        fn add(mut y: Self::State, _adder: ID, added: ID) -> Result<Self::State, Self::Error> {
+        fn add(
+            mut y: Self::State,
+            _adder: ID,
+            added: ID,
+            _operation_id: OP,
+        ) -> Result<Self::State, Self::Error> {
             y.members.insert(added);
             Ok(y)
         }
@@ -72,6 +77,7 @@ pub mod test_utils {
             mut y: Self::State,
             _remover: ID,
             removed: &ID,
+            _operation_id: OP,
         ) -> Result<Self::State, Self::Error> {
             y.members.remove(removed);
             Ok(y)

--- a/p2panda-group/src/data_scheme/group_secret.rs
+++ b/p2panda-group/src/data_scheme/group_secret.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashMap;
+use std::fmt;
+
+use p2panda_core::cbor::{DecodeError, EncodeError, decode_cbor, encode_cbor};
+use serde::de::{SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::crypto::Secret;
+use crate::crypto::sha2::sha2_256;
+use crate::{Rng, RngError};
+
+/// 256-bit secret group key.
+pub const GROUP_SECRET_SIZE: usize = 32;
+
+pub type GroupSecretId = [u8; 32];
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
+pub struct GroupSecret(Secret<GROUP_SECRET_SIZE>);
+
+impl GroupSecret {
+    pub(crate) fn from_rng(rng: &Rng) -> Result<Self, GroupSecretError> {
+        let bytes: [u8; GROUP_SECRET_SIZE] = rng.random_array()?;
+        Ok(Self(Secret::from_bytes(bytes)))
+    }
+
+    pub(crate) fn from_bytes(bytes: [u8; GROUP_SECRET_SIZE]) -> Self {
+        Self(Secret::from_bytes(bytes))
+    }
+
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, GroupSecretError> {
+        let bytes: [u8; GROUP_SECRET_SIZE] = bytes
+            .try_into()
+            .map_err(|_| GroupSecretError::InvalidKeySize)?;
+        Ok(Self::from_bytes(bytes))
+    }
+
+    pub fn id(&self) -> GroupSecretId {
+        sha2_256(&[self.0.as_bytes()])
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8; GROUP_SECRET_SIZE] {
+        self.0.as_bytes()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
+pub struct GroupSecretBundle(HashMap<GroupSecretId, GroupSecret>);
+
+impl GroupSecretBundle {
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, GroupSecretError> {
+        let bundle: Self = decode_cbor(&bytes[..])?;
+        Ok(bundle)
+    }
+
+    pub(crate) fn from_secrets(secrets: Vec<GroupSecret>) -> Self {
+        let mut bundle = HashMap::new();
+        for secret in secrets {
+            bundle.insert(secret.id(), secret);
+        }
+        Self(bundle)
+    }
+
+    pub(crate) fn to_bytes(&self) -> Result<Vec<u8>, GroupSecretError> {
+        let bytes = encode_cbor(self)?;
+        Ok(bytes)
+    }
+}
+
+impl Serialize for GroupSecretBundle {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_seq(Some(self.0.len()))?;
+        for secret in self.0.values() {
+            s.serialize_element(secret)?;
+        }
+        s.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for GroupSecretBundle {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct SecretVisitor;
+
+        impl<'de> Visitor<'de> for SecretVisitor {
+            type Value = Vec<GroupSecret>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("Header encoded as a sequence")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut result = Vec::new();
+                while let Some(secret) = seq.next_element()? {
+                    result.push(secret);
+                }
+                Ok(result)
+            }
+        }
+
+        let secrets = deserializer.deserialize_seq(SecretVisitor)?;
+
+        Ok(GroupSecretBundle::from_secrets(secrets))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum GroupSecretError {
+    #[error("the given key does not match the required 32 byte length")]
+    InvalidKeySize,
+
+    #[error(transparent)]
+    Rng(#[from] RngError),
+
+    #[error(transparent)]
+    Encode(#[from] EncodeError),
+
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+}

--- a/p2panda-group/src/data_scheme/group_secret.rs
+++ b/p2panda-group/src/data_scheme/group_secret.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::HashMap;
+use std::collections::hash_map::{IntoIter, Iter, Keys, Values};
 use std::fmt;
+use std::hash::Hash as StdHash;
 
 use p2panda_core::cbor::{DecodeError, EncodeError, decode_cbor, encode_cbor};
 use serde::de::{SeqAccess, Visitor};
@@ -18,8 +20,7 @@ pub const GROUP_SECRET_SIZE: usize = 32;
 
 pub type GroupSecretId = [u8; SHA256_DIGEST_SIZE];
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GroupSecret(Secret<GROUP_SECRET_SIZE>);
 
 impl GroupSecret {
@@ -32,13 +33,14 @@ impl GroupSecret {
         Self(Secret::from_bytes(bytes))
     }
 
-    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, GroupSecretError> {
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> Result<Self, GroupSecretError> {
         let bytes: [u8; GROUP_SECRET_SIZE] = bytes
             .try_into()
             .map_err(|_| GroupSecretError::InvalidKeySize)?;
         Ok(Self::from_bytes(bytes))
     }
 
+    /// Returns identifier (SHA256 hash) for this secret.
     pub fn id(&self) -> GroupSecretId {
         sha2_256(&[self.0.as_bytes()])
     }
@@ -48,27 +50,76 @@ impl GroupSecret {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
+impl StdHash for GroupSecret {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id().hash(state);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GroupSecretBundle(HashMap<GroupSecretId, GroupSecret>);
 
 impl GroupSecretBundle {
-    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, GroupSecretError> {
-        let bundle: Self = decode_cbor(bytes)?;
-        Ok(bundle)
+    pub fn new() -> Self {
+        Self(HashMap::new())
     }
 
-    pub(crate) fn from_secrets(secrets: Vec<GroupSecret>) -> Self {
-        let mut bundle = HashMap::new();
-        for secret in secrets {
-            bundle.insert(secret.id(), secret);
-        }
-        Self(bundle)
+    pub fn from_secrets(secrets: Vec<GroupSecret>) -> Self {
+        Self(HashMap::from_iter(
+            secrets.into_iter().map(|secret| (secret.id(), secret)),
+        ))
+    }
+
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> Result<Self, GroupSecretError> {
+        Ok(decode_cbor(bytes)?)
     }
 
     pub(crate) fn to_bytes(&self) -> Result<Vec<u8>, GroupSecretError> {
-        let bytes = encode_cbor(self)?;
-        Ok(bytes)
+        Ok(encode_cbor(self)?)
+    }
+
+    pub fn insert(&mut self, secret: GroupSecret) {
+        self.0.insert(secret.id(), secret);
+    }
+
+    pub fn get(&self, id: &GroupSecretId) -> Option<&GroupSecret> {
+        self.0.get(id)
+    }
+
+    pub fn remove(&mut self, id: &GroupSecretId) -> Option<GroupSecret> {
+        self.0.remove(id)
+    }
+
+    pub fn extend(&mut self, bundle: GroupSecretBundle) {
+        self.0.extend(bundle.0);
+    }
+
+    pub fn contains(&mut self, id: &GroupSecretId) -> bool {
+        self.0.contains_key(id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> Iter<'_, GroupSecretId, GroupSecret> {
+        self.0.iter()
+    }
+
+    pub fn into_iter(self) -> IntoIter<GroupSecretId, GroupSecret> {
+        self.0.into_iter()
+    }
+
+    pub fn ids(&self) -> Keys<'_, GroupSecretId, GroupSecret> {
+        self.0.keys()
+    }
+
+    pub fn secrets(&self) -> Values<'_, GroupSecretId, GroupSecret> {
+        self.0.values()
     }
 }
 
@@ -90,13 +141,13 @@ impl<'de> Deserialize<'de> for GroupSecretBundle {
     where
         D: serde::Deserializer<'de>,
     {
-        struct SecretVisitor;
+        struct SecretListVisitor;
 
-        impl<'de> Visitor<'de> for SecretVisitor {
+        impl<'de> Visitor<'de> for SecretListVisitor {
             type Value = Vec<GroupSecret>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("Header encoded as a sequence")
+                formatter.write_str("list of group secrets")
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
@@ -111,7 +162,7 @@ impl<'de> Deserialize<'de> for GroupSecretBundle {
             }
         }
 
-        let secrets = deserializer.deserialize_seq(SecretVisitor)?;
+        let secrets = deserializer.deserialize_seq(SecretListVisitor)?;
 
         Ok(GroupSecretBundle::from_secrets(secrets))
     }
@@ -130,4 +181,57 @@ pub enum GroupSecretError {
 
     #[error(transparent)]
     Decode(#[from] DecodeError),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Rng;
+
+    use super::{GroupSecret, GroupSecretBundle};
+
+    #[test]
+    fn group_secret_bundle() {
+        let rng = Rng::from_seed([1; 32]);
+
+        let secret = GroupSecret::from_rng(&rng).unwrap();
+        assert_ne!(secret.as_bytes(), &secret.id());
+
+        let mut bundle_1 = GroupSecretBundle::from_secrets(vec![secret.clone()]);
+        let mut bundle_2 = GroupSecretBundle::from_secrets(vec![secret.clone()]);
+        assert_eq!(bundle_1.len(), 1);
+        assert_eq!(bundle_2.len(), 1);
+
+        assert_eq!(bundle_1.get(&secret.id()), bundle_2.get(&secret.id()));
+        assert!(bundle_1.get(&secret.id()).is_some());
+        assert!(bundle_1.contains(&secret.id()));
+
+        let unknown_secret = GroupSecret::from_rng(&rng).unwrap();
+        assert!(bundle_1.get(&unknown_secret.id()).is_none());
+        assert!(!bundle_1.contains(&unknown_secret.id()));
+
+        let secret_2 = GroupSecret::from_rng(&rng).unwrap();
+        bundle_2.insert(secret_2.clone());
+        assert_eq!(bundle_2.len(), 2);
+
+        bundle_1.extend(bundle_2);
+        assert_eq!(bundle_1.len(), 2);
+
+        assert!(bundle_1.remove(&secret_2.id()).is_some());
+        assert_eq!(bundle_1.len(), 1);
+    }
+
+    #[test]
+    fn serde() {
+        let rng = Rng::from_seed([1; 32]);
+
+        let bundle = GroupSecretBundle::from_secrets(vec![
+            GroupSecret::from_rng(&rng).unwrap(),
+            GroupSecret::from_rng(&rng).unwrap(),
+            GroupSecret::from_rng(&rng).unwrap(),
+            GroupSecret::from_rng(&rng).unwrap(),
+        ]);
+
+        let bytes = bundle.to_bytes().unwrap();
+        assert_eq!(bundle, GroupSecretBundle::try_from_bytes(&bytes).unwrap());
+    }
 }

--- a/p2panda-group/src/data_scheme/group_secret.rs
+++ b/p2panda-group/src/data_scheme/group_secret.rs
@@ -21,6 +21,8 @@ pub const GROUP_SECRET_SIZE: usize = 32;
 
 pub type GroupSecretId = [u8; SHA256_DIGEST_SIZE];
 
+// TODO(adz): Replace sorting group secrets via timestamp with a hash graph instead (no dangling
+// nodes allowed) to prevent bugs / attacks where one secret always gets pushed first.
 pub type Timestamp = u64;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/p2panda-group/src/data_scheme/group_secret.rs
+++ b/p2panda-group/src/data_scheme/group_secret.rs
@@ -104,10 +104,7 @@ impl GroupSecretBundle {
     }
 
     pub fn latest(&self) -> Option<&GroupSecret> {
-        self.latest
-            .as_ref()
-            .map(|id| self.secrets.get(id))
-            .flatten()
+        self.latest.as_ref().and_then(|id| self.secrets.get(id))
     }
 
     pub fn insert(&mut self, secret: GroupSecret) {

--- a/p2panda-group/src/data_scheme/group_secret.rs
+++ b/p2panda-group/src/data_scheme/group_secret.rs
@@ -26,7 +26,7 @@ pub type GroupSecretId = [u8; SHA256_DIGEST_SIZE];
 
 /// UNIX timestamp indicating when the key was generated.
 ///
-/// This helps peers to pick the "latest" key or remove keys on their age (for forward secrecy)
+/// This helps peers to pick the "latest" key or remove keys based on their age (for forward secrecy)
 /// depending on the application. If other ordering strategies are applied by the application they
 /// can also be used instead to reason about the "latest" group secret.
 pub type Timestamp = u64;
@@ -118,7 +118,7 @@ impl SecretBundleState {
 
     /// Returns a secret based on the id.
     ///
-    /// This can be used to retreive a secret to decrypt data where we know which secret id has been
+    /// This can be used to retrieve a secret to decrypt data where we know which secret id has been
     /// used.
     pub fn get(&self, id: &GroupSecretId) -> Option<&GroupSecret> {
         self.secrets.get(id)

--- a/p2panda-group/src/data_scheme/group_secret.rs
+++ b/p2panda-group/src/data_scheme/group_secret.rs
@@ -58,6 +58,11 @@ impl GroupSecret {
         self.1
     }
 
+    #[cfg(any(test, feature = "test_utils"))]
+    pub(crate) fn set_timestamp(&mut self, timestamp: Timestamp) {
+        self.1 = timestamp;
+    }
+
     /// Returns secret key as bytes.
     pub(crate) fn as_bytes(&self) -> &[u8; GROUP_SECRET_SIZE] {
         self.0.as_bytes()

--- a/p2panda-group/src/data_scheme/group_secret.rs
+++ b/p2panda-group/src/data_scheme/group_secret.rs
@@ -12,9 +12,8 @@ use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::crypto::Secret;
 use crate::crypto::sha2::{SHA256_DIGEST_SIZE, sha2_256};
-use crate::{Rng, RngError};
+use crate::crypto::{Rng, RngError, Secret};
 
 /// 256-bit secret group key.
 pub const GROUP_SECRET_SIZE: usize = 32;
@@ -57,6 +56,11 @@ impl GroupSecret {
     /// Return creation date (UNIX timestamp in seconds) of this secret.
     pub fn timestamp(&self) -> Timestamp {
         self.1
+    }
+
+    /// Returns secret key as bytes.
+    pub fn as_bytes(&self) -> &[u8; GROUP_SECRET_SIZE] {
+        self.0.as_bytes()
     }
 
     /// Serialize group secret into CBOR representation.
@@ -154,6 +158,8 @@ impl GroupSecretBundle {
     }
 }
 
+/// Finds the "latest" secret to use from a list by comparing timestamps. If the timestamps of two
+/// distinct secrets match the id is used as a tie-breaker.
 fn find_latest(secrets: &HashMap<GroupSecretId, GroupSecret>) -> Option<GroupSecretId> {
     let mut latest_timestamp: Timestamp = 0;
     let mut latest_secret_id: Option<GroupSecretId> = None;

--- a/p2panda-group/src/data_scheme/group_secret.rs
+++ b/p2panda-group/src/data_scheme/group_secret.rs
@@ -21,8 +21,6 @@ pub const GROUP_SECRET_SIZE: usize = 32;
 
 pub type GroupSecretId = [u8; SHA256_DIGEST_SIZE];
 
-// TODO(adz): Replace sorting group secrets via timestamp with a hash graph instead (no dangling
-// nodes allowed) to prevent bugs / attacks where one secret always gets pushed first.
 pub type Timestamp = u64;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/p2panda-group/src/data_scheme/group_secret.rs
+++ b/p2panda-group/src/data_scheme/group_secret.rs
@@ -59,7 +59,7 @@ impl GroupSecret {
     }
 
     /// Returns secret key as bytes.
-    pub fn as_bytes(&self) -> &[u8; GROUP_SECRET_SIZE] {
+    pub(crate) fn as_bytes(&self) -> &[u8; GROUP_SECRET_SIZE] {
         self.0.as_bytes()
     }
 

--- a/p2panda-group/src/data_scheme/group_secret.rs
+++ b/p2panda-group/src/data_scheme/group_secret.rs
@@ -10,13 +10,13 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::crypto::Secret;
-use crate::crypto::sha2::sha2_256;
+use crate::crypto::sha2::{SHA256_DIGEST_SIZE, sha2_256};
 use crate::{Rng, RngError};
 
 /// 256-bit secret group key.
 pub const GROUP_SECRET_SIZE: usize = 32;
 
-pub type GroupSecretId = [u8; 32];
+pub type GroupSecretId = [u8; SHA256_DIGEST_SIZE];
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
@@ -54,7 +54,7 @@ pub struct GroupSecretBundle(HashMap<GroupSecretId, GroupSecret>);
 
 impl GroupSecretBundle {
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, GroupSecretError> {
-        let bundle: Self = decode_cbor(&bytes[..])?;
+        let bundle: Self = decode_cbor(bytes)?;
         Ok(bundle)
     }
 

--- a/p2panda-group/src/data_scheme/mod.rs
+++ b/p2panda-group/src/data_scheme/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+mod data;
 mod dcgka;
 mod dgm;
 mod group_secret;

--- a/p2panda-group/src/data_scheme/mod.rs
+++ b/p2panda-group/src/data_scheme/mod.rs
@@ -3,4 +3,5 @@
 mod dcgka;
 mod group_secret;
 
+#[allow(unused)]
 pub use group_secret::{GROUP_SECRET_SIZE, GroupSecret, GroupSecretBundle, GroupSecretError};

--- a/p2panda-group/src/data_scheme/mod.rs
+++ b/p2panda-group/src/data_scheme/mod.rs
@@ -9,9 +9,8 @@ mod tests;
 
 #[allow(unused)]
 pub use dcgka::{
-    AddMessage, ControlMessage, CreateMessage, Dcgka, DcgkaError, DcgkaResult, DcgkaState,
-    DirectMessage, DirectMessageContent, DirectMessageType, OperationOutput, ProcessMessage,
-    ProcessOutput, RemoveMessage, UpdateMessage,
+    ControlMessage, Dcgka, DcgkaError, DcgkaResult, DcgkaState, DirectMessage,
+    DirectMessageContent, DirectMessageType, OperationOutput, ProcessInput, ProcessOutput,
 };
 #[allow(unused)]
 pub use group_secret::{GROUP_SECRET_SIZE, GroupSecret, GroupSecretBundle, GroupSecretError};

--- a/p2panda-group/src/data_scheme/mod.rs
+++ b/p2panda-group/src/data_scheme/mod.rs
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod dcgka;
+mod dgm;
 mod group_secret;
+#[cfg(test)]
+mod tests;
 
+#[allow(unused)]
+pub use dcgka::{
+    AddMessage, ControlMessage, CreateMessage, Dcgka, DcgkaError, DcgkaResult, DcgkaState,
+    DirectMessage, DirectMessageContent, DirectMessageType, OperationOutput, ProcessMessage,
+    ProcessOutput, RemoveMessage, UpdateMessage,
+};
 #[allow(unused)]
 pub use group_secret::{GROUP_SECRET_SIZE, GroupSecret, GroupSecretBundle, GroupSecretError};

--- a/p2panda-group/src/data_scheme/mod.rs
+++ b/p2panda-group/src/data_scheme/mod.rs
@@ -13,4 +13,6 @@ pub use dcgka::{
     DirectMessageContent, DirectMessageType, OperationOutput, ProcessInput, ProcessOutput,
 };
 #[allow(unused)]
-pub use group_secret::{GROUP_SECRET_SIZE, GroupSecret, GroupSecretBundle, GroupSecretError};
+pub use group_secret::{
+    GROUP_SECRET_SIZE, GroupSecret, GroupSecretError, SecretBundle, SecretBundleState,
+};

--- a/p2panda-group/src/data_scheme/mod.rs
+++ b/p2panda-group/src/data_scheme/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+mod dcgka;
+mod group_secret;
+
+pub use group_secret::{GROUP_SECRET_SIZE, GroupSecret, GroupSecretBundle, GroupSecretError};

--- a/p2panda-group/src/data_scheme/tests.rs
+++ b/p2panda-group/src/data_scheme/tests.rs
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use crate::crypto::x25519::SecretKey;
+use crate::data_scheme::DcgkaError;
+use crate::data_scheme::dcgka::{Dcgka, DcgkaState};
+use crate::data_scheme::dgm::test_utils::TestDgm;
+use crate::message_scheme::test_utils::{MemberId, MessageId};
+use crate::traits::PreKeyManager;
+use crate::{KeyManager, KeyRegistry, Lifetime, Rng};
+
+use super::dcgka::GroupSecretOutput;
+use super::{ControlMessage, GroupSecretBundle, ProcessMessage};
+
+type TestDcgkaState = DcgkaState<
+    MemberId,
+    MessageId,
+    KeyRegistry<MemberId>,
+    TestDgm<MemberId, MessageId>,
+    KeyManager,
+>;
+
+#[test]
+fn group_operations() {
+    let rng = Rng::from_seed([1; 32]);
+
+    let alice = 0;
+    let bob = 1;
+    let charlie = 2;
+
+    // Alice initialises their key material.
+
+    let alice_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
+
+    let alice_dgm = TestDgm::init(alice);
+    let alice_pki = KeyRegistry::init();
+    let alice_keys = KeyManager::init(&alice_identity_secret, Lifetime::default(), &rng).unwrap();
+
+    let alice_prekeys = KeyManager::prekey_bundle(&alice_keys);
+
+    // Bob initialises their key material.
+
+    let bob_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
+
+    let bob_dgm = TestDgm::init(bob);
+    let bob_pki = KeyRegistry::init();
+    let bob_keys = KeyManager::init(&bob_identity_secret, Lifetime::default(), &rng).unwrap();
+
+    let bob_prekeys = KeyManager::prekey_bundle(&bob_keys);
+
+    // Charlie initialises their key material.
+
+    let charlie_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
+
+    let charlie_dgm = TestDgm::init(charlie);
+    let charlie_pki = KeyRegistry::init();
+    let charlie_keys =
+        KeyManager::init(&charlie_identity_secret, Lifetime::default(), &rng).unwrap();
+
+    let charlie_prekeys = KeyManager::prekey_bundle(&charlie_keys);
+
+    // Register key bundles.
+
+    let alice_pki = KeyRegistry::add_longterm_bundle(alice_pki, alice, alice_prekeys.clone());
+    let alice_pki = KeyRegistry::add_longterm_bundle(alice_pki, bob, bob_prekeys.clone());
+    let alice_pki = KeyRegistry::add_longterm_bundle(alice_pki, charlie, charlie_prekeys.clone());
+
+    let bob_pki = KeyRegistry::add_longterm_bundle(bob_pki, alice, alice_prekeys.clone());
+    let bob_pki = KeyRegistry::add_longterm_bundle(bob_pki, bob, bob_prekeys.clone());
+    let bob_pki = KeyRegistry::add_longterm_bundle(bob_pki, charlie, charlie_prekeys.clone());
+
+    let charlie_pki = KeyRegistry::add_longterm_bundle(charlie_pki, alice, alice_prekeys.clone());
+    let charlie_pki = KeyRegistry::add_longterm_bundle(charlie_pki, bob, bob_prekeys.clone());
+    let charlie_pki =
+        KeyRegistry::add_longterm_bundle(charlie_pki, charlie, charlie_prekeys.clone());
+
+    // Initialise DCGKA states.
+
+    let mut alice_bundle = GroupSecretBundle::new();
+    let alice_dcgka: TestDcgkaState = Dcgka::init(alice, alice_keys, alice_pki, alice_dgm);
+
+    let mut bob_bundle = GroupSecretBundle::new();
+    let bob_dcgka: TestDcgkaState = Dcgka::init(bob, bob_keys, bob_pki, bob_dgm);
+
+    let mut charlie_bundle = GroupSecretBundle::new();
+    let charlie_dcgka: TestDcgkaState =
+        Dcgka::init(charlie, charlie_keys, charlie_pki, charlie_dgm);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Alice creates a group with Bob
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    let (alice_dcgka, output) = Dcgka::create(alice_dcgka, vec![alice, bob], &rng).unwrap();
+    let alice_group_secret_0 = output.group_secret.unwrap();
+    alice_bundle.insert(alice_group_secret_0.clone());
+    assert_eq!(alice_bundle.len(), 1);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Bob processes Alice's "create" message
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    let ControlMessage::Create(create_message) = output.control_message else {
+        panic!("expected 'create' control message");
+    };
+
+    let direct_message = output
+        .direct_messages
+        .into_iter()
+        .find(|dm| dm.recipient == bob)
+        .expect("direct message for bob");
+
+    let (bob_dcgka, output) = Dcgka::process_remote(
+        bob_dcgka,
+        alice,
+        ProcessMessage::Create(create_message, direct_message),
+    )
+    .unwrap();
+
+    let GroupSecretOutput::Secret(bob_group_secret_0) = output.group_secret else {
+        panic!("expected group secret");
+    };
+
+    bob_bundle.insert(bob_group_secret_0.clone());
+    assert_eq!(bob_bundle.len(), 1);
+
+    // Alice and bob share the same group secret.
+    assert_eq!(alice_group_secret_0, bob_group_secret_0);
+    assert_eq!(alice_bundle, bob_bundle);
+
+    // ~~~~~~~~~~~~~~~~
+    // Bob adds Charlie
+    // ~~~~~~~~~~~~~~~~
+
+    let (bob_dcgka, output) = Dcgka::add(bob_dcgka, charlie, &bob_bundle, &rng).unwrap();
+    assert!(output.group_secret.is_none());
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Charlie processes Bob's "add" message
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    let ControlMessage::Add(add_message) = output.control_message else {
+        panic!("expected 'add' control message");
+    };
+
+    let direct_message = output
+        .direct_messages
+        .into_iter()
+        .find(|dm| dm.recipient == charlie)
+        .expect("direct message for charlie");
+
+    let (charlie_dcgka, output) = Dcgka::process_remote(
+        charlie_dcgka,
+        bob,
+        ProcessMessage::Add(add_message.clone(), Some(direct_message)),
+    )
+    .unwrap();
+
+    let GroupSecretOutput::Bundle(charlie_secret_bundle_0) = output.group_secret else {
+        panic!("expected group secret bundle");
+    };
+
+    charlie_bundle.extend(charlie_secret_bundle_0);
+    assert_eq!(charlie_bundle.len(), 1);
+
+    // Alice, Bob and Charlie share the same secrets.
+    assert_eq!(alice_bundle, bob_bundle);
+    assert_eq!(alice_bundle, charlie_bundle);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Alice processes Bob's "add" message
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    let (alice_dcgka, output) =
+        Dcgka::process_remote(alice_dcgka, bob, ProcessMessage::Add(add_message, None)).unwrap();
+    assert_eq!(output.group_secret, GroupSecretOutput::None);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~
+    // Alice updates the group
+    // ~~~~~~~~~~~~~~~~~~~~~~~
+
+    // Sleep for a moment to cause timestamp of generated group secret to be later than previously
+    // generated ones.
+    sleep(Duration::from_secs(1));
+
+    let (alice_dcgka, update_output) = Dcgka::update(alice_dcgka, &rng).unwrap();
+    assert_eq!(update_output.direct_messages.len(), 2); // dm's for Bob and Charlie
+
+    let alice_group_secret_1 = update_output.group_secret.unwrap();
+    alice_bundle.insert(alice_group_secret_1.clone());
+    assert_eq!(alice_bundle.len(), 2);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Bob processes Alice's "update" message
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    let ControlMessage::Update(update_message) = update_output.control_message else {
+        panic!("expected 'update' control message");
+    };
+
+    let direct_message = update_output
+        .direct_messages
+        .iter()
+        .find(|dm| dm.recipient == bob)
+        .expect("direct message for bob");
+
+    let (bob_dcgka, output) = Dcgka::process_remote(
+        bob_dcgka,
+        alice,
+        ProcessMessage::Update(update_message.clone(), direct_message.clone()),
+    )
+    .unwrap();
+
+    let GroupSecretOutput::Secret(bob_group_secret_1) = output.group_secret else {
+        panic!("expected group secret");
+    };
+
+    bob_bundle.insert(bob_group_secret_1);
+    assert_eq!(bob_bundle.len(), 2);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Charlie processes Alice's "update" message
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    let direct_message = update_output
+        .direct_messages
+        .into_iter()
+        .find(|dm| dm.recipient == charlie)
+        .expect("direct message for charlie");
+
+    let (charlie_dcgka, output) = Dcgka::process_remote(
+        charlie_dcgka,
+        alice,
+        ProcessMessage::Update(update_message, direct_message),
+    )
+    .unwrap();
+
+    let GroupSecretOutput::Secret(charlie_group_secret_1) = output.group_secret else {
+        panic!("expected group secret");
+    };
+
+    charlie_bundle.insert(charlie_group_secret_1);
+    assert_eq!(charlie_bundle.len(), 2);
+
+    // Alice, Bob and Charlie share the same secrets.
+    assert_eq!(alice_bundle, bob_bundle);
+    assert_eq!(alice_bundle, charlie_bundle);
+    assert_eq!(alice_bundle.latest(), bob_bundle.latest());
+    assert_eq!(charlie_bundle.latest(), bob_bundle.latest());
+
+    // ~~~~~~~~~~~~~~~~~~~~~
+    // Charlie removes Alice
+    // ~~~~~~~~~~~~~~~~~~~~~
+
+    // Sleep for a moment to cause timestamp of generated group secret to be later than previously
+    // generated ones.
+    sleep(Duration::from_secs(1));
+
+    let (_charlie_dcgka, remove_output) = Dcgka::remove(charlie_dcgka, alice, &rng).unwrap();
+    assert_eq!(remove_output.direct_messages.len(), 1);
+
+    charlie_bundle.insert(remove_output.group_secret.unwrap());
+    assert_eq!(charlie_bundle.len(), 3);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Bob processes Charlie's "remove" message
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    let ControlMessage::Remove(remove_message) = remove_output.control_message else {
+        panic!("expected 'remove' control message");
+    };
+
+    let direct_message = remove_output
+        .direct_messages
+        .into_iter()
+        .find(|dm| dm.recipient == bob)
+        .expect("direct message for bob");
+
+    let (_bob_dcgka, output) = Dcgka::process_remote(
+        bob_dcgka,
+        charlie,
+        ProcessMessage::Remove(remove_message.clone(), direct_message.clone()),
+    )
+    .unwrap();
+
+    let GroupSecretOutput::Secret(bob_group_secret_2) = output.group_secret else {
+        panic!("expected group secret");
+    };
+
+    bob_bundle.insert(bob_group_secret_2);
+    assert_eq!(bob_bundle.len(), 3);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Alice tries to process Charlie's "remove" message
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    assert!(matches!(
+        Dcgka::process_remote(
+            alice_dcgka,
+            charlie,
+            ProcessMessage::Remove(remove_message.clone(), direct_message),
+        ),
+        Err(DcgkaError::NotOurDirectMessage(_, _))
+    ));
+
+    // Bob and Charlie share the same secrets.
+    assert_eq!(charlie_bundle, bob_bundle);
+    assert_eq!(charlie_bundle.latest(), bob_bundle.latest());
+
+    // Alice does not share the latest secrets with Bob and Charlie.
+    assert_ne!(alice_bundle.latest(), bob_bundle.latest());
+    assert_ne!(alice_bundle.latest(), charlie_bundle.latest());
+}

--- a/p2panda-group/src/data_scheme/tests.rs
+++ b/p2panda-group/src/data_scheme/tests.rs
@@ -3,16 +3,18 @@
 use std::thread::sleep;
 use std::time::Duration;
 
+use crate::crypto::Rng;
 use crate::crypto::x25519::SecretKey;
-use crate::data_scheme::DcgkaError;
-use crate::data_scheme::dcgka::{Dcgka, DcgkaState};
+use crate::data_scheme::dcgka::{
+    ControlMessage, Dcgka, DcgkaError, DcgkaState, GroupSecretOutput, ProcessMessage,
+};
 use crate::data_scheme::dgm::test_utils::TestDgm;
+use crate::data_scheme::group_secret::GroupSecretBundle;
+use crate::key_bundle::Lifetime;
+use crate::key_manager::KeyManager;
+use crate::key_registry::KeyRegistry;
 use crate::message_scheme::test_utils::{MemberId, MessageId};
 use crate::traits::PreKeyManager;
-use crate::{KeyManager, KeyRegistry, Lifetime, Rng};
-
-use super::dcgka::GroupSecretOutput;
-use super::{ControlMessage, GroupSecretBundle, ProcessMessage};
 
 type TestDcgkaState = DcgkaState<
     MemberId,

--- a/p2panda-group/src/lib.rs
+++ b/p2panda-group/src/lib.rs
@@ -3,6 +3,7 @@
 // TODO: To be removed.
 #![allow(dead_code)]
 mod crypto;
+mod data_scheme;
 mod key_bundle;
 mod key_manager;
 mod key_registry;

--- a/p2panda-group/src/message_scheme/dcgka.rs
+++ b/p2panda-group/src/message_scheme/dcgka.rs
@@ -169,7 +169,7 @@ where
 {
     /// Returns new DCGKA state with our own identity and key managers.
     ///
-    /// Use this when creating a new group or accepting an invitation to an existing one.
+    /// Use this when creating a new group or before accepting an invitation to an existing one.
     pub fn init(
         my_id: ID,
         my_keys: KMG::State,

--- a/p2panda-group/src/traits/dgm.rs
+++ b/p2panda-group/src/traits/dgm.rs
@@ -57,3 +57,24 @@ pub trait AckedGroupMembership<ID, OP> {
     /// Returns true if given group operation removed a member.
     fn is_remove(y: &Self::State, operation_id: OP) -> bool;
 }
+
+pub trait GroupMembership<ID, OP> {
+    type State: Clone + Debug + Serialize + for<'a> Deserialize<'a>;
+
+    type Error: Error;
+
+    /// Creates a new group.
+    fn create(my_id: ID, initial_members: &[ID]) -> Result<Self::State, Self::Error>;
+
+    /// Processes the received DGM state from a welcome message.
+    fn from_welcome(my_id: ID, y: Self::State) -> Result<Self::State, Self::Error>;
+
+    /// Adds a member to the group.
+    fn add(y: Self::State, adder: ID, added: ID) -> Result<Self::State, Self::Error>;
+
+    /// Removes a member from a group.
+    fn remove(y: Self::State, remover: ID, removed: &ID) -> Result<Self::State, Self::Error>;
+
+    /// Returns the list of current members in the group.
+    fn members(y: &Self::State) -> Result<HashSet<ID>, Self::Error>;
+}

--- a/p2panda-group/src/traits/dgm.rs
+++ b/p2panda-group/src/traits/dgm.rs
@@ -70,10 +70,20 @@ pub trait GroupMembership<ID, OP> {
     fn from_welcome(my_id: ID, y: Self::State) -> Result<Self::State, Self::Error>;
 
     /// Adds a member to the group.
-    fn add(y: Self::State, adder: ID, added: ID) -> Result<Self::State, Self::Error>;
+    fn add(
+        y: Self::State,
+        adder: ID,
+        added: ID,
+        operation_id: OP,
+    ) -> Result<Self::State, Self::Error>;
 
     /// Removes a member from a group.
-    fn remove(y: Self::State, remover: ID, removed: &ID) -> Result<Self::State, Self::Error>;
+    fn remove(
+        y: Self::State,
+        remover: ID,
+        removed: &ID,
+        operation_id: OP,
+    ) -> Result<Self::State, Self::Error>;
 
     /// Returns the list of current members in the group.
     fn members(y: &Self::State) -> Result<HashSet<ID>, Self::Error>;

--- a/p2panda-group/src/traits/mod.rs
+++ b/p2panda-group/src/traits/mod.rs
@@ -8,7 +8,7 @@ mod key_bundle;
 mod key_manager;
 mod key_registry;
 
-pub use dgm::AckedGroupMembership;
+pub use dgm::{AckedGroupMembership, GroupMembership};
 pub use key_bundle::KeyBundle;
 pub use key_manager::{IdentityManager, PreKeyManager};
 pub use key_registry::{IdentityRegistry, PreKeyRegistry};


### PR DESCRIPTION
> This PR follows https://github.com/p2panda/p2panda/pull/737

### DCGKA

A decentralized continuous group key agreement protocol (DCGKA) for p2panda's "data encryption" scheme. The key agreement uses 2SM as well with strong forward-secrecy guarantees.

The encryption is simpler than the "message encryption" scheme (as introduced in https://github.com/p2panda/p2panda/pull/734) and uses an XChaCha20-Poly1305 AEAD to encrypt the data with longer-living group secrets.

Group secrets can be rotated manually ("update") or on member removal, thus guaranteeing post-compromise security.

### Group Secrets & Bundles

Secrets like `GroupSecret` which a group generated & learned about are bundled in a `SecretBundle` struct together with a timestamp for each secret. They can be referred to with their SHA256 hash id. Applications can decide to remove secrets for forward-secrecy.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] New files contain a SPDX license header
