### PR TITLE
`p2panda-auth` strong-remove resolver

### DIFF
--- a/p2panda-auth/src/group/display.rs
+++ b/p2panda-auth/src/group/display.rs
@@ -328,7 +328,7 @@ where
                 let table = format!(
                     "<<TABLE BGCOLOR=\"{INDIVIDUAL_NODE}\" BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\"><TR><TD>individual</TD><TD>{id}</TD></TR></TABLE>>"
                 );
-                let idx = match graph.node_references().find(|(idx, (_, t))| t == &table) {
+                let idx = match graph.node_references().find(|(_, (_, t))| t == &table) {
                     Some((idx, _)) => idx,
                     None => graph.add_node((None, table)),
                 };

--- a/p2panda-auth/src/group/display.rs
+++ b/p2panda-auth/src/group/display.rs
@@ -10,6 +10,15 @@ use petgraph::visit::IntoNodeReferences;
 use crate::group::{Group, GroupAction, GroupControlMessage, GroupMember, GroupState};
 use crate::traits::{GroupStore, IdentityHandle, Operation, OperationId, Ordering, Resolver};
 
+const OP_FILTER_NODE: &str = "#E63C3F";
+const OP_OK_NODE: &str = "#BFC6C77F";
+const OP_NOOP_NODE: &str = "#FFA142";
+const OP_ROOT_NODE: &str = "#EDD7B17F";
+const INDIVIDUAL_NODE: &str = "#EDD7B17F";
+const ADD_MEMBER_EDGE: &str = "#0091187F";
+const PREVIOUS_EDGE: &str = "#000000";
+const DEPENDENCIES_EDGE: &str = "#B748E37F";
+
 impl<ID, OP, C, RS, ORD, GS> GroupState<ID, OP, C, RS, ORD, GS>
 where
     ID: IdentityHandle + Ord + Display,
@@ -33,16 +42,22 @@ where
             &[Config::NodeNoLabel, Config::EdgeNoLabel],
             &|_, edge| {
                 let weight = edge.weight();
-                if weight == "previous" || weight == "member" || weight == "sub group" {
-                    return format!("label = \"{}\"", weight);
+                if weight == "previous" {
+                    return format!("color=\"{PREVIOUS_EDGE}\", penwidth = 2.0");
                 }
 
-                format!("label = \"{}\", constraint = false", weight)
+                if weight == "member" || weight == "sub group" {
+                    return format!("color=\"{ADD_MEMBER_EDGE}\", penwidth = 2.0");
+                }
+
+                format!("constraint = false, color=\"{DEPENDENCIES_EDGE}\", penwidth = 2.0")
             },
             &|_, (_, (_, s))| format!("label = {}", s),
         );
 
-        format!("{:?}", dag_graphviz)
+        let mut s = format!("{:?}", dag_graphviz);
+        s = s.replace("digraph {", "digraph {\n    splines=polyline\n");
+        s
     }
 
     fn add_nodes_and_previous_edges(
@@ -131,18 +146,18 @@ where
         let mut s = String::new();
 
         let color = if control_message.is_create() {
-            "bisque"
+            OP_ROOT_NODE
         } else {
             match Group::apply_action(
                 self.clone(),
                 operation.id(),
                 GroupMember::Individual(operation.author()),
-                &HashSet::from_iter(operation.previous()),
+                &HashSet::from_iter(operation.dependencies()),
                 &action,
             ) {
-                super::StateChangeResult::Ok { .. } => "grey",
-                super::StateChangeResult::Noop { .. } => "darkorange",
-                super::StateChangeResult::Filtered { .. } => "red",
+                super::StateChangeResult::Ok { .. } => OP_OK_NODE,
+                super::StateChangeResult::Noop { .. } => OP_NOOP_NODE,
+                super::StateChangeResult::Filtered { .. } => OP_FILTER_NODE,
             }
         };
 
@@ -159,8 +174,7 @@ where
                 self.format_dependencies(&previous)
             );
         }
-        let mut dependencies = operation.dependencies().clone();
-        dependencies.retain(|id| !previous.contains(id));
+        let dependencies = operation.dependencies().clone();
         if !dependencies.is_empty() {
             s += &format!(
                 "<TR><TD>dependencies</TD><TD>{}</TD></TR>",
@@ -304,28 +318,47 @@ where
     ) -> DiGraph<(Option<OP>, String), String> {
         match member {
             GroupMember::Individual(id) => {
-                let idx = graph.add_node((None, format!("<<TABLE BGCOLOR=\"bisque\" BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\"><TR><TD>individual</TD><TD>{id}</TD></TR></TABLE>>")));
+                let table = format!(
+                    "<<TABLE BGCOLOR=\"{INDIVIDUAL_NODE}\" BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\"><TR><TD>individual</TD><TD>{id}</TD></TR></TABLE>>"
+                );
+                let idx = match graph.node_references().find(|(idx, (_, t))| t == &table) {
+                    Some((idx, _)) => idx,
+                    None => graph.add_node((None, table)),
+                };
                 graph.add_edge(operation_idx, idx, "member".to_string());
             }
             GroupMember::Group(id) => {
                 let sub_group = self.get_sub_group(id).unwrap();
-                graph = sub_group.add_nodes_and_previous_edges(root.clone(), graph);
-
                 let create_operation = sub_group
                     .operations
                     .first()
                     .expect("create operation exists");
 
-                let (create_operation_idx, _) = graph
-                    .node_references()
-                    .find(|(_, (op, _))| {
-                        if let Some(op) = op {
-                            *op == create_operation.id()
-                        } else {
-                            false
-                        }
-                    })
-                    .unwrap();
+                let create_node = graph.node_references().find(|(_, (op, _))| {
+                    if let Some(op) = op {
+                        *op == create_operation.id()
+                    } else {
+                        false
+                    }
+                });
+
+                let create_operation_idx = match create_node {
+                    Some((idx, _)) => idx,
+                    None => {
+                        graph = sub_group.add_nodes_and_previous_edges(root.clone(), graph);
+                        let (idx, _) = graph
+                            .node_references()
+                            .find(|(_, (op, _))| {
+                                if let Some(op) = op {
+                                    *op == create_operation.id()
+                                } else {
+                                    false
+                                }
+                            })
+                            .unwrap();
+                        idx
+                    }
+                };
 
                 graph.add_edge(operation_idx, create_operation_idx, "sub group".to_string());
             }

--- a/p2panda-auth/src/group/display.rs
+++ b/p2panda-auth/src/group/display.rs
@@ -181,9 +181,7 @@ where
 
     fn format_final_members(&self) -> String {
         let mut s = String::new();
-        s += &format!(
-            "<<TABLE BGCOLOR=\"#00E30F7F\" BORDER=\"1\" CELLBORDER=\"1\" CELLSPACING=\"2\">"
-        );
+        s += "<<TABLE BGCOLOR=\"#00E30F7F\" BORDER=\"1\" CELLBORDER=\"1\" CELLSPACING=\"2\">";
 
         let mut members = self.transitive_members().unwrap();
         members.sort();

--- a/p2panda-auth/src/group/display.rs
+++ b/p2panda-auth/src/group/display.rs
@@ -126,7 +126,11 @@ where
         let color = if control_message.is_create() {
             "bisque"
         } else {
-            "grey"
+            if self.ignore.contains(&operation.id()) {
+                "red"
+            } else {
+                "grey"
+            }
         };
 
         s += &format!(

--- a/p2panda-auth/src/group/display.rs
+++ b/p2panda-auth/src/group/display.rs
@@ -14,7 +14,7 @@ impl<ID, OP, C, RS, ORD, GS> GroupState<ID, OP, C, RS, ORD, GS>
 where
     ID: IdentityHandle + Ord + Display,
     OP: OperationId + Ord + Display,
-    C: Clone + Debug + PartialEq + PartialOrd,
+    C: Clone + Debug + PartialEq + PartialOrd + Ord,
     RS: Resolver<ORD::Message, State = GroupState<ID, OP, C, RS, ORD, GS>> + Clone + Debug,
     ORD: Ordering<ID, OP, GroupControlMessage<ID, OP, C>> + Clone + Debug,
     ORD::State: Clone,
@@ -25,6 +25,8 @@ where
     pub fn display(&self) -> String {
         let mut graph = DiGraph::new();
         graph = self.add_nodes_and_previous_edges(self.clone(), graph);
+
+        graph.add_node((None, self.format_final_members()));
 
         let dag_graphviz = Dot::with_attr_getters(
             &graph,
@@ -173,6 +175,21 @@ where
             "<TR><TD COLSPAN=\"2\">{}</TD></TR>",
             self.format_members(operation)
         );
+        s += "</TABLE>>";
+        s
+    }
+
+    fn format_final_members(&self) -> String {
+        let mut s = String::new();
+        s += &format!(
+            "<<TABLE BGCOLOR=\"#00E30F7F\" BORDER=\"1\" CELLBORDER=\"1\" CELLSPACING=\"2\">");
+
+        let mut members = self.transitive_members().unwrap();
+        members.sort();
+        s += "<TR><TD>GROUP MEMBERS</TD></TR>";
+        for (id, access) in members {
+            s += &format!("<TR><TD> {} : {} </TD></TR>", id, access);
+        }
         s += "</TABLE>>";
         s
     }

--- a/p2panda-auth/src/group/display.rs
+++ b/p2panda-auth/src/group/display.rs
@@ -138,7 +138,7 @@ where
         );
         s += &format!("<TR><TD>group</TD><TD>{}</TD></TR>", self.id());
         s += &format!("<TR><TD>operation id</TD><TD>{}</TD></TR>", operation.id());
-        s += &format!("<TR><TD>actor</TD><TD>{}</TD></TR>", operation.sender());
+        s += &format!("<TR><TD>actor</TD><TD>{}</TD></TR>", operation.author());
         let previous = operation.previous();
         if !previous.is_empty() {
             s += &format!(

--- a/p2panda-auth/src/group/display.rs
+++ b/p2panda-auth/src/group/display.rs
@@ -78,7 +78,7 @@ where
                 ..
             } = operation.payload()
             {
-                for (member, _) in initial_members {
+                for (member, _access) in initial_members {
                     graph = self.add_member_to_graph(operation_idx, member, root.clone(), graph);
                 }
             }
@@ -156,7 +156,7 @@ where
         );
         s += &format!(
             "<TR><TD COLSPAN=\"2\">{}</TD></TR>",
-            self.format_members(&operation)
+            self.format_members(operation)
         );
         s += "</TABLE>>";
         s

--- a/p2panda-auth/src/group/display.rs
+++ b/p2panda-auth/src/group/display.rs
@@ -182,7 +182,8 @@ where
     fn format_final_members(&self) -> String {
         let mut s = String::new();
         s += &format!(
-            "<<TABLE BGCOLOR=\"#00E30F7F\" BORDER=\"1\" CELLBORDER=\"1\" CELLSPACING=\"2\">");
+            "<<TABLE BGCOLOR=\"#00E30F7F\" BORDER=\"1\" CELLBORDER=\"1\" CELLSPACING=\"2\">"
+        );
 
         let mut members = self.transitive_members().unwrap();
         members.sort();

--- a/p2panda-auth/src/group/display.rs
+++ b/p2panda-auth/src/group/display.rs
@@ -134,7 +134,7 @@ where
             match Group::apply_action(
                 self.clone(),
                 operation.id(),
-                GroupMember::Individual(operation.sender()),
+                GroupMember::Individual(operation.author()),
                 &HashSet::from_iter(operation.previous()),
                 &action,
             ) {

--- a/p2panda-auth/src/group/graph.rs
+++ b/p2panda-auth/src/group/graph.rs
@@ -1,5 +1,5 @@
 use petgraph::graphmap::DiGraphMap;
-use petgraph::visit::{Dfs, DfsPostOrder, Reversed};
+use petgraph::visit::{Dfs, Reversed};
 use std::collections::HashSet;
 
 use crate::traits::OperationId;
@@ -53,7 +53,7 @@ where
 {
     // Get all successors.
     let mut successors = HashSet::new();
-    let mut dfs = DfsPostOrder::new(&graph, target);
+    let mut dfs = Dfs::new(&graph, target);
     while let Some(nx) = dfs.next(&graph) {
         successors.insert(nx);
     }
@@ -61,7 +61,7 @@ where
     // Get all predecessors.
     let mut predecessors = HashSet::new();
     let reversed = Reversed(graph);
-    let mut dfs_rev = DfsPostOrder::new(&reversed, target);
+    let mut dfs_rev = Dfs::new(&reversed, target);
     while let Some(nx) = dfs_rev.next(&reversed) {
         predecessors.insert(nx);
     }

--- a/p2panda-auth/src/group/graph.rs
+++ b/p2panda-auth/src/group/graph.rs
@@ -1,10 +1,13 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashSet;
+
 use petgraph::graphmap::DiGraphMap;
 use petgraph::visit::{Dfs, Reversed};
-use std::collections::HashSet;
 
 use crate::traits::OperationId;
 
-pub fn concurrent_bubble<OP>(
+fn concurrent_bubble<OP>(
     graph: &DiGraphMap<OP, ()>,
     target: OP,
     processed: &mut HashSet<OP>,

--- a/p2panda-auth/src/group/graph.rs
+++ b/p2panda-auth/src/group/graph.rs
@@ -1,0 +1,200 @@
+use petgraph::graphmap::DiGraphMap;
+use petgraph::visit::{Dfs, DfsPostOrder, Reversed};
+use std::collections::HashSet;
+
+use crate::traits::OperationId;
+
+pub fn concurrent_bubble<OP>(
+    graph: &DiGraphMap<OP, ()>,
+    target: OP,
+    processed: &mut HashSet<OP>,
+) -> HashSet<OP>
+where
+    OP: OperationId + Ord,
+{
+    let mut bubble = HashSet::new();
+    bubble.insert(target);
+
+    concurrent_operations(graph, target)
+        .into_iter()
+        .for_each(|op| {
+            if processed.insert(op) {
+                bubble.extend(concurrent_bubble(graph, op, processed).iter())
+            }
+        });
+
+    bubble
+}
+
+/// Walk the graph and identify all sets of concurrent operations.
+pub fn concurrent_bubbles<OP>(graph: &DiGraphMap<OP, ()>) -> Vec<HashSet<OP>>
+where
+    OP: OperationId + Ord,
+{
+    let mut processed: HashSet<OP> = HashSet::new();
+    let mut bubbles = Vec::new();
+
+    graph.nodes().for_each(|target| {
+        if processed.insert(target) {
+            let bubble = concurrent_bubble(graph, target, &mut processed);
+            if bubble.len() > 1 {
+                bubbles.push(bubble)
+            }
+        }
+    });
+
+    bubbles
+}
+
+/// Return any operations concurrent with the given target operation.
+fn concurrent_operations<OP>(graph: &DiGraphMap<OP, ()>, target: OP) -> HashSet<OP>
+where
+    OP: OperationId + Ord,
+{
+    // Get all successors.
+    let mut successors = HashSet::new();
+    let mut dfs = DfsPostOrder::new(&graph, target);
+    while let Some(nx) = dfs.next(&graph) {
+        successors.insert(nx);
+    }
+
+    // Get all predecessors.
+    let mut predecessors = HashSet::new();
+    let reversed = Reversed(graph);
+    let mut dfs_rev = DfsPostOrder::new(&reversed, target);
+    while let Some(nx) = dfs_rev.next(&reversed) {
+        predecessors.insert(nx);
+    }
+
+    let relatives: HashSet<_> = successors.union(&predecessors).cloned().collect();
+
+    // Collect all operations which are not successors or predecessors.
+    graph.nodes().filter(|n| !relatives.contains(n)).collect()
+}
+
+/// Is `to` reachable from `from`
+pub fn has_path<OP>(graph: &DiGraphMap<OP, ()>, from: OP, to: OP) -> bool
+where
+    OP: OperationId + Ord,
+{
+    let mut dfs = Dfs::new(graph, from);
+    while let Some(node) = dfs.next(graph) {
+        if node == to {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use petgraph::{graph::DiGraph, prelude::DiGraphMap};
+
+    use crate::group::graph::concurrent_bubbles;
+
+    #[test]
+    fn test_linear_chain_no_concurrency() {
+        let mut graph = DiGraphMap::new();
+        graph.add_edge(1, 2, ());
+        graph.add_edge(2, 3, ());
+        graph.add_edge(3, 4, ());
+
+        let bubbles = concurrent_bubbles(&graph);
+        assert!(bubbles.is_empty());
+    }
+
+    #[test]
+    fn test_bubble() {
+        let mut graph = DiGraphMap::new();
+        graph.add_edge(1, 2, ());
+        graph.add_edge(1, 3, ());
+        graph.add_edge(2, 4, ());
+        graph.add_edge(3, 4, ());
+
+        let bubbles = concurrent_bubbles(&graph);
+
+        // 2 and 3 are concurrent.
+        assert_eq!(bubbles.len(), 1);
+        let expected: HashSet<_> = [2, 3].into_iter().collect();
+        assert_eq!(bubbles[0], expected);
+    }
+
+    #[test]
+    fn test_two_bubbles() {
+        let mut graph = DiGraphMap::new();
+        // Bubble 1: 1 → 2, 1 → 3, 2 → 4, 3 → 4
+        graph.add_edge(1, 2, ());
+        graph.add_edge(1, 3, ());
+        graph.add_edge(2, 4, ());
+        graph.add_edge(3, 4, ());
+        // Bubble 2: 4 → 5, 4 → 6, 5 → 7, 6 → 7
+        graph.add_edge(4, 5, ());
+        graph.add_edge(4, 6, ());
+        graph.add_edge(5, 7, ());
+        graph.add_edge(6, 7, ());
+
+        let bubbles = concurrent_bubbles(&graph);
+        assert_eq!(bubbles.len(), 2);
+
+        let b1: HashSet<_> = [2, 3].into_iter().collect();
+        let b2: HashSet<_> = [5, 6].into_iter().collect();
+
+        assert!(bubbles.contains(&b1));
+        assert!(bubbles.contains(&b2));
+    }
+
+    #[test]
+    fn complex_bubble() {
+        //       A
+        //     /   \
+        //    B     C
+        //   / \     \
+        //  D   E     F
+        //   \ /     /
+        //    G     H
+        //     \   /
+        //       I
+        //       |
+        //       J
+
+        let mut graph = DiGraph::new();
+
+        // Add nodes A–M.
+        let a = graph.add_node("A"); // 0
+        let b = graph.add_node("B"); // 1
+        let c = graph.add_node("C"); // 2
+        let d = graph.add_node("D"); // 3
+        let e = graph.add_node("E"); // 4
+        let f = graph.add_node("F"); // 5
+        let g = graph.add_node("G"); // 6
+        let h = graph.add_node("H"); // 7
+        let i = graph.add_node("I"); // 8
+        let j = graph.add_node("J"); // 9
+
+        // Add edges.
+        graph.extend_with_edges(&[
+            (a, b),
+            (a, c),
+            (b, d),
+            (b, e),
+            (d, g),
+            (e, g),
+            (c, f),
+            (f, h),
+            (h, i),
+            (g, i),
+            (i, j),
+        ]);
+
+        let graph_map = DiGraphMap::from_graph(graph);
+        let concurrent_bubbles = concurrent_bubbles(&graph_map);
+
+        assert_eq!(concurrent_bubbles.len(), 1);
+        let bubble = concurrent_bubbles.first().unwrap();
+        for id in &["B", "C", "D", "E", "F", "G", "H"] {
+            assert!(bubble.contains(id));
+        }
+    }
+}

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -574,7 +574,7 @@ where
     ORD::Message: Clone,
     GS: GroupStore<ID, OP, C, RS, ORD> + Clone + Debug,
 {
-    /// Action was applied an no error occured.
+    /// Action was applied an no error occurred.
     Ok {
         state: GroupState<ID, OP, C, RS, ORD, GS>,
     },
@@ -648,12 +648,12 @@ where
                     // 1) We expect some errors to occur when when intentionally filtered out
                     //    actions cause later operations to become invalid.
                     //
-                    // 2) Operations arriving from the network which are invalid due to buggy
-                    //    implementations or malicious behavior.
+                    // 2) Operations which other peers accepted into their graph _before_
+                    //    receiving some concurrent operation which caused them to be invalid.
                     //
                     // In both cases it's critical that the action does not cause any state
-                    // change. In the later, we also want to inform networking layers that a peer
-                    // in the group is behaving suspiciously.
+                    // change, however we do want to accept them into our graph so as to ensure
+                    // consistency consistency across peers.
                     y.states.insert(id, members_y);
                     return StateChangeResult::Noop {
                         state: y,

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -143,11 +143,11 @@ where
     ORD: Ordering<ID, OP, GroupControlMessage<ID, OP, C>>,
     GS: GroupStore<ID, OP, C, RS, ORD>,
 {
-    /// ID of the local actor.
-    pub my_id: ID,
-
     /// ID of the group.
     pub group_id: ID,
+
+    /// ID of the local actor.
+    pub my_id: ID,
 
     /// Group state at every position in the operation graph.
     pub states: HashMap<OP, GroupMembersState<GroupMember<ID>, C>>,
@@ -182,10 +182,10 @@ where
     GS: GroupStore<ID, OP, C, RS, ORD> + Debug,
 {
     /// Instantiate a new group state.
-    pub fn new(my_id: ID, group_id: ID, group_store: GS, orderer_y: ORD::State) -> Self {
+    pub fn new(group_id: ID, my_id: ID, group_store: GS, orderer_y: ORD::State) -> Self {
         Self {
-            my_id,
             group_id,
+            my_id,
             states: Default::default(),
             operations: Default::default(),
             ignore: Default::default(),
@@ -668,8 +668,8 @@ where
         let y_i = RS::process(y).map_err(|error| GroupError::ResolverError(error))?;
 
         let mut y_ii = GroupState::new(
-            y_i.my_id,
             y_i.group_id,
+            y_i.my_id,
             y_i.group_store.clone(),
             y_i.orderer_y,
         );

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -143,10 +143,10 @@ where
     ORD: Ordering<ID, OP, GroupControlMessage<ID, OP, C>>,
     GS: GroupStore<ID, OP, C, RS, ORD>,
 {
-    // ID of the local actor.
+    /// ID of the local actor.
     pub my_id: ID,
 
-    // ID of the group.
+    /// ID of the group.
     pub group_id: ID,
 
     /// Group state at every position in the operation graph.

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -598,7 +598,7 @@ where
 
         // The resolver implementation contains the logic which determines when rebuilds are
         // required.
-        if RS::rebuild_required(&y_i, &operation) {
+        if RS::rebuild_required(&y_i, &operation).map_err(|error| GroupError::ResolverError(error))? {
             // Perform the re-build and return the new state.
             return Self::rebuild(y_i);
         }

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -595,7 +595,7 @@ where
             //
             // To do this we need to prune the graph to only include predecessor operations,
             // re-calculate the filter, and re-build all states.
-            y = Group::validate_concurrent_action(y, &operation)?;
+            y = Group::validate_concurrent_action(y, operation)?;
 
             // Process the group state with the provided resolver. This will populate the set of
             // messages which should be ignored when applying group management actions and also
@@ -679,6 +679,7 @@ where
     GS: GroupStore<ID, OP, C, RS, ORD> + Clone + Debug,
 {
     /// Apply an action to a single group state.
+    #[allow(clippy::type_complexity)]
     fn apply_action(
         mut y: GroupState<ID, OP, C, RS, ORD, GS>,
         id: OP,
@@ -695,7 +696,7 @@ where
         };
 
         // Get the maximum access level for this actor.
-        let max_access = y.max_access_identity(actor, &dependencies)?;
+        let max_access = y.max_access_identity(actor, dependencies)?;
         let member_id = match max_access {
             Some((id, _)) => id,
             None => GroupMember::Individual(actor),
@@ -765,6 +766,7 @@ where
     ///
     /// This is a relatively expensive computation and should only be used when a re-build is
     /// actually required.
+    #[allow(clippy::type_complexity)]
     fn validate_concurrent_action(
         mut y: GroupState<ID, OP, C, RS, ORD, GS>,
         operation: &ORD::Message,

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -516,6 +516,10 @@ where
     ID: IdentityHandle + Display,
     OP: OperationId + Ord + Display,
     C: Clone + Debug + PartialEq + PartialOrd,
+    // @TODO: This is a very verbose trait bound. It would be nice to make this a trait alias but
+    // this feature is not supported in stable Rust yet. Creating a sub-trait is an option but
+    // this introduces it's own down sides. It also might be a sign that there should be better
+    // type separation between the Group and Resolver, this could be a good refactor later.
     RS: Resolver<
             ORD::Message,
             State = GroupState<ID, OP, C, RS, ORD, GS>,

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -218,6 +218,7 @@ where
     }
 
     /// The current graph tips for this group and any sub-groups who are currently members.
+    #[allow(clippy::type_complexity)]
     fn transitive_heads(&self) -> Result<HashSet<OP>, GroupError<ID, OP, C, RS, ORD, GS>> {
         let mut transitive_heads = self.heads();
         for (member, ..) in self.members() {
@@ -283,6 +284,7 @@ where
         self.members_at_inner(dependencies)
     }
 
+    #[allow(clippy::type_complexity)]
     fn transitive_members_at_inner(
         &self,
         dependencies: &HashSet<OP>,
@@ -344,6 +346,7 @@ where
     ///
     /// This method recurses into all sub-groups collecting all "tip" members, which are the
     /// stateless "individual" members of a group, likely identified by a public key.
+    #[allow(clippy::type_complexity)]
     pub fn transitive_members_at(
         &self,
         dependencies: &HashSet<OP>,
@@ -371,6 +374,7 @@ where
     ///
     /// This method recurses into all sub-groups collecting all "tip" members, which are the
     /// stateless "individual" members of a group, likely identified by a public key.
+    #[allow(clippy::type_complexity)]
     pub fn transitive_members(
         &self,
     ) -> Result<Vec<(ID, Access<C>)>, GroupError<ID, OP, C, RS, ORD, GS>> {
@@ -380,6 +384,7 @@ where
     }
 
     /// Get a sub group from the group store.
+    #[allow(clippy::type_complexity)]
     fn get_sub_group(
         &self,
         id: ID,
@@ -579,6 +584,10 @@ where
     /// Action was not applied because it failed internal validation.
     Noop {
         state: GroupState<ID, OP, C, RS, ORD, GS>,
+        // @TODO: errors occurring here will be logged or reported to higher layers, but we will
+        // not react to them inside of the groups module in any other way. Until this
+        // logging/reporting is implemented the error is not used.
+        #[allow(unused)]
         error: GroupMembershipError<GroupMember<ID>>,
     },
     /// Action was not applied because it has been filtered out.
@@ -666,6 +675,7 @@ where
         StateChangeResult::Ok { state: y }
     }
 
+    #[allow(clippy::type_complexity)]
     fn rebuild(
         y: GroupState<ID, OP, C, RS, ORD, GS>,
     ) -> Result<GroupState<ID, OP, C, RS, ORD, GS>, GroupError<ID, OP, C, RS, ORD, GS>> {

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -686,8 +686,12 @@ where
             // Sanity check: we should only apply operations for this group.
             assert_eq!(y_i.group_id, group_id);
 
-            // Sanity check: the first operation must be a create.
-            assert!(!create_found && !control_message.is_create());
+            // Sanity check: the first operation must be a create and all other operations must not be.
+            if create_found {
+                assert!(!control_message.is_create())
+            } else {
+                assert!(control_message.is_create())
+            }
 
             create_found = true;
 

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-#![allow(clippy::type_complexity)]
-#![allow(dead_code)]
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -598,7 +598,9 @@ where
 
         // The resolver implementation contains the logic which determines when rebuilds are
         // required.
-        if RS::rebuild_required(&y_i, &operation).map_err(|error| GroupError::ResolverError(error))? {
+        if RS::rebuild_required(&y_i, &operation)
+            .map_err(|error| GroupError::ResolverError(error))?
+        {
             // Perform the re-build and return the new state.
             return Self::rebuild(y_i);
         }
@@ -676,11 +678,12 @@ where
             y_i.group_store.clone(),
             y_i.orderer_y,
         );
+        y_ii.ignore = y_i.ignore;
+        y_ii.graph = y_i.graph;
 
         // Apply every operation.
-        let operations = y_i.operations;
         let mut create_found = false;
-        for operation in operations {
+        for operation in y_i.operations {
             let actor = operation.sender();
             let operation_id = operation.id();
             let control_message = operation.payload();
@@ -711,6 +714,9 @@ where
                 // this message variant.
                 GroupControlMessage::Revoke { .. } => unimplemented!(),
             };
+
+            // Push the operation to the group state.
+            y_ii.operations.push(operation);
         }
 
         Ok(y_ii)

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -538,7 +538,7 @@ where
         operation: &ORD::Message,
     ) -> Result<Self::State, GroupError<ID, OP, C, RS, ORD, GS>> {
         let operation_id = operation.id();
-        let actor = operation.sender();
+        let actor = operation.author();
         let control_message = operation.payload();
         let previous_operations = HashSet::from_iter(operation.previous().clone());
         let group_id = control_message.group_id();
@@ -679,7 +679,7 @@ where
         // Apply every operation.
         let mut create_found = false;
         for operation in y_i.operations {
-            let actor = operation.sender();
+            let actor = operation.author();
             let operation_id = operation.id();
             let control_message = operation.payload();
             let group_id = control_message.group_id();

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -722,7 +722,7 @@ where
     fn rebuild(
         y: GroupState<ID, OP, C, RS, ORD, GS>,
     ) -> Result<GroupState<ID, OP, C, RS, ORD, GS>, GroupError<ID, OP, C, RS, ORD, GS>> {
-        let mut y_i = GroupState::new(y.my_id, y.group_id, y.group_store.clone(), y.orderer_y);
+        let mut y_i = GroupState::new( y.group_id,y.my_id, y.group_store.clone(), y.orderer_y);
         y_i.ignore = y.ignore;
         y_i.graph = y.graph;
 

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -10,7 +10,7 @@ use petgraph::prelude::DiGraphMap;
 use petgraph::visit::NodeIndexable;
 use thiserror::Error;
 
-pub use crate::group::resolver::{GroupResolver, GroupResolverError};
+pub use crate::group::resolver::{StrongRemove, GroupResolverError};
 pub use crate::group::state::{Access, GroupMembersState, GroupMembershipError, MemberState};
 use crate::traits::{
     AuthGroup, GroupStore, IdentityHandle, Operation, OperationId, Ordering, Resolver,

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -613,15 +613,15 @@ where
         mut y: GroupState<ID, OP, C, RS, ORD, GS>,
         id: OP,
         actor: GroupMember<ID>,
-        previous: &HashSet<OP>,
+        dependencies: &HashSet<OP>,
         action: &GroupAction<ID, C>,
     ) -> StateChangeResult<ID, OP, C, RS, ORD, GS> {
-        // Compute the member's state by applying the new operation to it's claimed "previous"
+        // Compute the member's state by applying the new operation to it's claimed "dependencies"
         // state.
-        let members_y = if previous.is_empty() {
+        let members_y = if dependencies.is_empty() {
             GroupMembersState::default()
         } else {
-            y.state_at(previous)
+            y.state_at(dependencies)
         };
 
         // Only add the resulting member's state to the states map if the operation isn't
@@ -691,7 +691,7 @@ where
             let operation_id = operation.id();
             let control_message = operation.payload();
             let group_id = control_message.group_id();
-            let previous_operations = HashSet::from_iter(operation.previous().clone());
+            let dependencies = HashSet::from_iter(operation.dependencies().clone());
 
             // Sanity check: we should only apply operations for this group.
             assert_eq!(y_i.group_id, group_id);
@@ -711,7 +711,7 @@ where
                         y_i,
                         operation_id,
                         GroupMember::Individual(actor),
-                        &previous_operations,
+                        &dependencies,
                         &action,
                     ) {
                         StateChangeResult::Ok { state } => state,

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -539,10 +539,7 @@ where
     fn prepare(
         mut y: Self::State,
         action: &Self::Action,
-    ) -> Result<
-        (GroupState<ID, OP, C, RS, ORD, GS>, ORD::Message),
-        GroupError<ID, OP, C, RS, ORD, GS>,
-    > {
+    ) -> Result<(Self::State, ORD::Message), Self::Error> {
         // Get the next operation from our global orderer. The operation wraps the action we want
         // to perform, adding ordering and author meta-data.
         let ordering_y = y.orderer_y;
@@ -556,10 +553,7 @@ where
     }
 
     /// Process an operation created locally or received from a remote peer.
-    fn process(
-        mut y: Self::State,
-        operation: &ORD::Message,
-    ) -> Result<Self::State, GroupError<ID, OP, C, RS, ORD, GS>> {
+    fn process(mut y: Self::State, operation: &ORD::Message) -> Result<Self::State, Self::Error> {
         let operation_id = operation.id();
         let actor = operation.author();
         let control_message = operation.payload();

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -623,7 +623,7 @@ where
     RS: Resolver<ORD::Message, State = GroupState<ID, OP, C, RS, ORD, GS>> + Debug,
     ORD: Ordering<ID, OP, GroupControlMessage<ID, OP, C>> + Debug,
     ORD::Message: Clone,
-    GS: GroupStore<ID, Group = GroupState<ID, OP, C, RS, ORD, GS>> + Clone + Debug,
+    GS: GroupStore<ID, OP, C, RS, ORD> + Clone + Debug,
 {
     /// Action was applied an no error occured.
     Ok {

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-// #![allow(clippy::type_complexity)]
-// #![allow(dead_code)]
+#![allow(clippy::type_complexity)]
+#![allow(dead_code)]
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -722,7 +722,7 @@ where
     fn rebuild(
         y: GroupState<ID, OP, C, RS, ORD, GS>,
     ) -> Result<GroupState<ID, OP, C, RS, ORD, GS>, GroupError<ID, OP, C, RS, ORD, GS>> {
-        let mut y_i = GroupState::new( y.group_id,y.my_id, y.group_store.clone(), y.orderer_y);
+        let mut y_i = GroupState::new(y.group_id, y.my_id, y.group_store.clone(), y.orderer_y);
         y_i.ignore = y.ignore;
         y_i.graph = y.graph;
 

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -10,7 +10,7 @@ use petgraph::prelude::DiGraphMap;
 use petgraph::visit::NodeIndexable;
 use thiserror::Error;
 
-pub use crate::group::resolver::{StrongRemove, GroupResolverError};
+pub use crate::group::resolver::{GroupResolverError, StrongRemove};
 pub use crate::group::state::{Access, GroupMembersState, GroupMembershipError, MemberState};
 use crate::traits::{
     AuthGroup, GroupStore, IdentityHandle, Operation, OperationId, Ordering, Resolver,
@@ -266,13 +266,9 @@ where
         self.state_at_inner(dependencies)
     }
 
-    fn members_at_inner(
-        &self,
-        dependencies: &HashSet<OP>,
-    ) -> Vec<(GroupMember<ID>, Access<C>)> {
+    fn members_at_inner(&self, dependencies: &HashSet<OP>) -> Vec<(GroupMember<ID>, Access<C>)> {
         let y = self.state_at_inner(dependencies);
-        let members = y
-            .members
+        y.members
             .into_iter()
             .filter_map(|(id, state)| {
                 if state.is_member() {
@@ -281,16 +277,11 @@ where
                     None
                 }
             })
-            .collect::<Vec<_>>();
-
-        members
+            .collect::<Vec<_>>()
     }
 
     /// Get the group members at a certain point in groups history.
-    pub fn members_at(
-        &self,
-        dependencies: &HashSet<OP>,
-    ) -> Vec<(GroupMember<ID>, Access<C>)> {
+    pub fn members_at(&self, dependencies: &HashSet<OP>) -> Vec<(GroupMember<ID>, Access<C>)> {
         self.members_at_inner(dependencies)
     }
 
@@ -359,7 +350,7 @@ where
         &self,
         dependencies: &HashSet<OP>,
     ) -> Result<Vec<(ID, Access<C>)>, GroupError<ID, OP, C, RS, ORD, GS>> {
-        let members = self.transitive_members_at_inner(&dependencies)?;
+        let members = self.transitive_members_at_inner(dependencies)?;
         Ok(members)
     }
 

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -541,9 +541,8 @@ where
                     &action,
                 ) {
                     StateChangeResult::Ok { state } => state,
-                    StateChangeResult::Noop { state, .. } => {
-                        // TODO: introduce debug logging.
-                        state
+                    StateChangeResult::Noop { error, .. } => {
+                        return Err(GroupError::StateChangeError(operation_id, error));
                     }
                     StateChangeResult::Filtered { .. } => {
                         // Operations can't be filtered out before they were processed.
@@ -715,6 +714,10 @@ where
                     ) {
                         StateChangeResult::Ok { state } => state,
                         StateChangeResult::Noop { state, .. } => {
+                            // We don't error here as during re-build we expect some operations to
+                            // fail if they've been transitively invalidated by a change in
+                            // filter.
+                            //
                             // TODO: introduce debug logging.
                             state
                         }

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -239,7 +239,7 @@ where
         // admin access but now doesn't.
         let was_manager = self
             .transitive_members_at(&HashSet::from_iter(operation.dependencies()))
-            .expect("state exists for all operations")
+            .expect("get transitive members")
             .contains(&(removed_or_demoted_member.id(), Access::Manage));
 
         if was_manager {

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -10,7 +10,9 @@ use petgraph::visit::DfsPostOrder;
 use thiserror::Error;
 
 use crate::group::graph::{concurrent_bubbles, has_path};
-use crate::group::{Access, Group, GroupControlMessage, GroupMember, GroupState, StateChangeResult};
+use crate::group::{
+    Access, Group, GroupControlMessage, GroupMember, GroupState, StateChangeResult,
+};
 use crate::traits::{GroupStore, IdentityHandle, Operation, OperationId, Ordering, Resolver};
 
 use super::GroupAction;

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -120,15 +120,13 @@ where
         // concurrency. Multiple bubbles can occur in the same graph.
         let mut bubbles = concurrent_bubbles(&y.graph);
 
-        let topo_sort = toposort(&y.graph, None).unwrap();
-        let mut topo_sort_iter = topo_sort.into_iter();
-        // let mut dfs = DfsPostOrder::new(&y.graph, root);
+        let topo_sort = toposort(&y.graph, None).expect("group operation sets can be ordered topologically");
         let mut visited = HashSet::new();
 
         // Traverse the graph visiting the operations in topological order.
-        while let Some(target_operation_id) = topo_sort_iter.next() {
+        for target_operation_id in topo_sort.iter() {
             let Some(target_operation) = operations.get(&target_operation_id) else {
-                return Err(GroupError::MissingOperation(target_operation_id));
+                return Err(GroupError::MissingOperation(*target_operation_id));
             };
 
             let bubble = bubbles
@@ -136,7 +134,7 @@ where
                 .find(|bubble| bubble.contains(&target_operation_id))
                 .cloned();
 
-            visited.insert(target_operation_id);
+            visited.insert(*target_operation_id);
 
             let removed_manager = y.removed_manager(target_operation);
 
@@ -147,7 +145,7 @@ where
                 for bubble_operation_id in bubble.iter() {
                     // If there's a path between the bubble and target operation, then it's not
                     // concurrent, so we don't need to do anything.
-                    if has_path(&y.graph, *bubble_operation_id, target_operation_id) {
+                    if has_path(&y.graph, *bubble_operation_id, *target_operation_id) {
                         continue;
                     }
 

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -134,7 +134,7 @@ where
 
                 // If this concurrent operation is _not_ authored by the "target author" then we
                 // can continue to the next concurrent operation without taking any action.
-                if concurrent_operation.sender() != removed_manager {
+                if concurrent_operation.author() != removed_manager {
                     continue;
                 }
 
@@ -143,7 +143,7 @@ where
 
                 if let Some(concurrent_removed_admin) = concurrent_removed_admin {
                     // The removed member is concurrently removing the remover.
-                    if concurrent_removed_admin == target_operation.sender() {
+                    if concurrent_removed_admin == target_operation.author() {
                         // We don't want to filter out mutual remove/demote operations, but we
                         // still want to filter any dependent operations for both (mutually)
                         // removed members.
@@ -160,7 +160,7 @@ where
                 y.invalid_dependent_operations(
                     &operations,
                     *concurrent_operation_id,
-                    concurrent_operation.sender(),
+                    concurrent_operation.author(),
                     &mut invalid_operations,
                 );
             }
@@ -272,7 +272,7 @@ where
 
             // If this operation is someone else adding back the target author then break out
             // of the search as we don't want to invalidate any more operations.
-            if dependent_operation.sender() != target_author {
+            if dependent_operation.author() != target_author {
                 if let Some((_, added_manager)) = self.added_manager(dependent_operation) {
                     if added_manager == target_author && target != dependent_operation.id() {
                         break;
@@ -343,8 +343,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     use petgraph::graph::DiGraph;
     use petgraph::prelude::DiGraphMap;

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -10,7 +10,7 @@ use petgraph::visit::DfsPostOrder;
 use thiserror::Error;
 
 use crate::group::graph::{concurrent_bubbles, has_path};
-use crate::group::{Group, GroupControlMessage, GroupMember, GroupState, StateChangeResult};
+use crate::group::{Access, Group, GroupControlMessage, GroupMember, GroupState, StateChangeResult};
 use crate::traits::{GroupStore, IdentityHandle, Operation, OperationId, Ordering, Resolver};
 
 use super::GroupAction;
@@ -236,10 +236,9 @@ where
         // We only need to react to a filtered demote operation if the target author did have
         // admin access but now doesn't.
         let was_manager = self
-            .state_at(&HashSet::from_iter(operation.previous()))
+            .transitive_members_at(&HashSet::from_iter(operation.dependencies()))
             .expect("state exists for all operations")
-            .managers()
-            .contains(&removed_or_demoted_member);
+            .contains(&(removed_or_demoted_member.id(), Access::Manage));
 
         if was_manager {
             Some(removed_or_demoted_member.id())

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -32,7 +32,7 @@ where
 }
 
 /// An implementation of `GroupResolver` trait which follows strong remove ruleset.  
-/// 
+///
 /// Concurrent operations are identified and processed, any which should be invalidated are
 /// added to the operation filter and not applied to the group state. Once an operation has
 /// been filtered, any operations which depended on any resulting state will not be applied to
@@ -131,7 +131,7 @@ where
         // from the filter later.
         let mut mutual_removes = HashSet::new();
 
-        // Get all bubbles of concurrency. 
+        // Get all bubbles of concurrency.
         //
         // A concurrency bubble is a set of operations from the group graph which share some
         // concurrency. Multiple bubbles can occur in the same graph.
@@ -141,7 +141,7 @@ where
         let mut dfs = DfsPostOrder::new(&y.graph, root);
         let mut visited = HashSet::new();
 
-        // Traverse the graph visiting the operations in topological order. 
+        // Traverse the graph visiting the operations in topological order.
         while let Some(target_operation_id) = dfs.next(&y.graph) {
             let Some(target_operation) = operations.get(&target_operation_id) else {
                 return Err(GroupResolverError::MissingOperation(target_operation_id));

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -272,11 +272,13 @@ where
             let dependent_operation = operations.get(&dependent_operation_id).unwrap();
 
             if dependent_operation.sender() != target_author {
-                //    // TODO: if this operation is someone else adding back the target author then //
-                //    break out of the search as we don't want to invalidate any more operations.
-                //
-                //    if let Some((_, added_manager)) = self.added_manager(dependent_operation) { if
-                //        added_manager == target_author { break; } }
+                // If this operation is someone else adding back the target author then break out
+                // of the search as we don't want to invalidate any more operations.
+                if let Some((_, added_manager)) = self.added_manager(dependent_operation) {
+                    if added_manager == target_author && target != dependent_operation.id() {
+                        break;
+                    }
+                }
 
                 continue;
             }

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -421,8 +421,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     use petgraph::graph::DiGraph;
     use petgraph::prelude::DiGraphMap;

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -57,7 +57,12 @@ where
             return Err(GroupResolverError::IncorrectGroupId(group_id, y.group_id));
         }
 
-        Ok(y.heads().into_iter().collect::<Vec<_>>() != operation.previous())
+        // TODO: for now rebuild on every operation, there are some tricky edge-cases which I'm
+        // not sure how to handle yet. In particular when operations which should be filtered due
+        // to being a dependent operation (of a filtered operation), it's quite hard to detect
+        // this, if we want to do it efficiently we probably need to keep some more state around.
+        // Ok(y.heads().into_iter().collect::<Vec<_>>() != operation.previous())
+        Ok(true)
     }
 
     /// Resolve group membership by processing all concurrent operations in the graph.

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -125,7 +125,6 @@ where
         let bubbles = get_concurrent_bubbles(&y.inner.graph);
 
         for (operation_id, bubble) in bubbles {
-            // TODO: Consider keeping a HashMap in memory to optimise lookup.
             let Some(operation) = y.inner.operations.iter().find(|op| op.id() == operation_id)
             else {
                 // TODO: Error: Operation is expected to exist.

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -134,7 +134,7 @@ where
                         continue;
                     }
 
-                    let Some(bubble_operation) = operations.get(&bubble_operation_id) else {
+                    let Some(bubble_operation) = operations.get(bubble_operation_id) else {
                         return Err(GroupResolverError::MissingOperation(*bubble_operation_id));
                     };
 
@@ -257,10 +257,7 @@ where
                     unimplemented!()
                 };
 
-                match action {
-                    GroupAction::Create { .. } => true,
-                    _ => false,
-                }
+                matches!(action, GroupAction::Create { .. })
             })
             .expect("at least one create operation")
             .id()

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::{fmt::Debug, marker::PhantomData};
@@ -11,7 +13,6 @@ use crate::traits::{GroupStore, IdentityHandle, Operation, OperationId, Ordering
 
 use super::GroupAction;
 
-// TODO: introduce all error types.
 #[derive(Debug, Error)]
 pub enum GroupResolverError<ID, OP>
 where
@@ -334,8 +335,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     use petgraph::graph::DiGraph;
     use petgraph::prelude::DiGraphMap;

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -98,7 +98,6 @@ where
             .collect();
 
         let bubbles = get_concurrent_bubbles(&y.graph);
-        println!("bubbles: {:?}", bubbles);
 
         let mut invalid_operations = HashSet::new();
         let mut mutual_removes = HashSet::new();
@@ -268,11 +267,11 @@ where
             let dependent_operation = operations.get(&dependent_operation_id).unwrap();
 
             if dependent_operation.sender() != target_author {
-            //    // TODO: if this operation is someone else adding back the target author then //
-            //    break out of the search as we don't want to invalidate any more operations.
-            //  
-            //    if let Some((_, added_manager)) = self.added_manager(dependent_operation) { if
-            //        added_manager == target_author { break; } }
+                //    // TODO: if this operation is someone else adding back the target author then //
+                //    break out of the search as we don't want to invalidate any more operations.
+                //
+                //    if let Some((_, added_manager)) = self.added_manager(dependent_operation) { if
+                //        added_manager == target_author { break; } }
 
                 continue;
             }

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Strong remove group resolver implementation.
-
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::{fmt::Debug, marker::PhantomData};

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -120,18 +120,19 @@ where
         // concurrency. Multiple bubbles can occur in the same graph.
         let mut bubbles = concurrent_bubbles(&y.graph);
 
-        let topo_sort = toposort(&y.graph, None).expect("group operation sets can be ordered topologically");
+        let topo_sort =
+            toposort(&y.graph, None).expect("group operation sets can be ordered topologically");
         let mut visited = HashSet::new();
 
         // Traverse the graph visiting the operations in topological order.
         for target_operation_id in topo_sort.iter() {
-            let Some(target_operation) = operations.get(&target_operation_id) else {
+            let Some(target_operation) = operations.get(target_operation_id) else {
                 return Err(GroupError::MissingOperation(*target_operation_id));
             };
 
             let bubble = bubbles
                 .iter()
-                .find(|bubble| bubble.contains(&target_operation_id))
+                .find(|bubble| bubble.contains(target_operation_id))
                 .cloned();
 
             visited.insert(*target_operation_id);
@@ -259,7 +260,7 @@ where
 
         // @TODO: either remove this step (and check for mutual removes on all remove/demote
         // operations) or re-build graph state beforehand to in order to correctly handle
-        // certain edge-cases. 
+        // certain edge-cases.
         let was_manager = self
             .transitive_members_at(&HashSet::from_iter(operation.dependencies()))
             .expect("get transitive members")

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -727,7 +727,7 @@ mod tests {
         // We expect the addition of Claire (node C) and Dave (node D) to be filtered.
         // Alice should be the only member of the group after processing.
 
-        let group_id = '1';
+        let group = '1';
 
         let alice = 'A';
         let bob = 'B';
@@ -739,22 +739,21 @@ mod tests {
         let alice_store = TestGroupStore::default();
         let alice_orderer_y =
             TestOrdererState::new(alice, alice_store.clone(), StdRng::from_rng(&mut rng));
-        // TODO: Do we maybe want to switch the position of the args `alice` and `group_id`?
-        let alice_group_y = TestGroupState::new(alice, group_id, alice_store, alice_orderer_y);
+        let alice_group_y = TestGroupState::new(group, alice, alice_store, alice_orderer_y);
 
         let bob_store = TestGroupStore::default();
         let bob_orderer_y =
             TestOrdererState::new(bob, bob_store.clone(), StdRng::from_rng(&mut rng));
-        let bob_group_y = TestGroupState::new(bob, group_id, bob_store, bob_orderer_y);
+        let bob_group_y = TestGroupState::new(group, bob, bob_store, bob_orderer_y);
 
         let claire_store = TestGroupStore::default();
         let claire_orderer_y =
             TestOrdererState::new(claire, claire_store.clone(), StdRng::from_rng(&mut rng));
-        let claire_group_y = TestGroupState::new(claire, group_id, claire_store, claire_orderer_y);
+        let claire_group_y = TestGroupState::new(group, claire, claire_store, claire_orderer_y);
 
         // Create group with alice and bob as initial admin members.
         let control_message_001 = GroupControlMessage::GroupAction {
-            group_id,
+            group_id: group,
             action: GroupAction::Create {
                 initial_members: vec![
                     (GroupMember::Individual(alice), Access::Manage),
@@ -778,7 +777,7 @@ mod tests {
 
         // Alice removes Bob.
         let control_message_002 = GroupControlMessage::GroupAction {
-            group_id,
+            group_id: group,
             action: GroupAction::Remove {
                 member: GroupMember::Individual(bob),
             },
@@ -796,7 +795,7 @@ mod tests {
 
         // Bob adds claire with manage access.
         let control_message_003 = GroupControlMessage::GroupAction {
-            group_id,
+            group_id: group,
             action: GroupAction::Add {
                 member: GroupMember::Individual(claire),
                 access: Access::Manage,
@@ -818,7 +817,7 @@ mod tests {
 
         // Claire adds Dave with read access.
         let control_message_004 = GroupControlMessage::GroupAction {
-            group_id,
+            group_id: group,
             action: GroupAction::Add {
                 member: GroupMember::Individual(dave),
                 access: Access::Read,

--- a/p2panda-auth/src/group/test_utils/group_store.rs
+++ b/p2panda-auth/src/group/test_utils/group_store.rs
@@ -7,10 +7,8 @@ use std::rc::Rc;
 
 use thiserror::Error;
 
-use crate::group::test_utils::{Conditions, MemberId, MessageId, TestOrderer, TestResolver};
-use crate::traits::GroupStore;
-
-use super::TestGroupState;
+use crate::group::test_utils::TestGroupState;
+use crate::traits::{GroupStore, IdentityHandle};
 
 #[derive(Debug, Error)]
 pub enum GroupStoreError {}

--- a/p2panda-auth/src/group/test_utils/group_store.rs
+++ b/p2panda-auth/src/group/test_utils/group_store.rs
@@ -7,8 +7,8 @@ use std::rc::Rc;
 
 use thiserror::Error;
 
-use crate::group::test_utils::TestGroupState;
-use crate::traits::{GroupStore, IdentityHandle};
+use crate::group::test_utils::{Conditions, MemberId, MessageId, TestGroupState, TestOrderer, TestResolver};
+use crate::traits::GroupStore;
 
 #[derive(Debug, Error)]
 pub enum GroupStoreError {}

--- a/p2panda-auth/src/group/test_utils/group_store.rs
+++ b/p2panda-auth/src/group/test_utils/group_store.rs
@@ -7,7 +7,9 @@ use std::rc::Rc;
 
 use thiserror::Error;
 
-use crate::group::test_utils::{Conditions, MemberId, MessageId, TestGroupState, TestOrderer, TestResolver};
+use crate::group::test_utils::{
+    Conditions, MemberId, MessageId, TestGroupState, TestOrderer, TestResolver,
+};
 use crate::traits::GroupStore;
 
 #[derive(Debug, Error)]

--- a/p2panda-auth/src/group/test_utils/mod.rs
+++ b/p2panda-auth/src/group/test_utils/mod.rs
@@ -10,7 +10,7 @@ pub use network::Network;
 pub use orderer::*;
 pub use partial_ord::*;
 
-use crate::group::resolver::GroupResolver;
+use crate::group::resolver::StrongRemove;
 use crate::group::{Group, GroupState};
 use crate::traits::{IdentityHandle, OperationId};
 
@@ -22,7 +22,7 @@ pub type GroupId = char;
 pub type MessageId = u32;
 pub type Conditions = ();
 
-pub type GenericTestResolver<ORD, GS> = GroupResolver<MemberId, MessageId, Conditions, ORD, GS>;
+pub type GenericTestResolver<ORD, GS> = StrongRemove<MemberId, MessageId, Conditions, ORD, GS>;
 pub type GenericTestGroup<RS, ORD, GS> = Group<MemberId, MessageId, Conditions, RS, ORD, GS>;
 pub type GenericTestGroupState<RS, ORD, GS> =
     GroupState<MemberId, MessageId, Conditions, RS, ORD, GS>;

--- a/p2panda-auth/src/group/test_utils/network.rs
+++ b/p2panda-auth/src/group/test_utils/network.rs
@@ -194,7 +194,7 @@ impl Network {
         operation: &TestOperation<MemberId, MessageId, Conditions>,
     ) {
         // Do not process our own messages.
-        if &operation.sender() == member_id {
+        if &operation.author() == member_id {
             return;
         }
 
@@ -212,7 +212,7 @@ impl Network {
                 break;
             };
 
-            if &operation.sender() == member_id {
+            if &operation.author() == member_id {
                 continue;
             }
 

--- a/p2panda-auth/src/group/test_utils/network.rs
+++ b/p2panda-auth/src/group/test_utils/network.rs
@@ -10,13 +10,13 @@ use crate::group::{Access, GroupAction, GroupControlMessage, GroupMember};
 use crate::traits::{AuthGroup, GroupStore, Operation, Ordering};
 
 use super::{
-    Conditions, GroupId, MemberId, MessageId, TestGroup, TestGroupState, TestGroupStore,
-    TestOperation, TestOrderer, TestOrdererState,
+    GroupId, MemberId, MessageId, TestGroup, TestGroupState, TestGroupStore, TestOperation,
+    TestOrderer, TestOrdererState,
 };
 
 pub struct Network {
     members: HashMap<MemberId, NetworkMember>,
-    queue: VecDeque<TestOperation<MemberId, MessageId, Conditions>>,
+    queue: VecDeque<TestOperation>,
     rng: StdRng,
 }
 
@@ -188,11 +188,7 @@ impl Network {
         }
     }
 
-    fn member_process(
-        &mut self,
-        member_id: &MemberId,
-        operation: &TestOperation<MemberId, MessageId, Conditions>,
-    ) {
+    fn member_process(&mut self, member_id: &MemberId, operation: &TestOperation) {
         // Do not process our own messages.
         if &operation.author() == member_id {
             return;

--- a/p2panda-auth/src/group/test_utils/network.rs
+++ b/p2panda-auth/src/group/test_utils/network.rs
@@ -238,8 +238,7 @@ impl Network {
     ) -> Vec<(GroupMember<MemberId>, Access<()>)> {
         let group_y = self.get_y(member, group_id);
         let mut members = group_y
-            .members_at(&previous.clone().into_iter().collect::<HashSet<_>>())
-            .unwrap();
+            .members_at(&previous.clone().into_iter().collect::<HashSet<_>>());
         members.sort();
         members
     }

--- a/p2panda-auth/src/group/test_utils/network.rs
+++ b/p2panda-auth/src/group/test_utils/network.rs
@@ -237,8 +237,7 @@ impl Network {
         previous: &Vec<MessageId>,
     ) -> Vec<(GroupMember<MemberId>, Access<()>)> {
         let group_y = self.get_y(member, group_id);
-        let mut members = group_y
-            .members_at(&previous.clone().into_iter().collect::<HashSet<_>>());
+        let mut members = group_y.members_at(&previous.clone().into_iter().collect::<HashSet<_>>());
         members.sort();
         members
     }

--- a/p2panda-auth/src/group/test_utils/network.rs
+++ b/p2panda-auth/src/group/test_utils/network.rs
@@ -288,8 +288,8 @@ impl Network {
         match group_y {
             Some(group_y) => group_y,
             None => TestGroupState::new(
-                member.id,
                 *group_id,
+                member.id,
                 member.group_store.clone(),
                 member.orderer_y.clone(),
             ),

--- a/p2panda-auth/src/group/test_utils/network.rs
+++ b/p2panda-auth/src/group/test_utils/network.rs
@@ -111,6 +111,52 @@ impl Network {
         operation_id
     }
 
+    pub fn demote(
+        &mut self,
+        demoter: MemberId,
+        demoted: GroupMember<MemberId>,
+        group_id: GroupId,
+        access: Access<()>,
+    ) -> MessageId {
+        let y = self.get_y(&demoter, &group_id);
+        let control_message = GroupControlMessage::GroupAction {
+            group_id,
+            action: GroupAction::Demote {
+                member: demoted,
+                access,
+            },
+        };
+        let (y_i, operation) = TestGroup::prepare(y, &control_message).unwrap();
+        let y_ii = TestGroup::process(y_i, &operation).unwrap();
+        let operation_id = operation.id();
+        self.queue.push_back(operation);
+        self.set_y(y_ii);
+        operation_id
+    }
+
+    pub fn promote(
+        &mut self,
+        promoter: MemberId,
+        promoted: GroupMember<MemberId>,
+        group_id: GroupId,
+        access: Access<()>,
+    ) -> MessageId {
+        let y = self.get_y(&promoter, &group_id);
+        let control_message = GroupControlMessage::GroupAction {
+            group_id,
+            action: GroupAction::Promote {
+                member: promoted,
+                access,
+            },
+        };
+        let (y_i, operation) = TestGroup::prepare(y, &control_message).unwrap();
+        let y_ii = TestGroup::process(y_i, &operation).unwrap();
+        let operation_id = operation.id();
+        self.queue.push_back(operation);
+        self.set_y(y_ii);
+        operation_id
+    }
+
     pub fn process_ooo(&mut self) {
         if self.queue.is_empty() {
             return;

--- a/p2panda-auth/src/group/test_utils/network.rs
+++ b/p2panda-auth/src/group/test_utils/network.rs
@@ -169,7 +169,7 @@ impl Network {
             for id in &member_ids {
                 // Shuffle messages in the queue for each member.
                 self.shuffle();
-                self.member_process(&id, &operation)
+                self.member_process(id, &operation)
             }
         }
     }
@@ -183,7 +183,7 @@ impl Network {
 
         while let Some(operation) = self.queue.pop_front() {
             for id in &member_ids {
-                self.member_process(&id, &operation)
+                self.member_process(id, &operation)
             }
         }
     }
@@ -197,7 +197,7 @@ impl Network {
         let control_message = operation.payload();
         let mut group_id = control_message.group_id();
         let mut y = self.get_y(member_id, &group_id);
-        let orderer_y = TestOrderer::queue(y.orderer_y.clone(), &operation).unwrap();
+        let orderer_y = TestOrderer::queue(y.orderer_y.clone(), operation).unwrap();
 
         loop {
             let (orderer_y, result) = TestOrderer::next_ready_message(orderer_y.clone()).unwrap();
@@ -234,10 +234,10 @@ impl Network {
         &self,
         member: &MemberId,
         group_id: &GroupId,
-        previous: &Vec<MessageId>,
+        dependencies: &[MessageId],
     ) -> Vec<(GroupMember<MemberId>, Access<()>)> {
         let group_y = self.get_y(member, group_id);
-        let mut members = group_y.members_at(&previous.clone().into_iter().collect::<HashSet<_>>());
+        let mut members = group_y.members_at(&dependencies.iter().copied().collect::<HashSet<_>>());
         members.sort();
         members
     }
@@ -259,11 +259,11 @@ impl Network {
         &self,
         member: &MemberId,
         group_id: &GroupId,
-        dependencies: &Vec<MessageId>,
+        dependencies: &[MessageId],
     ) -> Vec<(MemberId, Access<()>)> {
         let group_y = self.get_y(member, group_id);
         let mut members = group_y
-            .transitive_members_at(&dependencies.clone().into_iter().collect::<HashSet<_>>())
+            .transitive_members_at(&dependencies.iter().copied().collect::<HashSet<_>>())
             .expect("get transitive members");
         members.sort();
         members

--- a/p2panda-auth/src/group/test_utils/orderer.rs
+++ b/p2panda-auth/src/group/test_utils/orderer.rs
@@ -30,7 +30,7 @@ pub struct TestOrdererStateInner {
     pub my_id: MemberId,
     pub group_store: TestGroupStore,
     pub orderer_y: PartialOrdererState<MessageId>,
-    pub messages: HashMap<MessageId, TestOperation<MemberId, MessageId, Conditions>>,
+    pub messages: HashMap<MessageId, TestOperation>,
     pub rng: StdRng,
 }
 
@@ -63,7 +63,7 @@ impl Ordering<MemberId, MessageId, GroupControlMessage<MemberId, MessageId, Cond
 
     type Error = OrdererError;
 
-    type Message = TestOperation<MemberId, MessageId, Conditions>;
+    type Message = TestOperation;
 
     /// Construct the next operation which should include meta-data required for establishing order
     /// between different operations.
@@ -220,37 +220,32 @@ impl Ordering<MemberId, MessageId, GroupControlMessage<MemberId, MessageId, Cond
 }
 
 #[derive(Clone, Debug)]
-pub struct TestOperation<ID, OP, C> {
-    pub id: OP,
-    pub author: ID,
-    pub dependencies: Vec<OP>,
-    pub previous: Vec<OP>,
-    pub payload: GroupControlMessage<ID, OP, C>,
+pub struct TestOperation {
+    pub id: u32,
+    pub author: char,
+    pub dependencies: Vec<u32>,
+    pub previous: Vec<u32>,
+    pub payload: GroupControlMessage<char, u32, ()>,
 }
 
-impl<ID, OP, C> Operation<ID, OP, GroupControlMessage<ID, OP, C>> for TestOperation<ID, OP, C>
-where
-    ID: Copy,
-    OP: Copy,
-    C: Clone + Debug + PartialEq + PartialOrd,
-{
-    fn id(&self) -> OP {
+impl Operation<char, u32, GroupControlMessage<char, u32, ()>> for TestOperation {
+    fn id(&self) -> u32 {
         self.id
     }
 
-    fn author(&self) -> ID {
+    fn author(&self) -> char {
         self.author
     }
 
-    fn dependencies(&self) -> Vec<OP> {
+    fn dependencies(&self) -> Vec<u32> {
         self.dependencies.clone()
     }
 
-    fn previous(&self) -> Vec<OP> {
+    fn previous(&self) -> Vec<u32> {
         self.previous.clone()
     }
 
-    fn payload(&self) -> GroupControlMessage<ID, OP, C> {
+    fn payload(&self) -> GroupControlMessage<char, u32, ()> {
         self.payload.clone()
     }
 }

--- a/p2panda-auth/src/group/test_utils/orderer.rs
+++ b/p2panda-auth/src/group/test_utils/orderer.rs
@@ -81,8 +81,8 @@ impl Ordering<MemberId, MessageId, GroupControlMessage<MemberId, MessageId, Cond
 
             // Instantiate a new group.
             let mut group_y = TestGroupState::new(
-                y_inner.my_id,
                 group_id,
+                y_inner.my_id,
                 y_inner.group_store.clone(),
                 y.clone(),
             );

--- a/p2panda-auth/src/group/test_utils/orderer.rs
+++ b/p2panda-auth/src/group/test_utils/orderer.rs
@@ -155,7 +155,7 @@ impl Ordering<MemberId, MessageId, GroupControlMessage<MemberId, MessageId, Cond
         // Construct the actual operation.
         let operation = TestOperation {
             id: next_id,
-            sender: y.my_id(),
+            author: y.my_id(),
             dependencies: dependencies.into_iter().collect::<Vec<_>>(),
             previous: previous.into_iter().collect::<Vec<_>>(),
             payload: control_message.clone(),
@@ -222,7 +222,7 @@ impl Ordering<MemberId, MessageId, GroupControlMessage<MemberId, MessageId, Cond
 #[derive(Clone, Debug)]
 pub struct TestOperation<ID, OP, C> {
     pub id: OP,
-    pub sender: ID,
+    pub author: ID,
     pub dependencies: Vec<OP>,
     pub previous: Vec<OP>,
     pub payload: GroupControlMessage<ID, OP, C>,
@@ -238,8 +238,8 @@ where
         self.id
     }
 
-    fn sender(&self) -> ID {
-        self.sender
+    fn author(&self) -> ID {
+        self.author
     }
 
     fn dependencies(&self) -> Vec<OP> {

--- a/p2panda-auth/src/group/tests.rs
+++ b/p2panda-auth/src/group/tests.rs
@@ -14,15 +14,16 @@ use super::{GroupAction, GroupControlMessage, GroupMember};
 
 #[test]
 fn basic_group() {
+    let group_id = '1';
     let alice = 'A';
     let store = TestGroupStore::default();
     let rng = StdRng::from_os_rng();
     let orderer_y = TestOrdererState::new(alice, store.clone(), rng);
-    let group_y = TestGroupState::new(alice, alice, store, orderer_y);
+    let group_y = TestGroupState::new(group_id, alice, store, orderer_y);
 
     // Create group with alice as initial admin member.
     let control_message_001 = GroupControlMessage::GroupAction {
-        group_id: alice,
+        group_id,
         action: GroupAction::Create {
             initial_members: vec![(GroupMember::Individual(alice), Access::Manage)],
         },
@@ -40,7 +41,7 @@ fn basic_group() {
     // Add bob with read access.
     let bob = 'B';
     let control_message_002 = GroupControlMessage::GroupAction {
-        group_id: alice,
+        group_id,
         action: GroupAction::Add {
             member: GroupMember::Individual(bob),
             access: Access::Read,
@@ -62,7 +63,7 @@ fn basic_group() {
     // Add claire with write access.
     let claire = 'C';
     let control_message_003 = GroupControlMessage::GroupAction {
-        group_id: alice,
+        group_id,
         action: GroupAction::Add {
             member: GroupMember::Individual(claire),
             access: Access::Write { conditions: None },
@@ -87,7 +88,7 @@ fn basic_group() {
 
     // Promote claire to admin.
     let control_message_004 = GroupControlMessage::GroupAction {
-        group_id: alice,
+        group_id,
         action: GroupAction::Promote {
             member: GroupMember::Individual(claire),
             access: Access::Manage,
@@ -109,7 +110,7 @@ fn basic_group() {
 
     // Demote bob to poll access.
     let control_message_005 = GroupControlMessage::GroupAction {
-        group_id: alice,
+        group_id,
         action: GroupAction::Demote {
             member: GroupMember::Individual(bob),
             access: Access::Pull,
@@ -131,7 +132,7 @@ fn basic_group() {
 
     // Remove bob.
     let control_message_006 = GroupControlMessage::GroupAction {
-        group_id: alice,
+        group_id,
         action: GroupAction::Remove {
             member: GroupMember::Individual(bob),
         },
@@ -166,14 +167,14 @@ fn nested_groups() {
 
     // One devices group instance.
     let devices_group_y = GroupState::new(
-        alice,
         alice_devices_group,
+        alice,
         store.clone(),
         alice_orderer_y.clone(),
     );
 
     // One team group instance.
-    let team_group_y = GroupState::new(alice, alice_team_group, store.clone(), alice_orderer_y);
+    let team_group_y = GroupState::new(alice_team_group, alice, store.clone(), alice_orderer_y);
 
     // Control message creating the devices group, with alice, alice_laptop and alice mobile as members.
     let control_message_001 = GroupControlMessage::GroupAction {

--- a/p2panda-auth/src/traits/operation.rs
+++ b/p2panda-auth/src/traits/operation.rs
@@ -9,8 +9,8 @@ pub trait Operation<ID, OP, P> {
     /// Id of this operation.
     fn id(&self) -> OP;
 
-    /// Id of the sender of this operation.
-    fn sender(&self) -> ID;
+    /// ID of the author of this operation.
+    fn author(&self) -> ID;
 
     /// Other operation dependencies.
     fn dependencies(&self) -> Vec<OP>;

--- a/p2panda-auth/src/traits/resolver.rs
+++ b/p2panda-auth/src/traits/resolver.rs
@@ -12,7 +12,7 @@ pub trait Resolver<MSG> {
 
     // Check if this message requires that a full state re-build takes place. This would usually
     // be due to concurrent operations arriving which require special handling.
-    fn rebuild_required(y: &Self::State, msg: &MSG) -> bool;
+    fn rebuild_required(y: &Self::State, msg: &MSG) -> Result<bool, Self::Error>;
 
     // Process all operations and update internal state as required.
     //


### PR DESCRIPTION
This PR introduces a group membership resolver implementation which follows a "strong remove" ruleset. Concurrent operations are identified and processed, any which should be invalidated are added to the operation filter and not applied to the group state. Once an operation has been filtered, any operations which depended on any resulting state will not be applied to group state either.

## Strong remove behaviors
![image](https://github.com/user-attachments/assets/2071f501-f51a-4a9b-a863-555dd751f90e)

## Ruleset for Concurrent Operations

The following ruleset is applied when choosing which operations to "filter" when concurrent operations are processed. It can be assumed that the behavior is equivalent for an admin member being removed, or demoted from admin to a lower access level.

### 1) Removals

If a removal has occurred, filter any concurrent operations by the removed member, as long as it's 1) not a predecessor of the remove operation, and 2) not a mutual removal (removal of the remover by the removed member).

### 2) Mutual removals

Mutual removals result in both members being removed from the group, and any dependent concurrent branches are not applied to group state. We imagine further implementations taking different approaches, like resolving by seniority, hash id, quorum or some other parameter.

If a mutual removal has occurred, we want to retain the removal operations but filter all concurrent operations performed by the removed members (keeping predecessors of the remove).

### 3) Re-adding member concurrently

If Alice removes Charlie and Bob removes then adds Charlie concurrently, Charlie is still in the group. However, if Charlie performed any concurrent actions, these will be filtered along with any dependent operations.

### 4) Filtering of dependent operations

When an operation is "explicitly" filtered it may cause dependent operations to become invalid, these operations will not be applied to the group state. 

### Example 1
- A and B concurrently remove each other, both are removed from the group
![graphviz(53)](https://github.com/user-attachments/assets/56aade93-8635-40c4-87c1-c02f082592c5)

### Example 2
- removal of B causes concurrent operations to be filtered
- B is re-added
- after "merge" B is back in the group and can perform actions
![graphviz(51)](https://github.com/user-attachments/assets/7ffb2f83-cad2-4e67-9c8f-5a9b56a8aa3f)

### Example 3
- removal of B causes concurrent operations to be filtered
- operations from C are also filtered as they depended on B's operation 
![graphviz(52)](https://github.com/user-attachments/assets/26086b7f-bd9e-4ea2-8dca-745806a5cc73)

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header