### PR TITLE
store: Expose sqlite migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
+### Added
+
+- Expose sqlite migrations [#744](https://github.com/p2panda/p2panda/pull/744)
+
 ## [0.3.1] - 14/04/2025
 
 ### Added

--- a/p2panda-store/src/sqlite/store.rs
+++ b/p2panda-store/src/sqlite/store.rs
@@ -86,9 +86,14 @@ pub async fn connection_pool(url: &str, max_connections: u32) -> Result<Pool, Sq
     Ok(pool)
 }
 
+/// Get migrations without running them
+pub fn migrations() -> migrate::Migrator {
+    migrate!()
+}
+
 /// Run any pending database migrations from inside the application.
 pub async fn run_pending_migrations(pool: &Pool) -> Result<(), SqliteStoreError> {
-    migrate!().run(pool).await?;
+    migrations().run(pool).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Since applications may run their own migrations we need them to be able to control the `Migrator` so the application can set `ignore missing` or combine different `MigratorSource`s

See for better explanation: https://github.com/launchbadge/sqlx/discussions/3407

Describe your changes here.

## 📋 Checklist

- [ x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ x] Link this PR to any issues it closes
- [ x] New files contain a SPDX license header
