### PR TITLE
`p2panda-spaces`: introduce `AuthStore` trait

### DIFF
--- a/p2panda-spaces/src/auth/message.rs
+++ b/p2panda-spaces/src/auth/message.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use p2panda_auth::traits::Operation as AuthOperation;
+use p2panda_auth::traits::{Conditions, Operation as AuthOperation};
 
 use crate::message::{AuthoredMessage, SpacesArgs, SpacesMessage};
-use crate::types::{ActorId, AuthControlMessage, Conditions, OperationId};
+use crate::types::{ActorId, AuthControlMessage, OperationId};
 
 #[derive(Clone, Debug)]
 pub struct AuthArgs<C> {
@@ -76,11 +76,6 @@ where
     }
 
     fn dependencies(&self) -> Vec<OperationId> {
-        // @TODO: We do not implement ordering yet.
-        Vec::new()
-    }
-
-    fn previous(&self) -> Vec<OperationId> {
         // @TODO: We do not implement ordering yet.
         Vec::new()
     }

--- a/p2panda-spaces/src/auth/orderer.rs
+++ b/p2panda-spaces/src/auth/orderer.rs
@@ -2,8 +2,10 @@
 
 use std::convert::Infallible;
 
+use p2panda_auth::traits::Conditions;
+
 use crate::auth::message::{AuthArgs, AuthMessage};
-use crate::types::{ActorId, AuthControlMessage, Conditions, OperationId};
+use crate::types::{ActorId, AuthControlMessage, OperationId};
 
 // Manages "dependencies" required for `p2panda-auth`.
 #[derive(Clone, Debug)]

--- a/p2panda-spaces/src/encryption/message.rs
+++ b/p2panda-spaces/src/encryption/message.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use p2panda_auth::traits::Conditions;
 use p2panda_encryption::crypto::xchacha20::XAeadNonce;
 use p2panda_encryption::data_scheme::GroupSecretId;
 use p2panda_encryption::traits::{GroupMessage as EncryptionOperation, GroupMessageContent};
 
 use crate::encryption::dgm::EncryptionGroupMembership;
 use crate::message::{AuthoredMessage, SpacesArgs, SpacesMessage};
-use crate::types::{
-    ActorId, Conditions, EncryptionControlMessage, EncryptionDirectMessage, OperationId,
-};
+use crate::types::{ActorId, EncryptionControlMessage, EncryptionDirectMessage, OperationId};
 
 #[derive(Clone, Debug)]
 pub enum EncryptionArgs {

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -19,7 +19,7 @@ use crate::forge::Forge;
 use crate::member::Member;
 use crate::message::{AuthoredMessage, SpacesArgs, SpacesMessage};
 use crate::space::{Space, SpaceError};
-use crate::store::{KeyStore, SpaceStore};
+use crate::store::{AuthStore, KeyStore, SpaceStore};
 use crate::types::{ActorId, AuthResolver, OperationId};
 
 // Create and manage spaces and groups.
@@ -56,7 +56,7 @@ pub(crate) struct ManagerInner<S, F, M, C, RS> {
 
 impl<S, F, M, C, RS> Manager<S, F, M, C, RS>
 where
-    S: SpaceStore<M, C> + KeyStore,
+    S: SpaceStore<M> + KeyStore + AuthStore<C>,
     F: Forge<M, C>,
     M: AuthoredMessage + SpacesMessage<C>,
     C: Conditions,
@@ -239,7 +239,7 @@ impl<S, F, M, C, RS> Clone for Manager<S, F, M, C, RS> {
 #[allow(clippy::large_enum_variant)]
 pub enum ManagerError<S, F, M, C, RS>
 where
-    S: SpaceStore<M, C> + KeyStore,
+    S: SpaceStore<M> + KeyStore + AuthStore<C>,
     F: Forge<M, C>,
     C: Conditions,
     RS: AuthResolver<C>,
@@ -254,7 +254,7 @@ where
     KeyStore(<S as KeyStore>::Error),
 
     #[error("{0}")]
-    SpaceStore(<S as SpaceStore<M, C>>::Error),
+    SpaceStore(<S as SpaceStore<M>>::Error),
 
     #[error("received unexpected message with id {0}, maybe it arrived out-of-order")]
     UnexpectedMessage(OperationId),

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::Debug;
 
+use p2panda_auth::traits::Conditions;
 use p2panda_encryption::crypto::xchacha20::XAeadNonce;
 use p2panda_encryption::data_scheme::GroupSecretId;
 use serde::{Deserialize, Serialize};
@@ -10,7 +11,7 @@ use crate::auth::message::AuthArgs;
 use crate::encryption::message::EncryptionArgs;
 use crate::space::secret_members;
 use crate::types::{
-    ActorId, AuthGroupAction, Conditions, EncryptionControlMessage, EncryptionDirectMessage,
+    ActorId, AuthGroupAction, EncryptionControlMessage, EncryptionDirectMessage,
     OperationId,
 };
 

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -11,8 +11,7 @@ use crate::auth::message::AuthArgs;
 use crate::encryption::message::EncryptionArgs;
 use crate::space::secret_members;
 use crate::types::{
-    ActorId, AuthGroupAction, EncryptionControlMessage, EncryptionDirectMessage,
-    OperationId,
+    ActorId, AuthGroupAction, EncryptionControlMessage, EncryptionDirectMessage, OperationId,
 };
 
 use p2panda_auth::Access;

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -18,11 +18,11 @@ use crate::event::Event;
 use crate::forge::Forge;
 use crate::manager::Manager;
 use crate::message::{AuthoredMessage, SpacesArgs, SpacesMessage};
-use crate::store::{KeyStore, SpaceStore};
+use crate::store::{AuthStore, KeyStore, SpaceStore};
 use crate::types::{
-    ActorId, AuthControlMessage, AuthGroup, AuthGroupAction, AuthGroupError, AuthGroupState,
-    AuthResolver, EncryptionGroup, EncryptionGroupError, EncryptionGroupOutput,
-    EncryptionGroupState, OperationId,
+    ActorId, AuthControlMessage, AuthGroup, AuthGroupAction, AuthGroupError, AuthResolver,
+    EncryptionGroup, EncryptionGroupError, EncryptionGroupOutput, EncryptionGroupState,
+    OperationId,
 };
 
 /// Encrypted data context with authorization boundary.
@@ -44,7 +44,7 @@ pub struct Space<S, F, M, C, RS> {
 
 impl<S, F, M, C, RS> Space<S, F, M, C, RS>
 where
-    S: SpaceStore<M, C> + KeyStore,
+    S: SpaceStore<M> + KeyStore + AuthStore<C>,
     F: Forge<M, C>,
     M: AuthoredMessage + SpacesMessage<C>,
     C: Conditions,
@@ -86,17 +86,6 @@ where
         }
 
         let (auth_y, auth_args) = {
-            // @TODO: Get this from store & establish initial orderer state.
-            //
-            // This initial orderer state is not necessarily "empty", can include pointers at other
-            // groups in case we've passed in "groups" as our initial members.
-            let orderer_y = ();
-
-            // @TODO: This state should already be instantiated as there is now
-            // only one state object for all auth groups. Move this into the
-            // manager and only access it here.
-            let y = AuthGroupState::<C>::new(orderer_y);
-
             let action = AuthControlMessage {
                 group_id: space_id,
                 action: AuthGroupAction::Create {
@@ -104,7 +93,9 @@ where
                 },
             };
 
-            AuthGroup::prepare(y, &action).map_err(SpaceError::AuthGroup)?
+            let manager = manager_ref.inner.read().await;
+            let auth_y = manager.store.auth().await.map_err(SpaceError::AuthStore)?;
+            AuthGroup::prepare(auth_y, &action).map_err(SpaceError::AuthGroup)?
         };
 
         // 3. Establish encryption group state (prepare & process) with "create" control message.
@@ -181,10 +172,12 @@ where
 
         manager
             .store
-            .set_space(
-                &space_id,
-                SpaceState::from_state(space_id, auth_y, encryption_y),
-            )
+            .set_auth(&auth_y)
+            .await
+            .map_err(SpaceError::AuthStore)?;
+        manager
+            .store
+            .set_space(&space_id, SpaceState::from_state(space_id, encryption_y))
             .await
             .map_err(SpaceError::SpaceStore)?;
 
@@ -235,19 +228,6 @@ where
             {
                 Some(y) => y,
                 None => {
-                    // @TODO: This repeats quite a lot, would be good to factor state
-                    // initialisation out.
-
-                    let auth_y = {
-                        // @TODO: Get this from store & establish initial orderer state.
-                        //
-                        // This initial orderer state is not necessarily "empty", can include pointers at other
-                        // groups in case we've passed in "groups" as our initial members.
-                        let orderer_y = ();
-
-                        AuthGroupState::<C>::new(orderer_y)
-                    };
-
                     let encryption_y = {
                         // Establish DGM state.
                         let dgm = EncryptionMembershipState {
@@ -272,16 +252,18 @@ where
                         EncryptionGroup::init(my_id, key_manager_y, key_registry_y, dgm, orderer_y)
                     };
 
-                    SpaceState::from_state(self.id, auth_y, encryption_y)
+                    SpaceState::from_state(self.id, encryption_y)
                 }
             }
         };
 
         // Process auth message.
 
-        y.auth_y = {
+        let auth_y = {
+            let manager = self.manager.inner.read().await;
             let auth_message = AuthMessage::from_forged(message);
-            AuthGroup::process(y.auth_y, &auth_message).map_err(SpaceError::AuthGroup)?
+            let auth_y = manager.store.auth().await.map_err(SpaceError::AuthStore)?;
+            AuthGroup::process(auth_y, &auth_message).map_err(SpaceError::AuthGroup)?
         };
 
         // Process encryption message.
@@ -291,7 +273,7 @@ where
 
             // Make encryption DGM aware of current auth members state.
 
-            let group_members = y.auth_y.members(self.id);
+            let group_members = auth_y.members(self.id);
             let secret_members = secret_members(group_members);
 
             y.encryption_y.dcgka.dgm = EncryptionMembershipState {
@@ -325,6 +307,11 @@ where
         // Persist new state.
 
         let mut manager = self.manager.inner.write().await;
+        manager
+            .store
+            .set_auth(&auth_y)
+            .await
+            .map_err(SpaceError::AuthStore)?;
         manager
             .store
             .set_space(&self.id, y)
@@ -384,8 +371,9 @@ where
     }
 
     pub async fn members(&self) -> Result<Vec<(ActorId, Access<C>)>, SpaceError<S, F, M, C, RS>> {
-        let space_y = self.state().await?;
-        let group_members = space_y.auth_y.members(self.id);
+        let manager = self.manager.inner.read().await;
+        let auth_y = manager.store.auth().await.map_err(SpaceError::AuthStore)?;
+        let group_members = auth_y.members(self.id);
         Ok(group_members)
     }
 
@@ -418,7 +406,7 @@ where
         Ok(message)
     }
 
-    async fn state(&self) -> Result<SpaceState<M, C>, SpaceError<S, F, M, C, RS>> {
+    async fn state(&self) -> Result<SpaceState<M>, SpaceError<S, F, M, C, RS>> {
         let manager = self.manager.inner.read().await;
         let space_y = manager
             .store
@@ -432,30 +420,18 @@ where
 
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
-pub struct SpaceState<M, C>
-where
-    C: Conditions,
-{
+pub struct SpaceState<M> {
     pub space_id: ActorId,
-    pub auth_y: AuthGroupState<C>,
     // @TODO: This contains the PKI and KMG states and other unnecessary data we don't need to
     // persist. We can make the fields public in `p2panda-encryption` and extract only the
     // information we really need.
     pub encryption_y: EncryptionGroupState<M>,
 }
 
-impl<M, C> SpaceState<M, C>
-where
-    C: Conditions,
-{
-    pub fn from_state(
-        space_id: ActorId,
-        auth_y: AuthGroupState<C>,
-        encryption_y: EncryptionGroupState<M>,
-    ) -> Self {
+impl<M> SpaceState<M> {
+    pub fn from_state(space_id: ActorId, encryption_y: EncryptionGroupState<M>) -> Self {
         Self {
             space_id,
-            auth_y,
             encryption_y,
         }
     }
@@ -471,7 +447,7 @@ pub fn secret_members<C>(members: Vec<(ActorId, Access<C>)>) -> Vec<ActorId> {
 #[derive(Debug, Error)]
 pub enum SpaceError<S, F, M, C, RS>
 where
-    S: SpaceStore<M, C> + KeyStore,
+    S: SpaceStore<M> + KeyStore + AuthStore<C>,
     F: Forge<M, C>,
     C: Conditions,
     RS: Resolver<ActorId, OperationId, C, AuthMessage<C>>,
@@ -489,10 +465,13 @@ where
     Forge(F::Error),
 
     #[error("{0}")]
+    AuthStore(<S as AuthStore<C>>::Error),
+
+    #[error("{0}")]
     KeyStore(<S as KeyStore>::Error),
 
     #[error("{0}")]
-    SpaceStore(<S as SpaceStore<M, C>>::Error),
+    SpaceStore(<S as SpaceStore<M>>::Error),
 
     #[error("tried to access unknown space id {0}")]
     UnknownSpace(ActorId),

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -117,11 +117,11 @@ where
                 members: HashSet::from_iter(members.iter().cloned()),
             };
 
-                        // @TODO: Get this from store & establish initial orderer state.
-                        //
-                        // This initial orderer state is not necessarily "empty", can include pointers at other
-                        // groups in case we've passed in "groups" as our initial members.
-                        let orderer_y = EncryptionOrdererState::new();
+            // @TODO: Get this from store & establish initial orderer state.
+            //
+            // This initial orderer state is not necessarily "empty", can include pointers at other
+            // groups in case we've passed in "groups" as our initial members.
+            let orderer_y = EncryptionOrdererState::new();
 
             let key_manager_y = manager
                 .store

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -117,8 +117,11 @@ where
                 members: HashSet::from_iter(members.iter().cloned()),
             };
 
-            // @TODO: Establish orderer state.
-            let orderer_y = EncryptionOrdererState::new();
+                        // @TODO: Get this from store & establish initial orderer state.
+                        //
+                        // This initial orderer state is not necessarily "empty", can include pointers at other
+                        // groups in case we've passed in "groups" as our initial members.
+                        let orderer_y = EncryptionOrdererState::new();
 
             let key_manager_y = manager
                 .store
@@ -228,13 +231,18 @@ where
             {
                 Some(y) => y,
                 None => {
+                    // @TODO: This repeats quite a lot, would be good to factor state
+                    // initialisation out.
                     let encryption_y = {
                         // Establish DGM state.
                         let dgm = EncryptionMembershipState {
                             members: HashSet::new(),
                         };
 
-                        // @TODO: Establish orderer state.
+                        // @TODO: Get this from store & establish initial orderer state.
+                        //
+                        // This initial orderer state is not necessarily "empty", can include pointers at other
+                        // groups in case we've passed in "groups" as our initial members.
                         let orderer_y = EncryptionOrdererState::new();
 
                         let key_manager_y = manager

--- a/p2panda-spaces/src/store.rs
+++ b/p2panda-spaces/src/store.rs
@@ -7,25 +7,22 @@ use p2panda_encryption::key_manager::KeyManagerState;
 use p2panda_encryption::key_registry::KeyRegistryState;
 
 use crate::space::SpaceState;
-use crate::types::ActorId;
+use crate::types::{ActorId, AuthGroupState};
 
-pub trait SpaceStore<M, C>
-where
-    C: Conditions,
-{
+pub trait SpaceStore<M> {
     type Error: Debug;
 
     fn space(
         &self,
         id: &ActorId,
-    ) -> impl Future<Output = Result<Option<SpaceState<M, C>>, Self::Error>>;
+    ) -> impl Future<Output = Result<Option<SpaceState<M>>, Self::Error>>;
 
     fn has_space(&self, id: &ActorId) -> impl Future<Output = Result<bool, Self::Error>>;
 
     fn set_space(
         &mut self,
         id: &ActorId,
-        y: SpaceState<M, C>,
+        y: SpaceState<M>,
     ) -> impl Future<Output = Result<(), Self::Error>>;
 }
 
@@ -45,4 +42,15 @@ pub trait KeyStore {
         &mut self,
         y: &KeyRegistryState<ActorId>,
     ) -> impl Future<Output = Result<(), Self::Error>>;
+}
+
+pub trait AuthStore<C>
+where
+    C: Conditions,
+{
+    type Error: Debug;
+
+    fn auth(&self) -> impl Future<Output = Result<AuthGroupState<C>, Self::Error>>;
+
+    fn set_auth(&mut self, y: &AuthGroupState<C>) -> impl Future<Output = Result<(), Self::Error>>;
 }

--- a/p2panda-spaces/src/store.rs
+++ b/p2panda-spaces/src/store.rs
@@ -2,13 +2,14 @@
 
 use std::fmt::Debug;
 
+use p2panda_auth::traits::Conditions;
 use p2panda_encryption::key_manager::KeyManagerState;
 use p2panda_encryption::key_registry::KeyRegistryState;
 
 use crate::space::SpaceState;
-use crate::types::{ActorId, Conditions};
+use crate::types::ActorId;
 
-pub trait SpaceStore<M, C, RS>
+pub trait SpaceStore<M, C>
 where
     C: Conditions,
 {
@@ -17,14 +18,14 @@ where
     fn space(
         &self,
         id: &ActorId,
-    ) -> impl Future<Output = Result<Option<SpaceState<M, C, RS>>, Self::Error>>;
+    ) -> impl Future<Output = Result<Option<SpaceState<M, C>>, Self::Error>>;
 
     fn has_space(&self, id: &ActorId) -> impl Future<Output = Result<bool, Self::Error>>;
 
     fn set_space(
         &mut self,
         id: &ActorId,
-        y: SpaceState<M, C, RS>,
+        y: SpaceState<M, C>,
     ) -> impl Future<Output = Result<(), Self::Error>>;
 }
 

--- a/p2panda-spaces/src/test_utils.rs
+++ b/p2panda-spaces/src/test_utils.rs
@@ -3,25 +3,26 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
 
+use p2panda_auth::traits::Conditions;
 use p2panda_encryption::key_manager::{KeyManager, KeyManagerState};
 use p2panda_encryption::key_registry::{KeyRegistry, KeyRegistryState};
 use p2panda_encryption::traits::PreKeyManager;
 
 use crate::space::SpaceState;
 use crate::store::{KeyStore, SpaceStore};
-use crate::types::{ActorId, Conditions};
+use crate::types::ActorId;
 
 #[derive(Debug)]
-pub struct MemoryStore<M, C, RS>
+pub struct MemoryStore<M, C>
 where
     C: Conditions,
 {
     key_manager: KeyManagerState,
     key_registry: KeyRegistryState<ActorId>,
-    spaces: HashMap<ActorId, SpaceState<M, C, RS>>,
+    spaces: HashMap<ActorId, SpaceState<M, C>>,
 }
 
-impl<M, C, RS> MemoryStore<M, C, RS>
+impl<M, C> MemoryStore<M, C>
 where
     C: Conditions,
 {
@@ -41,15 +42,14 @@ where
     }
 }
 
-impl<M, C, RS> SpaceStore<M, C, RS> for MemoryStore<M, C, RS>
+impl<M, C> SpaceStore<M, C> for MemoryStore<M, C>
 where
     M: Clone,
-    RS: Clone,
     C: Conditions,
 {
     type Error = Infallible;
 
-    async fn space(&self, id: &ActorId) -> Result<Option<SpaceState<M, C, RS>>, Self::Error> {
+    async fn space(&self, id: &ActorId) -> Result<Option<SpaceState<M, C>>, Self::Error> {
         Ok(self.spaces.get(id).cloned())
     }
 
@@ -57,17 +57,13 @@ where
         Ok(self.spaces.contains_key(id))
     }
 
-    async fn set_space(
-        &mut self,
-        id: &ActorId,
-        y: SpaceState<M, C, RS>,
-    ) -> Result<(), Self::Error> {
+    async fn set_space(&mut self, id: &ActorId, y: SpaceState<M, C>) -> Result<(), Self::Error> {
         self.spaces.insert(*id, y);
         Ok(())
     }
 }
 
-impl<M, C, RS> KeyStore for MemoryStore<M, C, RS>
+impl<M, C> KeyStore for MemoryStore<M, C>
 where
     C: Conditions,
 {

--- a/p2panda-spaces/src/test_utils.rs
+++ b/p2panda-spaces/src/test_utils.rs
@@ -9,8 +9,8 @@ use p2panda_encryption::key_registry::{KeyRegistry, KeyRegistryState};
 use p2panda_encryption::traits::PreKeyManager;
 
 use crate::space::SpaceState;
-use crate::store::{KeyStore, SpaceStore};
-use crate::types::ActorId;
+use crate::store::{AuthStore, KeyStore, SpaceStore};
+use crate::types::{ActorId, AuthGroupState};
 
 #[derive(Debug)]
 pub struct MemoryStore<M, C>
@@ -19,14 +19,15 @@ where
 {
     key_manager: KeyManagerState,
     key_registry: KeyRegistryState<ActorId>,
-    spaces: HashMap<ActorId, SpaceState<M, C>>,
+    auth: AuthGroupState<C>,
+    spaces: HashMap<ActorId, SpaceState<M>>,
 }
 
 impl<M, C> MemoryStore<M, C>
 where
     C: Conditions,
 {
-    pub fn new(my_id: ActorId, key_manager: KeyManagerState) -> Self {
+    pub fn new(my_id: ActorId, key_manager: KeyManagerState, auth: AuthGroupState<C>) -> Self {
         // Register our own pre-keys.
         let key_registry = {
             let key_bundle = KeyManager::prekey_bundle(&key_manager);
@@ -37,19 +38,20 @@ where
         Self {
             key_manager,
             key_registry,
+            auth,
             spaces: HashMap::new(),
         }
     }
 }
 
-impl<M, C> SpaceStore<M, C> for MemoryStore<M, C>
+impl<M, C> SpaceStore<M> for MemoryStore<M, C>
 where
     M: Clone,
     C: Conditions,
 {
     type Error = Infallible;
 
-    async fn space(&self, id: &ActorId) -> Result<Option<SpaceState<M, C>>, Self::Error> {
+    async fn space(&self, id: &ActorId) -> Result<Option<SpaceState<M>>, Self::Error> {
         Ok(self.spaces.get(id).cloned())
     }
 
@@ -57,7 +59,7 @@ where
         Ok(self.spaces.contains_key(id))
     }
 
-    async fn set_space(&mut self, id: &ActorId, y: SpaceState<M, C>) -> Result<(), Self::Error> {
+    async fn set_space(&mut self, id: &ActorId, y: SpaceState<M>) -> Result<(), Self::Error> {
         self.spaces.insert(*id, y);
         Ok(())
     }
@@ -84,6 +86,22 @@ where
 
     async fn set_key_registry(&mut self, y: &KeyRegistryState<ActorId>) -> Result<(), Self::Error> {
         self.key_registry = y.clone();
+        Ok(())
+    }
+}
+
+impl<M, C> AuthStore<C> for MemoryStore<M, C>
+where
+    C: Conditions,
+{
+    type Error = Infallible;
+
+    async fn auth(&self) -> Result<AuthGroupState<C>, Self::Error> {
+        Ok(self.auth.clone())
+    }
+
+    async fn set_auth(&mut self, y: &AuthGroupState<C>) -> Result<(), Self::Error> {
+        self.auth = y.clone();
         Ok(())
     }
 }

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -2,6 +2,7 @@
 
 use std::convert::Infallible;
 
+use p2panda_auth::traits::Conditions;
 use p2panda_auth::Access;
 use p2panda_auth::group::GroupMember;
 use p2panda_core::{Hash, PrivateKey, PublicKey};
@@ -15,7 +16,7 @@ use crate::forge::Forge;
 use crate::manager::Manager;
 use crate::message::{AuthoredMessage, ControlMessage, SpacesArgs, SpacesMessage};
 use crate::test_utils::MemoryStore;
-use crate::types::{ActorId, Conditions, OperationId, StrongRemoveResolver};
+use crate::types::{ActorId, OperationId, StrongRemoveResolver};
 
 type SeqNum = u64;
 
@@ -98,7 +99,7 @@ impl Forge<TestMessage, TestConditions> for TestForge {
     }
 }
 
-type TestStore = MemoryStore<TestMessage, TestConditions, StrongRemoveResolver<TestConditions>>;
+type TestStore = MemoryStore<TestMessage, TestConditions>;
 
 type TestManager = Manager<
     TestStore,

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -2,9 +2,9 @@
 
 use std::convert::Infallible;
 
-use p2panda_auth::traits::Conditions;
 use p2panda_auth::Access;
 use p2panda_auth::group::GroupMember;
+use p2panda_auth::traits::Conditions;
 use p2panda_core::{Hash, PrivateKey, PublicKey};
 use p2panda_encryption::Rng;
 use p2panda_encryption::crypto::x25519::SecretKey;
@@ -16,7 +16,7 @@ use crate::forge::Forge;
 use crate::manager::Manager;
 use crate::message::{AuthoredMessage, ControlMessage, SpacesArgs, SpacesMessage};
 use crate::test_utils::MemoryStore;
-use crate::types::{ActorId, OperationId, StrongRemoveResolver};
+use crate::types::{ActorId, AuthGroupState, OperationId, StrongRemoveResolver};
 
 type SeqNum = u64;
 
@@ -126,7 +126,9 @@ impl TestPeer {
             KeyManager::init(&identity_secret, Lifetime::default(), &rng).unwrap()
         };
 
-        let store = TestStore::new(my_id, key_manager_y);
+        let orderer_y = ();
+        let auth_y = AuthGroupState::new(orderer_y);
+        let store = TestStore::new(my_id, key_manager_y, auth_y);
         let forge = TestForge::new(private_key);
 
         let manager = TestManager::new(store, forge, rng).unwrap();
@@ -151,7 +153,9 @@ async fn create_space() {
         KeyManager::init(&identity_secret, Lifetime::default(), &rng).unwrap()
     };
 
-    let store = TestStore::new(my_id, key_manager_y);
+    let orderer_y = ();
+    let auth_y = AuthGroupState::new(orderer_y);
+    let store = TestStore::new(my_id, key_manager_y, auth_y);
     let forge = TestForge::new(private_key);
 
     let manager = TestManager::new(store, forge, rng).unwrap();

--- a/p2panda-spaces/src/types.rs
+++ b/p2panda-spaces/src/types.rs
@@ -4,9 +4,9 @@ use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-use p2panda_auth::group::{GroupCrdtInnerState as AuthInnerState};
+use p2panda_auth::group::GroupCrdtInnerState as AuthInnerState;
 use p2panda_auth::traits::{
-    Conditions, IdentityHandle as AuthIdentityHandle, OperationId as AuthOperationId, Resolver
+    Conditions, IdentityHandle as AuthIdentityHandle, OperationId as AuthOperationId, Resolver,
 };
 use p2panda_core::hash::{HASH_LEN, Hash};
 use p2panda_core::identity::{PUBLIC_KEY_LEN, PublicKey};

--- a/p2panda-spaces/src/types.rs
+++ b/p2panda-spaces/src/types.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::convert::Infallible;
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-use p2panda_auth::traits::{IdentityHandle as AuthIdentityHandle, OperationId as AuthOperationId};
+use p2panda_auth::group::{GroupCrdtInnerState as AuthInnerState};
+use p2panda_auth::traits::{
+    Conditions, IdentityHandle as AuthIdentityHandle, OperationId as AuthOperationId, Resolver
+};
 use p2panda_core::hash::{HASH_LEN, Hash};
 use p2panda_core::identity::{PUBLIC_KEY_LEN, PublicKey};
 use p2panda_core::{HashError, IdentityError};
@@ -17,6 +19,7 @@ use p2panda_encryption::traits::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::auth::message::AuthMessage;
 use crate::auth::orderer::AuthOrderer;
 use crate::encryption::dgm::EncryptionGroupMembership;
 use crate::encryption::orderer::EncryptionOrderer;
@@ -167,25 +170,37 @@ pub enum OperationIdError {
 // ~~~ Auth ~~~
 
 pub type AuthGroup<C, RS> =
-    p2panda_auth::group::GroupCrdt<ActorId, OperationId, C, RS, AuthOrderer, AuthDummyStore>;
+    p2panda_auth::group::GroupCrdt<ActorId, OperationId, C, RS, AuthOrderer>;
 
-pub type AuthGroupState<C, RS> =
-    p2panda_auth::group::GroupCrdtState<ActorId, OperationId, C, RS, AuthOrderer, AuthDummyStore>;
+pub type AuthGroupState<C> =
+    p2panda_auth::group::GroupCrdtState<ActorId, OperationId, C, AuthOrderer>;
 
 pub type AuthGroupError<C, RS> =
-    p2panda_auth::group::GroupCrdtError<ActorId, OperationId, C, RS, AuthOrderer, AuthDummyStore>;
+    p2panda_auth::group::GroupCrdtError<ActorId, OperationId, C, RS, AuthOrderer>;
 
 pub type AuthControlMessage<C> = p2panda_auth::group::GroupControlMessage<ActorId, C>;
 
 pub type AuthGroupAction<C> = p2panda_auth::group::GroupAction<ActorId, C>;
 
-pub type StrongRemoveResolver<C> = p2panda_auth::group::resolver::StrongRemove<
-    ActorId,
-    OperationId,
-    C,
-    AuthOrderer,
-    AuthDummyStore,
->;
+pub type StrongRemoveResolver<C> =
+    p2panda_auth::group::resolver::StrongRemove<ActorId, OperationId, C, AuthMessage<C>>;
+
+// @TODO: We can bound this state requirement in p2panda-auth to reduce
+// complexity in this trait signature.
+pub trait AuthResolver<C>:
+    Resolver<
+        ActorId,
+        OperationId,
+        C,
+        AuthMessage<C>,
+        State = AuthInnerState<ActorId, OperationId, C, AuthMessage<C>>,
+    >
+{
+}
+
+// Required as we define a new super-trait above with non-generic actor id,
+// operation id and message type.
+impl<C> AuthResolver<C> for StrongRemoveResolver<C> where C: Conditions {}
 
 // ~~~ Encryption ~~~
 
@@ -227,33 +242,6 @@ pub type EncryptionGroupOutput<M> = p2panda_encryption::data_scheme::GroupOutput
     EncryptionGroupMembership,
     EncryptionOrderer<M>,
 >;
-
-// ~~~ Hacks ~~~
-
-// @TODO: Will change in `p2panda-auth`.
-#[derive(Debug, Clone)]
-pub struct AuthDummyStore;
-
-impl<C, RS> p2panda_auth::traits::GroupStore<ActorId, OperationId, C, RS, AuthOrderer>
-    for AuthDummyStore
-where
-    C: Conditions,
-    Self: Sized,
-{
-    type Error = Infallible;
-
-    fn insert(&self, _id: &ActorId, _group: &AuthGroupState<C, RS>) -> Result<(), Self::Error> {
-        // Noop: Writing new group state will be handled outside of this layer.
-        Ok(())
-    }
-
-    fn get(&self, _id: &ActorId) -> Result<Option<AuthGroupState<C, RS>>, Self::Error> {
-        todo!()
-    }
-}
-
-// @TODO: this supertrait should be defined in p2panda-auth
-pub trait Conditions: Clone + Debug + PartialEq + PartialOrd {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
There is now only one auth state used for all groups (and therefore spaces). This should be globally accessible on the manager, so that any spaces can retrieve it, and set it again once any changes have been applied. For this we can use a new "auth store" interface (trait) with methods for getting and setting the auth state. This is implemented on the generic S store and as Manager is accessible from within a Space we can also access and set the auth state when required.

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
