### PR TITLE
Remove "revoke" group control message variant

### DIFF
--- a/p2panda-auth/src/group/message.rs
+++ b/p2panda-auth/src/group/message.rs
@@ -8,31 +8,12 @@ use crate::group::GroupAction;
 /// action should be applied. The other is a special message which can be used to "undo" a message which
 /// has been previously applied to the group.
 #[derive(Clone, Debug)]
-pub enum GroupControlMessage<ID, OP, C> {
-    /// An action to apply to the state of the specified group.
-    GroupAction {
-        group_id: ID,
-        action: GroupAction<ID, C>,
-    },
-
-    /// A revocation of the given operation for the specified group.
-    ///
-    /// Publishing a revocation message allows for invalidation of other group control messages
-    /// which are already included in the group graph. This action is agnostic to any, probably more
-    /// nuanced, resolving logic which reacts to group actions.
-    //
-    // TODO: revoking messages is not implemented yet. I'm still considering if it is required in
-    // or initial group implementation or something that can come later. There are distinct
-    // benefits to revoking messages, over "just" making sure to resolve concurrent group action
-    // conflicts (for example with "strong removal") strategy. By issuing a revoke message
-    // revoking the message which first added a member into the group, it's possible to
-    // completely erase that member from the group history. There can be an implicit "seniority"
-    // rule in play, where it's only possible for an admin to revoke messages that they
-    // published, or from when they were in the group.
-    Revoke { group_id: ID, id: OP },
+pub struct GroupControlMessage<ID, C> {
+    pub group_id: ID,
+    pub action: GroupAction<ID, C>,
 }
 
-impl<ID, OP, C> GroupControlMessage<ID, OP, C>
+impl<ID, C> GroupControlMessage<ID, C>
 where
     ID: Copy,
 {
@@ -40,7 +21,7 @@ where
     pub fn is_create(&self) -> bool {
         matches!(
             self,
-            GroupControlMessage::GroupAction {
+            GroupControlMessage {
                 action: GroupAction::Create { .. },
                 ..
             }
@@ -49,9 +30,6 @@ where
 
     /// Return the ID of the group this message should be applied to.
     pub fn group_id(&self) -> ID {
-        match self {
-            GroupControlMessage::Revoke { group_id, .. } => *group_id,
-            GroupControlMessage::GroupAction { group_id, .. } => *group_id,
-        }
+        self.group_id
     }
 }

--- a/p2panda-auth/src/group/mod.rs
+++ b/p2panda-auth/src/group/mod.rs
@@ -34,7 +34,7 @@ where
     ID: IdentityHandle,
     OP: OperationId + Ord,
     RS: Resolver<ID, OP, C, ORD, GS>,
-    ORD: Orderer<ID, OP, GroupControlMessage<ID, OP, C>>,
+    ORD: Orderer<ID, OP, GroupControlMessage<ID, C>>,
     GS: GroupStore<ID, OP, C, RS, ORD>,
 {
     #[error(transparent)]
@@ -75,7 +75,7 @@ where
     ID: IdentityHandle,
     OP: OperationId + Ord,
     RS: Resolver<ID, OP, C, ORD, GS> + Debug,
-    ORD: Orderer<ID, OP, GroupControlMessage<ID, OP, C>>,
+    ORD: Orderer<ID, OP, GroupControlMessage<ID, C>>,
     GS: GroupStore<ID, OP, C, RS, ORD>,
 {
     /// ID of the local actor.
@@ -95,7 +95,7 @@ where
     ID: IdentityHandle,
     OP: OperationId + Ord,
     RS: Resolver<ID, OP, C, ORD, GS> + Debug,
-    ORD: Orderer<ID, OP, GroupControlMessage<ID, OP, C>>,
+    ORD: Orderer<ID, OP, GroupControlMessage<ID, C>>,
     GS: GroupStore<ID, OP, C, RS, ORD>,
 {
     /// Initialise the `Group` state so that groups can be created and updated.
@@ -117,13 +117,13 @@ where
     OP: OperationId + Ord + Display,
     C: Clone + Debug + PartialEq + PartialOrd,
     RS: Resolver<ID, OP, C, ORD, GS> + Debug,
-    ORD: Orderer<ID, OP, GroupControlMessage<ID, OP, C>> + Clone + Debug,
+    ORD: Orderer<ID, OP, GroupControlMessage<ID, C>> + Clone + Debug,
     ORD::Operation: Clone,
     ORD::State: Clone,
     GS: GroupStore<ID, OP, C, RS, ORD> + Clone + Debug,
 {
     type State = GroupCrdtState<ID, OP, C, RS, ORD, GS>;
-    type Action = GroupControlMessage<ID, OP, C>;
+    type Action = GroupControlMessage<ID, C>;
     type Error = GroupError<ID, OP, C, RS, ORD, GS>;
 
     /// Create a group.
@@ -151,7 +151,7 @@ where
             self.orderer.clone(),
         );
 
-        let action = GroupControlMessage::GroupAction {
+        let action = GroupControlMessage {
             group_id: y.group_id,
             action: GroupAction::Create { initial_members },
         };
@@ -218,7 +218,7 @@ where
             return Err(GroupError::GroupMember(added, y.group_id));
         }
 
-        let action = GroupControlMessage::GroupAction {
+        let action = GroupControlMessage {
             group_id: y.group_id,
             action: GroupAction::Add {
                 member: GroupMember::Individual(added),
@@ -258,7 +258,7 @@ where
             return Err(GroupError::NotGroupMember(removed, y.group_id));
         }
 
-        let action = GroupControlMessage::GroupAction {
+        let action = GroupControlMessage {
             group_id: y.group_id,
             action: GroupAction::Remove {
                 member: GroupMember::Individual(removed),
@@ -301,7 +301,7 @@ where
             return Err(GroupError::SameAccessLevel(promoted, access, y.group_id));
         }
 
-        let action = GroupControlMessage::GroupAction {
+        let action = GroupControlMessage {
             group_id: y.group_id,
             action: GroupAction::Promote {
                 member: GroupMember::Individual(promoted),
@@ -344,7 +344,7 @@ where
             return Err(GroupError::SameAccessLevel(demoted, access, y.group_id));
         }
 
-        let action = GroupControlMessage::GroupAction {
+        let action = GroupControlMessage {
             group_id: y.group_id,
             action: GroupAction::Demote {
                 member: GroupMember::Individual(demoted),

--- a/p2panda-auth/src/test_utils/network.rs
+++ b/p2panda-auth/src/test_utils/network.rs
@@ -58,7 +58,7 @@ impl Network {
         initial_members: Vec<(GroupMember<MemberId>, Access<()>)>,
     ) -> MessageId {
         let y = self.get_y(&creator, &group_id);
-        let control_message = GroupControlMessage::GroupAction {
+        let control_message = GroupControlMessage {
             group_id,
             action: GroupAction::Create { initial_members },
         };
@@ -78,7 +78,7 @@ impl Network {
         access: Access<()>,
     ) -> MessageId {
         let y = self.get_y(&adder, &group_id);
-        let control_message = GroupControlMessage::GroupAction {
+        let control_message = GroupControlMessage {
             group_id,
             action: GroupAction::Add {
                 member: added,
@@ -100,7 +100,7 @@ impl Network {
         group_id: MemberId,
     ) -> MessageId {
         let y = self.get_y(&remover, &group_id);
-        let control_message = GroupControlMessage::GroupAction {
+        let control_message = GroupControlMessage {
             group_id,
             action: GroupAction::Remove { member: removed },
         };
@@ -120,7 +120,7 @@ impl Network {
         access: Access<()>,
     ) -> MessageId {
         let y = self.get_y(&demoter, &group_id);
-        let control_message = GroupControlMessage::GroupAction {
+        let control_message = GroupControlMessage {
             group_id,
             action: GroupAction::Demote {
                 member: demoted,
@@ -143,7 +143,7 @@ impl Network {
         access: Access<()>,
     ) -> MessageId {
         let y = self.get_y(&promoter, &group_id);
-        let control_message = GroupControlMessage::GroupAction {
+        let control_message = GroupControlMessage {
             group_id,
             action: GroupAction::Promote {
                 member: promoted,

--- a/p2panda-auth/src/test_utils/orderer.rs
+++ b/p2panda-auth/src/test_utils/orderer.rs
@@ -55,9 +55,7 @@ impl TestOrdererState {
 #[derive(Clone, Debug, Default)]
 pub struct TestOrderer {}
 
-impl Orderer<MemberId, MessageId, GroupControlMessage<MemberId, MessageId, Conditions>>
-    for TestOrderer
-{
+impl Orderer<MemberId, MessageId, GroupControlMessage<MemberId, Conditions>> for TestOrderer {
     type State = TestOrdererState;
 
     type Error = OrdererError;
@@ -72,7 +70,7 @@ impl Orderer<MemberId, MessageId, GroupControlMessage<MemberId, MessageId, Condi
     /// group graph, and also the tips of any sub-group graphs.
     fn next_message(
         y: Self::State,
-        control_message: &GroupControlMessage<MemberId, MessageId, Conditions>,
+        control_message: &GroupControlMessage<MemberId, Conditions>,
     ) -> Result<(Self::State, Self::Operation), Self::Error> {
         let group_id = control_message.group_id();
         let group_y = {
@@ -106,7 +104,7 @@ impl Orderer<MemberId, MessageId, GroupControlMessage<MemberId, MessageId, Condi
 
         // If this operation adds a new member to the group, and that member itself is a
         // sub-group, include their current transitive heads in our dependencies.
-        if let GroupControlMessage::GroupAction {
+        if let GroupControlMessage {
             action:
                 GroupAction::Add {
                     member: GroupMember::Group(id),
@@ -125,7 +123,7 @@ impl Orderer<MemberId, MessageId, GroupControlMessage<MemberId, MessageId, Condi
 
         // If this is a create action, check if any of the initial members are sub-groups and if
         // so include their current transitive heads in our dependencies.
-        if let GroupControlMessage::GroupAction {
+        if let GroupControlMessage {
             action: GroupAction::Create { initial_members },
             ..
         } = control_message
@@ -224,10 +222,10 @@ pub struct TestOperation {
     pub author: char,
     pub dependencies: Vec<u32>,
     pub previous: Vec<u32>,
-    pub payload: GroupControlMessage<char, u32, ()>,
+    pub payload: GroupControlMessage<char, ()>,
 }
 
-impl Operation<char, u32, GroupControlMessage<char, u32, ()>> for TestOperation {
+impl Operation<char, u32, GroupControlMessage<char, ()>> for TestOperation {
     fn id(&self) -> u32 {
         self.id
     }
@@ -244,7 +242,7 @@ impl Operation<char, u32, GroupControlMessage<char, u32, ()>> for TestOperation 
         self.previous.clone()
     }
 
-    fn payload(&self) -> GroupControlMessage<char, u32, ()> {
+    fn payload(&self) -> GroupControlMessage<char, ()> {
         self.payload.clone()
     }
 }

--- a/p2panda-auth/src/traits/resolver.rs
+++ b/p2panda-auth/src/traits/resolver.rs
@@ -9,7 +9,7 @@ pub trait Resolver<ID, OP, C, ORD, GS>
 where
     ID: IdentityHandle,
     OP: OperationId + Ord,
-    ORD: Orderer<ID, OP, GroupControlMessage<ID, OP, C>>,
+    ORD: Orderer<ID, OP, GroupControlMessage<ID, C>>,
     GS: GroupStore<ID, OP, C, Self, ORD>,
     Self: Sized,
 {

--- a/p2panda-auth/src/traits/store.rs
+++ b/p2panda-auth/src/traits/store.rs
@@ -13,7 +13,7 @@ pub trait GroupStore<ID, OP, C, RS, ORD>
 where
     ID: IdentityHandle,
     OP: OperationId,
-    ORD: Orderer<ID, OP, GroupControlMessage<ID, OP, C>>,
+    ORD: Orderer<ID, OP, GroupControlMessage<ID, C>>,
     Self: Sized,
 {
     type Error: Error + Display;


### PR DESCRIPTION
Remove unsupported `Revoke` group control message variant.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
