### PR TITLE
Remove libcrux and use other crates for crypto backend

### DIFF
--- a/p2panda-group/Cargo.toml
+++ b/p2panda-group/Cargo.toml
@@ -16,24 +16,20 @@ all-features = true
 workspace = true
 
 [dependencies]
-# TODO: Replace this with `libcrux-chacha20poly1305` as soon as it contains an
-# XChaCha20-Poly1305 implementation.
-chacha20poly1305 = "0.10.1"
+chacha20poly1305 = { version = "0.10.1", features = ["alloc"], default-features = false }
 curve25519-dalek = "4.1.3"
+ed25519-dalek = "2.1.1"
 hex = "0.4.3"
-# TODO: Replace this with `libcrux-hpke` as soon as it's released.
-libcrux = { git = "https://github.com/cryspen/libcrux", rev = "cf292a2829172cf9b36390f2f05f7a32b2304888" }
-libcrux-chacha20poly1305 = "0.0.2-beta.3"
-libcrux-ecdh = "0.0.2-beta.3"
-libcrux-ed25519 = "0.0.2-beta.3"
-libcrux-hkdf = "0.0.2-beta.3"
-libcrux-sha2 = "0.0.2-beta.3"
-libcrux-traits = "0.0.2-beta.3"
+hkdf = "0.12.4"
+hpke-rs = "0.2.0"
+hpke-rs-crypto = "0.2.0"
+hpke-rs-rust-crypto = "0.2.0"
 p2panda-core = { version = "0.3.0", path = "../p2panda-core", default-features = false }
-# TODO: Find out if we can use libcrux's DRBG instead.
 rand_chacha = { version = "0.9.0", features = ["os_rng"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_bytes = "0.11.17"
+sha2 = "0.10.8"
 subtle = "2.6.1"
 thiserror = "2.0.12"
+x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 zeroize = { version = "1.8.1", features = ["derive"] }

--- a/p2panda-group/src/crypto/aead.rs
+++ b/p2panda-group/src/crypto/aead.rs
@@ -22,12 +22,12 @@ pub fn aead_encrypt(
     // Implementation attaches authenticated tag (16 bytes) automatically to the end of ciphertext.
     let key = Key::from_slice(key);
     let nonce = Nonce::from_slice(&nonce);
-    let mut ciphertext: Vec<u8> = Vec::from(plaintext);
+    let mut ciphertext_with_tag: Vec<u8> = Vec::from(plaintext);
     let cipher = ChaCha20Poly1305::new(key);
     cipher
-        .encrypt_in_place(nonce, aad.unwrap_or_default(), &mut ciphertext)
+        .encrypt_in_place(nonce, aad.unwrap_or_default(), &mut ciphertext_with_tag)
         .map_err(AeadError::Encrypt)?;
-    Ok(ciphertext)
+    Ok(ciphertext_with_tag)
 }
 
 /// ChaCha20Poly1305 AEAD decryption function.

--- a/p2panda-group/src/crypto/aead.rs
+++ b/p2panda-group/src/crypto/aead.rs
@@ -3,14 +3,14 @@
 //! ChaCha20Poly1305 authenticated encryption with additional data (AEAD).
 //!
 //! <https://www.rfc-editor.org/rfc/rfc7905>
-use libcrux_chacha20poly1305::{KEY_LEN, NONCE_LEN, TAG_LEN};
+use chacha20poly1305::{AeadInPlace, ChaCha20Poly1305, Key, KeyInit, Nonce};
 use thiserror::Error;
 
 /// 96-bit nonce.
-pub type AeadNonce = [u8; NONCE_LEN];
+pub type AeadNonce = [u8; 12];
 
 /// 256-bit secret key.
-pub type AeadKey = [u8; KEY_LEN];
+pub type AeadKey = [u8; 32];
 
 /// ChaCha20Poly1305 AEAD encryption function.
 pub fn aead_encrypt(
@@ -20,16 +20,14 @@ pub fn aead_encrypt(
     aad: Option<&[u8]>,
 ) -> Result<Vec<u8>, AeadError> {
     // Implementation attaches authenticated tag (16 bytes) automatically to the end of ciphertext.
-    let mut ciphertext_with_tag = vec![0; plaintext.len() + TAG_LEN];
-    libcrux_chacha20poly1305::encrypt(
-        key,
-        plaintext,
-        &mut ciphertext_with_tag,
-        aad.unwrap_or_default(),
-        &nonce,
-    )
-    .map_err(AeadError::Encrypt)?;
-    Ok(ciphertext_with_tag)
+    let key = Key::from_slice(key);
+    let nonce = Nonce::from_slice(&nonce);
+    let mut ciphertext: Vec<u8> = Vec::from(plaintext);
+    let cipher = ChaCha20Poly1305::new(key);
+    cipher
+        .encrypt_in_place(nonce, aad.unwrap_or_default(), &mut ciphertext)
+        .map_err(AeadError::Encrypt)?;
+    Ok(ciphertext)
 }
 
 /// ChaCha20Poly1305 AEAD decryption function.
@@ -39,25 +37,23 @@ pub fn aead_decrypt(
     nonce: AeadNonce,
     aad: Option<&[u8]>,
 ) -> Result<Vec<u8>, AeadError> {
-    let mut buffer = vec![0; ciphertext_with_tag.len()];
-    let plaintext = libcrux_chacha20poly1305::decrypt(
-        key,
-        &mut buffer,
-        ciphertext_with_tag,
-        aad.unwrap_or_default(),
-        &nonce,
-    )
-    .map_err(AeadError::Decrypt)?;
-    Ok(plaintext.to_vec())
+    let key = Key::from_slice(key);
+    let nonce = Nonce::from_slice(&nonce);
+    let mut plaintext: Vec<u8> = Vec::from(ciphertext_with_tag);
+    let cipher = ChaCha20Poly1305::new(key);
+    cipher
+        .decrypt_in_place(nonce, aad.unwrap_or_default(), &mut plaintext)
+        .map_err(AeadError::Decrypt)?;
+    Ok(plaintext)
 }
 
 #[derive(Debug, Error)]
 pub enum AeadError {
     #[error("plaintext could not be encrypted with aead: {0}")]
-    Encrypt(libcrux_chacha20poly1305::AeadError),
+    Encrypt(chacha20poly1305::Error),
 
     #[error("ciphertext could not be decrypted with aead: {0}")]
-    Decrypt(libcrux_chacha20poly1305::AeadError),
+    Decrypt(chacha20poly1305::Error),
 }
 
 #[cfg(test)]
@@ -94,25 +90,19 @@ mod tests {
         // Invalid key.
         assert!(matches!(
             aead_decrypt(&invalid_key, &ciphertext, nonce, None),
-            Err(AeadError::Decrypt(
-                libcrux_chacha20poly1305::AeadError::InvalidCiphertext
-            ))
+            Err(AeadError::Decrypt(chacha20poly1305::Error))
         ));
 
         // Invalid nonce.
         assert!(matches!(
             aead_decrypt(&key, &ciphertext, invalid_nonce, None),
-            Err(AeadError::Decrypt(
-                libcrux_chacha20poly1305::AeadError::InvalidCiphertext
-            ))
+            Err(AeadError::Decrypt(chacha20poly1305::Error))
         ));
 
         // Invalid additional data.
         assert!(matches!(
             aead_decrypt(&key, &ciphertext, nonce, Some(b"invalid aad")),
-            Err(AeadError::Decrypt(
-                libcrux_chacha20poly1305::AeadError::InvalidCiphertext
-            ))
+            Err(AeadError::Decrypt(chacha20poly1305::Error))
         ));
     }
 }

--- a/p2panda-group/src/crypto/hkdf.rs
+++ b/p2panda-group/src/crypto/hkdf.rs
@@ -14,7 +14,7 @@ pub fn hkdf<const N: usize>(
     info: Option<&[u8]>,
 ) -> Result<[u8; N], HkdfError> {
     let salt = if salt.is_empty() { None } else { Some(salt) };
-    let hk = Hkdf::<Sha256>::new(salt, &ikm);
+    let hk = Hkdf::<Sha256>::new(salt, ikm);
     let mut okm = [0u8; N];
     hk.expand(info.unwrap_or_default(), &mut okm)
         .map_err(|_| HkdfError::InvalidArguments)?;

--- a/p2panda-group/src/crypto/hkdf.rs
+++ b/p2panda-group/src/crypto/hkdf.rs
@@ -4,21 +4,21 @@
 //! "hash-mode" with SHA256.
 //!
 //! <https://www.rfc-editor.org/rfc/rfc5869>
-use libcrux_hkdf::Algorithm;
+use hkdf::Hkdf;
+use sha2::Sha256;
 use thiserror::Error;
-
-const HKDF: Algorithm = Algorithm::Sha256;
 
 pub fn hkdf<const N: usize>(
     salt: &[u8],
     ikm: &[u8],
     info: Option<&[u8]>,
 ) -> Result<[u8; N], HkdfError> {
-    let hash = libcrux_hkdf::hkdf(HKDF, salt, ikm, info.unwrap_or_default(), N)
+    let salt = if salt.is_empty() { None } else { Some(salt) };
+    let hk = Hkdf::<Sha256>::new(salt, &ikm);
+    let mut okm = [0u8; N];
+    hk.expand(info.unwrap_or_default(), &mut okm)
         .map_err(|_| HkdfError::InvalidArguments)?;
-    Ok(hash
-        .try_into()
-        .expect("matching output size from hkdf function"))
+    Ok(okm)
 }
 
 #[derive(Debug, Error)]

--- a/p2panda-group/src/crypto/hpke.rs
+++ b/p2panda-group/src/crypto/hpke.rs
@@ -38,6 +38,8 @@ pub fn hpke_seal(
     aad: Option<&[u8]>,
     plaintext: &[u8],
 ) -> Result<HpkeCiphertext, HpkeError> {
+    // Unfortunately `hpke-rs` doesn't allow us to pass in our own rng without writing a lot of
+    // boilerplate, so we hope to replace it with a different API or solution sometime.
     let mut hpke = Hpke::<HpkeRustCrypto>::new(
         Mode::Base,
         KemAlgorithm::DhKem25519,

--- a/p2panda-group/src/crypto/hpke.rs
+++ b/p2panda-group/src/crypto/hpke.rs
@@ -4,17 +4,13 @@
 //! parameters.
 //!
 //! <https://www.rfc-editor.org/rfc/rfc9180>
-// TODO: Switch to `libcrux-hpke` as soon as it's ready.
-use libcrux::hpke::{HPKEConfig, HpkeOpen, HpkeSeal, Mode, aead, errors, kdf, kem};
+use hpke_rs::{Hpke, HpkePrivateKey, HpkePublicKey, Mode};
+use hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
+use hpke_rs_rust_crypto::HpkeRustCrypto;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::crypto::x25519::{PublicKey, SecretKey};
-use crate::crypto::{Rng, RngError};
-
-const KEM: kem::KEM = kem::KEM::DHKEM_X25519_HKDF_SHA256;
-const KDF: kdf::KDF = kdf::KDF::HKDF_SHA256;
-const AEAD: aead::AEAD = aead::AEAD::ChaCha20Poly1305;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HpkeCiphertext {
@@ -41,22 +37,25 @@ pub fn hpke_seal(
     info: Option<&[u8]>,
     aad: Option<&[u8]>,
     plaintext: &[u8],
-    rng: &Rng,
 ) -> Result<HpkeCiphertext, HpkeError> {
-    let config = HPKEConfig(Mode::mode_base, KEM, KDF, AEAD);
-    let randomness = rng.random_vec(kem::Nsk(KEM))?;
-    let libcrux::hpke::HPKECiphertext(kem_output, ciphertext) = HpkeSeal(
-        config,
-        public_key.as_bytes(),
-        info.unwrap_or_default(),
-        aad.unwrap_or_default(),
-        plaintext,
-        None,
-        None,
-        None,
-        randomness,
-    )
-    .map_err(HpkeError::Encryption)?;
+    let mut hpke = Hpke::<HpkeRustCrypto>::new(
+        Mode::Base,
+        KemAlgorithm::DhKem25519,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::ChaCha20Poly1305,
+    );
+    let pk_r = HpkePublicKey::new(public_key.as_bytes().to_vec());
+    let (kem_output, ciphertext) = hpke
+        .seal(
+            &pk_r,
+            info.unwrap_or_default(),
+            aad.unwrap_or_default(),
+            plaintext,
+            None,
+            None,
+            None,
+        )
+        .map_err(HpkeError::Encryption)?;
     Ok(HpkeCiphertext {
         kem_output,
         ciphertext,
@@ -74,33 +73,35 @@ pub fn hpke_open(
     info: Option<&[u8]>,
     aad: Option<&[u8]>,
 ) -> Result<Vec<u8>, HpkeError> {
-    let config = HPKEConfig(Mode::mode_base, KEM, KDF, AEAD);
-    let ciphertext =
-        libcrux::hpke::HPKECiphertext(input.kem_output.to_vec(), input.ciphertext.to_vec());
-    let plaintext = HpkeOpen(
-        config,
-        &ciphertext,
-        secret_key.as_bytes(),
-        info.unwrap_or_default(),
-        aad.unwrap_or_default(),
-        None,
-        None,
-        None,
-    )
-    .map_err(HpkeError::Decryption)?;
+    let hpke = Hpke::<HpkeRustCrypto>::new(
+        Mode::Base,
+        KemAlgorithm::DhKem25519,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::ChaCha20Poly1305,
+    );
+    let sk_r = HpkePrivateKey::new(secret_key.as_bytes().to_vec());
+    let plaintext = hpke
+        .open(
+            &input.kem_output,
+            &sk_r,
+            info.unwrap_or_default(),
+            aad.unwrap_or_default(),
+            &input.ciphertext,
+            None,
+            None,
+            None,
+        )
+        .map_err(HpkeError::Decryption)?;
     Ok(plaintext)
 }
 
 #[derive(Debug, Error)]
 pub enum HpkeError {
-    #[error(transparent)]
-    Rng(#[from] RngError),
-
     #[error("could not encrypt with hpke: {0:?}")]
-    Encryption(errors::HpkeError),
+    Encryption(hpke_rs::HpkeError),
 
     #[error("could not decrypt with hpke: {0:?}")]
-    Decryption(errors::HpkeError),
+    Decryption(hpke_rs::HpkeError),
 }
 
 #[cfg(test)]
@@ -119,8 +120,7 @@ mod tests {
 
         let info = b"some info";
         let aad = b"some aad";
-        let ciphertext =
-            hpke_seal(&public_key, Some(info), Some(aad), b"Hello, Panda!", &rng).unwrap();
+        let ciphertext = hpke_seal(&public_key, Some(info), Some(aad), b"Hello, Panda!").unwrap();
         let plaintext = hpke_open(&ciphertext, &secret_key, Some(info), Some(aad)).unwrap();
 
         assert_eq!(plaintext, b"Hello, Panda!");
@@ -135,8 +135,7 @@ mod tests {
 
         let info = b"some info";
         let aad = b"some aad";
-        let ciphertext =
-            hpke_seal(&public_key, Some(info), Some(aad), b"Hello, Panda!", &rng).unwrap();
+        let ciphertext = hpke_seal(&public_key, Some(info), Some(aad), b"Hello, Panda!").unwrap();
 
         // Invalid secret key.
         let invalid_secret_key = SecretKey::from_bytes(rng.random_array().unwrap());

--- a/p2panda-group/src/crypto/mod.rs
+++ b/p2panda-group/src/crypto/mod.rs
@@ -14,9 +14,6 @@
 //!
 //! Random Number Generator:
 //! - ChaCha20 stream cipher, seeded via `getrandom`
-//!
-//! Most of the implementations use the [`libcrux`](https://github.com/cryspen/libcrux) crate
-//! internally.
 pub mod aead;
 pub mod ed25519;
 pub mod hkdf;

--- a/p2panda-group/src/crypto/secret.rs
+++ b/p2panda-group/src/crypto/secret.rs
@@ -22,8 +22,6 @@ use zeroize::ZeroizeOnDrop;
 pub struct Secret<const N: usize>(#[serde(with = "serde_bytes")] [u8; N]);
 
 impl<const N: usize> Secret<N> {
-    // TODO: Remove this in later PRs.
-    #[allow(dead_code)]
     pub(crate) fn from_bytes(bytes: [u8; N]) -> Self {
         Self(bytes)
     }

--- a/p2panda-group/src/crypto/sha2.rs
+++ b/p2panda-group/src/crypto/sha2.rs
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! SHA2 hashing functions.
-use libcrux_traits::Digest;
+use sha2::{Digest, Sha512};
 
-pub const DIGEST_SIZE: usize = libcrux_sha2::SHA512_LENGTH;
+pub const SHA512_DIGEST_SIZE: usize = 64;
 
 /// SHA2-512 hashing function.
-pub fn sha2_512(messages: &[&[u8]]) -> [u8; DIGEST_SIZE] {
-    let mut hasher = libcrux_sha2::Sha512::new();
+pub fn sha2_512(messages: &[&[u8]]) -> [u8; SHA512_DIGEST_SIZE] {
+    let mut hasher = Sha512::new();
     for message in messages {
         hasher.update(message);
     }
-    let mut output = [0u8; DIGEST_SIZE];
-    hasher.finish(&mut output);
-    output
+    let result = hasher.finalize();
+    result[..].try_into().expect("sha512 digest size")
 }

--- a/p2panda-group/src/crypto/xchacha20.rs
+++ b/p2panda-group/src/crypto/xchacha20.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! XChaCha20Poly1305 is a ChaCha20 AEAD variant with an extended 192-bit (24-byte) nonce.
-// TODO: Switch to `libcrux` implementation as soon as it's ready.
 use chacha20poly1305::{AeadInPlace, Key, KeyInit, XChaCha20Poly1305, XNonce};
 use thiserror::Error;
 

--- a/p2panda-group/src/two_party/two_party.rs
+++ b/p2panda-group/src/two_party/two_party.rs
@@ -283,7 +283,7 @@ where
                 TwoPartyCiphertext::PreKey(ciphertext)
             }
             Some(their_public_key) => {
-                let ciphertext = hpke_seal(their_public_key, None, None, plaintext, rng)?;
+                let ciphertext = hpke_seal(their_public_key, None, None, plaintext)?;
                 TwoPartyCiphertext::Hpke(ciphertext)
             }
         };


### PR DESCRIPTION
Replacing most core cryptographic implementations coming from `libcrux` with other crates.

We might go back to `libcrux` when they've officially released all crates.

Unfortunately the `hpke-rs` is very opiniated in its API design and we can't use our own rng implementation here.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] New files contain a SPDX license header
