### PR TITLE
Improvements to `Access` 

### DIFF
--- a/p2panda-auth/src/group/access.rs
+++ b/p2panda-auth/src/group/access.rs
@@ -3,20 +3,26 @@
 use std::fmt::Display;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
-pub enum Access<C = ()> {
+pub enum AccessLevel {
     Pull,
     Read,
-    Write { conditions: Option<C> },
+    Write,
     Manage,
+}
+
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+pub struct Access<C = ()> {
+    pub level: AccessLevel,
+    pub conditions: Option<C>,
 }
 
 impl<C> Display for Access<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Access::Pull => "pull",
-            Access::Read => "read",
-            Access::Write { .. } => "write",
-            Access::Manage => "manage",
+        let s = match self.level {
+            AccessLevel::Pull => "pull",
+            AccessLevel::Read => "read",
+            AccessLevel::Write => "write",
+            AccessLevel::Manage => "manage",
         };
 
         write!(f, "{}", s)
@@ -25,34 +31,51 @@ impl<C> Display for Access<C> {
 
 impl<C> Access<C> {
     pub fn pull() -> Self {
-        Self::Pull
+        Self {
+            level: AccessLevel::Pull,
+            conditions: None,
+        }
     }
 
     pub fn read() -> Self {
-        Self::Read
+        Self {
+            level: AccessLevel::Read,
+            conditions: None,
+        }
     }
 
     pub fn write() -> Self {
-        Self::Write { conditions: None }
+        Self {
+            level: AccessLevel::Write,
+            conditions: None,
+        }
     }
 
     pub fn manage() -> Self {
-        Self::Manage
+        Self {
+            level: AccessLevel::Manage,
+            conditions: None,
+        }
+    }
+
+    pub fn with_conditions(mut self, conditions: C) -> Self {
+        self.conditions = Some(conditions);
+        self
     }
 
     pub fn is_pull(&self) -> bool {
-        matches!(self, Access::Pull)
+        matches!(self.level, AccessLevel::Pull)
     }
 
     pub fn is_read(&self) -> bool {
-        matches!(self, Access::Read)
+        matches!(self.level, AccessLevel::Read)
     }
 
     pub fn is_write(&self) -> bool {
-        matches!(self, Access::Write { .. })
+        matches!(self.level, AccessLevel::Write)
     }
 
     pub fn is_manage(&self) -> bool {
-        matches!(self, Access::Manage)
+        matches!(self.level, AccessLevel::Manage)
     }
 }

--- a/p2panda-auth/src/group/access.rs
+++ b/p2panda-auth/src/group/access.rs
@@ -3,7 +3,7 @@
 use std::fmt::Display;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
-pub enum Access<C> {
+pub enum Access<C = ()> {
     Pull,
     Read,
     Write { conditions: Option<C> },
@@ -20,5 +20,39 @@ impl<C> Display for Access<C> {
         };
 
         write!(f, "{}", s)
+    }
+}
+
+impl<C> Access<C> {
+    pub fn pull() -> Self {
+        Self::Pull
+    }
+
+    pub fn read() -> Self {
+        Self::Read
+    }
+
+    pub fn write() -> Self {
+        Self::Write { conditions: None }
+    }
+
+    pub fn manage() -> Self {
+        Self::Manage
+    }
+
+    pub fn is_pull(&self) -> bool {
+        matches!(self, Access::Pull)
+    }
+
+    pub fn is_read(&self) -> bool {
+        matches!(self, Access::Read)
+    }
+
+    pub fn is_write(&self) -> bool {
+        matches!(self, Access::Write { .. })
+    }
+
+    pub fn is_manage(&self) -> bool {
+        matches!(self, Access::Manage)
     }
 }

--- a/p2panda-auth/src/group/access.rs
+++ b/p2panda-auth/src/group/access.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt::Display;
+
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+pub enum Access<C> {
+    Pull,
+    Read,
+    Write { conditions: Option<C> },
+    Manage,
+}
+
+impl<C> Display for Access<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Access::Pull => "pull",
+            Access::Read => "read",
+            Access::Write { .. } => "write",
+            Access::Manage => "manage",
+        };
+
+        write!(f, "{}", s)
+    }
+}

--- a/p2panda-auth/src/group/access.rs
+++ b/p2panda-auth/src/group/access.rs
@@ -2,18 +2,27 @@
 
 use std::fmt::Display;
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+/// The four basic access levels which can be assigned to group members. Greater access levels are
+/// assumed to also contain all lower ones.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccessLevel {
+    /// Permission to sync a data set.
     Pull,
+
+    /// Permission to read a data set.
     Read,
+
+    /// Permission to write to a data set.
     Write,
+
+    /// Permission to apply membership changes to a group.
     Manage,
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq)]
 pub struct Access<C = ()> {
-    pub level: AccessLevel,
     pub conditions: Option<C>,
+    pub level: AccessLevel,
 }
 
 impl<C> Display for Access<C> {
@@ -77,5 +86,172 @@ impl<C> Access<C> {
 
     pub fn is_manage(&self) -> bool {
         matches!(self.level, AccessLevel::Manage)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Ordering;
+
+    use crate::group::Access;
+
+    /// Conditions which models access based on paths. Having access to "/public" gives you access
+    /// to "/public/stuff" and "/public/other/stuff" but not "/private" or "/private/stuff".
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct PathCondition(String);
+
+    impl PartialOrd for Access<PathCondition> {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            match (self.conditions.as_ref(), other.conditions.as_ref()) {
+                // If both have path conditions compare if other is a sub-path of self and then
+                // additionally compare access levels.
+                (Some(self_path), Some(other_path)) => {
+                    let self_parts: Vec<_> =
+                        self_path.0.split('/').filter(|s| !s.is_empty()).collect();
+                    let other_parts: Vec<_> =
+                        other_path.0.split('/').filter(|s| !s.is_empty()).collect();
+
+                    let min_len = self_parts.len().min(other_parts.len());
+                    let is_prefix = self_parts[..min_len] == other_parts[..min_len];
+
+                    if is_prefix {
+                        match self_parts.len().cmp(&other_parts.len()) {
+                            Ordering::Less => match self.level.cmp(&other.level) {
+                                Ordering::Less => Some(Ordering::Less),
+                                Ordering::Equal | Ordering::Greater => Some(Ordering::Greater),
+                            },
+                            Ordering::Equal => Some(self.level.cmp(&other.level)),
+                            Ordering::Greater => Some(Ordering::Less),
+                        }
+                    } else {
+                        None
+                    }
+                }
+                // If self has no conditions, but other does, then compare levels, if they are
+                // equal then return Ord::Greater as we don't have conditions (but they do) so our
+                // access is greater.
+                (None, Some(_)) => match self.level.cmp(&other.level) {
+                    Ordering::Less => Some(Ordering::Less),
+                    Ordering::Equal | Ordering::Greater => Some(Ordering::Greater),
+                },
+                // Fallback to level comparison
+                _ => Some(self.level.cmp(&other.level)),
+            }
+        }
+    }
+
+    impl Ord for Access<PathCondition> {
+        fn cmp(&self, other: &Self) -> Ordering {
+            self.partial_cmp(other).unwrap_or(Ordering::Less)
+        }
+    }
+
+    #[test]
+    fn path_condition_comparators() {
+        let root_access = Access::read().with_conditions(PathCondition("/root".to_string()));
+        let private_access =
+            Access::read().with_conditions(PathCondition("/root/private".to_string()));
+        let public_access =
+            Access::read().with_conditions(PathCondition("/root/public".to_string()));
+
+        // Access to "/root" gives access to all sub-paths
+        assert!(root_access >= private_access);
+        assert!(root_access >= public_access);
+
+        // Unrelated paths are not comparable.
+        assert!(!(private_access >= public_access));
+        assert!(!(private_access <= public_access));
+
+        let read_access_to_root =
+            Access::read().with_conditions(PathCondition("/root".to_string()));
+        let requested_write_access_to_sub_path =
+            Access::write().with_conditions(PathCondition("/root/private".to_string()));
+
+        assert!(requested_write_access_to_sub_path < read_access_to_root);
+
+        let unconditional_read = Access::<PathCondition>::read();
+        assert!(unconditional_read > public_access);
+    }
+
+    /// Conditions containing an access expiry timestamp.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ExpiryTimestamp(u64);
+
+    impl PartialOrd for Access<ExpiryTimestamp> {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            match (self.conditions.as_ref(), other.conditions.as_ref()) {
+                // If both self and other have an expiry then we should compare them followed by
+                // comparing levels.
+                (Some(self_expiry), Some(other_expiry)) => {
+                    if self_expiry.0 < other_expiry.0 {
+                        Some(Ordering::Less)
+                    } else {
+                        match self.level.cmp(&other.level) {
+                            Ordering::Less => Some(Ordering::Less),
+                            Ordering::Equal | Ordering::Greater => {
+                                Some(self_expiry.0.cmp(&other_expiry.0))
+                            }
+                        }
+                    }
+                }
+
+                // If self has no conditions, but other does, then compare levels, if they are
+                // equal then return Ord::Greater as we don't have conditions (but they do) so our
+                // access is greater.
+                (None, Some(_)) => match self.level.cmp(&other.level) {
+                    Ordering::Less => Some(Ordering::Less),
+                    Ordering::Equal | Ordering::Greater => Some(Ordering::Greater),
+                },
+                _ => Some(self.level.cmp(&other.level)),
+            }
+        }
+    }
+
+    impl Ord for Access<ExpiryTimestamp> {
+        fn cmp(&self, other: &Self) -> Ordering {
+            self.partial_cmp(other).unwrap_or(Ordering::Less)
+        }
+    }
+
+    #[test]
+    fn expiry_timestamp_access_ordering() {
+        let access_expires_soon = Access::read().with_conditions(ExpiryTimestamp(10));
+        let access_expires_later = Access::read().with_conditions(ExpiryTimestamp(100));
+
+        // access_expires_later grants more access (access valid for longer).
+        assert!(access_expires_later > access_expires_soon);
+
+        // access_expires_soon grants less access (access valid for shorter time).
+        assert!(access_expires_soon < access_expires_later);
+
+        // It's likely access levels will be tested against some kind of request, here we
+        // construct a request that requires that the requestor has access equal or greater than
+        // "Read" which expires at timestamp 50.
+        const NOW: ExpiryTimestamp = ExpiryTimestamp(50);
+        let requested_read_access = Access::read().with_conditions(NOW);
+
+        // This access has already expired, it is less than the requested access, and the request
+        // would be rejected.
+        assert!(access_expires_soon < requested_read_access);
+
+        // This access is still valid, it is greater than the requested access, and the request
+        // would be accepted.
+        assert!(access_expires_later >= requested_read_access);
+
+        // Even though the held access level (Read) is greater than the requested access level (Pull)
+        // the condition has expired and so the held access is still less than the requested and
+        // the request would be rejected.
+        let requested_pull_access = Access::pull().with_conditions(NOW);
+        assert!(access_expires_soon < requested_pull_access);
+
+        // On the other hand, if the condition is still valid, but the requested access level is
+        // greater than the held one, the request will still be rejected.
+        let requested_write_access = Access::write().with_conditions(NOW);
+        assert!(access_expires_later < requested_write_access);
+
+        // An access level without an expiry is greater or equal than one with.
+        let requested_read_access = Access::read().with_conditions(NOW);
+        let access_no_expiry = Access::<ExpiryTimestamp>::read();
+        assert!(access_no_expiry > requested_read_access);
     }
 }

--- a/p2panda-auth/src/group/dgm.rs
+++ b/p2panda-auth/src/group/dgm.rs
@@ -125,7 +125,7 @@ where
         members: Vec<(GroupMember<ID>, Access<C>)>,
     ) -> Result<(Self::State, ORD::Message), Self::Error> {
         // The creator of the group is automatically added as a manager.
-        let creator = (GroupMember::Individual(self.my_id), Access::Manage);
+        let creator = (GroupMember::Individual(self.my_id), Access::manage());
 
         let mut initial_members = Vec::new();
         initial_members.push(creator);
@@ -375,12 +375,9 @@ mod tests {
         let orderer = TestOrdererState::new(MY_ID, store.clone(), rng);
 
         let initial_members = [
-            (GroupMember::Individual(ALICE), Access::Manage),
-            (GroupMember::Individual(BOB), Access::Read),
-            (
-                GroupMember::Individual(CLAIRE),
-                Access::Write { conditions: None },
-            ),
+            (GroupMember::Individual(ALICE), Access::manage()),
+            (GroupMember::Individual(BOB), Access::read()),
+            (GroupMember::Individual(CLAIRE), Access::write()),
         ]
         .to_vec();
 
@@ -399,18 +396,19 @@ mod tests {
         let y = setup();
 
         // Bob is not a manager.
+        let _expected_access = <Access>::read();
         assert!(matches!(
-            GroupManager::add(y.clone(), BOB, DAVE, Access::Pull),
+            GroupManager::add(y.clone(), BOB, DAVE, Access::pull()),
             Err(GroupManagerError::InsufficientAccess(
                 BOB,
-                Access::Read,
+                _expected_access,
                 GROUP_ID
             ))
         ));
 
         // Claire is already a group member.
         assert!(matches!(
-            GroupManager::add(y, ALICE, CLAIRE, Access::Pull),
+            GroupManager::add(y, ALICE, CLAIRE, Access::pull()),
             Err(GroupManagerError::GroupMember(CLAIRE, GROUP_ID))
         ));
     }
@@ -420,11 +418,12 @@ mod tests {
         let y = setup();
 
         // Bob is not a manager.
+        let _expected_access = <Access>::read();
         assert!(matches!(
             GroupManager::remove(y.clone(), BOB, CLAIRE),
             Err(GroupManagerError::InsufficientAccess(
                 BOB,
-                Access::Read,
+                _expected_access,
                 GROUP_ID
             ))
         ));
@@ -441,27 +440,29 @@ mod tests {
         let y = setup();
 
         // Bob is not a manager.
+        let _expected_access = <Access>::read();
         assert!(matches!(
-            GroupManager::promote(y.clone(), BOB, CLAIRE, Access::Manage),
+            GroupManager::promote(y.clone(), BOB, CLAIRE, Access::manage()),
             Err(GroupManagerError::InsufficientAccess(
                 BOB,
-                Access::Read,
+                _expected_access,
                 GROUP_ID
             ))
         ));
 
         // Dave is not a group member.
         assert!(matches!(
-            GroupManager::promote(y.clone(), ALICE, DAVE, Access::Read),
+            GroupManager::promote(y.clone(), ALICE, DAVE, Access::read()),
             Err(GroupManagerError::NotGroupMember(DAVE, GROUP_ID))
         ));
 
         // Bob already has `Read` access.
+        let _expected_access = <Access>::read();
         assert!(matches!(
-            GroupManager::promote(y, ALICE, BOB, Access::Read),
+            GroupManager::promote(y, ALICE, BOB, Access::read()),
             Err(GroupManagerError::SameAccessLevel(
                 BOB,
-                Access::Read,
+                _expected_access,
                 GROUP_ID
             ))
         ));
@@ -472,27 +473,29 @@ mod tests {
         let y = setup();
 
         // Bob is not a manager.
+        let _expected_access = <Access>::read();
         assert!(matches!(
-            GroupManager::demote(y.clone(), BOB, CLAIRE, Access::Pull),
+            GroupManager::demote(y.clone(), BOB, CLAIRE, Access::pull()),
             Err(GroupManagerError::InsufficientAccess(
                 BOB,
-                Access::Read,
+                _expected_access,
                 GROUP_ID
             ))
         ));
 
         // Dave is not a group member.
         assert!(matches!(
-            GroupManager::demote(y.clone(), ALICE, DAVE, Access::Read),
+            GroupManager::demote(y.clone(), ALICE, DAVE, Access::read()),
             Err(GroupManagerError::NotGroupMember(DAVE, GROUP_ID))
         ));
 
         // Bob already has `Read` access.
+        let _expected_access = <Access>::read();
         assert!(matches!(
-            GroupManager::demote(y, ALICE, BOB, Access::Read),
+            GroupManager::demote(y, ALICE, BOB, Access::read()),
             Err(GroupManagerError::SameAccessLevel(
                 BOB,
-                Access::Read,
+                _expected_access,
                 GROUP_ID
             ))
         ));

--- a/p2panda-auth/src/group/display.rs
+++ b/p2panda-auth/src/group/display.rs
@@ -23,7 +23,7 @@ impl<ID, OP, C, RS, ORD, GS> GroupState<ID, OP, C, RS, ORD, GS>
 where
     ID: IdentityHandle + Ord + Display,
     OP: OperationId + Ord + Display,
-    C: Clone + Debug + PartialEq + PartialOrd + Ord,
+    C: Clone + Debug + PartialEq + PartialOrd,
     RS: Resolver<
             ORD::Message,
             State = GroupState<ID, OP, C, RS, ORD, GS>,
@@ -204,8 +204,7 @@ where
         let mut s = String::new();
         s += "<<TABLE BGCOLOR=\"#00E30F7F\" BORDER=\"1\" CELLBORDER=\"1\" CELLSPACING=\"2\">";
 
-        let mut members = self.transitive_members().unwrap();
-        members.sort();
+        let members = self.transitive_members().unwrap();
         s += "<TR><TD>GROUP MEMBERS</TD></TR>";
         for (id, access) in members {
             s += &format!("<TR><TD> {} : {} </TD></TR>", id, access);

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -17,10 +17,10 @@ use petgraph::prelude::DiGraphMap;
 use petgraph::visit::{DfsPostOrder, IntoNodeIdentifiers, NodeIndexable, Reversed};
 use thiserror::Error;
 
+pub use crate::group::access::Access;
 pub use crate::group::dgm::{GroupManager, GroupManagerError};
 pub use crate::group::resolver::StrongRemove;
 pub use crate::group::state::{GroupMembersState, GroupMembershipError, MemberState};
-pub use crate::group::access::Access;
 
 use crate::traits::{
     AuthGroup, GroupMembershipQuery, GroupStore, IdentityHandle, Operation, OperationId, Ordering,

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -19,12 +19,15 @@ use thiserror::Error;
 
 pub use crate::group::dgm::{GroupManager, GroupManagerError};
 pub use crate::group::resolver::StrongRemove;
-pub use crate::group::state::{Access, GroupMembersState, GroupMembershipError, MemberState};
+pub use crate::group::state::{GroupMembersState, GroupMembershipError, MemberState};
+pub use crate::group::access::Access;
+
 use crate::traits::{
     AuthGroup, GroupMembershipQuery, GroupStore, IdentityHandle, Operation, OperationId, Ordering,
     Resolver,
 };
 
+mod access;
 mod dgm;
 #[cfg(any(test, feature = "test_utils"))]
 mod display;

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -539,27 +539,19 @@ where
     }
 
     fn is_puller(y: &Self::State, member: &ID) -> Result<bool, Self::Error> {
-        let is_puller = matches!(GroupState::access(y, member)?, Access::Pull);
-
-        Ok(is_puller)
+        Ok(GroupState::access(y, member)?.is_pull())
     }
 
     fn is_reader(y: &Self::State, member: &ID) -> Result<bool, Self::Error> {
-        let is_reader = matches!(GroupState::access(y, member)?, Access::Read);
-
-        Ok(is_reader)
+        Ok(GroupState::access(y, member)?.is_read())
     }
 
     fn is_writer(y: &Self::State, member: &ID) -> Result<bool, Self::Error> {
-        let is_writer = matches!(GroupState::access(y, member)?, Access::Write { .. });
-
-        Ok(is_writer)
+        Ok(GroupState::access(y, member)?.is_write())
     }
 
     fn is_manager(y: &Self::State, member: &ID) -> Result<bool, Self::Error> {
-        let is_manager = matches!(GroupState::access(y, member)?, Access::Manage);
-
-        Ok(is_manager)
+        Ok(GroupState::access(y, member)?.is_manage())
     }
 }
 

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -263,7 +263,7 @@ where
         let was_manager = self
             .transitive_members_at(&HashSet::from_iter(operation.dependencies()))
             .expect("get transitive members")
-            .contains(&(removed_or_demoted_member.id(), Access::Manage));
+            .contains(&(removed_or_demoted_member.id(), Access::manage()));
 
         if was_manager {
             Some(removed_or_demoted_member.id())
@@ -314,9 +314,9 @@ mod tests {
             group,
             alice,
             vec![
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(bob), Access::Manage),
-                (GroupMember::Individual(claire), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(bob), Access::manage()),
+                (GroupMember::Individual(claire), Access::manage()),
             ],
         );
 
@@ -334,19 +334,19 @@ mod tests {
         let alice_members = network.members(&alice, &group);
         assert_eq!(
             alice_members,
-            vec![(GroupMember::Individual(claire), Access::Manage),]
+            vec![(GroupMember::Individual(claire), Access::manage()),]
         );
 
         let bob_members = network.members(&bob, &group);
         assert_eq!(
             bob_members,
-            vec![(GroupMember::Individual(claire), Access::Manage),]
+            vec![(GroupMember::Individual(claire), Access::manage()),]
         );
 
         let claire_members = network.members(&claire, &group);
         assert_eq!(
             claire_members,
-            vec![(GroupMember::Individual(claire), Access::Manage),]
+            vec![(GroupMember::Individual(claire), Access::manage()),]
         );
 
         // We expect the "ignore" operation set to be empty, indicating that no operations have
@@ -388,9 +388,9 @@ mod tests {
             group,
             alice,
             vec![
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(bob), Access::Manage),
-                (GroupMember::Individual(claire), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(bob), Access::manage()),
+                (GroupMember::Individual(claire), Access::manage()),
             ],
         );
 
@@ -402,7 +402,7 @@ mod tests {
             alice,
             GroupMember::Individual(bob),
             group,
-            Access::Write { conditions: None },
+            Access::write(),
         );
 
         // Bob removes Claire concurrently.
@@ -419,12 +419,12 @@ mod tests {
         assert_eq!(
             alice_members,
             vec![
-                (GroupMember::Individual(alice), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
                 (
                     GroupMember::Individual(bob),
-                    Access::Write { conditions: None }
+                    Access::write()
                 ),
-                (GroupMember::Individual(claire), Access::Manage),
+                (GroupMember::Individual(claire), Access::manage()),
             ]
         );
 
@@ -432,12 +432,12 @@ mod tests {
         assert_eq!(
             bob_members,
             vec![
-                (GroupMember::Individual(alice), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
                 (
                     GroupMember::Individual(bob),
-                    Access::Write { conditions: None }
+                    Access::write()
                 ),
-                (GroupMember::Individual(claire), Access::Manage),
+                (GroupMember::Individual(claire), Access::manage()),
             ]
         );
 
@@ -445,12 +445,12 @@ mod tests {
         assert_eq!(
             claire_members,
             vec![
-                (GroupMember::Individual(alice), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
                 (
                     GroupMember::Individual(bob),
-                    Access::Write { conditions: None }
+                    Access::write()
                 ),
-                (GroupMember::Individual(claire), Access::Manage),
+                (GroupMember::Individual(claire), Access::manage()),
             ]
         );
 
@@ -492,9 +492,9 @@ mod tests {
             group,
             alice,
             vec![
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(bob), Access::Manage),
-                (GroupMember::Individual(claire), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(bob), Access::manage()),
+                (GroupMember::Individual(claire), Access::manage()),
             ],
         );
 
@@ -506,11 +506,11 @@ mod tests {
             alice,
             GroupMember::Individual(bob),
             group,
-            Access::Write { conditions: None },
+            Access::write(),
         );
 
         // Bob adds Dave concurrently.
-        network.add(bob, GroupMember::Individual(dave), group, Access::Read);
+        network.add(bob, GroupMember::Individual(dave), group, Access::read());
 
         // Everyone processes these operations.
         network.process();
@@ -520,12 +520,12 @@ mod tests {
 
         // We expect Alice (Manage), Bob (Write) and Claire (Manage) to be the only group members.
         let expected_members = vec![
-            (GroupMember::Individual(alice), Access::Manage),
+            (GroupMember::Individual(alice), Access::manage()),
             (
                 GroupMember::Individual(bob),
-                Access::Write { conditions: None },
+                Access::write(),
             ),
-            (GroupMember::Individual(claire), Access::Manage),
+            (GroupMember::Individual(claire), Access::manage()),
         ];
 
         let alice_members = network.members(&alice, &group);
@@ -569,7 +569,7 @@ mod tests {
         let (alice_group, op_create) = create_group(
             alice,
             group_id,
-            vec![(alice, Access::Manage), (bob, Access::Manage)],
+            vec![(alice, Access::manage()), (bob, Access::manage())],
             &mut rng,
         );
 
@@ -579,8 +579,8 @@ mod tests {
         assert_members(
             &alice_group,
             &[
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(bob), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(bob), Access::manage()),
             ],
         );
 
@@ -589,33 +589,33 @@ mod tests {
 
         assert_members(
             &alice_group,
-            &[(GroupMember::Individual(alice), Access::Manage)],
+            &[(GroupMember::Individual(alice), Access::manage())],
         );
 
         // Bob (in his own branch) adds Claire
-        let (bob_group, op_add_claire) = add_member(bob_group, group_id, claire, Access::Manage);
+        let (bob_group, op_add_claire) = add_member(bob_group, group_id, claire, Access::manage());
         let claire_group = sync(claire_group, &[op_add_claire.clone()]);
 
         assert_members(
             &bob_group,
             &[
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(bob), Access::Manage),
-                (GroupMember::Individual(claire), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(bob), Access::manage()),
+                (GroupMember::Individual(claire), Access::manage()),
             ],
         );
 
         // Claire adds Dave
-        let (claire_group, op_add_dave) = add_member(claire_group, group_id, dave, Access::Read);
+        let (claire_group, op_add_dave) = add_member(claire_group, group_id, dave, Access::read());
         let bob_group = sync(bob_group, &[op_add_dave.clone()]);
 
         assert_members(
             &bob_group,
             &[
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(bob), Access::Manage),
-                (GroupMember::Individual(claire), Access::Manage),
-                (GroupMember::Individual(dave), Access::Read),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(bob), Access::manage()),
+                (GroupMember::Individual(claire), Access::manage()),
+                (GroupMember::Individual(dave), Access::read()),
             ],
         );
 
@@ -624,7 +624,7 @@ mod tests {
         let bob_group = sync(bob_group, &[op_remove_bob.clone()]);
         let claire_group = sync(claire_group, &[op_remove_bob.clone()]);
 
-        let expected_members = vec![(GroupMember::Individual(alice), Access::Manage)];
+        let expected_members = vec![(GroupMember::Individual(alice), Access::manage())];
 
         assert_members(&alice_group, &expected_members);
         assert_members(&bob_group, &expected_members);
@@ -664,9 +664,9 @@ mod tests {
             alice,
             group_id,
             vec![
-                (alice, Access::Manage),
-                (bob, Access::Manage),
-                (claire, Access::Manage),
+                (alice, Access::manage()),
+                (bob, Access::manage()),
+                (claire, Access::manage()),
             ],
             &mut rng,
         );
@@ -676,9 +676,9 @@ mod tests {
         assert_members(
             &alice_group,
             &[
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(bob), Access::Manage),
-                (GroupMember::Individual(claire), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(bob), Access::manage()),
+                (GroupMember::Individual(claire), Access::manage()),
             ],
         );
 
@@ -688,33 +688,33 @@ mod tests {
         assert_members(
             &alice_group,
             &[
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(claire), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(claire), Access::manage()),
             ],
         );
 
         // 3: Alice re-adds Bob
-        let (alice_group, op_readd_bob) = add_member(alice_group, group_id, bob, Access::Manage);
+        let (alice_group, op_readd_bob) = add_member(alice_group, group_id, bob, Access::manage());
 
         assert_members(
             &alice_group,
             &[
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(bob), Access::Manage),
-                (GroupMember::Individual(claire), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(bob), Access::manage()),
+                (GroupMember::Individual(claire), Access::manage()),
             ],
         );
 
         // 4: Bob adds Dave
-        let (bob_group, op_add_dave) = add_member(bob_group, group_id, dave, Access::Read);
+        let (bob_group, op_add_dave) = add_member(bob_group, group_id, dave, Access::read());
 
         assert_members(
             &bob_group,
             &[
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(bob), Access::Manage),
-                (GroupMember::Individual(claire), Access::Manage),
-                (GroupMember::Individual(dave), Access::Read),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(bob), Access::manage()),
+                (GroupMember::Individual(claire), Access::manage()),
+                (GroupMember::Individual(dave), Access::read()),
             ],
         );
 
@@ -723,15 +723,15 @@ mod tests {
         let bob_group = sync(bob_group, &[op_remove_bob.clone(), op_readd_bob.clone()]);
 
         // Bob adds Eve
-        let (bob_group, op_add_eve) = add_member(bob_group, group_id, eve, Access::Read);
+        let (bob_group, op_add_eve) = add_member(bob_group, group_id, eve, Access::read());
         let alice_group = sync(alice_group, &[op_add_eve.clone()]);
 
         // Final assertions: All 4 members should be present
         let expected = vec![
-            (GroupMember::Individual(alice), Access::Manage),
-            (GroupMember::Individual(bob), Access::Manage),
-            (GroupMember::Individual(claire), Access::Manage),
-            (GroupMember::Individual(eve), Access::Read),
+            (GroupMember::Individual(alice), Access::manage()),
+            (GroupMember::Individual(bob), Access::manage()),
+            (GroupMember::Individual(claire), Access::manage()),
+            (GroupMember::Individual(eve), Access::read()),
         ];
 
         assert_members(&alice_group, &expected);
@@ -780,7 +780,7 @@ mod tests {
         let (alice_group, op_create) = create_group(
             alice,
             group_id,
-            vec![(alice, Access::Manage), (bob, Access::Manage)],
+            vec![(alice, Access::manage()), (bob, Access::manage())],
             &mut rng,
         );
 
@@ -792,8 +792,8 @@ mod tests {
         assert_members(
             &alice_group,
             &[
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(bob), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(bob), Access::manage()),
             ],
         );
 
@@ -801,13 +801,13 @@ mod tests {
         let (alice_group, op_remove_bob) = remove_member(alice_group, group_id, bob);
 
         // 3: Bob adds Claire (concurrent with 2)
-        let (_bob_group, op_add_claire) = add_member(bob_group, group_id, claire, Access::Read);
+        let (_bob_group, op_add_claire) = add_member(bob_group, group_id, claire, Access::read());
 
         // Alice processes Bob's operation
         let alice_group = sync(alice_group, &[op_add_claire.clone()]);
 
         // 4: Alice adds Dave (merges states 2 & 3)
-        let (alice_group, op_add_dave) = add_member(alice_group, group_id, dave, Access::Manage);
+        let (alice_group, op_add_dave) = add_member(alice_group, group_id, dave, Access::manage());
 
         // New member Dave syncs state
         let dave_group = sync(
@@ -820,12 +820,12 @@ mod tests {
         );
 
         // 5: Dave adds Eve (depends on 4)
-        let (dave_group, op_add_eve) = add_member(dave_group, group_id, eve, Access::Read);
+        let (dave_group, op_add_eve) = add_member(dave_group, group_id, eve, Access::read());
 
         let alice_group = sync(alice_group, &[op_add_eve.clone()]);
 
         // 6: Alice adds Frank (concurrent with 8)
-        let (_alice_group, op_add_frank) = add_member(alice_group, group_id, frank, Access::Manage);
+        let (_alice_group, op_add_frank) = add_member(alice_group, group_id, frank, Access::manage());
 
         let frank_group = sync(
             frank_group,
@@ -839,7 +839,7 @@ mod tests {
         );
 
         // 7: Frank adds Grace (concurrent with 8)
-        let (_, op_add_grace) = add_member(frank_group, group_id, grace, Access::Read);
+        let (_, op_add_grace) = add_member(frank_group, group_id, grace, Access::read());
 
         // 8: Dave removes Alice (concurrently with 6 & 7)
         let (dave_group, _op_remove_alice) = remove_member(dave_group, group_id, alice);
@@ -847,8 +847,8 @@ mod tests {
         let dave_group = sync(dave_group, &[op_add_frank.clone(), op_add_grace.clone()]);
 
         let expected_members = vec![
-            (GroupMember::Individual(dave), Access::Manage),
-            (GroupMember::Individual(eve), Access::Read),
+            (GroupMember::Individual(dave), Access::manage()),
+            (GroupMember::Individual(eve), Access::read()),
         ];
 
         let mut dave_members = dave_group.members();

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -398,12 +398,7 @@ mod tests {
         network.process();
 
         // Alice demotes Bob.
-        network.demote(
-            alice,
-            GroupMember::Individual(bob),
-            group,
-            Access::write(),
-        );
+        network.demote(alice, GroupMember::Individual(bob), group, Access::write());
 
         // Bob removes Claire concurrently.
         network.remove(bob, GroupMember::Individual(claire), group);
@@ -420,10 +415,7 @@ mod tests {
             alice_members,
             vec![
                 (GroupMember::Individual(alice), Access::manage()),
-                (
-                    GroupMember::Individual(bob),
-                    Access::write()
-                ),
+                (GroupMember::Individual(bob), Access::write()),
                 (GroupMember::Individual(claire), Access::manage()),
             ]
         );
@@ -433,10 +425,7 @@ mod tests {
             bob_members,
             vec![
                 (GroupMember::Individual(alice), Access::manage()),
-                (
-                    GroupMember::Individual(bob),
-                    Access::write()
-                ),
+                (GroupMember::Individual(bob), Access::write()),
                 (GroupMember::Individual(claire), Access::manage()),
             ]
         );
@@ -446,10 +435,7 @@ mod tests {
             claire_members,
             vec![
                 (GroupMember::Individual(alice), Access::manage()),
-                (
-                    GroupMember::Individual(bob),
-                    Access::write()
-                ),
+                (GroupMember::Individual(bob), Access::write()),
                 (GroupMember::Individual(claire), Access::manage()),
             ]
         );
@@ -502,12 +488,7 @@ mod tests {
         network.process();
 
         // Alice demotes Bob.
-        network.demote(
-            alice,
-            GroupMember::Individual(bob),
-            group,
-            Access::write(),
-        );
+        network.demote(alice, GroupMember::Individual(bob), group, Access::write());
 
         // Bob adds Dave concurrently.
         network.add(bob, GroupMember::Individual(dave), group, Access::read());
@@ -521,10 +502,7 @@ mod tests {
         // We expect Alice (Manage), Bob (Write) and Claire (Manage) to be the only group members.
         let expected_members = vec![
             (GroupMember::Individual(alice), Access::manage()),
-            (
-                GroupMember::Individual(bob),
-                Access::write(),
-            ),
+            (GroupMember::Individual(bob), Access::write()),
             (GroupMember::Individual(claire), Access::manage()),
         ];
 
@@ -825,7 +803,8 @@ mod tests {
         let alice_group = sync(alice_group, &[op_add_eve.clone()]);
 
         // 6: Alice adds Frank (concurrent with 8)
-        let (_alice_group, op_add_frank) = add_member(alice_group, group_id, frank, Access::manage());
+        let (_alice_group, op_add_frank) =
+            add_member(alice_group, group_id, frank, Access::manage());
 
         let frank_group = sync(
             frank_group,

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -60,7 +60,7 @@ impl<ID, OP, C, ORD, GS> Resolver<ORD::Message> for StrongRemove<ID, OP, C, ORD,
 where
     ID: IdentityHandle + Display + Ord,
     OP: OperationId + Display + Ord,
-    C: Clone + Debug + PartialEq + PartialOrd + Ord,
+    C: Clone + Debug + PartialEq + PartialOrd,
     ORD: Ordering<ID, OP, GroupControlMessage<ID, OP, C>> + Clone + Debug,
     ORD::Message: Clone,
     ORD::State: Clone,

--- a/p2panda-auth/src/group/state.rs
+++ b/p2panda-auth/src/group/state.rs
@@ -3,7 +3,7 @@
 //! Group membership CRDT.
 
 use std::collections::{HashMap, HashSet};
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::hash::Hash;
 
 use thiserror::Error;

--- a/p2panda-auth/src/group/state.rs
+++ b/p2panda-auth/src/group/state.rs
@@ -54,19 +54,19 @@ where
     }
 
     pub fn is_puller(&self) -> bool {
-        self.access == Access::Pull
+        self.access.is_pull()
     }
 
     pub fn is_reader(&self) -> bool {
-        self.access == Access::Read
+        self.access.is_read()
     }
 
     pub fn is_writer(&self) -> bool {
-        self.access != Access::Pull && self.access != Access::Read && self.access != Access::Manage
+        self.access.is_write()
     }
 
     pub fn is_manager(&self) -> bool {
-        self.access == Access::Manage
+        self.access.is_manage()
     }
 }
 
@@ -844,7 +844,7 @@ mod tests {
         assert!(charlie_state.access_counter == 2);
 
         // We expect the access level to be Pull for Charlie.
-        assert!(charlie_state.access == Access::Pull);
+        assert!(charlie_state.is_puller());
     }
 
     #[test]
@@ -886,6 +886,6 @@ mod tests {
         let charlie_state = group_y.members.get(&charlie).unwrap();
 
         // We expect the access level to be Pull for Charlie.
-        assert!(charlie_state.access == Access::Pull);
+        assert!(charlie_state.is_puller());
     }
 }

--- a/p2panda-auth/src/group/state.rs
+++ b/p2panda-auth/src/group/state.rs
@@ -8,6 +8,8 @@ use std::hash::Hash;
 
 use thiserror::Error;
 
+use crate::group::Access;
+
 #[derive(Debug, Error, PartialEq)]
 pub enum GroupMembershipError<ID> {
     #[error("attempted to add a member who is already active in the group: {0}")]
@@ -30,27 +32,6 @@ pub enum GroupMembershipError<ID> {
 
     #[error("member is not known to the group: {0}")]
     UnrecognisedMember(ID),
-}
-
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
-pub enum Access<C> {
-    Pull,
-    Read,
-    Write { conditions: Option<C> },
-    Manage,
-}
-
-impl<C> Display for Access<C> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Access::Pull => "pull",
-            Access::Read => "read",
-            Access::Write { .. } => "write",
-            Access::Manage => "manage",
-        };
-
-        write!(f, "{}", s)
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/p2panda-auth/src/group/test_utils/mod.rs
+++ b/p2panda-auth/src/group/test_utils/mod.rs
@@ -31,7 +31,6 @@ pub type TestResolver = GenericTestResolver<TestOrderer, TestGroupStore>;
 pub type TestGroup = GenericTestGroup<TestResolver, TestOrderer, TestGroupStore>;
 pub type TestGroupState = GenericTestGroupState<TestResolver, TestOrderer, TestGroupStore>;
 
-
 /// During testing we want Ord to be implemented on Access so we can easily assert test cases
 /// involving collections of access levels.
 impl<C: Ord> Ord for Access<C> {

--- a/p2panda-auth/src/group/test_utils/mod.rs
+++ b/p2panda-auth/src/group/test_utils/mod.rs
@@ -11,7 +11,7 @@ pub use orderer::*;
 pub use partial_ord::*;
 
 use crate::group::resolver::StrongRemove;
-use crate::group::{Group, GroupState};
+use crate::group::{Access, Group, GroupState};
 use crate::traits::{IdentityHandle, OperationId};
 
 impl IdentityHandle for char {}
@@ -30,3 +30,17 @@ pub type GenericTestGroupState<RS, ORD, GS> =
 pub type TestResolver = GenericTestResolver<TestOrderer, TestGroupStore>;
 pub type TestGroup = GenericTestGroup<TestResolver, TestOrderer, TestGroupStore>;
 pub type TestGroupState = GenericTestGroupState<TestResolver, TestOrderer, TestGroupStore>;
+
+
+/// During testing we want Ord to be implemented on Access so we can easily assert test cases
+/// involving collections of access levels.
+impl<C: Ord> Ord for Access<C> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let level_cmp = self.level.cmp(&other.level);
+        if level_cmp != std::cmp::Ordering::Equal {
+            level_cmp
+        } else {
+            self.conditions.cmp(&other.conditions)
+        }
+    }
+}

--- a/p2panda-auth/src/group/tests.rs
+++ b/p2panda-auth/src/group/tests.rs
@@ -111,7 +111,7 @@ fn basic_group() {
     let control_message_001 = GroupControlMessage::GroupAction {
         group_id,
         action: GroupAction::Create {
-            initial_members: vec![(GroupMember::Individual(alice), Access::Manage)],
+            initial_members: vec![(GroupMember::Individual(alice), Access::manage())],
         },
     };
     let (group_y, operation_001) = TestGroup::prepare(group_y, &control_message_001).unwrap();
@@ -121,7 +121,7 @@ fn basic_group() {
     members.sort();
     assert_eq!(
         members,
-        vec![(GroupMember::Individual(alice), Access::Manage)]
+        vec![(GroupMember::Individual(alice), Access::manage())]
     );
 
     // Add bob with read access.
@@ -130,7 +130,7 @@ fn basic_group() {
         group_id,
         action: GroupAction::Add {
             member: GroupMember::Individual(bob),
-            access: Access::Read,
+            access: Access::read(),
         },
     };
     let (group_y, operation_002) = TestGroup::prepare(group_y, &control_message_002).unwrap();
@@ -141,8 +141,8 @@ fn basic_group() {
     assert_eq!(
         members,
         vec![
-            (GroupMember::Individual(alice), Access::Manage),
-            (GroupMember::Individual(bob), Access::Read)
+            (GroupMember::Individual(alice), Access::manage()),
+            (GroupMember::Individual(bob), Access::read())
         ]
     );
 
@@ -152,7 +152,7 @@ fn basic_group() {
         group_id,
         action: GroupAction::Add {
             member: GroupMember::Individual(claire),
-            access: Access::Write { conditions: None },
+            access: Access::write(),
         },
     };
     let (group_y, operation_003) = TestGroup::prepare(group_y, &control_message_003).unwrap();
@@ -163,11 +163,11 @@ fn basic_group() {
     assert_eq!(
         members,
         vec![
-            (GroupMember::Individual(alice), Access::Manage),
-            (GroupMember::Individual(bob), Access::Read),
+            (GroupMember::Individual(alice), Access::manage()),
+            (GroupMember::Individual(bob), Access::read()),
             (
                 GroupMember::Individual(claire),
-                Access::Write { conditions: None }
+                Access::write()
             )
         ]
     );
@@ -177,7 +177,7 @@ fn basic_group() {
         group_id,
         action: GroupAction::Promote {
             member: GroupMember::Individual(claire),
-            access: Access::Manage,
+            access: Access::manage(),
         },
     };
     let (group_y, operation_004) = TestGroup::prepare(group_y, &control_message_004).unwrap();
@@ -188,9 +188,9 @@ fn basic_group() {
     assert_eq!(
         members,
         vec![
-            (GroupMember::Individual(alice), Access::Manage),
-            (GroupMember::Individual(bob), Access::Read),
-            (GroupMember::Individual(claire), Access::Manage)
+            (GroupMember::Individual(alice), Access::manage()),
+            (GroupMember::Individual(bob), Access::read()),
+            (GroupMember::Individual(claire), Access::manage())
         ]
     );
 
@@ -199,7 +199,7 @@ fn basic_group() {
         group_id,
         action: GroupAction::Demote {
             member: GroupMember::Individual(bob),
-            access: Access::Pull,
+            access: Access::pull(),
         },
     };
     let (group_y, operation_005) = TestGroup::prepare(group_y, &control_message_005).unwrap();
@@ -210,9 +210,9 @@ fn basic_group() {
     assert_eq!(
         members,
         vec![
-            (GroupMember::Individual(alice), Access::Manage),
-            (GroupMember::Individual(bob), Access::Pull),
-            (GroupMember::Individual(claire), Access::Manage)
+            (GroupMember::Individual(alice), Access::manage()),
+            (GroupMember::Individual(bob), Access::pull()),
+            (GroupMember::Individual(claire), Access::manage())
         ]
     );
 
@@ -231,8 +231,8 @@ fn basic_group() {
     assert_eq!(
         members,
         vec![
-            (GroupMember::Individual(alice), Access::Manage),
-            (GroupMember::Individual(claire), Access::Manage)
+            (GroupMember::Individual(alice), Access::manage()),
+            (GroupMember::Individual(claire), Access::manage())
         ]
     );
 }
@@ -267,11 +267,11 @@ fn nested_groups() {
         group_id: devices_group_y.id(),
         action: GroupAction::Create {
             initial_members: vec![
-                (GroupMember::Individual(alice), Access::Manage),
-                (GroupMember::Individual(alice_laptop), Access::Manage),
+                (GroupMember::Individual(alice), Access::manage()),
+                (GroupMember::Individual(alice_laptop), Access::manage()),
                 (
                     GroupMember::Individual(alice_mobile),
-                    Access::Write { conditions: None },
+                    Access::write(),
                 ),
             ],
         },
@@ -290,11 +290,11 @@ fn nested_groups() {
     assert_eq!(
         members,
         vec![
-            (GroupMember::Individual(alice), Access::Manage),
-            (GroupMember::Individual(alice_laptop), Access::Manage),
+            (GroupMember::Individual(alice), Access::manage()),
+            (GroupMember::Individual(alice_laptop), Access::manage()),
             (
                 GroupMember::Individual(alice_mobile),
-                Access::Write { conditions: None }
+                Access::write()
             ),
         ],
     );
@@ -303,7 +303,7 @@ fn nested_groups() {
     let control_message_002 = GroupControlMessage::GroupAction {
         group_id: team_group_y.id(),
         action: GroupAction::Create {
-            initial_members: vec![(GroupMember::Individual(alice), Access::Manage)],
+            initial_members: vec![(GroupMember::Individual(alice), Access::manage())],
         },
     };
 
@@ -319,7 +319,7 @@ fn nested_groups() {
         group_id: team_group_y.id(),
         action: GroupAction::Add {
             member: GroupMember::Group(devices_group_y.id()),
-            access: Access::Read,
+            access: Access::read(),
         },
     };
     let (team_group_y, operation_003) =
@@ -332,8 +332,8 @@ fn nested_groups() {
     assert_eq!(
         members,
         vec![
-            (GroupMember::Individual(alice), Access::Manage),
-            (GroupMember::Group(alice_devices_group), Access::Read)
+            (GroupMember::Individual(alice), Access::manage()),
+            (GroupMember::Group(alice_devices_group), Access::read())
         ]
     );
 
@@ -344,9 +344,9 @@ fn nested_groups() {
     assert_eq!(
         transitive_members,
         vec![
-            (alice, Access::Manage),
-            (alice_laptop, Access::Read),
-            (alice_mobile, Access::Read),
+            (alice, Access::manage()),
+            (alice_laptop, Access::read()),
+            (alice_mobile, Access::read()),
         ]
     );
 }
@@ -372,7 +372,7 @@ fn multi_user() {
     network.create(
         alice_team_group,
         alice,
-        vec![(GroupMember::Individual(alice), Access::Manage)],
+        vec![(GroupMember::Individual(alice), Access::manage())],
     );
 
     // And then adds bob as manager.
@@ -380,7 +380,7 @@ fn multi_user() {
         alice,
         GroupMember::Individual(bob),
         alice_team_group,
-        Access::Manage,
+        Access::manage(),
     );
 
     // Everyone processes these operations.
@@ -392,8 +392,8 @@ fn multi_user() {
     assert_eq!(
         alice_members,
         vec![
-            (GroupMember::Individual('A'), Access::Manage),
-            (GroupMember::Individual('B'), Access::Manage),
+            (GroupMember::Individual('A'), Access::manage()),
+            (GroupMember::Individual('B'), Access::manage()),
         ]
     );
     assert_eq!(alice_members, claire_members);
@@ -404,7 +404,7 @@ fn multi_user() {
     let claire_transitive_members = network.transitive_members(&claire, &alice_team_group);
     assert_eq!(
         alice_transitive_members,
-        vec![('A', Access::Manage), ('B', Access::Manage),]
+        vec![('A', Access::manage()), ('B', Access::manage()),]
     );
     assert_eq!(alice_transitive_members, bob_transitive_members);
     assert_eq!(alice_transitive_members, claire_transitive_members);
@@ -414,7 +414,7 @@ fn multi_user() {
         bob,
         GroupMember::Individual(claire),
         alice_team_group,
-        Access::Read,
+        Access::read(),
     );
 
     // Alice (concurrently) creates a devices group.
@@ -424,9 +424,9 @@ fn multi_user() {
         vec![
             (
                 GroupMember::Individual(alice_mobile),
-                Access::Write { conditions: None },
+                Access::write(),
             ),
-            (GroupMember::Individual(alice_laptop), Access::Manage),
+            (GroupMember::Individual(alice_laptop), Access::manage()),
         ],
     );
 
@@ -435,7 +435,7 @@ fn multi_user() {
         alice,
         GroupMember::Group(alice_devices_group),
         alice_team_group,
-        Access::Manage,
+        Access::manage(),
     );
 
     // Everyone processes these operations.
@@ -447,10 +447,10 @@ fn multi_user() {
     assert_eq!(
         alice_members,
         vec![
-            (GroupMember::Individual('A'), Access::Manage),
-            (GroupMember::Individual('B'), Access::Manage),
-            (GroupMember::Individual('C'), Access::Read),
-            (GroupMember::Group('D'), Access::Manage)
+            (GroupMember::Individual('A'), Access::manage()),
+            (GroupMember::Individual('B'), Access::manage()),
+            (GroupMember::Individual('C'), Access::read()),
+            (GroupMember::Group('D'), Access::manage())
         ]
     );
     assert_eq!(alice_members, bob_members);
@@ -462,11 +462,11 @@ fn multi_user() {
     assert_eq!(
         alice_transitive_members,
         vec![
-            ('A', Access::Manage),
-            ('B', Access::Manage),
-            ('C', Access::Read),
-            ('L', Access::Manage),
-            ('M', Access::Write { conditions: None })
+            ('A', Access::manage()),
+            ('B', Access::manage()),
+            ('C', Access::read()),
+            ('L', Access::manage()),
+            ('M', Access::write())
         ]
     );
     assert_eq!(alice_transitive_members, bob_transitive_members);
@@ -495,9 +495,9 @@ fn ooo() {
         friends_group,
         alice,
         vec![
-            (GroupMember::Individual(alice), Access::Manage),
-            (GroupMember::Individual(bob), Access::Manage),
-            (GroupMember::Individual(claire), Access::Manage),
+            (GroupMember::Individual(alice), Access::manage()),
+            (GroupMember::Individual(bob), Access::manage()),
+            (GroupMember::Individual(claire), Access::manage()),
         ],
     );
 
@@ -509,7 +509,7 @@ fn ooo() {
             alice,
             GroupMember::Individual(*friend),
             friends_group,
-            Access::Read,
+            Access::read(),
         );
     }
 
@@ -524,7 +524,7 @@ fn ooo() {
             bob,
             GroupMember::Individual(*friend),
             friends_group,
-            Access::Read,
+            Access::read(),
         );
     }
 
@@ -535,7 +535,7 @@ fn ooo() {
             claire,
             GroupMember::Individual(*friend),
             friends_group,
-            Access::Read,
+            Access::read(),
         );
     }
 
@@ -554,18 +554,18 @@ fn ooo() {
     assert_eq!(
         alice_members,
         vec![
-            (GroupMember::Individual('A'), Access::Manage),
-            (GroupMember::Individual('B'), Access::Manage),
-            (GroupMember::Individual('C'), Access::Manage),
-            // (GroupMember::Individual('D'), Access::Read),
-            (GroupMember::Individual('E'), Access::Read),
-            (GroupMember::Individual('F'), Access::Read),
-            // (GroupMember::Individual('G'), Access::Read),
-            (GroupMember::Individual('H'), Access::Read),
-            (GroupMember::Individual('I'), Access::Read),
-            // (GroupMember::Individual('J'), Access::Read),
-            (GroupMember::Individual('K'), Access::Read),
-            (GroupMember::Individual('L'), Access::Read),
+            (GroupMember::Individual('A'), Access::manage()),
+            (GroupMember::Individual('B'), Access::manage()),
+            (GroupMember::Individual('C'), Access::manage()),
+            // (GroupMember::Individual('D'), Access::read()),
+            (GroupMember::Individual('E'), Access::read()),
+            (GroupMember::Individual('F'), Access::read()),
+            // (GroupMember::Individual('G'), Access::read()),
+            (GroupMember::Individual('H'), Access::read()),
+            (GroupMember::Individual('I'), Access::read()),
+            // (GroupMember::Individual('J'), Access::read()),
+            (GroupMember::Individual('K'), Access::read()),
+            (GroupMember::Individual('L'), Access::read()),
         ]
     );
     assert_eq!(alice_members, claire_members);
@@ -587,14 +587,14 @@ fn add_remove_add() {
     network.create(
         friends_group,
         alice,
-        vec![(GroupMember::Individual(alice), Access::Manage)],
+        vec![(GroupMember::Individual(alice), Access::manage())],
     );
 
     network.add(
         alice,
         GroupMember::Individual(bob),
         friends_group,
-        Access::Read,
+        Access::read(),
     );
 
     network.remove(alice, GroupMember::Individual(bob), friends_group);
@@ -602,14 +602,14 @@ fn add_remove_add() {
     let members = network.members(&alice, &friends_group);
     assert_eq!(
         members,
-        vec![(GroupMember::Individual('A'), Access::Manage),]
+        vec![(GroupMember::Individual('A'), Access::manage()),]
     );
 
     network.add(
         alice,
         GroupMember::Individual(bob),
         friends_group,
-        Access::Read,
+        Access::read(),
     );
 
     network.process();
@@ -618,8 +618,8 @@ fn add_remove_add() {
     assert_eq!(
         members,
         vec![
-            (GroupMember::Individual('A'), Access::Manage),
-            (GroupMember::Individual('B'), Access::Read),
+            (GroupMember::Individual('A'), Access::manage()),
+            (GroupMember::Individual('B'), Access::read()),
         ]
     );
 }
@@ -645,10 +645,10 @@ fn test_groups(rng: StdRng) -> (Network, Vec<MessageId>) {
         BOB_DEVICES_GROUP,
         BOB,
         vec![
-            (GroupMember::Individual(BOB), Access::Manage),
+            (GroupMember::Individual(BOB), Access::manage()),
             (
                 GroupMember::Individual(BOB_LAPTOP),
-                Access::Write { conditions: None },
+                Access::write(),
             ),
         ],
     );
@@ -658,7 +658,7 @@ fn test_groups(rng: StdRng) -> (Network, Vec<MessageId>) {
         BOB,
         GroupMember::Individual(BOB_MOBILE),
         BOB_DEVICES_GROUP,
-        Access::Read,
+        Access::read(),
     );
     operations.push(id);
 
@@ -668,8 +668,8 @@ fn test_groups(rng: StdRng) -> (Network, Vec<MessageId>) {
         CHARLIE_TEAM_GROUP,
         CHARLIE,
         vec![
-            (GroupMember::Individual(CHARLIE), Access::Manage),
-            (GroupMember::Individual(EDITH), Access::Read),
+            (GroupMember::Individual(CHARLIE), Access::manage()),
+            (GroupMember::Individual(EDITH), Access::read()),
         ],
     );
     operations.push(id);
@@ -677,7 +677,7 @@ fn test_groups(rng: StdRng) -> (Network, Vec<MessageId>) {
     let id = network.create(
         ALICE_ORG_GROUP,
         ALICE,
-        vec![(GroupMember::Individual(ALICE), Access::Manage)],
+        vec![(GroupMember::Individual(ALICE), Access::manage())],
     );
     operations.push(id);
 
@@ -687,7 +687,7 @@ fn test_groups(rng: StdRng) -> (Network, Vec<MessageId>) {
         CHARLIE,
         GroupMember::Group(BOB_DEVICES_GROUP),
         CHARLIE_TEAM_GROUP,
-        Access::Manage,
+        Access::manage(),
     );
     operations.push(id);
 
@@ -697,7 +697,7 @@ fn test_groups(rng: StdRng) -> (Network, Vec<MessageId>) {
         ALICE,
         GroupMember::Group(CHARLIE_TEAM_GROUP),
         ALICE_ORG_GROUP,
-        Access::Write { conditions: None },
+        Access::write(),
     );
     operations.push(id);
 
@@ -712,49 +712,49 @@ fn transitive_members() {
     let (network, _) = test_groups(rng);
 
     let expected_bob_devices_group_direct_members = vec![
-        (GroupMember::Individual(BOB), Access::Manage),
+        (GroupMember::Individual(BOB), Access::manage()),
         (
             GroupMember::Individual(BOB_LAPTOP),
-            Access::Write { conditions: None },
+            Access::write(),
         ),
-        (GroupMember::Individual(BOB_MOBILE), Access::Read),
+        (GroupMember::Individual(BOB_MOBILE), Access::read()),
     ];
 
     let expected_bob_devices_group_transitive_members = vec![
-        (BOB, Access::Manage),
-        (BOB_LAPTOP, Access::Write { conditions: None }),
-        (BOB_MOBILE, Access::Read),
+        (BOB, Access::manage()),
+        (BOB_LAPTOP, Access::write()),
+        (BOB_MOBILE, Access::read()),
     ];
 
     let expected_charlie_team_group_direct_members = vec![
-        (GroupMember::Individual(CHARLIE), Access::Manage),
-        (GroupMember::Individual(EDITH), Access::Read),
-        (GroupMember::Group(BOB_DEVICES_GROUP), Access::Manage),
+        (GroupMember::Individual(CHARLIE), Access::manage()),
+        (GroupMember::Individual(EDITH), Access::read()),
+        (GroupMember::Group(BOB_DEVICES_GROUP), Access::manage()),
     ];
 
     let expected_charlie_team_group_transitive_members = vec![
-        (BOB, Access::Manage),
-        (CHARLIE, Access::Manage),
-        (EDITH, Access::Read),
-        (BOB_LAPTOP, Access::Write { conditions: None }),
-        (BOB_MOBILE, Access::Read),
+        (BOB, Access::manage()),
+        (CHARLIE, Access::manage()),
+        (EDITH, Access::read()),
+        (BOB_LAPTOP, Access::write()),
+        (BOB_MOBILE, Access::read()),
     ];
 
     let expected_alice_org_group_direct_members = vec![
-        (GroupMember::Individual(ALICE), Access::Manage),
+        (GroupMember::Individual(ALICE), Access::manage()),
         (
             GroupMember::Group(CHARLIE_TEAM_GROUP),
-            Access::Write { conditions: None },
+            Access::write(),
         ),
     ];
 
     let expected_alice_org_group_transitive_members = vec![
-        (ALICE, Access::Manage),
-        (BOB, Access::Write { conditions: None }),
-        (CHARLIE, Access::Write { conditions: None }),
-        (EDITH, Access::Read),
-        (BOB_LAPTOP, Access::Write { conditions: None }),
-        (BOB_MOBILE, Access::Read),
+        (ALICE, Access::manage()),
+        (BOB, Access::write()),
+        (CHARLIE, Access::write()),
+        (EDITH, Access::read()),
+        (BOB_LAPTOP, Access::write()),
+        (BOB_MOBILE, Access::read()),
     ];
 
     let members = network.members(&BOB, &BOB_DEVICES_GROUP);
@@ -799,7 +799,7 @@ fn members_at() {
 
     // Initial state of the org group.
     let members = network.transitive_members_at(&ALICE, &ALICE_ORG_GROUP, &vec![create_org_op_id]);
-    assert_eq!(members, vec![(ALICE, Access::Manage)]);
+    assert_eq!(members, vec![(ALICE, Access::manage())]);
 
     // CHARLIE_TEAM was added but before BOB_DEVICES was added to the team.
     let members = network.transitive_members_at(
@@ -810,9 +810,9 @@ fn members_at() {
     assert_eq!(
         members,
         vec![
-            (ALICE, Access::Manage),
-            (CHARLIE, Access::Write { conditions: None }),
-            (EDITH, Access::Read)
+            (ALICE, Access::manage()),
+            (CHARLIE, Access::write()),
+            (EDITH, Access::read())
         ]
     );
 
@@ -829,11 +829,11 @@ fn members_at() {
     assert_eq!(
         members,
         vec![
-            (ALICE, Access::Manage),
-            (BOB, Access::Write { conditions: None }),
-            (CHARLIE, Access::Write { conditions: None }),
-            (EDITH, Access::Read),
-            (BOB_LAPTOP, Access::Write { conditions: None }),
+            (ALICE, Access::manage()),
+            (BOB, Access::write()),
+            (CHARLIE, Access::write()),
+            (EDITH, Access::read()),
+            (BOB_LAPTOP, Access::write()),
         ]
     );
 
@@ -850,12 +850,12 @@ fn members_at() {
     assert_eq!(
         members_at_most_recent_heads,
         vec![
-            (ALICE, Access::Manage),
-            (BOB, Access::Write { conditions: None }),
-            (CHARLIE, Access::Write { conditions: None }),
-            (EDITH, Access::Read),
-            (BOB_LAPTOP, Access::Write { conditions: None }),
-            (BOB_MOBILE, Access::Read),
+            (ALICE, Access::manage()),
+            (BOB, Access::write()),
+            (CHARLIE, Access::write()),
+            (EDITH, Access::read()),
+            (BOB_LAPTOP, Access::write()),
+            (BOB_MOBILE, Access::read()),
         ]
     );
 
@@ -887,9 +887,9 @@ fn error_cases() {
         alice,
         group_id,
         vec![
-            (alice, Access::Manage),
-            (bob, Access::Read),
-            (claire, Access::Read),
+            (alice, Access::manage()),
+            (bob, Access::read()),
+            (claire, Access::read()),
         ],
         &mut rng,
     );
@@ -906,7 +906,7 @@ fn error_cases() {
             group_id,
             action: GroupAction::Add {
                 member: GroupMember::Individual(bob),
-                access: Access::Read,
+                access: Access::read(),
             },
         },
     };
@@ -969,7 +969,7 @@ fn error_cases() {
             group_id,
             action: GroupAction::Add {
                 member: GroupMember::Individual(dave),
-                access: Access::Read,
+                access: Access::read(),
             },
         },
     };
@@ -1011,7 +1011,7 @@ fn error_cases() {
             group_id,
             action: GroupAction::Add {
                 member: GroupMember::Individual(dave),
-                access: Access::Read,
+                access: Access::read(),
             },
         },
     };
@@ -1033,7 +1033,7 @@ fn error_cases() {
             group_id,
             action: GroupAction::Promote {
                 member: GroupMember::Individual(claire),
-                access: Access::Write { conditions: None },
+                access: Access::write(),
             },
         },
     };
@@ -1055,7 +1055,7 @@ fn error_cases() {
             group_id,
             action: GroupAction::Add {
                 member: GroupMember::Individual(dave),
-                access: Access::Read,
+                access: Access::read(),
             },
         },
     };
@@ -1077,7 +1077,7 @@ fn error_cases() {
             group_id,
             action: GroupAction::Promote {
                 member: GroupMember::Individual(eve),
-                access: Access::Write { conditions: None },
+                access: Access::write(),
             },
         },
     };
@@ -1104,9 +1104,9 @@ fn error_cases_resolver() {
         alice,
         group_id,
         vec![
-            (alice, Access::Manage),
-            (bob, Access::Read),
-            (claire, Access::Read),
+            (alice, Access::manage()),
+            (bob, Access::read()),
+            (claire, Access::read()),
         ],
         &mut rng,
     );
@@ -1116,8 +1116,8 @@ fn error_cases_resolver() {
     // Remove all current members and all all non-members as managers in a concurrent branch.
     let (mut y_ii, _) = remove_member(y_i, group_id, bob);
     (y_ii, _) = remove_member(y_ii, group_id, claire);
-    (y_ii, _) = add_member(y_ii, group_id, dave, Access::Manage);
-    (y_ii, _) = add_member(y_ii, group_id, eve, Access::Manage);
+    (y_ii, _) = add_member(y_ii, group_id, dave, Access::manage());
+    (y_ii, _) = add_member(y_ii, group_id, eve, Access::manage());
     (y_ii, _) = remove_member(y_ii, group_id, alice);
 
     let mut members = y_ii.members();
@@ -1125,8 +1125,8 @@ fn error_cases_resolver() {
     assert_eq!(
         members,
         vec![
-            (GroupMember::Individual(dave), Access::Manage),
-            (GroupMember::Individual(eve), Access::Manage)
+            (GroupMember::Individual(dave), Access::manage()),
+            (GroupMember::Individual(eve), Access::manage())
         ]
     );
 
@@ -1144,7 +1144,7 @@ fn error_cases_resolver() {
             group_id,
             action: GroupAction::Add {
                 member: GroupMember::Individual(bob),
-                access: Access::Read,
+                access: Access::read(),
             },
         },
     };
@@ -1205,7 +1205,7 @@ fn error_cases_resolver() {
             group_id,
             action: GroupAction::Add {
                 member: GroupMember::Individual(dave),
-                access: Access::Read,
+                access: Access::read(),
             },
         },
     };
@@ -1245,7 +1245,7 @@ fn error_cases_resolver() {
             group_id,
             action: GroupAction::Add {
                 member: GroupMember::Individual(dave),
-                access: Access::Read,
+                access: Access::read(),
             },
         },
     };
@@ -1267,7 +1267,7 @@ fn error_cases_resolver() {
             group_id,
             action: GroupAction::Promote {
                 member: GroupMember::Individual(claire),
-                access: Access::Write { conditions: None },
+                access: Access::write(),
             },
         },
     };
@@ -1289,7 +1289,7 @@ fn error_cases_resolver() {
             group_id,
             action: GroupAction::Add {
                 member: GroupMember::Individual(dave),
-                access: Access::Read,
+                access: Access::read(),
             },
         },
     };
@@ -1311,7 +1311,7 @@ fn error_cases_resolver() {
             group_id,
             action: GroupAction::Promote {
                 member: GroupMember::Individual(eve),
-                access: Access::Write { conditions: None },
+                access: Access::write(),
             },
         },
     };

--- a/p2panda-auth/src/group/tests.rs
+++ b/p2panda-auth/src/group/tests.rs
@@ -165,10 +165,7 @@ fn basic_group() {
         vec![
             (GroupMember::Individual(alice), Access::manage()),
             (GroupMember::Individual(bob), Access::read()),
-            (
-                GroupMember::Individual(claire),
-                Access::write()
-            )
+            (GroupMember::Individual(claire), Access::write())
         ]
     );
 
@@ -269,10 +266,7 @@ fn nested_groups() {
             initial_members: vec![
                 (GroupMember::Individual(alice), Access::manage()),
                 (GroupMember::Individual(alice_laptop), Access::manage()),
-                (
-                    GroupMember::Individual(alice_mobile),
-                    Access::write(),
-                ),
+                (GroupMember::Individual(alice_mobile), Access::write()),
             ],
         },
     };
@@ -292,10 +286,7 @@ fn nested_groups() {
         vec![
             (GroupMember::Individual(alice), Access::manage()),
             (GroupMember::Individual(alice_laptop), Access::manage()),
-            (
-                GroupMember::Individual(alice_mobile),
-                Access::write()
-            ),
+            (GroupMember::Individual(alice_mobile), Access::write()),
         ],
     );
 
@@ -422,10 +413,7 @@ fn multi_user() {
         alice_devices_group,
         alice,
         vec![
-            (
-                GroupMember::Individual(alice_mobile),
-                Access::write(),
-            ),
+            (GroupMember::Individual(alice_mobile), Access::write()),
             (GroupMember::Individual(alice_laptop), Access::manage()),
         ],
     );
@@ -646,10 +634,7 @@ fn test_groups(rng: StdRng) -> (Network, Vec<MessageId>) {
         BOB,
         vec![
             (GroupMember::Individual(BOB), Access::manage()),
-            (
-                GroupMember::Individual(BOB_LAPTOP),
-                Access::write(),
-            ),
+            (GroupMember::Individual(BOB_LAPTOP), Access::write()),
         ],
     );
     operations.push(id);
@@ -713,10 +698,7 @@ fn transitive_members() {
 
     let expected_bob_devices_group_direct_members = vec![
         (GroupMember::Individual(BOB), Access::manage()),
-        (
-            GroupMember::Individual(BOB_LAPTOP),
-            Access::write(),
-        ),
+        (GroupMember::Individual(BOB_LAPTOP), Access::write()),
         (GroupMember::Individual(BOB_MOBILE), Access::read()),
     ];
 
@@ -742,10 +724,7 @@ fn transitive_members() {
 
     let expected_alice_org_group_direct_members = vec![
         (GroupMember::Individual(ALICE), Access::manage()),
-        (
-            GroupMember::Group(CHARLIE_TEAM_GROUP),
-            Access::write(),
-        ),
+        (GroupMember::Group(CHARLIE_TEAM_GROUP), Access::write()),
     ];
 
     let expected_alice_org_group_transitive_members = vec![


### PR DESCRIPTION
- make conditions `C` assignable to any access level
- remove `Ord` trait bounds for `C` from public API
- move Access into own module
- add tests demonstrating possible use cases

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
