### PR TITLE
Derive `Clone` and `Debug` on all public partial ordering structs

### DIFF
--- a/p2panda-stream/src/ordering/partial/mod.rs
+++ b/p2panda-stream/src/ordering/partial/mod.rs
@@ -79,7 +79,7 @@ pub enum PartialOrderError {
 ///
 /// Note that no checks are made for cycles occurring in the graph, this should be validated on
 /// another layer.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PartialOrder<K, S> {
     /// Store for managing "ready" and "pending" items.
     store: S,

--- a/p2panda-stream/src/ordering/partial/operations.rs
+++ b/p2panda-stream/src/ordering/partial/operations.rs
@@ -16,7 +16,7 @@ use crate::ordering::partial::{
 /// This struct is a thin wrapper around ordering::PartialOrder struct which takes care of sorting
 /// the operation dependency graph into a partial order. Here we have the addition of a `LogStore`
 /// and `OperationStore` implementation (traits from `p2panda-store`).
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PartialOrder<L, E, OS, POS> {
     /// A store containing p2panda operations.
     ///

--- a/p2panda-stream/src/ordering/partial/store.rs
+++ b/p2panda-stream/src/ordering/partial/store.rs
@@ -45,7 +45,7 @@ where
 }
 
 /// Memory implementation of the `PartialOrderStore` trait.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MemoryStore<K> {
     pub(crate) ready: HashSet<K>,
     pub(crate) ready_queue: VecDeque<K>,


### PR DESCRIPTION
Derive `Clone` and `Debug` on all public partial ordering structs.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
