### PR TITLE
Introduce core group CRDT for auth

### DIFF
--- a/p2panda-auth/Cargo.toml
+++ b/p2panda-auth/Cargo.toml
@@ -16,6 +16,8 @@ keywords = ["auth", "access-control", "groups"]
 all-features = true
 
 [dependencies]
+anyhow = "1.0.98"
+thiserror = "2.0.12"
 
 [lints]
 workspace = true

--- a/p2panda-auth/Cargo.toml
+++ b/p2panda-auth/Cargo.toml
@@ -16,7 +16,6 @@ keywords = ["auth", "access-control", "groups"]
 all-features = true
 
 [dependencies]
-anyhow = "1.0.98"
 thiserror = "2.0.12"
 
 [lints]

--- a/p2panda-auth/src/group-crdt.rs
+++ b/p2panda-auth/src/group-crdt.rs
@@ -1,0 +1,282 @@
+// Group membership CRDT functions.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use anyhow::Error;
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
+pub enum Access {
+    Pull,
+    Read,
+    Write,
+    Manage, // Admin
+}
+
+#[derive(Clone, Debug)]
+pub struct MemberState<ID> {
+    pub member: ID,
+    pub member_counter: usize,
+    pub access: Access,
+    pub access_counter: usize,
+}
+
+impl<ID> MemberState<ID> {
+    pub fn is_member(&self) -> bool {
+        self.member_counter % 2 != 0
+    }
+
+    pub fn is_admin(&self) -> bool {
+        self.access == Access::Manage
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GroupMembersState<ID> {
+    pub members: HashMap<ID, MemberState<ID>>,
+}
+
+impl<ID> GroupMembersState<ID>
+where
+    ID: Clone + Hash + Eq,
+{
+    pub fn members(&self) -> HashSet<ID> {
+        self.members
+            .values()
+            .filter_map(|state| {
+                if state.is_member() {
+                    Some(state.member.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<HashSet<_>>()
+    }
+
+    pub fn admins(&self) -> HashSet<ID> {
+        self.members
+            .values()
+            .filter_map(|state| {
+                if state.is_admin() && state.is_member() {
+                    Some(state.member.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<HashSet<_>>()
+    }
+}
+
+impl<ID> Default for GroupMembersState<ID> {
+    fn default() -> Self {
+        Self {
+            members: Default::default(),
+        }
+    }
+}
+
+pub fn create_group<ID: Clone + Eq + Hash>(
+    initial_members: &[(ID, Access)],
+) -> Result<GroupMembersState<ID>, Error> {
+    let mut members = HashMap::new();
+    for (id, access) in initial_members {
+        let member = MemberState {
+            member: id.clone(),
+            member_counter: 1,
+            access: *access,
+            access_counter: 0,
+        };
+        members.insert(id.clone(), member);
+    }
+
+    let state = GroupMembersState { members };
+
+    Ok(state)
+}
+
+pub fn add_member<ID: Clone + Eq + Hash>(
+    state: GroupMembersState<ID>,
+    actor: ID,
+    member: ID,
+    access: Access,
+) -> Result<GroupMembersState<ID>, Error> {
+    // TODO: Consider whether we want to return Error rather than the unchanged state...
+    // The error would communicate why there was an early return.
+
+    // Check the actor is known to the group.
+    let Some(actor) = state.members.get(&actor) else {
+        // Throw error here.
+        panic!()
+    };
+
+    // If "actor" is not a current group member or not an admin, do not perform the add and
+    // directly return the state.
+    if !actor.is_member() || !actor.is_admin() {
+        panic!()
+    };
+
+    // Add "member" to the group or increment their counter if they are already known but were
+    // previously removed.
+    let mut state = state;
+    state
+        .members
+        .entry(member.clone())
+        .and_modify(|state| {
+            if !state.is_member() {
+                state.member_counter += 1;
+                state.access = access;
+                state.access_counter = 0;
+            }
+        })
+        .or_insert(MemberState {
+            member,
+            member_counter: 1,
+            access,
+            access_counter: 0,
+        });
+
+    Ok(state)
+}
+
+pub fn remove_member<ID: Eq + Hash>(
+    state: GroupMembersState<ID>,
+    actor: ID,
+    member: ID,
+) -> Result<GroupMembersState<ID>, Error> {
+    // Check "actor" is known to the group.
+    let Some(actor) = state.members.get(&actor) else {
+        return Ok(state);
+    };
+
+    // If "actor" is not a current group member or not an admin, do not perform the remove and
+    // directly return the state.
+    if !actor.is_member() || !actor.is_admin() {
+        panic!()
+    };
+
+    // Check "member" is in the group.
+    if state.members.get(&member).is_none() {
+        panic!()
+    };
+
+    // Increment "member" counter unless they are already removed.
+    let mut state = state;
+    state.members.entry(member).and_modify(|state| {
+        if state.is_member() {
+            state.member_counter += 1;
+            state.access_counter = 0;
+        }
+    });
+
+    Ok(state)
+}
+
+pub fn promote<ID: Eq + Hash>(
+    state: GroupMembersState<ID>,
+    actor: ID,
+    member: ID,
+    access: Access,
+) -> Result<GroupMembersState<ID>, Error> {
+    // Check "actor" is known to the group.
+    let Some(actor) = state.members.get(&actor) else {
+        panic!()
+    };
+
+    // If "actor" is not a current group member or not an admin, do not perform the remove and
+    // directly return the state.
+    if !actor.is_member() || !actor.is_admin() {
+        panic!()
+    };
+
+    // Check "member" is in the group.
+    if state.members.get(&member).is_none() {
+        panic!()
+    };
+
+    // Update access level.
+    let mut state = state;
+    state.members.entry(member).and_modify(|state| {
+        if state.access < access {
+            state.access = access;
+            state.access_counter += 1;
+        }
+    });
+
+    Ok(state)
+}
+
+pub fn demote<ID: Eq + Hash>(
+    state: GroupMembersState<ID>,
+    actor: ID,
+    member: ID,
+    access: Access,
+) -> Result<GroupMembersState<ID>, Error> {
+    // Check "actor" is known to the group.
+    let Some(actor) = state.members.get(&actor) else {
+        panic!()
+    };
+
+    // If "actor" is not a current group member or not an admin, do not perform the remove and
+    // directly return the state.
+    if !actor.is_member() || !actor.is_admin() {
+        panic!()
+    };
+
+    // Check "member" is in the group.
+    if state.members.get(&member).is_none() {
+        panic!()
+    };
+
+    // Update access level.
+    let mut state = state;
+    state.members.entry(member).and_modify(|state| {
+        if state.access > access {
+            state.access = access;
+            state.access_counter += 1;
+        }
+    });
+
+    Ok(state)
+}
+
+pub fn merge<ID: Clone + Eq + Hash>(
+    state_1: GroupMembersState<ID>,
+    state_2: GroupMembersState<ID>,
+) -> Result<GroupMembersState<ID>, Error> {
+    // Start from state_2 state.
+    let mut next_state = state_2.clone();
+
+    // Iterate over entries in state_1.
+    for (id, member_state_1) in state_1.members {
+        if let Some(member_state) = next_state.members.get_mut(&id) {
+            // If the member is present in both states take the higher counter.
+            if member_state_1.member_counter > member_state.member_counter {
+                member_state.member_counter = member_state_1.member_counter;
+                member_state.access = member_state_1.access;
+                member_state.access_counter = member_state_1.access_counter;
+            }
+
+            // If the member counters are equal, take the access level for the state with a higher
+            // access counter. If the access counters are equal, do nothing.
+            if member_state_1.member_counter == member_state.member_counter {
+                if member_state_1.access_counter > member_state.access_counter {
+                    member_state.access = member_state_1.access;
+                    member_state.access_counter = member_state_1.access_counter;
+                }
+
+                // If the access counters are the same, take the lower of the two access levels.
+                if member_state_1.access_counter == member_state.access_counter {
+                    if member_state_1.access < member_state.access {
+                        member_state.access = member_state_1.access;
+                    }
+                }
+            }
+        } else {
+            // Otherwise insert the member into the next state.
+            next_state.members.insert(id, member_state_1);
+        }
+    }
+
+    Ok(next_state)
+}

--- a/p2panda-auth/src/group_crdt.rs
+++ b/p2panda-auth/src/group_crdt.rs
@@ -174,7 +174,7 @@ pub fn remove_member<ID: Eq + Hash, C: Clone + Debug + PartialEq>(
     };
 
     // Check "member" is in the group.
-    if state.members.get(&member).is_none() {
+    if !state.members.contains_key(&member) {
         panic!()
     };
 
@@ -208,7 +208,7 @@ pub fn promote<ID: Eq + Hash, C: Clone + Debug + PartialEq + PartialOrd>(
     };
 
     // Check "member" is in the group.
-    if state.members.get(&member).is_none() {
+    if !state.members.contains_key(&member) {
         panic!()
     };
 
@@ -242,7 +242,7 @@ pub fn demote<ID: Eq + Hash, C: Clone + Debug + PartialEq + PartialOrd>(
     };
 
     // Check "member" is in the group.
-    if state.members.get(&member).is_none() {
+    if !state.members.contains_key(&member) {
         panic!()
     };
 
@@ -286,10 +286,10 @@ pub fn merge<ID: Clone + Eq + Hash, C: Clone + Debug + PartialEq + PartialOrd>(
                 }
 
                 // If the access counters are the same, take the lower of the two access levels.
-                if member_state_1.access_counter == member_state.access_counter {
-                    if member_state_1.access < member_state.access {
-                        member_state.access = member_state_1.access;
-                    }
+                if member_state_1.access_counter == member_state.access_counter
+                    && member_state_1.access < member_state.access
+                {
+                    member_state.access = member_state_1.access;
                 }
             }
         } else {

--- a/p2panda-auth/src/lib.rs
+++ b/p2panda-auth/src/lib.rs
@@ -1,16 +1,1 @@
-mod group_crdt;
-
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod group_crdt;

--- a/p2panda-auth/src/lib.rs
+++ b/p2panda-auth/src/lib.rs
@@ -1,3 +1,5 @@
+mod group_crdt;
+
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }


### PR DESCRIPTION
Here we introduce a Causal Length CRDT (CL-CRDT) to track individual member and group states.

We define four access levels: `Pull`, `Read`, `Write` and `Manage`. The `Write` access level can optionally include generic `conditions`. 

- [x] `Access`
- [x] `MemberState`
- [x] `GroupMembersState`
- [x] `GroupMembershipError`
- [x] `create()`
- [x] `add()`
- [x] `remove()`
- [x] `promote()`
- [x] `demote()`
- [x] `modify()`
- [x] `merge()`
- [ ] Handle "all members can add" scenario

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] New files contain a SPDX license header
