### PR TITLE
WIP: Implement supervised gossip actor sub-system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "p2panda-discovery",
     "p2panda-encryption",
     "p2panda-net",
+    "p2panda-net-next",
     "p2panda-store",
     "p2panda-stream",
     "p2panda-sync",

--- a/p2panda-net-next/Cargo.toml
+++ b/p2panda-net-next/Cargo.toml
@@ -5,11 +5,15 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.97"
+futures-lite = "2.6.1"
 iroh = { version = "0.34.1", default-features = false }
 iroh-base = "0.34.1"
 iroh-gossip = "0.34.1"
 p2panda-core = { path = "../p2panda-core", version = "0.4.0" }
+ractor = { version = "0.15.8", features = ["cluster"] }
 serde = { version = "1.0.219", features = ["derive"] }
+tokio = { version = "1.44.2", features = ["rt", "sync", "time"] }
+tracing = "0.1.41"
 
 [lints]
 workspace = true

--- a/p2panda-net-next/Cargo.toml
+++ b/p2panda-net-next/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "p2panda-net-next"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/p2panda-net-next/Cargo.toml
+++ b/p2panda-net-next/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1.0.97"
+iroh = { version = "0.34.1", default-features = false }
+iroh-base = "0.34.1"
+iroh-gossip = "0.34.1"
+p2panda-core = { path = "../p2panda-core", version = "0.4.0" }
+serde = { version = "1.0.219", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/p2panda-net-next/src/actors/gossip/listener.rs
+++ b/p2panda-net-next/src/actors/gossip/listener.rs
@@ -1,0 +1,97 @@
+//! Listen for messages from the user and forward them to the gossip sender.
+
+use ractor::{Actor, ActorProcessingErr, ActorRef, Message};
+use tokio::sync::mpsc::Receiver;
+use tracing::warn;
+
+use crate::actors::gossip::sender::ToGossipSender;
+use crate::network::ToNetwork;
+
+pub enum ToGossipListener {
+    /// Wait for a message on the gossip topic channel.
+    WaitForMessage,
+}
+
+impl Message for ToGossipListener {}
+
+pub struct GossipListenerState {
+    receiver: Option<Receiver<ToNetwork>>,
+}
+
+pub struct GossipListener {
+    sender: ActorRef<ToGossipSender>,
+}
+
+impl GossipListener {
+    pub fn new(sender: ActorRef<ToGossipSender>) -> Self {
+        Self { sender }
+    }
+}
+
+impl Actor for GossipListener {
+    type State = GossipListenerState;
+    type Msg = ToGossipListener;
+    type Arguments = Receiver<ToNetwork>;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        receiver: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        // Invoke the handler to wait for the first message on the receiver.
+        let _ = myself.cast(ToGossipListener::WaitForMessage);
+
+        let state = GossipListenerState {
+            receiver: Some(receiver),
+        };
+
+        Ok(state)
+    }
+
+    async fn post_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn post_stop(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        drop(state.receiver.take());
+
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        _message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        if let Some(receiver) = &mut state.receiver {
+            match receiver.recv().await {
+                Some(msg) => {
+                    // Forward the message bytes to the gossip sender for broadcast.
+                    let ToNetwork::Message { bytes } = msg;
+                    let _ = self.sender.cast(ToGossipSender::Broadcast(bytes));
+                }
+                None => {
+                    warn!("gossip listener actor: user dropped sender - channel closed");
+                    drop(state.receiver.take());
+                    myself.stop(Some("receiver channel closed".to_string()));
+
+                    return Ok(());
+                }
+            }
+        }
+
+        // Invoke the handler to wait for the next message on the receiver.
+        let _ = myself.cast(ToGossipListener::WaitForMessage);
+
+        Ok(())
+    }
+}

--- a/p2panda-net-next/src/actors/gossip/mod.rs
+++ b/p2panda-net-next/src/actors/gossip/mod.rs
@@ -1,0 +1,201 @@
+//! An iroh-specific gossip actor for message broadcast.
+
+mod listener;
+mod receiver;
+mod sender;
+mod session;
+
+use std::collections::HashMap;
+
+use iroh::Endpoint as IrohEndpoint;
+use iroh_gossip::net::Gossip as IrohGossip;
+use iroh_gossip::proto::DeliveryScope as IrohDeliveryScope;
+use p2panda_core::PublicKey;
+use ractor::{Actor, ActorId, ActorProcessingErr, ActorRef, Message, RpcReplyPort};
+use session::ToGossipSession;
+use tokio::sync::mpsc::{self, Receiver, Sender};
+
+use crate::actors::gossip::session::GossipSession;
+use crate::network::{FromNetwork, ToNetwork};
+use crate::{from_public_key, TopicId};
+
+// NOTE: The `GossipSession` actor does not know the topic id for it's session. Instead, the
+// `Gossip` actor holds a mapping of `topic_id` -> `actor_id` for each gossip subscription
+// session.
+
+pub enum ToGossip {
+    /// Return a handle to the iroh gossip actor.
+    ///
+    /// This is required when registering the gossip ALPN with the router.
+    Handle(RpcReplyPort<IrohGossip>),
+
+    /// Join the given topic, using the given peers as gossip bootstrap nodes.
+    Join {
+        topic_id: TopicId,
+        peers: Vec<PublicKey>,
+        reply: RpcReplyPort<(Sender<ToNetwork>, Receiver<FromNetwork>)>,
+    },
+
+    /// Joined a topic by connecting to the given peers.
+    Joined {
+        peers: Vec<PublicKey>,
+        session_id: ActorId,
+    },
+
+    /// Gained a new, direct neighbor in the gossip overlay.
+    NeighborUp {
+        peer: PublicKey,
+        session_id: ActorId,
+    },
+
+    /// Lost a direct neighbor in the gossip overlay.
+    NeighborDown {
+        peer: PublicKey,
+        session_id: ActorId,
+    },
+
+    /// Received a message from the gossip overlay.
+    ReceivedMessage {
+        bytes: Vec<u8>,
+        delivered_from: PublicKey,
+        delivery_scope: IrohDeliveryScope,
+        session_id: ActorId,
+    },
+}
+
+impl Message for ToGossip {}
+
+pub struct GossipState {
+    gossip: IrohGossip,
+    sessions: HashMap<TopicId, ActorRef<ToGossipSession>>,
+    from_gossip_senders: HashMap<TopicId, Vec<Sender<FromNetwork>>>,
+    // TODO: Store topic_id -> actor_id mappings for session actors.
+}
+
+pub struct Gossip;
+
+impl Actor for Gossip {
+    type State = GossipState;
+    type Msg = ToGossip;
+    type Arguments = IrohEndpoint;
+
+    // Configure the Gossip.
+    //
+    // A cloned IrohEndpoint is passed in when this actor is spawned by the Endpoint actor.
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        endpoint: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        // TODO: Pass config in with the endpoint as arguments.
+        // TODO: Configure iroh gossip properly.
+        let gossip = IrohGossip::builder().spawn(endpoint.clone()).await?;
+        let sessions = HashMap::new();
+        let from_gossip_senders = HashMap::new();
+
+        // TODO: The router needs to be configured to accept gossip protocol.
+        // This needs to be done when the router is built.
+        // Consider how to do this via config.
+
+        let state = GossipState {
+            gossip,
+            sessions,
+            from_gossip_senders,
+        };
+
+        Ok(state)
+    }
+
+    async fn post_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn post_stop(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        // TODO: Clean-up on shutdown.
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            ToGossip::Handle(reply) => {
+                let gossip = state.gossip.clone();
+
+                // Don't respond if the receiver has been dropped.
+                if !reply.is_closed() {
+                    let _ = reply.send(gossip);
+                }
+
+                Ok(())
+            }
+            ToGossip::Join {
+                topic_id,
+                peers,
+                reply,
+            } => {
+                // Channel to receive messages from the user (to the network).
+                let (to_network_tx, to_network_rx) = mpsc::channel(128);
+                // Channel to receive messages from the network (to the user).
+                let (from_network_tx, from_network_rx) = mpsc::channel(128);
+
+                // Convert p2panda public keys to iroh node ids.
+                let peers = peers
+                    .iter()
+                    .map(|key: &PublicKey| from_public_key(*key))
+                    .collect();
+
+                let subscription = state.gossip.subscribe(topic_id.into(), peers)?;
+
+                // Spawn the session actor with the gossip topic subscription.
+                let (gossip_session_actor, _) = Actor::spawn_linked(
+                    None,
+                    GossipSession::new(myself.clone()),
+                    (subscription, to_network_rx),
+                    myself.clone().into(),
+                )
+                .await?;
+
+                let _ = state.sessions.insert(topic_id, gossip_session_actor);
+                let _ = state
+                    .from_gossip_senders
+                    .entry(topic_id)
+                    .or_insert_with(Vec::new)
+                    .push(from_network_tx);
+
+                // Return sender / receiver pair to the user.
+                // TODO: Handle case where receiver channel has been dropped.
+                if !reply.is_closed() {
+                    let _ = reply.send((to_network_tx, from_network_rx));
+                }
+
+                Ok(())
+            }
+            ToGossip::ReceivedMessage {
+                bytes,
+                delivered_from,
+                delivery_scope,
+                session_id,
+            } => {
+                // TODO: Write the received bytes into the appropriate user channel.
+                todo!()
+            }
+            ToGossip::Joined { peers, session_id } => todo!(),
+            ToGossip::NeighborUp { peer, session_id } => todo!(),
+            ToGossip::NeighborDown { peer, session_id } => todo!(),
+        }
+    }
+
+    // TODO: Child actor supervision.
+}

--- a/p2panda-net-next/src/actors/gossip/receiver.rs
+++ b/p2panda-net-next/src/actors/gossip/receiver.rs
@@ -1,0 +1,102 @@
+//! Gossip recevier actor which holds the gossip topic receiver, receives overlay messages and sends
+//! them to the gossip session actor.
+
+use futures_lite::StreamExt;
+use iroh_gossip::net::GossipReceiver as IrohGossipReceiver;
+use ractor::{Actor, ActorProcessingErr, ActorRef, Message};
+use tracing::error;
+
+use crate::actors::gossip::session::ToGossipSession;
+
+pub enum ToGossipReceiver {
+    /// Wait for an event on the gossip topic receiver.
+    WaitForEvent,
+}
+
+impl Message for ToGossipReceiver {}
+
+pub struct GossipReceiverState {
+    receiver: Option<IrohGossipReceiver>,
+}
+
+pub struct GossipReceiver {
+    session: ActorRef<ToGossipSession>,
+}
+
+impl GossipReceiver {
+    pub fn new(session: ActorRef<ToGossipSession>) -> Self {
+        Self { session }
+    }
+}
+
+impl Actor for GossipReceiver {
+    type State = GossipReceiverState;
+    type Msg = ToGossipReceiver;
+    type Arguments = IrohGossipReceiver;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        receiver: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        // Invoke the handler to wait for the first event on the receiver.
+        let _ = myself.cast(ToGossipReceiver::WaitForEvent);
+
+        let state = GossipReceiverState {
+            receiver: Some(receiver),
+        };
+
+        Ok(state)
+    }
+
+    async fn post_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn post_stop(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        drop(state.receiver.take());
+
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        _message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        // There's no need to match on `_message` here, since this actor only has a single message
+        // variant (`WaitForEvent`).
+
+        if let Some(receiver) = &mut state.receiver {
+            if let Some(received) = receiver.next().await {
+                match received {
+                    Ok(event) => {
+                        // Send the event up the chain for processing.
+                        let _ = self.session.cast(ToGossipSession::ProcessEvent(event));
+                    }
+                    Err(err) => {
+                        error!("gossip receiver actor: {}", err);
+                        drop(state.receiver.take());
+                        myself.stop(Some("channel closed".to_string()));
+
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        // Invoke the handler to wait for the next event on the receiver.
+        let _ = myself.cast(ToGossipReceiver::WaitForEvent);
+
+        Ok(())
+    }
+}

--- a/p2panda-net-next/src/actors/gossip/sender.rs
+++ b/p2panda-net-next/src/actors/gossip/sender.rs
@@ -1,0 +1,67 @@
+//! Gossip sender actor which holds the topic sender, receives local messages and broadcasts them
+//! to the overlay.
+
+use iroh_gossip::net::GossipSender as IrohGossipSender;
+use ractor::{Actor, ActorProcessingErr, ActorRef, Message};
+
+pub enum ToGossipSender {
+    Broadcast(Vec<u8>),
+}
+
+impl Message for ToGossipSender {}
+
+pub struct GossipSenderState {
+    sender: Option<IrohGossipSender>,
+}
+
+pub struct GossipSender;
+
+impl Actor for GossipSender {
+    type State = GossipSenderState;
+    type Msg = ToGossipSender;
+    type Arguments = IrohGossipSender;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        sender: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let state = GossipSenderState {
+            sender: Some(sender),
+        };
+
+        Ok(state)
+    }
+
+    async fn post_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn post_stop(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        drop(state.sender.take());
+
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        if let Some(sender) = &mut state.sender {
+            let ToGossipSender::Broadcast(bytes) = message;
+            sender.broadcast(bytes.into()).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/p2panda-net-next/src/actors/gossip/session.rs
+++ b/p2panda-net-next/src/actors/gossip/session.rs
@@ -1,0 +1,243 @@
+//! Gossip session actor.
+//!
+//! This actor is responsible for supervising a gossip session over a single topic; a separate
+//! instance is spawned for each subscribed topic. The actor waits for the topic to be joined
+//! and then spawns sender and receiver actors. It receives gossip events from the receiver and
+//! forwards them up the chain to the main gossip orchestration actor.
+
+use std::time::Duration;
+
+use iroh_gossip::net::{
+    Event as IrohEvent, GossipEvent as IrohGossipEvent, GossipTopic as IrohGossipTopic,
+};
+use p2panda_core::PublicKey;
+use ractor::{Actor, ActorProcessingErr, ActorRef, Message, SupervisionEvent};
+use tokio::sync::mpsc::Receiver;
+use tracing::{debug, warn};
+
+use crate::actors::gossip::listener::{GossipListener, ToGossipListener};
+use crate::actors::gossip::receiver::{GossipReceiver, ToGossipReceiver};
+use crate::actors::gossip::sender::{GossipSender, ToGossipSender};
+use crate::actors::gossip::ToGossip;
+use crate::network::ToNetwork;
+use crate::to_public_key;
+
+pub enum ToGossipSession {
+    /// An event received from the gossip overlay.
+    ProcessEvent(IrohEvent),
+}
+
+impl Message for ToGossipSession {}
+
+pub struct GossipSessionState {
+    gossip_sender_actor: ActorRef<ToGossipSender>,
+    gossip_receiver_actor: ActorRef<ToGossipReceiver>,
+    gossip_listener_actor: ActorRef<ToGossipListener>,
+}
+
+pub struct GossipSession {
+    gossip_actor: ActorRef<ToGossip>,
+}
+
+impl GossipSession {
+    pub fn new(gossip_actor: ActorRef<ToGossip>) -> Self {
+        Self { gossip_actor }
+    }
+}
+
+impl Actor for GossipSession {
+    type State = GossipSessionState;
+    type Msg = ToGossipSession;
+    // TODO: We also need to receive a channel receiver from userland.
+    // That is then passed into the spawned listener.
+    type Arguments = (IrohGossipTopic, Receiver<ToNetwork>);
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let (mut subscription, receiver_from_user) = args;
+
+        subscription.joined().await?;
+
+        let (sender, receiver) = subscription.split();
+
+        let (gossip_sender_actor, _) =
+            Actor::spawn_linked(None, GossipSender, sender, myself.clone().into()).await?;
+
+        let (gossip_receiver_actor, _) = Actor::spawn_linked(
+            None,
+            GossipReceiver::new(myself.clone()),
+            receiver,
+            myself.clone().into(),
+        )
+        .await?;
+
+        // TODO: Spawn the channel listener.
+        // Must take a reference to the `gossip_sender_actor` for direct message passing.
+        // The channel listener receives messages from userland and forwards them to the gossip
+        // sender.
+        let (gossip_listener_actor, _) = Actor::spawn_linked(
+            None,
+            GossipListener::new(gossip_sender_actor.clone()),
+            receiver_from_user,
+            myself.clone().into(),
+        )
+        .await?;
+
+        let state = GossipSessionState {
+            gossip_sender_actor,
+            gossip_receiver_actor,
+            gossip_listener_actor,
+        };
+
+        Ok(state)
+    }
+
+    async fn post_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn post_stop(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            ToGossipSession::ProcessEvent(event) => match event {
+                IrohEvent::Lagged => {
+                    warn!("gossip session actor: missed messages - dropping gossip event")
+                }
+                // Gossip events are passed up the chain to the main gossip actor.
+                //
+                // We perform type conversion here to reduce the workload of the gossip actor.
+                IrohEvent::Gossip(gossip_event) => match gossip_event {
+                    IrohGossipEvent::Joined(peers) => {
+                        let peers: Vec<PublicKey> = peers.into_iter().map(to_public_key).collect();
+                        let session_id = myself.get_id();
+
+                        let _ = self
+                            .gossip_actor
+                            .cast(ToGossip::Joined { peers, session_id });
+                    }
+                    IrohGossipEvent::Received(msg) => {
+                        let bytes = msg.content.into();
+                        let delivered_from = to_public_key(msg.delivered_from);
+                        let delivery_scope = msg.scope;
+                        let session_id = myself.get_id();
+
+                        let _ = self.gossip_actor.cast(ToGossip::ReceivedMessage {
+                            bytes,
+                            delivered_from,
+                            delivery_scope,
+                            session_id,
+                        });
+                    }
+                    IrohGossipEvent::NeighborUp(peer) => {
+                        let peer = to_public_key(peer);
+                        let session_id = myself.get_id();
+
+                        let _ = self
+                            .gossip_actor
+                            .cast(ToGossip::NeighborUp { peer, session_id });
+                    }
+                    IrohGossipEvent::NeighborDown(peer) => {
+                        let peer = to_public_key(peer);
+                        let session_id = myself.get_id();
+
+                        let _ = self
+                            .gossip_actor
+                            .cast(ToGossip::NeighborUp { peer, session_id });
+                    }
+                },
+            },
+        }
+
+        Ok(())
+    }
+
+    async fn handle_supervisor_evt(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: SupervisionEvent,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            SupervisionEvent::ActorStarted(actor) => {
+                let actor_id = actor.get_id();
+                if actor_id == state.gossip_sender_actor.get_id() {
+                    debug!(
+                        "gossip session actor: received ready from gossip sender actor #{}",
+                        actor_id
+                    )
+                } else if actor_id == state.gossip_receiver_actor.get_id() {
+                    debug!(
+                        "gossip session actor: received ready from gossip receiver actor #{}",
+                        actor_id
+                    )
+                }
+            }
+            // We're not interested in respawning a terminated actor in the context of a gossip
+            // session. We simply process any queued messages in the remaining actor and stop
+            // the session. The main gossip actor will be alerted of the session outcome by a
+            // supervision event. The same is true for a failed sender or receiver actor.
+            SupervisionEvent::ActorTerminated(actor, _last_state, reason) => {
+                let actor_id = actor.get_id();
+                if actor_id == state.gossip_sender_actor.get_id() {
+                    debug!(
+                        "gossip session actor: gossip sender actor #{} terminated with reason: {:?}",
+                        actor_id, reason
+                    );
+                } else if actor_id == state.gossip_receiver_actor.get_id() {
+                    debug!(
+                        "gossip session actor: gossip receiver actor #{} terminated with reason: {:?}",
+                        actor_id, reason
+                    );
+                }
+
+                // Process any remaining messages in the queue of the gossip sender and receiver
+                // actors, waiting a maximum of 100 milliseconds for their collective exit.
+                myself
+                    .drain_children_and_wait(Some(Duration::from_millis(100)))
+                    .await;
+                myself.stop(Some("lost connection to gossip overlay".to_string()));
+            }
+            SupervisionEvent::ActorFailed(actor, panic_msg) => {
+                let actor_id = actor.get_id();
+                if actor_id == state.gossip_sender_actor.get_id() {
+                    debug!(
+                        "gossip session actor: gossip sender actor #{} failed with message: {:?}",
+                        actor_id, panic_msg
+                    );
+                } else if actor_id == state.gossip_receiver_actor.get_id() {
+                    debug!(
+                        "gossip session actor: gossip receiver actor #{} failed with message: {:?}",
+                        actor_id, panic_msg
+                    );
+                }
+
+                myself
+                    .drain_children_and_wait(Some(Duration::from_millis(100)))
+                    .await;
+                myself.stop(Some("lost connection to gossip overlay".to_string()));
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+}

--- a/p2panda-net-next/src/actors/mod.rs
+++ b/p2panda-net-next/src/actors/mod.rs
@@ -1,0 +1,1 @@
+mod gossip;

--- a/p2panda-net-next/src/addrs.rs
+++ b/p2panda-net-next/src/addrs.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt::Display;
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+use anyhow::Context;
+use iroh::RelayUrl as IrohRelayUrl;
+use iroh::{NodeAddr as IrohNodeAddr, NodeId};
+use p2panda_core::PublicKey;
+use serde::{Deserialize, Serialize};
+
+use crate::to_public_key;
+
+/// Default STUN port used by the relay server.
+///
+/// The STUN port as defined by [RFC 8489](<https://www.rfc-editor.org/rfc/rfc8489#section-18.6>)
+pub const DEFAULT_STUN_PORT: u16 = 3478;
+
+/// URL identifying a relay server.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
+pub struct RelayUrl(IrohRelayUrl);
+
+impl RelayUrl {
+    pub fn port(&self) -> Option<u16> {
+        self.0.port()
+    }
+}
+
+impl FromStr for RelayUrl {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let inner = IrohRelayUrl::from_str(s).context("invalid URL")?;
+        Ok(Self(inner))
+    }
+}
+
+impl Display for RelayUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0.to_string())
+    }
+}
+
+impl From<RelayUrl> for IrohRelayUrl {
+    fn from(value: RelayUrl) -> Self {
+        value.0
+    }
+}
+
+/// Converts a `iroh` relay url type to the `p2panda-net` implementation.
+pub(crate) fn to_relay_url(url: IrohRelayUrl) -> RelayUrl {
+    RelayUrl(url)
+}
+
+/// Node address including public key, socket address(es) and an optional relay URL.
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
+pub struct NodeAddress {
+    pub public_key: PublicKey,
+    pub direct_addresses: Vec<SocketAddr>,
+    pub relay_url: Option<RelayUrl>,
+}
+
+impl NodeAddress {
+    pub fn from_public_key(public_key: PublicKey) -> Self {
+        Self {
+            public_key,
+            direct_addresses: Vec::new(),
+            relay_url: None,
+        }
+    }
+}
+
+/// Converts an `iroh` node address type to the `p2panda-net` implementation.
+pub(crate) fn to_node_addr(addr: IrohNodeAddr) -> NodeAddress {
+    NodeAddress {
+        public_key: to_public_key(addr.node_id),
+        direct_addresses: addr
+            .direct_addresses
+            .iter()
+            .map(|addr| addr.to_owned())
+            .collect(),
+        relay_url: addr.relay_url.map(to_relay_url),
+    }
+}
+
+/// Converts a `p2panda-net` node address type to the `iroh` implementation.
+pub(crate) fn from_node_addr(addr: NodeAddress) -> IrohNodeAddr {
+    let node_id = NodeId::from_bytes(addr.public_key.as_bytes()).expect("invalid public key");
+    let mut node_addr =
+        IrohNodeAddr::new(node_id).with_direct_addresses(addr.direct_addresses.to_vec());
+    if let Some(url) = addr.relay_url {
+        node_addr = node_addr.with_relay_url(url.into());
+    }
+    node_addr
+}

--- a/p2panda-net-next/src/lib.rs
+++ b/p2panda-net-next/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/p2panda-net-next/src/lib.rs
+++ b/p2panda-net-next/src/lib.rs
@@ -1,14 +1,16 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+mod addrs;
+
+/// Converts an `iroh` public key type to the `p2panda-core` implementation.
+pub(crate) fn to_public_key(key: iroh_base::PublicKey) -> p2panda_core::PublicKey {
+    p2panda_core::PublicKey::from_bytes(key.as_bytes()).expect("already validated public key")
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// Converts a `p2panda-core` public key to the "iroh" type.
+pub(crate) fn from_public_key(key: p2panda_core::PublicKey) -> iroh_base::PublicKey {
+    iroh_base::PublicKey::from_bytes(key.as_bytes()).expect("already validated public key")
+}
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+/// Converts a `p2panda-core` private key to the "iroh" type.
+pub(crate) fn from_private_key(key: p2panda_core::PrivateKey) -> iroh_base::SecretKey {
+    iroh_base::SecretKey::from_bytes(key.as_bytes())
 }

--- a/p2panda-net-next/src/lib.rs
+++ b/p2panda-net-next/src/lib.rs
@@ -1,5 +1,6 @@
 mod actors;
 mod addrs;
+mod network;
 
 pub type TopicId = [u8; 32];
 

--- a/p2panda-net-next/src/lib.rs
+++ b/p2panda-net-next/src/lib.rs
@@ -1,4 +1,7 @@
+mod actors;
 mod addrs;
+
+pub type TopicId = [u8; 32];
 
 /// Converts an `iroh` public key type to the `p2panda-core` implementation.
 pub(crate) fn to_public_key(key: iroh_base::PublicKey) -> p2panda_core::PublicKey {

--- a/p2panda-net-next/src/network.rs
+++ b/p2panda-net-next/src/network.rs
@@ -1,0 +1,22 @@
+use p2panda_core::PublicKey;
+
+/// An event to be broadcast to the network.
+#[derive(Clone, Debug)]
+pub enum ToNetwork {
+    Message { bytes: Vec<u8> },
+}
+
+/// An event received from the network.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FromNetwork {
+    GossipMessage {
+        bytes: Vec<u8>,
+        delivered_from: PublicKey,
+    },
+    SyncMessage {
+        header: Vec<u8>,
+        payload: Option<Vec<u8>>,
+        delivered_from: PublicKey,
+    },
+}


### PR DESCRIPTION
This PR introduces a new crate: `p2panda-net-next`, which is intended to serve as a clean-slate for refactoring `p2panda-net` into a fault-tolerant system using supervised actors.

The refactored gossip sub-system forms the focus of this PR. It's split into the following modules / actors:

 - Gossip : main interface with userland (manage channels, spawn sessions); also processes overlay events 
   - GossipSession : super a gossip session over a single topic
     - GossipListener : receive messages from userland and forward them to gossip sender
     - GossipSender : broadcast messages into the topic overlay
     - GossipReceiver : receive messages from the topic overlay and forward them to the session

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
