### PR TITLE
Introduce high-level group membership API

### DIFF
--- a/p2panda-auth/src/group/dgm.rs
+++ b/p2panda-auth/src/group/dgm.rs
@@ -99,7 +99,11 @@ where
     ID: IdentityHandle + Display,
     OP: OperationId + Ord + Display,
     C: Clone + Debug + PartialEq + PartialOrd,
-    RS: Resolver<ORD::Message, State = GroupState<ID, OP, C, RS, ORD, GS>> + Debug,
+    RS: Resolver<
+            ORD::Message,
+            State = GroupState<ID, OP, C, RS, ORD, GS>,
+            Error = GroupError<ID, OP, C, RS, ORD, GS>,
+        > + Debug,
     ORD: Ordering<ID, OP, GroupControlMessage<ID, OP, C>> + Clone + Debug,
     ORD::Message: Clone,
     ORD::State: Clone,

--- a/p2panda-auth/src/group/dgm.rs
+++ b/p2panda-auth/src/group/dgm.rs
@@ -111,18 +111,21 @@ where
 
     /// Create a group.
     ///
-    /// The caller of this method should ensure that the given `group_id` is unique. The set of
-    /// initial members must not be empty; failure to meet these conditions will result in an error.
-    /// Group updates will not be possible if the group is not created with at least one manager,
-    /// since `Manage` access is required to perform any group state modifications.
+    /// The creator of the group is automatically added as a manager.
+    ///
+    /// The caller of this method must ensure that the given `group_id` is unique; failure to meet
+    /// this condition will result in an error.
     fn create(
         &self,
         group_id: ID,
-        initial_members: Vec<(GroupMember<ID>, Access<C>)>,
+        members: Vec<(GroupMember<ID>, Access<C>)>,
     ) -> Result<(Self::State, ORD::Message), Self::Error> {
-        if initial_members.is_empty() {
-            return Err(GroupManagerError::EmptyGroup);
-        }
+        // The creator of the group is automatically added as a manager.
+        let creator = (GroupMember::Individual(self.my_id), Access::Manage);
+
+        let mut initial_members = Vec::new();
+        initial_members.push(creator);
+        initial_members.extend(members);
 
         // TODO: Understand exactly what happens if two groups are created with the same
         // `group_id`. Does an error occur? If so, where and when?

--- a/p2panda-auth/src/group/dgm.rs
+++ b/p2panda-auth/src/group/dgm.rs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// TODO: Rename this to `src/group/dgm.rs`.
+
+use std::fmt::{Debug, Display};
+
+use thiserror::Error;
+
+use crate::group::{
+    Access, Group, GroupAction, GroupControlMessage, GroupError, GroupMember, GroupState,
+};
+use crate::traits::{
+    AuthGroup, GroupMembership, GroupMembershipQuery, GroupStore, IdentityHandle, OperationId,
+    Ordering, Resolver,
+};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Error)]
+pub enum GroupManagerError<ID, OP, C, RS, ORD, GS>
+where
+    ID: IdentityHandle,
+    OP: OperationId + Ord,
+    RS: Resolver<ORD::Message>,
+    ORD: Ordering<ID, OP, GroupControlMessage<ID, OP, C>>,
+    GS: GroupStore<ID, OP, C, RS, ORD>,
+{
+    #[error(transparent)]
+    Group(#[from] GroupError<ID, OP, C, RS, ORD, GS>),
+
+    // TODO: We already have a `GroupMembershipError` which covers this case.
+    // Be sure we're not creating duplicate errors.
+    // Either allow lower-level errors to bubble up or unify the type into this variant.
+    #[error("action requires manager access but actor is {0}")]
+    InsufficientAuthority(Access<C>),
+}
+
+pub struct GroupManager<ID, OP, C, RS, ORD, GS>
+where
+    ID: IdentityHandle,
+    OP: OperationId + Ord,
+    RS: Resolver<ORD::Message>,
+    ORD: Ordering<ID, OP, GroupControlMessage<ID, OP, C>>,
+    GS: GroupStore<ID, OP, C, RS, ORD>,
+{
+    // TODO: Do we want to store state here or go purely functional?
+    // If not here, where? Then we're probably passing the responsibility to the user to hold it
+    // somewhere appropriate.
+    _state: GroupState<ID, OP, C, RS, ORD, GS>,
+}
+
+// TODO: More validation?
+
+impl<ID, OP, C, RS, ORD, GS> GroupMembership<ID, OP, C, GS, ORD>
+    for GroupManager<ID, OP, C, RS, ORD, GS>
+where
+    ID: IdentityHandle + Display,
+    OP: OperationId + Ord + Display,
+    C: Clone + Debug + PartialEq + PartialOrd,
+    RS: Resolver<ORD::Message, State = GroupState<ID, OP, C, RS, ORD, GS>> + Debug,
+    ORD: Ordering<ID, OP, GroupControlMessage<ID, OP, C>> + Debug,
+    ORD::Message: Clone,
+    GS: GroupStore<ID, OP, C, RS, ORD> + Debug,
+{
+    type State = GroupState<ID, OP, C, RS, ORD, GS>;
+    type Action = GroupControlMessage<ID, OP, C>;
+    type Error = GroupManagerError<ID, OP, C, RS, ORD, GS>;
+
+    // TODO: Pass in the store and orderer here (for now...review during integration process).
+    // See L175 in `src/group.mod.rs`
+    fn create(
+        my_id: ID,
+        group_id: ID,
+        initial_members: Vec<(GroupMember<ID>, Access<C>)>,
+        store: GS,
+        orderer: ORD::State,
+    ) -> Result<(Self::State, ORD::Message), Self::Error> {
+        let y = GroupState::new(my_id, group_id, store, orderer);
+
+        let action = GroupControlMessage::GroupAction {
+            group_id: y.group_id,
+            action: GroupAction::Create { initial_members },
+        };
+
+        let (y, operation) = Group::prepare(y, &action)?;
+        let y = Group::process(y, &operation)?;
+
+        Ok((y, operation))
+    }
+
+    fn add(
+        y: Self::State,
+        adder: ID,
+        added: ID,
+        access: Access<C>,
+    ) -> Result<(Self::State, ORD::Message), Self::Error> {
+        if !Self::State::is_manager(&y, &adder) {
+            let adder_access = Self::State::access(&y, &adder)?;
+            return Err(GroupManagerError::InsufficientAuthority(adder_access));
+        }
+
+        let action = GroupControlMessage::GroupAction {
+            group_id: y.group_id,
+            action: GroupAction::Add {
+                member: GroupMember::Individual(added),
+                access,
+            },
+        };
+
+        // TODO: Possibly another validation check. Is `added` already part of the group?
+        let (y, operation) = Group::prepare(y, &action)?;
+        // At this point you've already trusted that the operation should be included in the group.
+        // The operation will still be appended to the graph, even if it ends up being invalid.
+        let y = Group::process(y, &operation)?;
+
+        Ok((y, operation))
+    }
+
+    fn remove(
+        y: Self::State,
+        remover: ID,
+        removed: ID,
+    ) -> Result<(Self::State, ORD::Message), Self::Error> {
+        if !Self::State::is_manager(&y, &remover) {
+            let remover_access = Self::State::access(&y, &remover)?;
+            return Err(GroupManagerError::InsufficientAuthority(remover_access));
+        }
+
+        let action = GroupControlMessage::GroupAction {
+            group_id: y.group_id,
+            action: GroupAction::Remove {
+                member: GroupMember::Individual(removed),
+            },
+        };
+
+        // TODO: Possibly another validation check. Is `removed` a current member of the group?
+        let (y, operation) = Group::prepare(y, &action)?;
+        let y = Group::process(y, &operation)?;
+
+        Ok((y, operation))
+    }
+
+    fn promote(
+        y: Self::State,
+        promoter: ID,
+        promoted: ID,
+        access: Access<C>,
+    ) -> Result<(Self::State, ORD::Message), Self::Error> {
+        if !Self::State::is_manager(&y, &promoter) {
+            let promoter_access = Self::State::access(&y, &promoter)?;
+            return Err(GroupManagerError::InsufficientAuthority(promoter_access));
+        }
+
+        let action = GroupControlMessage::GroupAction {
+            group_id: y.group_id,
+            action: GroupAction::Promote {
+                member: GroupMember::Individual(promoted),
+                access,
+            },
+        };
+
+        let (y, operation) = Group::prepare(y, &action)?;
+        let y = Group::process(y, &operation)?;
+
+        Ok((y, operation))
+    }
+
+    fn demote(
+        y: Self::State,
+        demoter: ID,
+        demoted: ID,
+        access: Access<C>,
+    ) -> Result<(Self::State, ORD::Message), Self::Error> {
+        if !Self::State::is_manager(&y, &demoter) {
+            let demoter_access = Self::State::access(&y, &demoter)?;
+            return Err(GroupManagerError::InsufficientAuthority(demoter_access));
+        }
+
+        let action = GroupControlMessage::GroupAction {
+            group_id: y.group_id,
+            action: GroupAction::Demote {
+                member: GroupMember::Individual(demoted),
+                access,
+            },
+        };
+
+        let (y, operation) = Group::prepare(y, &action)?;
+        let y = Group::process(y, &operation)?;
+
+        Ok((y, operation))
+    }
+}

--- a/p2panda-auth/src/group/dgm.rs
+++ b/p2panda-auth/src/group/dgm.rs
@@ -204,14 +204,16 @@ where
 
     /// Remove a group member.
     ///
-    /// The `remover` must be a manager and the `removed` identity must already be a member of
-    /// the group; failure to meet these conditions will result in an error.
+    /// A member may remove themself, even if they are not a manager. In order to remove any other
+    /// member, the `remover` must be a manager and the `removed` identity must already be a member
+    /// of the group; failure to meet these conditions will result in an error.
     fn remove(
         y: Self::State,
         remover: ID,
         removed: ID,
     ) -> Result<(Self::State, ORD::Message), Self::Error> {
-        if !Self::State::is_manager(&y, &remover) {
+        // A member may remove themself, even if they're not a manager.
+        if remover != removed && !Self::State::is_manager(&y, &remover) {
             let remover_access = Self::State::access(&y, &remover)?;
             return Err(GroupManagerError::InsufficientAccess(
                 remover,

--- a/p2panda-auth/src/group/dgm.rs
+++ b/p2panda-auth/src/group/dgm.rs
@@ -25,6 +25,9 @@ where
     #[error(transparent)]
     Group(#[from] GroupError<ID, OP, C, RS, ORD, GS>),
 
+    #[error("group must be created with at least one initial member")]
+    EmptyGroup,
+
     #[error("actor {0} is already a member of group {1}")]
     GroupMember(ID, ID),
 
@@ -38,6 +41,20 @@ where
     SameAccessLevel(ID, Access<C>, ID),
 }
 
+/// Decentralised Group Management (DGM).
+///
+/// The `GroupManager` provides a high-level interface for creating and updating groups. These
+/// groups provide a means for restricting access to application data and resources. Groups are
+/// comprised of members, which may be individuals or groups, and are assigned a user-chosen
+/// identity. Each member is assigned a unique user-chosen identifier and access level. Access
+/// levels are used to enforce restrictions over access to data and the mutation of that data.
+/// They are also used to grant permissions which allow for mutating the group state by adding,
+/// removing and modifying the access level of other members.
+///
+/// Each `GroupManager` method performs internal validation to ensure that the desired group
+/// action is valid in light of the current group state. Attempting to perform an invalid action
+/// results in a `GroupManagerError`. For example, attempting to remove a member who is not
+/// currently part of the group.
 pub struct GroupManager<ID, OP, C, RS, ORD, GS>
 where
     ID: IdentityHandle,
@@ -92,11 +109,24 @@ where
     type Action = GroupControlMessage<ID, OP, C>;
     type Error = GroupManagerError<ID, OP, C, RS, ORD, GS>;
 
+    /// Create a group.
+    ///
+    /// The caller of this method should ensure that the given `group_id` is unique. The set of
+    /// initial members must not be empty; failure to meet these conditions will result in an error.
+    /// Group updates will not be possible if the group is not created with at least one manager,
+    /// since `Manage` access is required to perform any group state modifications.
     fn create(
         &self,
         group_id: ID,
         initial_members: Vec<(GroupMember<ID>, Access<C>)>,
     ) -> Result<(Self::State, ORD::Message), Self::Error> {
+        if initial_members.is_empty() {
+            return Err(GroupManagerError::EmptyGroup);
+        }
+
+        // TODO: Understand exactly what happens if two groups are created with the same
+        // `group_id`. Does an error occur? If so, where and when?
+
         let y = GroupState::new(
             self.my_id,
             group_id,
@@ -115,6 +145,7 @@ where
         Ok((y, operation))
     }
 
+    /// Create a group by processing a remote operation.
     fn create_from_remote(
         &self,
         remote_operation: ORD::Message,
@@ -131,6 +162,10 @@ where
         Ok(y)
     }
 
+    /// Add a group member.
+    ///
+    /// The `adder` must be a manager and the `added` identity must not already be a member of
+    /// the group; failure to meet these conditions will result in an error.
     fn add(
         y: Self::State,
         adder: ID,
@@ -164,6 +199,10 @@ where
         Ok((y, operation))
     }
 
+    /// Remove a group member.
+    ///
+    /// The `remover` must be a manager and the `removed` identity must already be a member of
+    /// the group; failure to meet these conditions will result in an error.
     fn remove(
         y: Self::State,
         remover: ID,
@@ -195,6 +234,12 @@ where
         Ok((y, operation))
     }
 
+    /// Promote a group member to the given access level.
+    ///
+    /// The `promoter` must be a manager and the `promoted` identity must already be a member of
+    /// the group; failure to meet thess conditions will result in an error. A redundant access
+    /// level assignment will also result in an error; for example, if the `promoted` member
+    /// currently has `Read` access and the given access is also `Read`.
     fn promote(
         y: Self::State,
         promoter: ID,
@@ -235,6 +280,12 @@ where
         Ok((y, operation))
     }
 
+    /// Demote a group member to the given access level.
+    ///
+    /// The `demoter` must be a manager and the `demoted` identity must already be a member of
+    /// the group; failure to meet these conditions will result in an error. A redundant access
+    /// level assignment will also result in an error; for example, if the `demoted` member
+    /// currently has `Manage` access and the given access is also `Manage`.
     fn demote(
         y: Self::State,
         demoter: ID,

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -17,6 +17,7 @@ use petgraph::prelude::DiGraphMap;
 use petgraph::visit::{DfsPostOrder, IntoNodeIdentifiers, NodeIndexable, Reversed};
 use thiserror::Error;
 
+pub use crate::group::dgm::{GroupManager, GroupManagerError};
 pub use crate::group::resolver::StrongRemove;
 pub use crate::group::state::{Access, GroupMembersState, GroupMembershipError, MemberState};
 use crate::traits::{
@@ -24,7 +25,7 @@ use crate::traits::{
     Resolver,
 };
 
-pub mod dgm;
+mod dgm;
 #[cfg(any(test, feature = "test_utils"))]
 mod display;
 mod graph;

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -48,6 +48,7 @@ impl<ID> GroupMember<ID>
 where
     ID: Copy,
 {
+    /// Return the ID of a group member.
     pub fn id(&self) -> ID {
         match self {
             GroupMember::Individual(id) => *id,
@@ -351,6 +352,7 @@ where
                 }
             }
         }
+
         Ok(members.into_iter().collect())
     }
 
@@ -392,6 +394,7 @@ where
     ) -> Result<Vec<(ID, Access<C>)>, GroupError<ID, OP, C, RS, ORD, GS>> {
         let heads = self.transitive_heads()?;
         let members = self.transitive_members_at(&heads)?;
+
         Ok(members)
     }
 
@@ -497,56 +500,63 @@ where
     type Error = GroupError<ID, OP, C, RS, ORD, GS>;
 
     fn access(y: &Self::State, member: &ID) -> Result<Access<C>, Self::Error> {
-        let current_state = y.current_state();
-
-        let member_state = current_state
-            .members
+        let member_state = y
+            .transitive_members()?
             .into_iter()
-            .find(|(member_id, _state)| member_id.id() == member);
+            .find(|(member_id, _state)| member_id == member);
 
         if let Some(state) = member_state {
-            Ok(state.1.access)
+            let access = state.1.to_owned();
+
+            Ok(access)
         } else {
             Err(GroupError::MemberNotFound(y.group_id, *member))
         }
     }
 
-    fn member_ids(y: &Self::State) -> HashSet<ID> {
-        let current_state = y.current_state();
-
-        current_state
-            .members()
-            .iter()
-            .map(|member| member.id().to_owned())
-            .collect()
-    }
-
-    fn is_member(y: &Self::State, member: &ID) -> bool {
-        let current_state = y.current_state();
-
-        let member_state = current_state
-            .members
+    fn member_ids(y: &Self::State) -> Result<HashSet<ID>, Self::Error> {
+        let member_ids = y
+            .transitive_members()?
             .into_iter()
-            .find(|(member_id, _state)| member_id.id() == member);
+            .map(|(member_id, _state)| member_id)
+            .collect();
 
-        member_state.is_some()
+        Ok(member_ids)
     }
 
-    fn is_puller(y: &Self::State, member: &ID) -> bool {
-        // TODO(glyph): Would we rather propagate the error (`MemberNotFound`)?
-        matches!(GroupState::access(y, member), Ok(Access::Pull))
+    fn is_member(y: &Self::State, member: &ID) -> Result<bool, Self::Error> {
+        let member_state = y
+            .transitive_members()?
+            .into_iter()
+            .find(|(member_id, _state)| member_id == member);
+
+        let is_member = member_state.is_some();
+
+        Ok(is_member)
     }
 
-    fn is_reader(y: &Self::State, member: &ID) -> bool {
-        matches!(GroupState::access(y, member), Ok(Access::Read))
+    fn is_puller(y: &Self::State, member: &ID) -> Result<bool, Self::Error> {
+        let is_puller = matches!(GroupState::access(y, member)?, Access::Pull);
+
+        Ok(is_puller)
     }
 
-    fn is_writer(y: &Self::State, member: &ID) -> bool {
-        matches!(GroupState::access(y, member), Ok(Access::Write { .. }))
+    fn is_reader(y: &Self::State, member: &ID) -> Result<bool, Self::Error> {
+        let is_reader = matches!(GroupState::access(y, member)?, Access::Read);
+
+        Ok(is_reader)
     }
 
-    fn is_manager(y: &Self::State, member: &ID) -> bool {
-        matches!(GroupState::access(y, member), Ok(Access::Manage))
+    fn is_writer(y: &Self::State, member: &ID) -> Result<bool, Self::Error> {
+        let is_writer = matches!(GroupState::access(y, member)?, Access::Write { .. });
+
+        Ok(is_writer)
+    }
+
+    fn is_manager(y: &Self::State, member: &ID) -> Result<bool, Self::Error> {
+        let is_manager = matches!(GroupState::access(y, member)?, Access::Manage);
+
+        Ok(is_manager)
     }
 }
 

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -194,10 +194,10 @@ where
     GS: GroupStore<ID, OP, C, RS, ORD> + Debug,
 {
     /// Instantiate a new group state.
-    pub fn new(group_id: ID, my_id: ID, group_store: GS, orderer_y: ORD::State) -> Self {
+    pub fn new(my_id: ID, group_id: ID, group_store: GS, orderer_y: ORD::State) -> Self {
         Self {
-            group_id,
             my_id,
+            group_id,
             states: Default::default(),
             operations: Default::default(),
             ignore: Default::default(),
@@ -802,15 +802,11 @@ where
                 GroupAction::Remove { member, .. } => {
                     state::remove(members_y.clone(), member_id, member)
                 }
-                GroupAction::Promote { member, .. } => {
-                    // TODO: need changes in the group_crdt api so that we can pass in the access
-                    // level rather than only the conditions.
-                    state::promote(members_y.clone(), member_id, member, None)
+                GroupAction::Promote { member, access } => {
+                    state::promote(members_y.clone(), member_id, member, access)
                 }
-                GroupAction::Demote { member, .. } => {
-                    // TODO: need changes in the group_crdt api so that we can pass in the access
-                    // level rather than only the conditions.
-                    state::demote(members_y.clone(), member_id, member, None)
+                GroupAction::Demote { member, access } => {
+                    state::demote(members_y.clone(), member_id, member, access)
                 }
                 GroupAction::Create { initial_members } => Ok(state::create(&initial_members)),
             };
@@ -942,7 +938,7 @@ where
     fn rebuild(
         y: GroupState<ID, OP, C, RS, ORD, GS>,
     ) -> Result<GroupState<ID, OP, C, RS, ORD, GS>, GroupError<ID, OP, C, RS, ORD, GS>> {
-        let mut y_i = GroupState::new(y.group_id, y.my_id, y.group_store.clone(), y.orderer_y);
+        let mut y_i = GroupState::new(y.my_id, y.group_id, y.group_store.clone(), y.orderer_y);
         y_i.ignore = y.ignore;
 
         // Apply every operation.

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-// TODO(glyph): This module really needs to be aggressively split into smaller modules:
+// TODO(glyph): I'd love to see this module split into smaller modules to make it easier to
+// understand the various components and how they're related. Right now it feels a bit overwhelming
+// to navigate.
 //
 // src/group/member.rs
 // src/group/action.rs
@@ -364,7 +366,6 @@ where
         Ok(members)
     }
 
-    // TODO: Consider moving this to the query trait.
     /// Get all current members of the group.
     pub fn members(&self) -> Vec<(GroupMember<ID>, Access<C>)> {
         self.current_state()
@@ -499,65 +500,52 @@ where
 
         let member_state = current_state
             .members
-            // TODO(glyph): Hmm...we're ignoring the Group variant here but that seems like an
-            // oversight. Surely we want the access level for the `member`, regardless of whether
-            // it's a group or an individual.
-            .get(&GroupMember::Individual(*member))
-            // TODO: Errors.
-            .unwrap();
+            .into_iter()
+            .find(|(member_id, _state)| member_id.id() == member);
 
-        Ok(member_state.access.clone())
+        if let Some(state) = member_state {
+            Ok(state.1.access)
+        } else {
+            Err(GroupError::MemberNotFound(y.group_id, *member))
+        }
     }
 
-    fn members(y: &Self::State, viewer: &ID) -> Result<HashSet<ID>, Self::Error> {
+    fn member_ids(y: &Self::State) -> HashSet<ID> {
         let current_state = y.current_state();
 
-        let members = current_state
+        current_state
             .members()
             .iter()
-            .map(|member| match member {
-                GroupMember::Individual(id) => id.to_owned(),
-                GroupMember::Group(id) => id.to_owned(),
-            })
-            .collect();
-
-        Ok(members)
+            .map(|member| member.id().to_owned())
+            .collect()
     }
 
-    fn is_member(y: &Self::State, possible_member: &ID) -> bool {
-        y.current_state()
-            .members()
-            .contains(&GroupMember::Individual(*possible_member))
-            || y.current_state()
-                .members()
-                .contains(&GroupMember::Group(*possible_member))
+    fn is_member(y: &Self::State, member: &ID) -> bool {
+        let current_state = y.current_state();
+
+        let member_state = current_state
+            .members
+            .into_iter()
+            .find(|(member_id, _state)| member_id.id() == member);
+
+        member_state.is_some()
     }
 
     fn is_puller(y: &Self::State, member: &ID) -> bool {
-        // TODO(glyph): This feels very clumsy...
-        //
-        // I want to query `puller` state for the member but the members returned by
-        // `current_state` are all wrapped in `GroupMember` which doesn't implement a `is_puller`
-        // convenience method. I'd really rather not have to match on both variants each time
-        // (`Individual` and `Group`).
-
-        todo!()
+        // TODO(glyph): Would we rather propagate the error (`MemberNotFound`)?
+        matches!(GroupState::access(y, member), Ok(Access::Pull))
     }
 
     fn is_reader(y: &Self::State, member: &ID) -> bool {
-        todo!()
+        matches!(GroupState::access(y, member), Ok(Access::Read))
     }
 
     fn is_writer(y: &Self::State, member: &ID) -> bool {
-        todo!()
-    }
-
-    fn was_member(y: &Self::State, possible_member: &ID) -> bool {
-        todo!()
+        matches!(GroupState::access(y, member), Ok(Access::Write { .. }))
     }
 
     fn is_manager(y: &Self::State, member: &ID) -> bool {
-        todo!()
+        matches!(GroupState::access(y, member), Ok(Access::Manage))
     }
 }
 

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -567,14 +567,14 @@ mod tests {
 
         // Create initial group with Alice and Bob
         let (alice_group, op_create) = create_group(
-            group_id,
             alice,
+            group_id,
             vec![(alice, Access::Manage), (bob, Access::Manage)],
             &mut rng,
         );
 
-        let bob_group = from_create(group_id, bob, &op_create, &mut rng);
-        let claire_group = from_create(group_id, claire, &op_create, &mut rng);
+        let bob_group = from_create(bob, group_id, &op_create, &mut rng);
+        let claire_group = from_create(claire, group_id, &op_create, &mut rng);
 
         assert_members(
             &alice_group,
@@ -661,8 +661,8 @@ mod tests {
 
         // 1: Alice creates group with Alice, Bob, Claire
         let (alice_group, op_create) = create_group(
-            group_id,
             alice,
+            group_id,
             vec![
                 (alice, Access::Manage),
                 (bob, Access::Manage),
@@ -671,7 +671,7 @@ mod tests {
             &mut rng,
         );
 
-        let bob_group = from_create(group_id, bob, &op_create, &mut rng);
+        let bob_group = from_create(bob, group_id, &op_create, &mut rng);
 
         assert_members(
             &alice_group,
@@ -778,16 +778,16 @@ mod tests {
 
         // 1: Create initial group with Alice and Bob
         let (alice_group, op_create) = create_group(
-            group_id,
             alice,
+            group_id,
             vec![(alice, Access::Manage), (bob, Access::Manage)],
             &mut rng,
         );
 
         // Initialize all member groups from the create operation
-        let bob_group = from_create(group_id, bob, &op_create, &mut rng);
-        let dave_group = from_create(group_id, dave, &op_create, &mut rng);
-        let frank_group = from_create(group_id, frank, &op_create, &mut rng);
+        let bob_group = from_create(bob, group_id, &op_create, &mut rng);
+        let dave_group = from_create(dave, group_id, &op_create, &mut rng);
+        let frank_group = from_create(frank, group_id, &op_create, &mut rng);
 
         assert_members(
             &alice_group,

--- a/p2panda-auth/src/group/test_utils/network.rs
+++ b/p2panda-auth/src/group/test_utils/network.rs
@@ -282,8 +282,8 @@ impl Network {
         match group_y {
             Some(group_y) => group_y,
             None => TestGroupState::new(
-                *group_id,
                 member.id,
+                *group_id,
                 member.group_store.clone(),
                 member.orderer_y.clone(),
             ),

--- a/p2panda-auth/src/group/test_utils/orderer.rs
+++ b/p2panda-auth/src/group/test_utils/orderer.rs
@@ -81,8 +81,8 @@ impl Ordering<MemberId, MessageId, GroupControlMessage<MemberId, MessageId, Cond
 
             // Instantiate a new group.
             let mut group_y = TestGroupState::new(
-                group_id,
                 y_inner.my_id,
+                group_id,
                 y_inner.group_store.clone(),
                 y.clone(),
             );

--- a/p2panda-auth/src/group/tests.rs
+++ b/p2panda-auth/src/group/tests.rs
@@ -17,26 +17,26 @@ use super::test_utils::MessageId;
 use super::{GroupAction, GroupControlMessage, GroupMember};
 
 pub(crate) fn from_create(
-    group_id: char,
     actor_id: char,
+    group_id: char,
     op_create: &TestOperation,
     rng: &mut StdRng,
 ) -> TestGroupState {
     let store = TestGroupStore::default();
     let orderer = TestOrdererState::new(actor_id, store.clone(), StdRng::from_rng(rng));
-    let group = TestGroupState::new(group_id, actor_id, store, orderer);
+    let group = TestGroupState::new(actor_id, group_id, store, orderer);
     TestGroup::process(group, op_create).unwrap()
 }
 
 pub(crate) fn create_group(
-    group_id: char,
     actor_id: char,
+    group_id: char,
     members: Vec<(char, Access<()>)>,
     rng: &mut StdRng,
 ) -> (TestGroupState, TestOperation) {
     let store = TestGroupStore::default();
     let orderer = TestOrdererState::new(actor_id, store.clone(), StdRng::from_rng(rng));
-    let group = TestGroupState::new(group_id, actor_id, store, orderer);
+    let group = TestGroupState::new(actor_id, group_id, store, orderer);
     let control_message = GroupControlMessage::GroupAction {
         group_id,
         action: GroupAction::Create {
@@ -105,7 +105,7 @@ fn basic_group() {
     let store = TestGroupStore::default();
     let rng = StdRng::from_os_rng();
     let orderer_y = TestOrdererState::new(alice, store.clone(), rng);
-    let group_y = TestGroupState::new(group_id, alice, store, orderer_y);
+    let group_y = TestGroupState::new(alice, group_id, store, orderer_y);
 
     // Create group with alice as initial admin member.
     let control_message_001 = GroupControlMessage::GroupAction {
@@ -253,14 +253,14 @@ fn nested_groups() {
 
     // One devices group instance.
     let devices_group_y = GroupState::new(
-        alice_devices_group,
         alice,
+        alice_devices_group,
         store.clone(),
         alice_orderer_y.clone(),
     );
 
     // One team group instance.
-    let team_group_y = GroupState::new(alice_team_group, alice, store.clone(), alice_orderer_y);
+    let team_group_y = GroupState::new(alice, alice_team_group, store.clone(), alice_orderer_y);
 
     // Control message creating the devices group, with alice, alice_laptop and alice mobile as members.
     let control_message_001 = GroupControlMessage::GroupAction {
@@ -884,8 +884,8 @@ fn error_cases() {
     let mut rng = StdRng::from_os_rng();
 
     let (y_i, _) = create_group(
-        group_id,
         alice,
+        group_id,
         vec![
             (alice, Access::Manage),
             (bob, Access::Read),
@@ -1101,8 +1101,8 @@ fn error_cases_resolver() {
     let mut rng = StdRng::from_os_rng();
 
     let (y_i, _) = create_group(
-        group_id,
         alice,
+        group_id,
         vec![
             (alice, Access::Manage),
             (bob, Access::Read),

--- a/p2panda-auth/src/traits/dgm.rs
+++ b/p2panda-auth/src/traits/dgm.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashSet;
+use std::error::Error;
+use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize};
+
+use crate::group::{Access, GroupMember};
+use crate::traits::{IdentityHandle, OperationId, Ordering};
+
+// TODO: Maybe `GroupApi` or `GroupQuery...` something something.
+
+/// Decentralised group membership (DGM) API for managing membership of a single group.
+pub trait GroupMembership<ID, OP, C, GS, ORD>
+where
+    ID: IdentityHandle,
+    OP: OperationId,
+    ORD: Ordering<ID, OP, Self::Action>,
+{
+    //type State: Clone + Debug + Serialize + for<'a> Deserialize<'a>;
+    type State;
+    type Action;
+    type Error: Error;
+
+    // TODO(glyph): Do we have any concept of destroying a group?
+
+    /// Creates a new group, returning the updated state and the creation operation message.
+    fn create(
+        my_id: ID,
+        group_id: ID,
+        initial_members: Vec<(GroupMember<ID>, Access<C>)>,
+        store: GS,
+        orderer: ORD::State,
+    ) -> Result<(Self::State, ORD::Message), Self::Error>;
+
+    // TODO: Sometimes we want to "create" a group that was started elsewhere (from another peer).
+    // `from_welcome()` or `from_message()` or something...
+    // Need to think about this..
+    // Two-step process or one?
+    //
+    // Initialise the group by processing a remotely-authored `create` message.
+    //fn create_from_remote()
+
+    /// Adds a member to the group.
+    fn add(
+        y: Self::State,
+        adder: ID,
+        added: ID,
+        access: Access<C>,
+    ) -> Result<(Self::State, ORD::Message), Self::Error>;
+
+    /// Removes a member from the group.
+    fn remove(
+        y: Self::State,
+        remover: ID,
+        removed: ID,
+    ) -> Result<(Self::State, ORD::Message), Self::Error>;
+
+    /// Promote a member to the given access level.
+    fn promote(
+        y: Self::State,
+        promoter: ID,
+        promoted: ID,
+        access: Access<C>,
+    ) -> Result<(Self::State, ORD::Message), Self::Error>;
+
+    /// Demote a member to the given access level.
+    fn demote(
+        y: Self::State,
+        demoter: ID,
+        demoted: ID,
+        access: Access<C>,
+    ) -> Result<(Self::State, ORD::Message), Self::Error>;
+}

--- a/p2panda-auth/src/traits/dgm.rs
+++ b/p2panda-auth/src/traits/dgm.rs
@@ -6,10 +6,14 @@ use crate::group::{Access, GroupMember};
 use crate::traits::{IdentityHandle, OperationId, Ordering};
 
 /// Decentralised group membership (DGM) API for managing membership of a single group.
-pub trait GroupMembership<ID, OP, C, GS, ORD>
+pub trait GroupMembership<ID, OP, C, ORD>
 where
     ID: IdentityHandle,
     OP: OperationId,
+    // TODO: Do we strictly need the orderer here? Could it rather be a generic message?
+    // We might not actually need to know anything about the message type, only in the `Orderer`.
+    // In the _implementation_ we'd say it's an `ORD::Message` but not here (move that knowledge
+    // into the implementation.
     ORD: Ordering<ID, OP, Self::Action>,
 {
     type State;
@@ -32,6 +36,12 @@ where
     /// called. The `group_id` is extracted from the operation itself.
     fn create_from_remote(
         &self,
+        remote_operation: ORD::Message,
+    ) -> Result<Self::State, Self::Error>;
+
+    /// Process a remotely-authored group action message.
+    fn receive_from_remote(
+        y: Self::State,
         remote_operation: ORD::Message,
     ) -> Result<Self::State, Self::Error>;
 

--- a/p2panda-auth/src/traits/dgm.rs
+++ b/p2panda-auth/src/traits/dgm.rs
@@ -16,26 +16,22 @@ where
     type Action;
     type Error: Error;
 
-    /// Initialise the group state.
-    fn init(
-        my_id: ID,
-        group_id: ID,
-        store: GS,
-        orderer: ORD::State,
-    ) -> Result<Self::State, Self::Error>;
-
     /// Creates a new group, returning the updated state and the creation operation message.
+    ///
+    /// The group state must first be initialised by calling `init()` before this function is
+    /// called.
     fn create(
-        y: Self::State,
+        &self,
+        group_id: ID,
         initial_members: Vec<(GroupMember<ID>, Access<C>)>,
     ) -> Result<(Self::State, ORD::Message), Self::Error>;
 
     /// Initialise the group by processing a remotely-authored `create` message.
     ///
     /// The group state must first be initialised by calling `init()` before this function is
-    /// called. The `group_id` can be extracted from the operation itself.
+    /// called. The `group_id` is extracted from the operation itself.
     fn create_from_remote(
-        y: Self::State,
+        &self,
         remote_operation: ORD::Message,
     ) -> Result<Self::State, Self::Error>;
 

--- a/p2panda-auth/src/traits/group_store.rs
+++ b/p2panda-auth/src/traits/group_store.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+// TODO: Rename this module from `group_store.rs` to `store.rs`.
+
 use std::error::Error;
+use std::fmt::Display;
 
 use crate::group::{GroupControlMessage, GroupState};
 use crate::traits::{IdentityHandle, OperationId, Ordering};
@@ -13,7 +16,7 @@ where
     ORD: Ordering<ID, OP, GroupControlMessage<ID, OP, C>>,
     Self: Sized,
 {
-    type Error: Error;
+    type Error: Error + Display;
 
     /// Insert a group state into the store.
     fn insert(

--- a/p2panda-auth/src/traits/mod.rs
+++ b/p2panda-auth/src/traits/mod.rs
@@ -3,16 +3,20 @@
 use std::fmt::Debug;
 use std::hash::Hash as StdHash;
 
+mod dgm;
 mod group;
 mod group_store;
 mod operation;
 mod ordering;
+mod query;
 mod resolver;
 
+pub use dgm::GroupMembership;
 pub use group::AuthGroup;
 pub use group_store::GroupStore;
 pub use operation::Operation;
 pub use ordering::Ordering;
+pub use query::GroupMembershipQuery;
 pub use resolver::Resolver;
 
 /// Handle to identify a group member.

--- a/p2panda-auth/src/traits/ordering.rs
+++ b/p2panda-auth/src/traits/ordering.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 
 /// Interface for processing messages which have particular ordering requirements.
 ///
-/// Messages have a sender id, a unique identifier and a generic payload.
+/// Messages have an author id, a unique identifier and a generic payload.
 pub trait Ordering<ID, OP, P> {
     type State;
     type Message: Operation<ID, OP, P>;

--- a/p2panda-auth/src/traits/query.rs
+++ b/p2panda-auth/src/traits/query.rs
@@ -11,23 +11,25 @@ pub trait GroupMembershipQuery<ID, OP, C> {
     type Error: Error;
 
     /// Query the current access level of the given member.
+    ///
+    /// The member is expected to be a "stateless" individual, not a "stateful" group.
     fn access(y: &Self::State, member: &ID) -> Result<Access<C>, Self::Error>;
 
     /// Query group membership.
-    fn member_ids(y: &Self::State) -> HashSet<ID>;
+    fn member_ids(y: &Self::State) -> Result<HashSet<ID>, Self::Error>;
 
     /// Return `true` if the given ID is an active member of the group.
-    fn is_member(y: &Self::State, possible_member: &ID) -> bool;
+    fn is_member(y: &Self::State, member: &ID) -> Result<bool, Self::Error>;
 
     /// Return `true` if the given member is currently assigned the `Pull` access level.
-    fn is_puller(y: &Self::State, member: &ID) -> bool;
+    fn is_puller(y: &Self::State, member: &ID) -> Result<bool, Self::Error>;
 
     /// Return `true` if the given member is currently assigned the `Read` access level.
-    fn is_reader(y: &Self::State, member: &ID) -> bool;
+    fn is_reader(y: &Self::State, member: &ID) -> Result<bool, Self::Error>;
 
     /// Return `true` if the given member is currently assigned the `Write` access level.
-    fn is_writer(y: &Self::State, member: &ID) -> bool;
+    fn is_writer(y: &Self::State, member: &ID) -> Result<bool, Self::Error>;
 
     /// Return `true` if the given member is currently assigned the `Manage` access level.
-    fn is_manager(y: &Self::State, member: &ID) -> bool;
+    fn is_manager(y: &Self::State, member: &ID) -> Result<bool, Self::Error>;
 }

--- a/p2panda-auth/src/traits/query.rs
+++ b/p2panda-auth/src/traits/query.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashSet;
+use std::error::Error;
+use std::fmt::Debug;
+
+use crate::group::Access;
+
+use serde::{Deserialize, Serialize};
+
+/// Interface for querying group membership and access levels.
+pub trait GroupMembershipQuery<ID, OP, C> {
+    //type State: Clone + Debug + Serialize + for<'a> Deserialize<'a>;
+    type State;
+    type Error: Error;
+
+    /// Query the current access level of the given member.
+    fn access(y: &Self::State, member: &ID) -> Result<Access<C>, Self::Error>;
+
+    /// Query group membership from the perspective of the given viewer.
+    fn members(y: &Self::State, viewer: &ID) -> Result<HashSet<ID>, Self::Error>;
+
+    /// Return `true` if the given ID is an active member of the group.
+    fn is_member(y: &Self::State, possible_member: &ID) -> bool;
+
+    /// Return `true` if the given ID was an active member of the group.
+    ///
+    /// This represents a member who has been removed from the group.
+    fn was_member(y: &Self::State, possible_member: &ID) -> bool;
+
+    /// Return `true` if the given member is currently assigned the `Pull` access level.
+    fn is_puller(y: &Self::State, member: &ID) -> bool;
+
+    /// Return `true` if the given member is currently assigned the `Read` access level.
+    fn is_reader(y: &Self::State, member: &ID) -> bool;
+
+    /// Return `true` if the given member is currently assigned the `Write` access level.
+    fn is_writer(y: &Self::State, member: &ID) -> bool;
+
+    /// Return `true` if the given member is currently assigned the `Manage` access level.
+    fn is_manager(y: &Self::State, member: &ID) -> bool;
+}

--- a/p2panda-auth/src/traits/query.rs
+++ b/p2panda-auth/src/traits/query.rs
@@ -2,31 +2,22 @@
 
 use std::collections::HashSet;
 use std::error::Error;
-use std::fmt::Debug;
 
 use crate::group::Access;
 
-use serde::{Deserialize, Serialize};
-
 /// Interface for querying group membership and access levels.
 pub trait GroupMembershipQuery<ID, OP, C> {
-    //type State: Clone + Debug + Serialize + for<'a> Deserialize<'a>;
     type State;
     type Error: Error;
 
     /// Query the current access level of the given member.
     fn access(y: &Self::State, member: &ID) -> Result<Access<C>, Self::Error>;
 
-    /// Query group membership from the perspective of the given viewer.
-    fn members(y: &Self::State, viewer: &ID) -> Result<HashSet<ID>, Self::Error>;
+    /// Query group membership.
+    fn member_ids(y: &Self::State) -> HashSet<ID>;
 
     /// Return `true` if the given ID is an active member of the group.
     fn is_member(y: &Self::State, possible_member: &ID) -> bool;
-
-    /// Return `true` if the given ID was an active member of the group.
-    ///
-    /// This represents a member who has been removed from the group.
-    fn was_member(y: &Self::State, possible_member: &ID) -> bool;
 
     /// Return `true` if the given member is currently assigned the `Pull` access level.
     fn is_puller(y: &Self::State, member: &ID) -> bool;


### PR DESCRIPTION
This PR introduces `GroupManager` which exposes the high-level API for creating and updating groups.

Groups provide a means for restricting access to application data and resources. They are comprised of members, which may be individuals or groups, and are assigned a user-chosen identity (`group_id`). Each member is assigned a unique user-chosen identifier and access level. Access levels are used to enforce restrictions over access to data and the mutation of that data. They are also used to grant permissions which allow for mutating the group state by adding, removing and modifying the access level of other members.

The `GroupManager` API is a thin wrapper around the `GroupState` and `Group` APIs, with the addition of validation checks to ensure that invalid control message operations are not created and appended to the group state DAG. For example, it should not be possible to remove a member who is not currently part of the group. This would result in a `GroupManagerError` being returned.

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header