### PR TITLE
`p2panda-spaces`: global shared auth state and basic groups API

### DIFF
--- a/p2panda-auth/src/group/action.rs
+++ b/p2panda-auth/src/group/action.rs
@@ -3,8 +3,12 @@
 use crate::Access;
 use crate::group::GroupMember;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Actions for creating groups and modifying group membership.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum GroupAction<ID, C> {
     Create {
         initial_members: Vec<(GroupMember<ID>, Access<C>)>,

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -329,6 +329,11 @@ where
     pub fn members(&self, group_id: ID) -> Vec<(ID, Access<C>)> {
         self.inner.members(group_id)
     }
+
+    /// Returns `true` if the passed group exists in the current state.
+    pub fn has_group(&self, group_id: ID) -> bool {
+        self.inner.current_state().contains_key(&group_id)
+    }
 }
 
 /// Core group CRDT for maintaining group membership state in a decentralized

--- a/p2panda-auth/src/group/message.rs
+++ b/p2panda-auth/src/group/message.rs
@@ -2,12 +2,16 @@
 
 use crate::group::GroupAction;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Control messages which are processed in order to update group state.
 ///
 /// There are two variants, one containing a group action and the ID of the group to which the
 /// action should be applied. The other is a special message which can be used to "undo" a message which
 /// has been previously applied to the group.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct GroupControlMessage<ID, C> {
     pub group_id: ID,
     pub action: GroupAction<ID, C>,

--- a/p2panda-spaces/src/auth/message.rs
+++ b/p2panda-spaces/src/auth/message.rs
@@ -3,6 +3,7 @@
 use p2panda_auth::traits::{Conditions, Operation as AuthOperation};
 
 use crate::message::{AuthoredMessage, SpacesArgs, SpacesMessage};
+use crate::traits::SpaceId;
 use crate::types::{ActorId, AuthControlMessage, OperationId};
 
 #[derive(Clone, Debug)]
@@ -26,9 +27,10 @@ impl<C> AuthMessage<C>
 where
     C: Conditions,
 {
-    pub(crate) fn from_forged<M>(message: &M) -> Self
+    pub(crate) fn from_forged<ID, M>(message: &M) -> Self
     where
-        M: AuthoredMessage + SpacesMessage<C>,
+        ID: SpaceId,
+        M: AuthoredMessage + SpacesMessage<ID, C>,
     {
         let SpacesArgs::Auth {
             control_message,

--- a/p2panda-spaces/src/auth/message.rs
+++ b/p2panda-spaces/src/auth/message.rs
@@ -30,11 +30,9 @@ where
     where
         M: AuthoredMessage + SpacesMessage<C>,
     {
-        let SpacesArgs::ControlMessage {
-            id,
+        let SpacesArgs::Auth {
             control_message,
             auth_dependencies,
-            ..
         } = message.args()
         else {
             panic!("unexpected message type")
@@ -44,10 +42,7 @@ where
             operation_id: message.id(),
             args: AuthArgs {
                 dependencies: auth_dependencies.clone(),
-                control_message: AuthControlMessage {
-                    group_id: *id,
-                    action: control_message.to_auth_action(),
-                },
+                control_message: control_message.to_owned(),
             },
         }
     }

--- a/p2panda-spaces/src/encryption/message.rs
+++ b/p2panda-spaces/src/encryption/message.rs
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use p2panda_auth::traits::Conditions;
+use p2panda_auth::traits::{Conditions, Operation};
 use p2panda_encryption::crypto::xchacha20::XAeadNonce;
 use p2panda_encryption::data_scheme::GroupSecretId;
 use p2panda_encryption::traits::{GroupMessage as EncryptionOperation, GroupMessageContent};
 
+use crate::auth::message::AuthMessage;
 use crate::encryption::dgm::EncryptionGroupMembership;
 use crate::message::{AuthoredMessage, SpacesArgs, SpacesMessage};
+use crate::space::removed_members;
 use crate::traits::SpaceId;
-use crate::types::{ActorId, EncryptionControlMessage, EncryptionDirectMessage, OperationId};
+use crate::types::{
+    ActorId, AuthGroupAction, EncryptionControlMessage, EncryptionDirectMessage, OperationId,
+};
 
 #[derive(Clone, Debug)]
 pub enum EncryptionArgs {
@@ -37,39 +41,7 @@ pub enum EncryptionMessage {
 }
 
 impl EncryptionMessage {
-    pub(crate) fn from_membership<ID, M, C>(space_message: &M) -> Vec<Self>
-    where
-        ID: SpaceId,
-        M: AuthoredMessage + SpacesMessage<ID, C>,
-        C: Conditions,
-    {
-        let SpacesArgs::SpaceMembership {
-            space_dependencies,
-            control_messages,
-            ..
-        } = space_message.args()
-        else {
-            panic!("unexpected message type")
-        };
-
-        control_messages
-            .clone()
-            .into_iter()
-            .map(|message| {
-                let encryption_args = EncryptionArgs::System {
-                    dependencies: space_dependencies.clone(),
-                    control_message: message.encryption_control_message(),
-                    direct_messages: message.direct_messages().to_owned(),
-                };
-                EncryptionMessage::Forged {
-                    author: space_message.author(),
-                    operation_id: space_message.id(),
-                    args: encryption_args,
-                }
-            })
-            .collect()
-    }
-
+    /// Construct an encryption message from a space application message.
     pub(crate) fn from_application<ID, M, C>(space_message: &M) -> Self
     where
         ID: SpaceId,
@@ -101,15 +73,101 @@ impl EncryptionMessage {
         }
     }
 
-    pub(crate) fn dependencies(&self) -> &Vec<OperationId> {
-        let args = match self {
-            EncryptionMessage::Args(args) => args,
-            EncryptionMessage::Forged { args, .. } => args,
+    /// Construct an encryption message from a corresponding space message and required additional
+    /// arguments.
+    ///
+    /// This method is required when we receive a space message and associated auth message and we
+    /// want to adjust our local encryption state accordingly. The main requirement is that we
+    /// process our own direct messages (contained in the space message), in many cases the actual
+    /// encryption control message type and content is redundant as the DGM state is always
+    /// manually replaced with the latest membership state provided by p2panda-auth. The only case
+    /// where it does matter is if we ourselves were added or removed from the group, here we
+    /// should make sure that the control message contains our own actor id.
+    pub(crate) fn from_membership<ID, M, C>(
+        space_message: &M,
+        my_id: ActorId,
+        auth_message: &AuthMessage<C>,
+        current_members: Vec<ActorId>,
+        next_members: Vec<ActorId>,
+    ) -> Self
+    where
+        ID: SpaceId,
+        M: AuthoredMessage + SpacesMessage<ID, C>,
+        C: Conditions,
+    {
+        let SpacesArgs::SpaceMembership {
+            space_dependencies,
+            auth_message_id,
+            direct_messages,
+            ..
+        } = space_message.args()
+        else {
+            panic!("unexpected message type");
         };
 
-        match args {
-            EncryptionArgs::System { dependencies, .. } => dependencies,
-            EncryptionArgs::Application { dependencies, .. } => dependencies,
+        // Sanity check.
+        assert_eq!(auth_message.id(), *auth_message_id);
+
+        // Check if there are any direct messages for me.
+        let my_direct_message = direct_messages
+            .iter()
+            .any(|message| message.recipient == my_id);
+
+        let encryption_args = match auth_message.payload().action {
+            // The auth message is "create" and so a corresponding "create" encryption control
+            // message is constructed containing only the next secret members.
+            AuthGroupAction::Create { .. } => {
+                let control_message = EncryptionControlMessage::Create {
+                    initial_members: next_members,
+                };
+                EncryptionArgs::System {
+                    dependencies: space_dependencies.to_owned(),
+                    control_message,
+                    direct_messages: direct_messages.clone(),
+                }
+            }
+            // The auth message is "add", if there is a direct message for us then use our ActorId
+            // for the added member, otherwise use the added members ActorId. Even if this is a
+            // group being added, meaning they won't actual be known to the DCGKA, we can use
+            // their id as the only thing we care about is making sure the direct messages are
+            // processed.
+            AuthGroupAction::Add { member, .. } => {
+                let control_message = if my_direct_message {
+                    EncryptionControlMessage::Add { added: my_id }
+                } else {
+                    EncryptionControlMessage::Add { added: member.id() }
+                };
+                EncryptionArgs::System {
+                    dependencies: space_dependencies.to_owned(),
+                    control_message,
+                    direct_messages: direct_messages.clone(),
+                }
+            }
+            // The auth message is "remove", if we were removed, then use our ActorId for the
+            // removed member, otherwise use the ActorId of the actual removed member (which may
+            // be an individual or group).
+            AuthGroupAction::Remove { member } => {
+                let removed = removed_members(current_members, next_members);
+                let control_message = if removed.contains(&my_id) {
+                    EncryptionControlMessage::Remove { removed: my_id }
+                } else {
+                    EncryptionControlMessage::Remove {
+                        removed: member.id(),
+                    }
+                };
+                EncryptionArgs::System {
+                    dependencies: space_dependencies.to_owned(),
+                    control_message,
+                    direct_messages: direct_messages.clone(),
+                }
+            }
+            _ => unimplemented!(),
+        };
+
+        EncryptionMessage::Forged {
+            author: space_message.author(),
+            operation_id: space_message.id(),
+            args: encryption_args,
         }
     }
 }
@@ -164,10 +222,9 @@ impl EncryptionOperation<ActorId, OperationId, EncryptionGroupMembership> for En
     }
 
     fn direct_messages(&self) -> Vec<EncryptionDirectMessage> {
-        let EncryptionMessage::Forged { args, .. } = self else {
-            // Nothing of this will ever be called at this stage where we're just preparing the
-            // arguments for a future message to be forged.
-            unreachable!();
+        let args = match self {
+            EncryptionMessage::Args(args) => args,
+            EncryptionMessage::Forged { args, .. } => args,
         };
 
         match args {

--- a/p2panda-spaces/src/encryption/message.rs
+++ b/p2panda-spaces/src/encryption/message.rs
@@ -7,6 +7,7 @@ use p2panda_encryption::traits::{GroupMessage as EncryptionOperation, GroupMessa
 
 use crate::encryption::dgm::EncryptionGroupMembership;
 use crate::message::{AuthoredMessage, SpacesArgs, SpacesMessage};
+use crate::traits::SpaceId;
 use crate::types::{ActorId, EncryptionControlMessage, EncryptionDirectMessage, OperationId};
 
 #[derive(Clone, Debug)]
@@ -36,9 +37,10 @@ pub enum EncryptionMessage {
 }
 
 impl EncryptionMessage {
-    pub(crate) fn from_membership<M, C>(space_message: &M) -> Vec<Self>
+    pub(crate) fn from_membership<ID, M, C>(space_message: &M) -> Vec<Self>
     where
-        M: AuthoredMessage + SpacesMessage<C>,
+        ID: SpaceId,
+        M: AuthoredMessage + SpacesMessage<ID, C>,
         C: Conditions,
     {
         let SpacesArgs::SpaceMembership {
@@ -68,9 +70,10 @@ impl EncryptionMessage {
             .collect()
     }
 
-    pub(crate) fn from_application<M, C>(space_message: &M) -> Self
+    pub(crate) fn from_application<ID, M, C>(space_message: &M) -> Self
     where
-        M: AuthoredMessage + SpacesMessage<C>,
+        ID: SpaceId,
+        M: AuthoredMessage + SpacesMessage<ID, C>,
         C: Conditions,
     {
         let SpacesArgs::Application {

--- a/p2panda-spaces/src/encryption/message.rs
+++ b/p2panda-spaces/src/encryption/message.rs
@@ -109,7 +109,7 @@ impl EncryptionMessage {
         assert_eq!(auth_message.id(), *auth_message_id);
 
         // Check if there are any direct messages for me.
-        let my_direct_message = direct_messages
+        let hash_my_direct_messages = direct_messages
             .iter()
             .any(|message| message.recipient == my_id);
 
@@ -132,7 +132,7 @@ impl EncryptionMessage {
             // their id as the only thing we care about is making sure the direct messages are
             // processed.
             AuthGroupAction::Add { member, .. } => {
-                let control_message = if my_direct_message {
+                let control_message = if hash_my_direct_messages {
                     EncryptionControlMessage::Add { added: my_id }
                 } else {
                     EncryptionControlMessage::Add { added: member.id() }

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::types::ActorId;
-
-pub enum Event {
-    Application { space_id: ActorId, data: Vec<u8> },
-    Removed { space_id: ActorId },
+pub enum Event<ID> {
+    Application { space_id: ID, data: Vec<u8> },
+    Removed { space_id: ID },
 }

--- a/p2panda-spaces/src/forge.rs
+++ b/p2panda-spaces/src/forge.rs
@@ -6,7 +6,7 @@ use p2panda_core::{PrivateKey, PublicKey};
 
 use crate::message::SpacesArgs;
 
-pub trait Forge<M, C> {
+pub trait Forge<ID, M, C> {
     type Error: Debug;
 
     fn public_key(&self) -> PublicKey;
@@ -21,11 +21,11 @@ pub trait Forge<M, C> {
     //
     // @TODO: Another thing is that we want to maybe detect key rotations as it means that people
     // will loose access to their spaces.
-    fn forge(&mut self, args: SpacesArgs<C>) -> impl Future<Output = Result<M, Self::Error>>;
+    fn forge(&mut self, args: SpacesArgs<ID, C>) -> impl Future<Output = Result<M, Self::Error>>;
 
     fn forge_ephemeral(
         &mut self,
         private_key: PrivateKey,
-        args: SpacesArgs<C>,
+        args: SpacesArgs<ID, C>,
     ) -> impl Future<Output = Result<M, Self::Error>>;
 }

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -20,9 +20,6 @@ use crate::types::{
     AuthResolver, EncryptionGroupError,
 };
 
-/// Encrypted data context with authorization boundary.
-///
-/// Only members with suitable access to the group can read and write to it.
 #[derive(Debug)]
 pub struct Group<S, F, M, C, RS> {
     /// Reference to the manager.

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -82,7 +82,7 @@ where
         let auth_message =
             Self::process_local_control(manager_ref.clone(), control_message).await?;
         let space_messages = manager_ref
-            .sync_spaces(&auth_message)
+            .apply_group_change_to_spaces(&auth_message)
             .await
             .map_err(|err| GroupError::SyncSpaces(auth_message.id(), format!("{err:?}")))?;
 
@@ -119,7 +119,7 @@ where
             Self::process_local_control(self.manager.clone(), control_message).await?;
         let space_messages = self
             .manager
-            .sync_spaces(&auth_message)
+            .apply_group_change_to_spaces(&auth_message)
             .await
             .map_err(|err| GroupError::SyncSpaces(auth_message.id(), format!("{err:?}")))?;
 
@@ -146,7 +146,7 @@ where
             Self::process_local_control(self.manager.clone(), control_message).await?;
         let space_messages = self
             .manager
-            .sync_spaces(&auth_message)
+            .apply_group_change_to_spaces(&auth_message)
             .await
             .map_err(|err| GroupError::SyncSpaces(auth_message.id(), format!("{err:?}")))?;
 

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -26,7 +26,7 @@ use crate::utils::{typed_member, typed_members};
 pub struct Group<ID, S, F, M, C, RS> {
     /// Reference to the manager.
     ///
-    /// This allows us build an API where users can treat "group" instances independently from the
+    /// This allows us to build an API where users can treat "group" instances independently from the
     /// manager API, even though internally it has a reference to it.
     manager: Manager<ID, S, F, M, C, RS>,
 

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -51,7 +51,6 @@ where
         }
     }
 
-    #[allow(clippy::result_large_err)]
     pub(crate) async fn create(
         manager_ref: Manager<ID, S, F, M, C, RS>,
         initial_members: Vec<(ActorId, Access<C>)>,
@@ -85,7 +84,6 @@ where
         ))
     }
 
-    #[allow(clippy::result_large_err)]
     pub(crate) async fn add(
         &self,
         member: ActorId,
@@ -107,7 +105,6 @@ where
         Ok(message)
     }
 
-    #[allow(clippy::result_large_err)]
     pub(crate) async fn remove(
         &self,
         member: ActorId,

--- a/p2panda-spaces/src/lib.rs
+++ b/p2panda-spaces/src/lib.rs
@@ -17,6 +17,7 @@ pub mod store;
 pub mod test_utils;
 #[cfg(test)]
 mod tests;
+pub mod traits;
 pub mod types;
 
 pub use types::{ActorId, OperationId};

--- a/p2panda-spaces/src/lib.rs
+++ b/p2panda-spaces/src/lib.rs
@@ -19,5 +19,6 @@ pub mod test_utils;
 mod tests;
 pub mod traits;
 pub mod types;
+pub mod utils;
 
 pub use types::{ActorId, OperationId};

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -59,8 +59,11 @@ pub(crate) struct ManagerInner<ID, S, F, M, C, RS> {
 impl<ID, S, F, M, C, RS> Manager<ID, S, F, M, C, RS>
 where
     ID: SpaceId,
-    S: SpaceStore<ID, M, C> + KeyStore + AuthStore<C> + MessageStore<M>,
-    F: Forge<ID, M, C>,
+    // @TODO: the Debug bound is required as we are string formatting the manager error in
+    // groups.rs due to challenges handling cyclical errors. If that issue is solved in a more
+    // satisfactory way then this bound can be removed.
+    S: SpaceStore<ID, M, C> + KeyStore + AuthStore<C> + MessageStore<M> + Debug,
+    F: Forge<ID, M, C> + Debug,
     M: AuthoredMessage + SpacesMessage<ID, C>,
     C: Conditions,
     // @TODO: Can we get rid of this Debug requirement here?

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -286,13 +286,12 @@ where
                         ));
                     };
 
-                    let auth_message = match message.args() {
+                    match message.args() {
                         SpacesArgs::Auth { .. } => AuthMessage::from_forged(&message),
                         _ => {
                             return Err(ManagerError::IncorrectMessageVariant(*auth_message_id));
                         }
-                    };
-                    auth_message
+                    }
                 };
 
                 let space = match self.space(*space_id).await? {

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -256,7 +256,7 @@ where
     /// This is required so that all spaces stay "in sync" with the shared auth state and produce
     /// any required encryption direct messages in order to correctly update a spaces' encryption
     /// state.
-    pub(crate) async fn sync_spaces(
+    pub(crate) async fn apply_group_change_to_spaces(
         &self,
         auth_message: &M,
     ) -> Result<Vec<M>, ManagerError<ID, S, F, M, C, RS>> {
@@ -275,7 +275,7 @@ where
                 panic!("expect space to exist");
             };
             let Some(message) = space
-                .sync_auth(auth_message)
+                .handle_auth_group_change(auth_message)
                 .await
                 .map_err(ManagerError::Space)?
             else {

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -250,7 +250,12 @@ where
         Ok(events)
     }
 
-    /// Sync all spaces with a shared auth state change.
+    /// Apply an auth message applied to the shared auth state to each space we know about
+    /// locally.
+    /// 
+    /// This is required so that all spaces stay "in sync" with the shared auth state and produce
+    /// any required encryption direct messages in order to correctly update a spaces' encryption
+    /// state.
     pub(crate) async fn sync_spaces(
         &self,
         auth_message: &M,
@@ -259,7 +264,7 @@ where
             let manager = self.inner.read().await;
             manager
                 .store
-                .spaces()
+                .spaces_ids()
                 .await
                 .map_err(ManagerError::SpaceStore)?
         };

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -252,7 +252,7 @@ where
 
     /// Apply an auth message applied to the shared auth state to each space we know about
     /// locally.
-    /// 
+    ///
     /// This is required so that all spaces stay "in sync" with the shared auth state and produce
     /// any required encryption direct messages in order to correctly update a spaces' encryption
     /// state.

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -118,7 +118,6 @@ where
         }
     }
 
-    #[allow(clippy::type_complexity, clippy::result_large_err)]
     pub async fn create_space(
         &self,
         id: ID,
@@ -131,7 +130,6 @@ where
         Ok((space, messages))
     }
 
-    #[allow(clippy::type_complexity, clippy::result_large_err)]
     pub async fn create_group(
         &self,
         initial_members: &[(ActorId, Access<C>)],

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -30,6 +30,7 @@ pub enum SpacesArgs<ID, C> {
     KeyBundle {
         // @TODO: Key bundle material.
     },
+
     /// System message containing an auth control message.
     Auth {
         /// "Control message" describing group operation ("add member", "remove member", etc.).
@@ -38,6 +39,9 @@ pub enum SpacesArgs<ID, C> {
         /// Auth dependencies. These are the latest heads of the global auth control message graph.
         auth_dependencies: Vec<OperationId>,
     },
+    
+    /// System message containing a reference to an `SpacesArgs::Auth` message and additional
+    /// fields for applying the resulting membership change to a specific space.
     SpaceMembership {
         /// Space this message should be applied to.
         space_id: ID,
@@ -58,6 +62,8 @@ pub enum SpacesArgs<ID, C> {
         /// message on this space.
         direct_messages: Vec<EncryptionDirectMessage>,
     },
+
+    /// Rotate the entropy for a space's encryption context.
     SpaceUpdate {
         /// Space this message should be applied to.
         space_id: ID,
@@ -68,6 +74,8 @@ pub enum SpacesArgs<ID, C> {
         /// Last known space operation graph tips.
         space_dependencies: Vec<OperationId>,
     },
+
+    /// An encrypted application message.
     Application {
         /// Space this message should be applied to.
         space_id: ID,

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -23,12 +23,12 @@ pub trait AuthoredMessage: Debug {
     // @TODO: Do we need a method here to check the signature?
 }
 
-pub trait SpacesMessage<C> {
-    fn args(&self) -> &SpacesArgs<C>;
+pub trait SpacesMessage<ID, C> {
+    fn args(&self) -> &SpacesArgs<ID, C>;
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum SpacesArgs<C> {
+pub enum SpacesArgs<ID, C> {
     /// System message, contains key bundle of the given author.
     ///
     /// Note: Applications should check if the key bundle was authored by the sender.
@@ -46,7 +46,7 @@ pub enum SpacesArgs<C> {
     },
     SpaceMembership {
         /// Space this message should be applied to.
-        space_id: ActorId,
+        space_id: ID,
 
         /// Group associated with this space from which group membership is derived.
         group_id: ActorId,
@@ -68,7 +68,7 @@ pub enum SpacesArgs<C> {
     },
     SpaceUpdate {
         /// Space this message should be applied to.
-        space_id: ActorId,
+        space_id: ID,
 
         /// Group associated with this space from which group membership is derived.
         group_id: ActorId,
@@ -78,7 +78,7 @@ pub enum SpacesArgs<C> {
     },
     Application {
         /// Space this message should be applied to.
-        space_id: ActorId,
+        space_id: ID,
 
         /// Last known space operation graph tips.
         space_dependencies: Vec<OperationId>,

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -35,7 +35,6 @@ pub enum SpacesArgs<ID, C> {
         /// "Control message" describing group operation ("add member", "remove member", etc.).
         control_message: AuthControlMessage<C>,
 
-        // @TODO: We eventually want application dependencies here too.
         /// Auth dependencies. These are the latest heads of the global auth control message graph.
         auth_dependencies: Vec<OperationId>,
     },

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -39,7 +39,7 @@ pub enum SpacesArgs<ID, C> {
         /// Auth dependencies. These are the latest heads of the global auth control message graph.
         auth_dependencies: Vec<OperationId>,
     },
-    
+
     /// System message containing a reference to an `SpacesArgs::Auth` message and additional
     /// fields for applying the resulting membership change to a specific space.
     SpaceMembership {

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -2,20 +2,16 @@
 
 use std::fmt::Debug;
 
-use p2panda_auth::traits::Conditions;
 use p2panda_encryption::crypto::xchacha20::XAeadNonce;
 use p2panda_encryption::data_scheme::GroupSecretId;
 use serde::{Deserialize, Serialize};
 
-use crate::auth::message::AuthArgs;
-use crate::encryption::message::EncryptionArgs;
-use crate::space::secret_members;
-use crate::types::{
-    ActorId, AuthGroupAction, EncryptionControlMessage, EncryptionDirectMessage, OperationId,
+use crate::{
+    encryption::message::{EncryptionArgs, EncryptionMessage},
+    types::{
+        ActorId, AuthControlMessage, EncryptionControlMessage, EncryptionDirectMessage, OperationId,
+    },
 };
-
-use p2panda_auth::Access;
-use p2panda_auth::group::GroupMember;
 
 // @TODO: This could be an interesting trait for `p2panda-core`, next to another one where we
 // declare dependencies.
@@ -39,41 +35,56 @@ pub enum SpacesArgs<C> {
     KeyBundle {
         // @TODO: Key bundle material.
     },
-
-    /// System message containing a space- or group control message.
-    ControlMessage {
-        /// Space- or group id.
-        id: ActorId,
-
+    /// System message containing an auth control message.
+    Auth {
         /// "Control message" describing group operation ("add member", "remove member", etc.).
-        control_message: ControlMessage<C>,
+        control_message: AuthControlMessage<C>,
 
         // @TODO: We eventually want application dependencies here too.
         /// Auth dependencies. These are the latest heads of the global auth control message graph.
         auth_dependencies: Vec<OperationId>,
-
-        /// Encryption dependencies. These are the latest heads of the encryption control
-        /// and application message graph.
-        encryption_dependencies: Vec<OperationId>,
-
-        /// Encrypted, direct messages to members in the group, used for key agreement.
-        direct_messages: Vec<EncryptionDirectMessage>,
     },
-
-    /// Encrypted application message used inside a space.
-    Application {
-        /// Space this message was encrypted for. Members in that space should be able to decrypt
-        /// it.
+    SpaceMembership {
+        /// Space this message should be applied to.
         space_id: ActorId,
+
+        /// Group associated with this space from which group membership is derived.
+        group_id: ActorId,
+
+        /// Last known space operation graph tips.
+        space_dependencies: Vec<OperationId>,
+
+        /// Reference to (global/shared) auth message which should be applied to the (local) space
+        /// state.
+        ///
+        /// This is a dependency and should be considered when ordering space messages.
+        auth_message_id: OperationId,
+
+        /// The control messages which should be applied to the spaces' group encryption state.
+        ///
+        /// // @TODO: need to clarify validation requirements when assuring the control messages
+        /// // match the related auth message.
+        control_messages: Vec<SpaceMembershipControlMessage>,
+    },
+    SpaceUpdate {
+        /// Space this message should be applied to.
+        space_id: ActorId,
+
+        /// Group associated with this space from which group membership is derived.
+        group_id: ActorId,
+
+        /// Last known space operation graph tips.
+        space_dependencies: Vec<OperationId>,
+    },
+    Application {
+        /// Space this message should be applied to.
+        space_id: ActorId,
+
+        /// Last known space operation graph tips.
+        space_dependencies: Vec<OperationId>,
 
         /// Used key id for AEAD.
         group_secret_id: GroupSecretId,
-
-        // @TODO: We probably also want auth dependencies here too.
-        // auth_dependencies: Vec<OperationId>,
-        /// Encryption dependencies. These are the latest heads of the encryption control
-        /// and application message graph.
-        encryption_dependencies: Vec<OperationId>,
 
         /// Used nonce for AEAD.
         nonce: XAeadNonce,
@@ -83,213 +94,79 @@ pub enum SpacesArgs<C> {
     },
 }
 
-impl<C> SpacesArgs<C>
-where
-    C: Conditions,
-{
-    pub(crate) fn from_args(
-        group_id: ActorId,
-        auth_args: Option<AuthArgs<C>>,
-        encryption_args: Option<EncryptionArgs>,
-    ) -> Self {
-        let (encryption_action, encryption_dependencies, direct_messages) = match encryption_args {
-            Some(EncryptionArgs::System {
-                control_message,
-                dependencies,
-                direct_messages,
-            }) => (Some(control_message), dependencies, direct_messages),
-            None => (None, Vec::new(), Vec::new()),
-            Some(EncryptionArgs::Application {
-                dependencies,
-                group_secret_id,
-                nonce,
-                ciphertext,
-            }) => {
-                return Self::from_application_args(
-                    group_id,
-                    group_secret_id,
-                    nonce,
-                    ciphertext,
-                    dependencies,
-                );
-            }
-        };
-
-        let (auth_action, auth_dependencies) = match auth_args {
-            Some(args) => (Some(args.control_message.action), args.dependencies),
-            None => (None, vec![]),
-        };
-
-        match (auth_action, encryption_action) {
-            (None, Some(encryption_control_message)) => {
-                Self::from_encryption_args(group_id, encryption_control_message, direct_messages)
-            }
-            (Some(auth_action), None) => {
-                Self::from_auth_args(group_id, auth_action, auth_dependencies)
-            }
-            (Some(auth_action), Some(encryption_control_message)) => Self::from_both_args(
-                group_id,
-                auth_action,
-                auth_dependencies,
-                encryption_control_message,
-                encryption_dependencies,
-                direct_messages,
-            ),
-            _ => panic!("invalid arguments"),
-        }
-    }
-
-    fn from_application_args(
-        space_id: ActorId,
-        group_secret_id: GroupSecretId,
-        nonce: XAeadNonce,
-        ciphertext: Vec<u8>,
-        encryption_dependencies: Vec<OperationId>,
-    ) -> Self {
-        Self::Application {
-            space_id,
-            group_secret_id,
-            nonce,
-            ciphertext,
-            encryption_dependencies,
-        }
-    }
-
-    fn from_auth_args(
-        group_id: ActorId,
-        auth_action: AuthGroupAction<C>,
-        auth_dependencies: Vec<OperationId>,
-    ) -> Self {
-        Self::ControlMessage {
-            id: group_id,
-            control_message: ControlMessage::from_auth_action(&auth_action),
-            auth_dependencies,
-            encryption_dependencies: vec![],
-            direct_messages: vec![],
-        }
-    }
-
-    // @TODO: Handle encryption-only cases ("update")
-    fn from_encryption_args(
-        _group_id: ActorId,
-        _control_message: EncryptionControlMessage,
-        _direct_messages: Vec<EncryptionDirectMessage>,
-    ) -> Self {
-        todo!();
-    }
-
-    fn from_both_args(
-        group_id: ActorId,
-        auth_action: AuthGroupAction<C>,
-        auth_dependencies: Vec<OperationId>,
-        encryption_control_message: EncryptionControlMessage,
-        encryption_dependencies: Vec<OperationId>,
-        direct_messages: Vec<EncryptionDirectMessage>,
-    ) -> Self {
-        let control_message = match (&auth_action, &encryption_control_message) {
-            (AuthGroupAction::Create { .. }, EncryptionControlMessage::Create { .. }) => {
-                ControlMessage::from_auth_action(&auth_action)
-            }
-            (AuthGroupAction::Add { .. }, EncryptionControlMessage::Add { .. }) => {
-                ControlMessage::from_auth_action(&auth_action)
-            }
-            (AuthGroupAction::Remove { .. }, EncryptionControlMessage::Remove { .. }) => {
-                ControlMessage::from_auth_action(&auth_action)
-            }
-            _ => unimplemented!(), // @TODO: More cases will go here. Panic on invalid ones.
-        };
-
-        Self::ControlMessage {
-            id: group_id,
-            control_message,
-            auth_dependencies,
-            encryption_dependencies,
-            direct_messages,
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-// @TODO: Clone is a requirement in reflection where SpacesArgs are implemented
-// as p2panda Extensions where Clone is a trait bound. Because of this Clone
-// needed to be moved out from behind the test_utils feature flag.
-//
-// #[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
-pub enum ControlMessage<C> {
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum SpaceMembershipControlMessage {
     Create {
-        // GroupMember is required for understanding if a public key / actor id is an individual or
-        // a group in case we're adding something with only pull-access. In that case that actor
-        // doesn't need to publish a key bundle and every receiver will not strictly be able to
-        // verify if it's _really_ a group or individual.
-        //
-        // In any other case we always want to verify if the group member type is correct.
-        initial_members: Vec<(GroupMember<ActorId>, Access<C>)>,
+        initial_members: Vec<ActorId>,
+        direct_messages: Vec<EncryptionDirectMessage>,
     },
     Add {
-        member: GroupMember<ActorId>,
-
-        access: Access<C>,
+        added: ActorId,
+        direct_messages: Vec<EncryptionDirectMessage>,
     },
     Remove {
-        member: GroupMember<ActorId>,
-    }, // @TODO: introduce all other variants.
+        removed: ActorId,
+        direct_messages: Vec<EncryptionDirectMessage>,
+    },
 }
 
-impl<C> ControlMessage<C>
-where
-    C: Conditions,
-{
-    pub fn is_create(&self) -> bool {
-        matches!(self, ControlMessage::Create { .. })
-    }
-
-    pub(crate) fn to_auth_action(&self) -> AuthGroupAction<C> {
+impl SpaceMembershipControlMessage {
+    pub(crate) fn direct_messages(&self) -> &Vec<EncryptionDirectMessage> {
         match self {
-            ControlMessage::Create { initial_members } => AuthGroupAction::Create {
-                initial_members: initial_members.to_owned(),
-            },
-            ControlMessage::Add { member, access } => AuthGroupAction::Add {
-                member: member.to_owned(),
-                access: access.to_owned(),
-            },
-            ControlMessage::Remove { member } => AuthGroupAction::Remove {
-                member: member.to_owned(),
-            },
+            SpaceMembershipControlMessage::Create {
+                direct_messages, ..
+            } => direct_messages,
+            SpaceMembershipControlMessage::Add {
+                direct_messages, ..
+            } => direct_messages,
+            SpaceMembershipControlMessage::Remove {
+                direct_messages, ..
+            } => direct_messages,
         }
     }
 
-    // @TODO: The spaces control message will later contain an array of encryption control
-    // messages and so this method will return an array. It will contain only the changes caused
-    // by the spaces control message which effect the secret group membership.
-    pub(crate) fn to_encryption_control_message(&self) -> Option<EncryptionControlMessage> {
-        match self {
-            ControlMessage::Create { initial_members } => Some(EncryptionControlMessage::Create {
-                initial_members: secret_members(
-                    initial_members
-                        .iter()
-                        .map(|(member, access)| (member.id(), access.clone()))
-                        .collect(),
-                ),
-            }),
-            ControlMessage::Add { member, access } if !access.is_pull() => {
-                Some(EncryptionControlMessage::Add { added: member.id() })
+    pub(crate) fn encryption_control_message(&self) -> EncryptionControlMessage {
+        match self.to_owned() {
+            SpaceMembershipControlMessage::Create {
+                initial_members, ..
+            } => EncryptionControlMessage::Create { initial_members },
+            SpaceMembershipControlMessage::Add { added, .. } => {
+                EncryptionControlMessage::Add { added }
             }
-            ControlMessage::Add { access, .. } if access.is_pull() => None,
-            ControlMessage::Remove { member } => Some(EncryptionControlMessage::Remove {
-                removed: member.id(),
-            }),
-            _ => unimplemented!(),
+            SpaceMembershipControlMessage::Remove { removed, .. } => {
+                EncryptionControlMessage::Remove { removed }
+            }
         }
     }
 
-    pub(crate) fn from_auth_action(action: &AuthGroupAction<C>) -> Self {
-        match action.clone() {
-            AuthGroupAction::Create { initial_members } => {
-                ControlMessage::Create { initial_members }
+    pub(crate) fn from_encryption_message(encryption_message: &EncryptionMessage) -> Self {
+        let EncryptionMessage::Args(args) = encryption_message else {
+            panic!("unexpected message type")
+        };
+        let EncryptionArgs::System {
+            control_message,
+            direct_messages,
+            ..
+        } = args.to_owned()
+        else {
+            panic!("unexpected message type")
+        };
+        match control_message {
+            EncryptionControlMessage::Create { initial_members } => {
+                SpaceMembershipControlMessage::Create {
+                    initial_members,
+                    direct_messages,
+                }
             }
-            AuthGroupAction::Add { member, access } => ControlMessage::Add { member, access },
-            AuthGroupAction::Remove { member } => ControlMessage::Remove { member },
-            _ => unimplemented!(), // @TODO: More cases will go here. Panic on invalid ones.
+            EncryptionControlMessage::Add { added } => SpaceMembershipControlMessage::Add {
+                added,
+                direct_messages,
+            },
+            EncryptionControlMessage::Remove { removed } => SpaceMembershipControlMessage::Remove {
+                removed,
+                direct_messages,
+            },
+            _ => panic!("unexpected message type"),
         }
     }
 }

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -471,7 +471,7 @@ where
     }
 
     /// Sync a shared auth state change with this space.
-    pub(crate) async fn sync_auth(
+    pub(crate) async fn handle_auth_group_change(
         &self,
         auth_message: &M,
     ) -> Result<Option<M>, SpaceError<ID, S, F, M, C, RS>> {

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -143,9 +143,9 @@ where
         group.remove(member).await.map_err(SpaceError::Group)
     }
 
-    /// Wrap an already forged auth message in a space message and apply any required group
-    /// membership changes to the encryption group context. Any resulting encryption control
-    /// messages are published on the space message alongside a reference to the auth message.
+    /// Forge a space message from an already existing auth message and apply any resulting group
+    /// membership changes. Any resulting encryption direct messages are included in the space
+    /// message alongside a reference to the auth message.
     pub(crate) async fn process_auth_message(
         manager_ref: Manager<ID, S, F, M, C, RS>,
         mut y: SpaceState<ID, M, C>,

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -61,7 +61,6 @@ where
         }
     }
 
-    #[allow(clippy::result_large_err)]
     pub(crate) async fn create(
         manager_ref: Manager<ID, S, F, M, C, RS>,
         space_id: ID,
@@ -116,7 +115,6 @@ where
         ))
     }
 
-    #[allow(clippy::result_large_err)]
     pub(crate) async fn add(
         &self,
         member: ActorId,
@@ -132,7 +130,6 @@ where
         Ok(vec![auth_message, space_message])
     }
 
-    #[allow(clippy::result_large_err)]
     pub(crate) async fn remove(
         &self,
         member: ActorId,

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -49,8 +49,8 @@ pub struct Space<ID, S, F, M, C, RS> {
 impl<ID, S, F, M, C, RS> Space<ID, S, F, M, C, RS>
 where
     ID: SpaceId,
-    S: SpaceStore<ID, M, C> + KeyStore + AuthStore<C> + MessageStore<M>,
-    F: Forge<ID, M, C>,
+    S: SpaceStore<ID, M, C> + KeyStore + AuthStore<C> + MessageStore<M> + Debug,
+    F: Forge<ID, M, C> + Debug,
     M: AuthoredMessage + SpacesMessage<ID, C>,
     C: Conditions,
     RS: Debug + AuthResolver<C>,

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 
 use p2panda_auth::Access;
 use p2panda_auth::traits::{Conditions, Operation};
+use p2panda_encryption::traits::GroupMessage;
 use p2panda_encryption::{Rng, RngError};
 use petgraph::algo::toposort;
 use thiserror::Error;
@@ -19,13 +20,13 @@ use crate::event::Event;
 use crate::forge::Forge;
 use crate::group::{Group, GroupError};
 use crate::manager::Manager;
-use crate::message::{AuthoredMessage, SpaceMembershipControlMessage, SpacesArgs, SpacesMessage};
+use crate::message::{AuthoredMessage, SpacesArgs, SpacesMessage};
 use crate::store::{AuthStore, KeyStore, MessageStore, SpaceStore};
 use crate::traits::SpaceId;
 use crate::types::{
     ActorId, AuthGroup, AuthGroupAction, AuthGroupError, AuthGroupState, AuthResolver,
-    EncryptionGroup, EncryptionGroupError, EncryptionGroupOutput, EncryptionGroupState,
-    OperationId,
+    EncryptionDirectMessage, EncryptionGroup, EncryptionGroupError, EncryptionGroupOutput,
+    EncryptionGroupState, OperationId,
 };
 
 /// Encrypted data context with authorization boundary.
@@ -165,7 +166,7 @@ where
         let next_members = secret_members(y.auth_y.members(y.group_id));
 
         // Process the change of membership on encryption the context.
-        let (encryption_y, encryption_messages) = if current_members != next_members {
+        let (encryption_y, direct_messages) = if current_members != next_members {
             let manager = manager_ref.inner.read().await;
             Self::apply_secret_member_change(
                 y.encryption_y,
@@ -183,17 +184,12 @@ where
         // Construct space message and sign it in the forge (F)
         let dependencies: Vec<OperationId> = y.encryption_y.orderer.heads().to_vec();
         let space_message = {
-            let control_messages = encryption_messages
-                .iter()
-                .map(SpaceMembershipControlMessage::from_encryption_message)
-                .collect();
-
             let args = SpacesArgs::SpaceMembership {
                 space_id: y.space_id,
                 group_id: y.group_id,
                 space_dependencies: dependencies.clone(),
                 auth_message_id: auth_message.id(),
-                control_messages,
+                direct_messages,
             };
 
             let mut manager = manager_ref.inner.write().await;
@@ -286,7 +282,7 @@ where
                 space_id: y.space_id,
                 group_id: y.group_id,
                 auth_message_id: operation.id(),
-                control_messages: vec![],
+                direct_messages: vec![],
                 space_dependencies,
             };
             let message = manager.forge.forge(args).await.map_err(SpaceError::Forge)?;
@@ -313,40 +309,42 @@ where
         let SpacesArgs::SpaceMembership {
             group_id,
             space_dependencies,
-            auth_message_id,
             ..
         } = space_message.args()
         else {
             panic!("unexpected message type");
         };
 
-        // Sanity check.
-        assert_eq!(auth_message.id(), *auth_message_id);
-
-        // Process auth message on local auth state.
+        // Get space state and current members.
         let mut y = Self::get_or_init_state(self.id, *group_id, self.manager.clone()).await?;
+        let current_members = secret_members(y.auth_y.members(y.group_id));
+
+        // Process auth message on space auth state.
         y.auth_y = AuthGroup::process(y.auth_y, auth_message).map_err(SpaceError::AuthGroup)?;
         y.processed_auth.insert(auth_message.id());
 
-        // Process encryption messages.
-        let encryption_messages = EncryptionMessage::from_membership(space_message);
-        let mut encryption_output = vec![];
-        for encryption_message in encryption_messages {
-            // Make encryption DGM aware of current auth members state.
-            let group_members = y.auth_y.members(y.group_id);
-            let secret_members = secret_members(group_members);
-            y.encryption_y.dcgka.dgm = EncryptionMembershipState {
-                members: HashSet::from_iter(secret_members.into_iter()),
-            };
+        // Get next space members.
+        let next_members = secret_members(y.auth_y.members(y.group_id));
 
-            let (encryption_y, encryption_output_inner) =
-                EncryptionGroup::receive(y.encryption_y, &encryption_message)
-                    .map_err(SpaceError::EncryptionGroup)?;
+        // Make the dgm aware of the new space members.
+        y.encryption_y.dcgka.dgm.members = HashSet::from_iter(next_members.clone());
 
-            encryption_output.extend(encryption_output_inner);
+        // Construct encryption message.
+        let my_id = self.manager.id().await;
+        let encryption_message = EncryptionMessage::from_membership(
+            space_message,
+            my_id,
+            auth_message,
+            current_members,
+            next_members,
+        );
 
-            y.encryption_y = encryption_y
-        }
+        // Process encryption message.
+        let (encryption_y, encryption_output) =
+            EncryptionGroup::receive(y.encryption_y, &encryption_message)
+                .map_err(SpaceError::EncryptionGroup)?;
+
+        y.encryption_y = encryption_y;
 
         // Persist new space state.
         {
@@ -365,33 +363,33 @@ where
 
     /// Apply a group membership change to the group encryption state.
     ///
-    /// The difference between the current and next secret group members (those with "read"
-    /// access) is computed and only the diff processed on the encryption group.
-    ///
-    /// If it is a group being removed/added to the encryption context, then one encryption
-    /// control message for each actor (individual) will be generated.
+    /// For "add" and "remove" actions, the difference between the current and next secret group
+    /// members (those with "read" access) is computed and only the diff processed on the
+    /// encryption group.
     async fn apply_secret_member_change(
         mut encryption_y: EncryptionGroupState<M>,
         auth_message: &AuthMessage<C>,
         current_members: Vec<ActorId>,
         next_members: Vec<ActorId>,
         rng: &Rng,
-    ) -> Result<(EncryptionGroupState<M>, Vec<EncryptionMessage>), SpaceError<ID, S, F, M, C, RS>>
-    {
+    ) -> Result<
+        (EncryptionGroupState<M>, Vec<EncryptionDirectMessage>),
+        SpaceError<ID, S, F, M, C, RS>,
+    > {
         // Make the DGM aware of group members after this group membership change has been
         // processed.
         encryption_y.dcgka.dgm = EncryptionMembershipState {
             members: HashSet::from_iter(next_members.clone().into_iter()),
         };
 
-        let mut messages = vec![];
+        let mut direct_messages = vec![];
         let encryption_y = {
             match &auth_message.payload().action {
                 AuthGroupAction::Create { .. } => {
                     let (encryption_y, message) =
                         EncryptionGroup::create(encryption_y, next_members.clone(), rng)
                             .map_err(SpaceError::EncryptionGroup)?;
-                    messages.push(message);
+                    direct_messages.extend(message.direct_messages());
                     encryption_y
                 }
                 AuthGroupAction::Add { .. } => {
@@ -406,7 +404,7 @@ where
                             EncryptionGroup::add(encryption_y, added, rng)
                                 .map_err(SpaceError::EncryptionGroup)?;
                         encryption_y = encryption_y_inner;
-                        messages.push(message);
+                        direct_messages.extend(message.direct_messages());
                     }
                     encryption_y
                 }
@@ -422,7 +420,7 @@ where
                             EncryptionGroup::remove(encryption_y, removed, rng)
                                 .map_err(SpaceError::EncryptionGroup)?;
                         encryption_y = encryption_y_inner;
-                        messages.push(message);
+                        direct_messages.extend(message.direct_messages());
                     }
                     encryption_y
                 }
@@ -430,7 +428,7 @@ where
             }
         };
 
-        Ok((encryption_y, messages))
+        Ok((encryption_y, direct_messages))
     }
 
     /// Handle space application messages.

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -328,7 +328,7 @@ where
                 };
 
                 let (encryption_y, encryption_output_inner) =
-                    EncryptionGroup::receive(y.encryption_y, &encryption_message)
+                    EncryptionGroup::receive(y.encryption_y, encryption_message)
                         .map_err(SpaceError::EncryptionGroup)?;
 
                 encryption_output.extend(encryption_output_inner);

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -739,7 +739,7 @@ where
     S: SpaceStore<ID, M, C> + KeyStore + AuthStore<C> + MessageStore<M>,
     F: Forge<ID, M, C>,
     C: Conditions,
-    RS: AuthResolver<C>,
+    RS: AuthResolver<C> + Debug,
 {
     #[error(transparent)]
     Rng(#[from] RngError),

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -235,7 +235,8 @@ where
             SpacesArgs::KeyBundle {} => unreachable!("can't process key bundles here"),
             SpacesArgs::SpaceMembership { space_id, .. } => {
                 assert_eq!(space_id, &self.id); // Sanity check.
-                let auth_message = auth_message.expect("all space membership messages have auth message");
+                let auth_message =
+                    auth_message.expect("all space membership messages have auth message");
                 self.handle_membership_message(space_message, auth_message)
                     .await?
             }
@@ -311,7 +312,7 @@ where
     ) -> Result<Vec<Event<ID>>, SpaceError<ID, S, F, M, C, RS>> {
         let SpacesArgs::SpaceMembership {
             group_id,
-            space_dependencies, 
+            space_dependencies,
             auth_message_id,
             ..
         } = space_message.args()

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -237,7 +237,7 @@ where
             }
             SpacesArgs::Application { space_id, .. } => {
                 assert_eq!(space_id, &self.id); // Sanity check.
-                self.handle_application_message(&space_message).await?
+                self.handle_application_message(space_message).await?
             }
             _ => panic!("unexpected message"),
         };
@@ -348,7 +348,7 @@ where
             let mut manager = self.manager.inner.write().await;
             y.encryption_y
                 .orderer
-                .add_dependency(space_message.id(), &space_dependencies);
+                .add_dependency(space_message.id(), space_dependencies);
             manager
                 .store
                 .set_space(&self.id, y)

--- a/p2panda-spaces/src/store.rs
+++ b/p2panda-spaces/src/store.rs
@@ -25,7 +25,7 @@ where
 
     fn has_space(&self, id: &ID) -> impl Future<Output = Result<bool, Self::Error>>;
 
-    fn spaces(&self) -> impl Future<Output = Result<Vec<ID>, Self::Error>>;
+    fn spaces_ids(&self) -> impl Future<Output = Result<Vec<ID>, Self::Error>>;
 
     fn set_space(
         &mut self,

--- a/p2panda-spaces/src/store.rs
+++ b/p2panda-spaces/src/store.rs
@@ -64,5 +64,9 @@ pub trait MessageStore<M> {
 
     fn message(&self, id: &OperationId) -> impl Future<Output = Result<Option<M>, Self::Error>>;
 
-    fn set_message(&mut self, id: &OperationId, message: &M) -> impl Future<Output = Result<(), Self::Error>>;
+    fn set_message(
+        &mut self,
+        id: &OperationId,
+        message: &M,
+    ) -> impl Future<Output = Result<(), Self::Error>>;
 }

--- a/p2panda-spaces/src/store.rs
+++ b/p2panda-spaces/src/store.rs
@@ -6,23 +6,27 @@ use p2panda_auth::traits::Conditions;
 use p2panda_encryption::key_manager::KeyManagerState;
 use p2panda_encryption::key_registry::KeyRegistryState;
 
+use crate::OperationId;
 use crate::space::SpaceState;
 use crate::types::{ActorId, AuthGroupState};
 
-pub trait SpaceStore<M> {
+pub trait SpaceStore<M, C>
+where
+    C: Conditions,
+{
     type Error: Debug;
 
     fn space(
         &self,
         id: &ActorId,
-    ) -> impl Future<Output = Result<Option<SpaceState<M>>, Self::Error>>;
+    ) -> impl Future<Output = Result<Option<SpaceState<M, C>>, Self::Error>>;
 
     fn has_space(&self, id: &ActorId) -> impl Future<Output = Result<bool, Self::Error>>;
 
     fn set_space(
         &mut self,
         id: &ActorId,
-        y: SpaceState<M>,
+        y: SpaceState<M, C>,
     ) -> impl Future<Output = Result<(), Self::Error>>;
 }
 
@@ -53,4 +57,12 @@ where
     fn auth(&self) -> impl Future<Output = Result<AuthGroupState<C>, Self::Error>>;
 
     fn set_auth(&mut self, y: &AuthGroupState<C>) -> impl Future<Output = Result<(), Self::Error>>;
+}
+
+pub trait MessageStore<M> {
+    type Error: Debug;
+
+    fn message(&self, id: &OperationId) -> impl Future<Output = Result<Option<M>, Self::Error>>;
+
+    fn set_message(&mut self, id: &OperationId, message: &M) -> impl Future<Output = Result<(), Self::Error>>;
 }

--- a/p2panda-spaces/src/store.rs
+++ b/p2panda-spaces/src/store.rs
@@ -8,25 +8,27 @@ use p2panda_encryption::key_registry::KeyRegistryState;
 
 use crate::OperationId;
 use crate::space::SpaceState;
+use crate::traits::SpaceId;
 use crate::types::{ActorId, AuthGroupState};
 
-pub trait SpaceStore<M, C>
+pub trait SpaceStore<ID, M, C>
 where
+    ID: SpaceId,
     C: Conditions,
 {
     type Error: Debug;
 
     fn space(
         &self,
-        id: &ActorId,
-    ) -> impl Future<Output = Result<Option<SpaceState<M, C>>, Self::Error>>;
+        id: &ID,
+    ) -> impl Future<Output = Result<Option<SpaceState<ID, M, C>>, Self::Error>>;
 
-    fn has_space(&self, id: &ActorId) -> impl Future<Output = Result<bool, Self::Error>>;
+    fn has_space(&self, id: &ID) -> impl Future<Output = Result<bool, Self::Error>>;
 
     fn set_space(
         &mut self,
-        id: &ActorId,
-        y: SpaceState<M, C>,
+        id: &ID,
+        y: SpaceState<ID, M, C>,
     ) -> impl Future<Output = Result<(), Self::Error>>;
 }
 

--- a/p2panda-spaces/src/store.rs
+++ b/p2panda-spaces/src/store.rs
@@ -25,6 +25,8 @@ where
 
     fn has_space(&self, id: &ID) -> impl Future<Output = Result<bool, Self::Error>>;
 
+    fn spaces(&self) -> impl Future<Output = Result<Vec<ID>, Self::Error>>;
+
     fn set_space(
         &mut self,
         id: &ID,

--- a/p2panda-spaces/src/test_utils.rs
+++ b/p2panda-spaces/src/test_utils.rs
@@ -66,6 +66,10 @@ where
         Ok(self.spaces.contains_key(id))
     }
 
+    async fn spaces(&self) -> Result<Vec<ID>, Self::Error> {
+        Ok(self.spaces.keys().cloned().collect())
+    }
+
     async fn set_space(&mut self, id: &ID, y: SpaceState<ID, M, C>) -> Result<(), Self::Error> {
         self.spaces.insert(*id, y);
         Ok(())

--- a/p2panda-spaces/src/test_utils.rs
+++ b/p2panda-spaces/src/test_utils.rs
@@ -66,7 +66,7 @@ where
         Ok(self.spaces.contains_key(id))
     }
 
-    async fn spaces(&self) -> Result<Vec<ID>, Self::Error> {
+    async fn spaces_ids(&self) -> Result<Vec<ID>, Self::Error> {
         Ok(self.spaces.keys().cloned().collect())
     }
 

--- a/p2panda-spaces/src/test_utils.rs
+++ b/p2panda-spaces/src/test_utils.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::hash::Hash;
 
 use p2panda_auth::traits::Conditions;
 use p2panda_encryption::key_manager::{KeyManager, KeyManagerState};
@@ -11,22 +12,24 @@ use p2panda_encryption::traits::PreKeyManager;
 use crate::OperationId;
 use crate::space::SpaceState;
 use crate::store::{AuthStore, KeyStore, MessageStore, SpaceStore};
+use crate::traits::SpaceId;
 use crate::types::{ActorId, AuthGroupState};
 
 #[derive(Debug)]
-pub struct MemoryStore<M, C>
+pub struct MemoryStore<ID, M, C>
 where
     C: Conditions,
 {
     key_manager: KeyManagerState,
     key_registry: KeyRegistryState<ActorId>,
     auth: AuthGroupState<C>,
-    spaces: HashMap<ActorId, SpaceState<M, C>>,
+    spaces: HashMap<ID, SpaceState<ID, M, C>>,
     messages: HashMap<OperationId, M>,
 }
 
-impl<M, C> MemoryStore<M, C>
+impl<ID, M, C> MemoryStore<ID, M, C>
 where
+    ID: SpaceId,
     C: Conditions,
 {
     pub fn new(my_id: ActorId, key_manager: KeyManagerState, auth: AuthGroupState<C>) -> Self {
@@ -47,29 +50,31 @@ where
     }
 }
 
-impl<M, C> SpaceStore<M, C> for MemoryStore<M, C>
+impl<ID, M, C> SpaceStore<ID, M, C> for MemoryStore<ID, M, C>
 where
+    ID: SpaceId + Hash,
     M: Clone,
     C: Conditions,
 {
     type Error = Infallible;
 
-    async fn space(&self, id: &ActorId) -> Result<Option<SpaceState<M, C>>, Self::Error> {
+    async fn space(&self, id: &ID) -> Result<Option<SpaceState<ID, M, C>>, Self::Error> {
         Ok(self.spaces.get(id).cloned())
     }
 
-    async fn has_space(&self, id: &ActorId) -> Result<bool, Self::Error> {
+    async fn has_space(&self, id: &ID) -> Result<bool, Self::Error> {
         Ok(self.spaces.contains_key(id))
     }
 
-    async fn set_space(&mut self, id: &ActorId, y: SpaceState<M, C>) -> Result<(), Self::Error> {
+    async fn set_space(&mut self, id: &ID, y: SpaceState<ID, M, C>) -> Result<(), Self::Error> {
         self.spaces.insert(*id, y);
         Ok(())
     }
 }
 
-impl<M, C> KeyStore for MemoryStore<M, C>
+impl<ID, M, C> KeyStore for MemoryStore<ID, M, C>
 where
+    ID: SpaceId,
     C: Conditions,
 {
     type Error = Infallible;
@@ -93,8 +98,9 @@ where
     }
 }
 
-impl<M, C> AuthStore<C> for MemoryStore<M, C>
+impl<ID, M, C> AuthStore<C> for MemoryStore<ID, M, C>
 where
+    ID: SpaceId,
     C: Conditions,
 {
     type Error = Infallible;
@@ -109,8 +115,9 @@ where
     }
 }
 
-impl<M, C> MessageStore<M> for MemoryStore<M, C>
+impl<ID, M, C> MessageStore<M> for MemoryStore<ID, M, C>
 where
+    ID: SpaceId,
     M: Clone,
     C: Conditions,
 {

--- a/p2panda-spaces/src/test_utils.rs
+++ b/p2panda-spaces/src/test_utils.rs
@@ -8,10 +8,10 @@ use p2panda_encryption::key_manager::{KeyManager, KeyManagerState};
 use p2panda_encryption::key_registry::{KeyRegistry, KeyRegistryState};
 use p2panda_encryption::traits::PreKeyManager;
 
+use crate::OperationId;
 use crate::space::SpaceState;
 use crate::store::{AuthStore, KeyStore, MessageStore, SpaceStore};
 use crate::types::{ActorId, AuthGroupState};
-use crate::OperationId;
 
 #[derive(Debug)]
 pub struct MemoryStore<M, C>
@@ -115,11 +115,11 @@ where
     C: Conditions,
 {
     type Error = Infallible;
-    
+
     async fn message(&self, id: &OperationId) -> Result<Option<M>, Self::Error> {
         Ok(self.messages.get(id).cloned())
     }
-    
+
     async fn set_message(&mut self, id: &OperationId, message: &M) -> Result<(), Self::Error> {
         self.messages.insert(*id, message.clone());
         Ok(())

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -466,6 +466,37 @@ async fn add_member_to_space() {
 }
 
 #[tokio::test]
+async fn register_key_bundles_after_space_creation() {
+    let alice = TestPeer::new(0);
+    let bob = <TestPeer>::new(1);
+
+    let manager = alice.manager.clone();
+
+    // Create Space
+    // ~~~~~~~~~~~~
+
+    let space_id = 0;
+    let (space, _) = manager.create_space(space_id, &[]).await.unwrap();
+    drop(space);
+
+    // Register key bundles _after_ the space was already created
+    // ~~~~~~~~~~~~
+
+    alice
+        .manager
+        .register_member(&bob.manager.me().await.unwrap())
+        .await
+        .unwrap();
+
+    // Add new member to Space
+    // ~~~~~~~~~~~~
+    let space = manager.space(space_id).await.unwrap().unwrap();
+    let result = space.add(bob.manager.id().await, Access::read()).await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
 async fn send_and_receive_after_add() {
     let alice = TestPeer::new(0);
     let bob = TestPeer::new(1);

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -1019,11 +1019,14 @@ async fn space_from_existing_auth_state() {
     // Create Group with bob and claire as managers.
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = alice_manager
+    let (group, messages) = alice_manager
         .create_group(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
         .await
         .unwrap();
     let member_group_id = group.id();
+
+    assert_eq!(messages.len(), 1);
+    let message_01 = messages[0].clone();
 
     // Create Space with group as member
     // ~~~~~~~~~~~~
@@ -1147,10 +1150,13 @@ async fn create_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = manager
+    let (group, messages) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
+
+    assert_eq!(messages.len(), 1);
+    let message_01 = messages[0].clone();
 
     let mut members = group.members().await.unwrap();
     members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(actor_b));
@@ -1205,12 +1211,17 @@ async fn add_member_to_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = manager
+    let (group, messages) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
 
-    let message_02 = group.add(claire_id, Access::read()).await.unwrap();
+    assert_eq!(messages.len(), 1);
+    let message_01 = messages[0].clone();
+
+    let messages = group.add(claire_id, Access::read()).await.unwrap();
+    assert_eq!(messages.len(), 1);
+    let message_02 = messages[0].clone();
 
     let mut members = group.members().await.unwrap();
     members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(actor_b));
@@ -1265,15 +1276,19 @@ async fn remove_member_from_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = manager
+    let (group, messages) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
+    assert_eq!(messages.len(), 1);
+    let message_01 = messages[0].clone();
 
     // Remove bob from group
     // ~~~~~~~~~~~~
 
-    let message_02 = group.remove(bob_id).await.unwrap();
+    let messages = group.remove(bob_id).await.unwrap();
+    assert_eq!(messages.len(), 1);
+    let message_02 = messages[0].clone();
 
     let members = group.members().await.unwrap();
     assert_eq!(members, vec![(alice_id, Access::manage()),]);
@@ -1323,16 +1338,20 @@ async fn receive_auth_messages() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = alice_manager
+    let (group, messages) = alice_manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
     let group_id = group.id();
+    assert_eq!(messages.len(), 1);
+    let message_01 = messages[0].clone();
 
     // Add claire
     // ~~~~~~~~~~~~
 
-    let message_02 = group.add(claire_id, Access::read()).await.unwrap();
+    let messages = group.add(claire_id, Access::read()).await.unwrap();
+    assert_eq!(messages.len(), 1);
+    let message_02 = messages[0].clone();
     drop(group);
 
     // Bob receives message 01 & 02

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -29,7 +29,7 @@ use crate::types::{
 
 type SeqNum = u64;
 
-// Implement SpaceId for i32 which is what we use space identifiers in the tests.
+// Implement SpaceId for i32 which is what we use as space identifiers in the tests.
 impl SpaceId for i32 {}
 
 #[derive(Clone, Debug)]

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -16,11 +16,14 @@ use crate::auth::orderer::AuthOrderer;
 use crate::event::Event;
 use crate::forge::Forge;
 use crate::manager::Manager;
-use crate::message::{AuthoredMessage, ControlMessage, SpacesArgs, SpacesMessage};
+use crate::message::{AuthoredMessage, SpacesArgs, SpacesMessage};
 use crate::space::SpaceError;
 use crate::store::{AuthStore, SpaceStore};
 use crate::test_utils::MemoryStore;
-use crate::types::{ActorId, AuthGroupState, OperationId, StrongRemoveResolver};
+use crate::types::{
+    ActorId, AuthControlMessage, AuthGroupAction, AuthGroupState, EncryptionControlMessage,
+    OperationId, StrongRemoveResolver,
+};
 
 type SeqNum = u64;
 
@@ -181,7 +184,7 @@ async fn create_space() {
     // Create Space
     // ~~~~~~~~~~~~
 
-    let (space, message) = manager.create_space(&[]).await.unwrap();
+    let (space, messages) = manager.create_space(&[]).await.unwrap();
 
     // We've added ourselves automatically with manage access.
     assert_eq!(
@@ -189,41 +192,71 @@ async fn create_space() {
         vec![(my_id, Access::manage())]
     );
 
-    let SpacesArgs::ControlMessage {
-        id: group_id,
-        control_message,
-        direct_messages,
+    // There are two messages (one auth, one space)
+    assert_eq!(messages.len(), 2);
+    let message_01 = messages[0].clone();
+    let message_02 = messages[1].clone();
+
+    let SpacesArgs::Auth {
+        control_message: auth_control_message,
         auth_dependencies,
-        encryption_dependencies,
-    } = message.args()
+    } = message_01.args()
+    else {
+        panic!("expected auth message");
+    };
+
+    let SpacesArgs::SpaceMembership {
+        space_id,
+        group_id,
+        space_dependencies,
+        auth_message_id,
+        control_messages: space_control_messages,
+    } = message_02.args()
     else {
         panic!("expected system message");
     };
 
-    assert_eq!(*group_id, space.id());
+    assert_eq!(*space_id, space.id());
+    assert_ne!(*group_id, space.id());
+    assert_eq!(*auth_message_id, message_01.id());
 
     // Dependencies are empty for both auth and encryption.
-    assert_eq!(auth_dependencies.to_owned(), vec![]);
-    assert_eq!(encryption_dependencies.to_owned(), vec![]);
+    assert_eq!(auth_dependencies, &vec![]);
+    assert_eq!(space_dependencies.to_owned(), vec![]);
 
     // Control message contains "create".
     assert_eq!(
-        control_message,
-        &ControlMessage::Create {
-            initial_members: vec![(GroupMember::Individual(my_id), Access::manage())]
+        auth_control_message.to_owned(),
+        AuthControlMessage {
+            group_id: *group_id,
+            action: AuthGroupAction::Create {
+                initial_members: vec![(GroupMember::Individual(my_id), Access::manage())]
+            }
         },
     );
 
+    // There is one encryption control message.
+    assert_eq!(space_control_messages.len(), 1);
+    let space_control_message = space_control_messages[0].clone();
+
+    // The encryption control message is an "add" for bob.
+    assert_eq!(
+        space_control_message.encryption_control_message(),
+        EncryptionControlMessage::Create {
+            initial_members: vec![my_id]
+        }
+    );
+
     // No direct messages as we are the only member.
-    assert!(direct_messages.is_empty());
+    assert!(space_control_message.direct_messages().is_empty());
 
     // Orderer states have been updated.
     let manager_ref = manager.inner.read().await;
-    let y = manager_ref.store.space(&space.id()).await.unwrap().unwrap();
-    assert_eq!(vec![message.id()], y.encryption_y.orderer.heads());
-
     let auth_y = manager_ref.store.auth().await.unwrap();
-    assert_eq!(vec![message.id()], auth_y.orderer_y.heads)
+    assert_eq!(vec![message_01.id()], auth_y.orderer_y.heads());
+
+    let y = manager_ref.store.space(&space.id()).await.unwrap().unwrap();
+    assert_eq!(vec![message_02.id()], y.encryption_y.orderer.heads());
 
     // @TODO: Currently the "create" message has been signed by the author's permament key. We
     // would like to sign it with the ephemeral key instead.
@@ -255,7 +288,7 @@ async fn send_and_receive() {
 
     // Alice creates a space with Bob.
 
-    let (alice_space, alice_create_message) = alice
+    let (alice_space, alice_messages) = alice
         .manager
         .create_space(&[(bob.manager.id().await, Access::write())])
         .await
@@ -263,15 +296,18 @@ async fn send_and_receive() {
 
     // @TODO: Currently the "create" message has been signed by the author's permament key. We
     // would like to sign it with the ephemeral key instead.
-    assert_eq!(alice_create_message.author(), alice.manager.id().await);
+    // let alice_create_message = alice_create_messages.pop().unwrap();
+    // assert_eq!(alice_create_message.author(), alice.manager.id().await);
 
-    // Bob processes Alice's "create" message.
+    // Bob processes Alice's messages.
 
-    bob.manager.process(&alice_create_message).await.unwrap();
+    for message in alice_messages {
+        bob.manager.process(&message).await.unwrap();
+    }
 
     // Bob sends a message to Alice.
 
-    let bob_space = bob.manager.space(&alice_space.id()).await.unwrap().unwrap();
+    let bob_space = bob.manager.space(alice_space.id()).await.unwrap().unwrap();
 
     let message = bob_space.publish(b"Hello, Alice!").await.unwrap();
 
@@ -310,40 +346,47 @@ async fn add_member_to_space() {
     // Create Space
     // ~~~~~~~~~~~~
 
-    let (space, message_01) = manager.create_space(&[]).await.unwrap();
+    let (space, messages) = manager.create_space(&[]).await.unwrap();
     let space_id = space.id();
+
+    // There are two messages (one auth, and one space)
+    assert_eq!(messages.len(), 2);
+    let message_01 = messages[0].clone();
+    let message_02 = messages[1].clone();
+
     drop(space);
-
-    // Orderer states have been updated.
-    let manager_ref = manager.inner.read().await;
-    let y = manager_ref.store.space(&space_id).await.unwrap().unwrap();
-    assert_eq!(vec![message_01.id()], y.encryption_y.orderer.heads());
-
-    let auth_y = manager_ref.store.auth().await.unwrap();
-    assert_eq!(vec![message_01.id()], auth_y.orderer_y.heads);
-    drop(manager_ref);
 
     // Add new member to Space
     // ~~~~~~~~~~~~
 
-    let space = manager.space(&space_id).await.unwrap().unwrap();
-    let message_02 = space
-        .add(
-            GroupMember::Individual(bob.manager.id().await),
-            Access::read(),
-        )
+    let space = manager.space(space_id).await.unwrap().unwrap();
+    let messages = space
+        .add(bob.manager.id().await, Access::read())
         .await
         .unwrap();
     let mut members = space.members().await.unwrap();
     drop(space);
 
-    let SpacesArgs::ControlMessage {
-        id: group_id,
-        control_message,
+    // There are two messages (one auth, and one space)
+    assert_eq!(messages.len(), 2);
+    let message_03 = messages[0].clone();
+    let message_04 = messages[1].clone();
+
+    let SpacesArgs::Auth {
+        control_message: auth_control_message,
         auth_dependencies,
-        encryption_dependencies,
-        direct_messages,
-    } = message_02.args()
+    } = message_03.args()
+    else {
+        panic!("expected auth message");
+    };
+
+    let SpacesArgs::SpaceMembership {
+        space_id,
+        group_id,
+        space_dependencies,
+        control_messages: space_control_messages,
+        ..
+    } = message_04.args()
     else {
         panic!("expected system message");
     };
@@ -357,29 +400,35 @@ async fn add_member_to_space() {
 
     // Dependencies are set for both auth and encryption.
     assert_eq!(auth_dependencies.to_owned(), vec![message_01.id()]);
-    assert_eq!(encryption_dependencies.to_owned(), vec![message_01.id()]);
+    assert_eq!(space_dependencies.to_owned(), vec![message_02.id()]);
 
-    // Correct space id.
-    assert_eq!(*group_id, space_id);
+    // Space id and group id are not equal.
+    assert_ne!(group_id, space_id);
 
-    // Control message contains "add".
+    // Auth control message contains "add" for bob.
     assert_eq!(
-        control_message,
-        &ControlMessage::Add {
-            member: GroupMember::Individual(bob_id),
-            access: Access::read()
+        auth_control_message.to_owned(),
+        AuthControlMessage {
+            group_id: *group_id,
+            action: AuthGroupAction::Add {
+                member: GroupMember::Individual(bob_id),
+                access: Access::read()
+            }
         },
     );
 
-    // Orderer states have been updated.
-    let manager_ref = manager.inner.read().await;
-    let y = manager_ref.store.space(&space_id).await.unwrap().unwrap();
-    assert_eq!(vec![message_02.id()], y.encryption_y.orderer.heads());
+    // There is one encryption control message.
+    assert_eq!(space_control_messages.len(), 1);
+    let space_control_message = space_control_messages[0].clone();
 
-    let auth_y = manager_ref.store.auth().await.unwrap();
-    assert_eq!(vec![message_02.id()], auth_y.orderer_y.heads);
+    // The encryption control message is an "add" for bob.
+    assert_eq!(
+        space_control_message.encryption_control_message(),
+        EncryptionControlMessage::Add { added: bob_id }
+    );
 
-    // There is one direct message and it's for bob.
+    // There is one direct message and it's also for bob.
+    let direct_messages = space_control_message.direct_messages();
     assert_eq!(direct_messages.len(), 1);
     let message = direct_messages.to_owned().pop().unwrap();
     assert!(matches!(
@@ -388,7 +437,15 @@ async fn add_member_to_space() {
             recipient,
             ..
         } if recipient == bob_id
-    ))
+    ));
+
+    // Orderer states have been updated.
+    let manager_ref = manager.inner.read().await;
+    let y = manager_ref.store.space(&space_id).await.unwrap().unwrap();
+    assert_eq!(vec![message_04.id()], y.encryption_y.orderer.heads());
+
+    let auth_y = manager_ref.store.auth().await.unwrap();
+    assert_eq!(vec![message_03.id()], auth_y.orderer_y.heads);
 }
 
 #[tokio::test]
@@ -413,18 +470,21 @@ async fn send_and_receive_after_add() {
 
     // Alice creates a space, adds Bob in a following step and then sends a message.
 
-    let (alice_space, message_01) = alice.manager.create_space(&[]).await.unwrap();
-    let message_02 = alice_space
-        .add(GroupMember::Individual(bob_id), Access::read())
-        .await
-        .unwrap();
-    let message_03 = alice_space.publish(b"Hello bob").await.unwrap();
+    let (alice_space, messages) = alice.manager.create_space(&[]).await.unwrap();
+    let message_01 = messages[0].clone();
+    let message_02 = messages[1].clone();
+    let messages = alice_space.add(bob_id, Access::read()).await.unwrap();
+    let message_03 = messages[0].clone();
+    let message_04 = messages[1].clone();
+    let message_05 = alice_space.publish(b"Hello bob").await.unwrap();
 
     // Bob processes all of Alice's messages.
 
     bob.manager.process(&message_01).await.unwrap();
     bob.manager.process(&message_02).await.unwrap();
-    let events = bob.manager.process(&message_03).await.unwrap();
+    bob.manager.process(&message_03).await.unwrap();
+    bob.manager.process(&message_04).await.unwrap();
+    let events = bob.manager.process(&message_05).await.unwrap();
     assert_eq!(events.len(), 1);
 }
 
@@ -449,37 +509,50 @@ async fn add_pull_member_to_space() {
     // Create Space
     // ~~~~~~~~~~~~
 
-    let (space, message_01) = manager.create_space(&[]).await.unwrap();
+    let (space, messages) = manager.create_space(&[]).await.unwrap();
+    assert_eq!(messages.len(), 2);
+    let message_01 = messages[0].clone();
+    let message_02 = messages[1].clone();
     let space_id = space.id();
     drop(space);
 
     // Add new pull-only member to Space
     // ~~~~~~~~~~~~
 
-    let space = manager.space(&space_id).await.unwrap().unwrap();
-    let message_02 = space
-        .add(
-            GroupMember::Individual(bob.manager.id().await),
-            Access::pull(),
-        )
+    let space = manager.space(space_id).await.unwrap().unwrap();
+    let messages = space
+        .add(bob.manager.id().await, Access::pull())
         .await
         .unwrap();
     let mut members = space.members().await.unwrap();
-    drop(space);
 
-    let SpacesArgs::ControlMessage {
-        id: group_id,
-        control_message,
+    // There are two messages (one auth, one space)
+    assert_eq!(messages.len(), 2);
+    let message_03 = messages[0].clone();
+    let message_04 = messages[1].clone();
+
+    let SpacesArgs::Auth {
+        control_message: auth_control_message,
         auth_dependencies,
-        encryption_dependencies,
-        direct_messages,
-    } = message_02.args()
+    } = message_03.args()
+    else {
+        panic!("expected auth message");
+    };
+
+    let SpacesArgs::SpaceMembership {
+        space_id,
+        group_id,
+        space_dependencies,
+        auth_message_id,
+        control_messages: encryption_control_messages,
+    } = message_04.args()
     else {
         panic!("expected system message");
     };
 
-    // Correct space id.
-    assert_eq!(*group_id, space_id);
+    assert_eq!(*space_id, space.id());
+    assert_ne!(*group_id, space.id());
+    assert_eq!(*auth_message_id, message_03.id());
 
     // Alice and bob are both members.
     members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(actor_b));
@@ -489,29 +562,32 @@ async fn add_pull_member_to_space() {
     );
 
     assert_eq!(auth_dependencies.to_owned(), vec![message_01.id()]);
-    // There is no dependency for encryption.
-    assert_eq!(encryption_dependencies.to_owned(), vec![]);
+    // There is no space dependencies.
+    assert_eq!(space_dependencies.to_owned(), vec![message_02.id()]);
 
-    // Control message contains "add".
+    // Auth control message contains "add" for bob.
     assert_eq!(
-        control_message,
-        &ControlMessage::Add {
-            member: GroupMember::Individual(bob_id),
-            access: Access::pull()
+        auth_control_message.to_owned(),
+        AuthControlMessage {
+            group_id: *group_id,
+            action: AuthGroupAction::Add {
+                member: GroupMember::Individual(bob_id),
+                access: Access::pull()
+            }
         },
     );
 
-    let manager_ref = manager.inner.read().await;
-    let y = manager_ref.store.space(&space_id).await.unwrap().unwrap();
-    // Encryption order still has message_01 as it's latest state.
-    assert_eq!(vec![message_01.id()], y.encryption_y.orderer.heads());
+    // There are no encryption control messages.
+    assert_eq!(encryption_control_messages.len(), 0);
 
+    let manager_ref = manager.inner.read().await;
     // Auth order has been updated.
     let auth_y = manager_ref.store.auth().await.unwrap();
-    assert_eq!(vec![message_02.id()], auth_y.orderer_y.heads);
+    assert_eq!(vec![message_03.id()], auth_y.orderer_y.heads);
 
-    // There are no direct messages.
-    assert_eq!(direct_messages.len(), 0);
+    let y = manager_ref.store.space(&space_id).await.unwrap().unwrap();
+    // Encryption order has been updated.
+    assert_eq!(vec![message_04.id()], y.encryption_y.orderer.heads());
 }
 
 #[tokio::test]
@@ -543,15 +619,29 @@ async fn receive_control_messages() {
     // Alice: Create Space
     // ~~~~~~~~~~~~
 
-    let (space, message_01) = alice_manager.create_space(&[]).await.unwrap();
+    let (space, messages) = alice_manager.create_space(&[]).await.unwrap();
     let space_id = space.id();
+    let group_id = space.group_id().await.unwrap();
     drop(space);
 
-    // Bob: Receive Message 01
+    // Bob: Receive Message 01 & 02
     // ~~~~~~~~~~~~
 
+    let message_01 = messages[0].clone();
+    let message_02 = messages[1].clone();
     bob.manager.process(&message_01).await.unwrap();
-    let space = bob_manager.space(&space_id).await.unwrap().unwrap();
+
+    // Global auth state has been updated.
+    {
+        let manager_ref = bob_manager.inner.read().await;
+        let auth_y = manager_ref.store.auth().await.unwrap();
+        let members = auth_y.members(group_id);
+        assert_eq!(members, vec![(alice_id, Access::manage())]);
+        assert_eq!(vec![message_01.id()], auth_y.orderer_y.heads());
+    }
+
+    bob.manager.process(&message_02).await.unwrap();
+    let space = bob_manager.space(space_id).await.unwrap().unwrap();
 
     // Alice is the only group member.
     let members = space.members().await.unwrap();
@@ -561,44 +651,43 @@ async fn receive_control_messages() {
     let error = space.publish(&[0, 1, 2]).await.unwrap_err();
     assert!(matches!(error, TestSpaceError::NotWelcomed(_)));
 
-    // Orderer states have been updated.
+    // Orderer state has been updated.
     let manager_ref = bob_manager.inner.read().await;
     let y = manager_ref.store.space(&space_id).await.unwrap().unwrap();
-    assert_eq!(vec![message_01.id()], y.encryption_y.orderer.heads());
+    assert_eq!(vec![message_02.id()], y.encryption_y.orderer.heads());
 
-    let auth_y = manager_ref.store.auth().await.unwrap();
-    assert_eq!(vec![message_01.id()], auth_y.orderer_y.heads);
     drop(manager_ref);
 
     // Alice: Publishes a message into the space
     // ~~~~~~~~~~~~
 
-    let space = alice_manager.space(&space_id).await.unwrap().unwrap();
-    let message_02 = space.publish(&[0, 1, 2]).await.unwrap();
+    let space = alice_manager.space(space_id).await.unwrap().unwrap();
+    let message_03 = space.publish(&[0, 1, 2]).await.unwrap();
 
     // Alice: Add new member to Space
     // ~~~~~~~~~~~~
 
-    let message_03 = space
-        .add(
-            GroupMember::Individual(bob.manager.id().await),
-            Access::read(),
-        )
+    let messages = space
+        .add(bob.manager.id().await, Access::read())
         .await
         .unwrap();
+    let message_04 = messages[0].clone();
+    let message_05 = messages[1].clone();
 
     drop(space);
 
-    // Bob: Receive Message 02 & 03
+    // Bob: Receive Message 03, 04 and 05
     // ~~~~~~~~~~~~
 
-    let events = bob.manager.process(&message_02).await.unwrap();
-    assert!(events.is_empty());
     let events = bob.manager.process(&message_03).await.unwrap();
+    assert!(events.is_empty());
+    let _ = bob.manager.process(&message_04).await.unwrap();
+    assert!(events.is_empty());
+    let events = bob.manager.process(&message_05).await.unwrap();
     // The application message arrives only after bob is welcomed.
     assert_eq!(events.len(), 1);
-    let space = bob_manager.space(&space_id).await.unwrap().unwrap();
 
+    let space = bob_manager.space(space_id).await.unwrap().unwrap();
     // Alice and bob are both members.
     let mut members = space.members().await.unwrap();
     members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(actor_b));
@@ -609,11 +698,12 @@ async fn receive_control_messages() {
 
     // Orderer states have been updated.
     let manager_ref = bob_manager.inner.read().await;
-    let y = manager_ref.store.space(&space_id).await.unwrap().unwrap();
-    assert_eq!(vec![message_03.id()], y.encryption_y.orderer.heads());
 
     let auth_y = manager_ref.store.auth().await.unwrap();
-    assert_eq!(vec![message_03.id()], auth_y.orderer_y.heads);
+    assert_eq!(vec![message_04.id()], auth_y.orderer_y.heads);
+
+    let y = manager_ref.store.space(&space_id).await.unwrap().unwrap();
+    assert_eq!(vec![message_05.id()], y.encryption_y.orderer.heads());
 }
 
 #[tokio::test]
@@ -644,38 +734,82 @@ async fn remove_member() {
     // Alice: Create Space with themselves and bob
     // ~~~~~~~~~~~~
 
-    let (space, message_01) = alice_manager
+    let (space, messages) = alice_manager
         .create_space(&[(bob_id, Access::read())])
         .await
         .unwrap();
     let space_id = space.id();
     drop(space);
 
-    // Bob: Receive Message 01
+    // There are two messages (one auth, and one space)
+    assert_eq!(messages.len(), 2);
+    let message_01 = messages[0].clone();
+    let message_02 = messages[1].clone();
+
+    // Bob: Receive Message 01 & 02
     // ~~~~~~~~~~~~
 
     bob_manager.process(&message_01).await.unwrap();
+    bob_manager.process(&message_02).await.unwrap();
 
     // Alice: Removes bob
     // ~~~~~~~~~~~~
 
-    let space = alice_manager.space(&space_id).await.unwrap().unwrap();
-    let message_02 = space.remove(GroupMember::Individual(bob_id)).await.unwrap();
+    let space = alice_manager.space(space_id).await.unwrap().unwrap();
+    let messages = space.remove(bob_id).await.unwrap();
 
-    let SpacesArgs::ControlMessage {
-        direct_messages, ..
-    } = message_02.args()
+    // There are two messages (one auth, and one space)
+    assert_eq!(messages.len(), 2);
+    let message_03 = messages[0].clone();
+    let message_04 = messages[1].clone();
+
+    let SpacesArgs::Auth {
+        control_message: auth_control_message,
+        ..
+    } = message_03.args()
+    else {
+        panic!("expected auth message");
+    };
+
+    let SpacesArgs::SpaceMembership {
+        group_id,
+        control_messages: space_control_messages,
+        ..
+    } = message_04.args()
     else {
         panic!("expected system message");
     };
 
-    // There are no direct messages (Bob shouldn't receive the new group secret).
-    assert_eq!(direct_messages.len(), 0);
+    // Auth control message contains "remove".
+    assert_eq!(
+        auth_control_message.to_owned(),
+        AuthControlMessage {
+            group_id: *group_id,
+            action: AuthGroupAction::Remove {
+                member: GroupMember::Individual(bob_id)
+            }
+        },
+    );
 
-    // Bob: Receive Message 02
+    // There is one encryption control message.
+    assert_eq!(space_control_messages.len(), 1);
+    let space_control_message = space_control_messages[0].clone();
+
+    // The encryption control message is an "remove" of bob.
+    assert_eq!(
+        space_control_message.encryption_control_message(),
+        EncryptionControlMessage::Remove { removed: bob_id }
+    );
+
+    // There are no direct messages (Bob shouldn't receive the new group secret).
+    assert_eq!(space_control_message.direct_messages().len(), 0);
+
+    // Bob: Receive Message 03 & 04
     // ~~~~~~~~~~~~
 
-    let events = bob_manager.process(&message_02).await.unwrap();
+    let events = bob_manager.process(&message_03).await.unwrap();
+    assert!(events.is_empty());
+    let events = bob_manager.process(&message_04).await.unwrap();
     let event = events.first().unwrap();
     assert!(matches!(event, Event::Removed { .. }));
 }
@@ -734,59 +868,100 @@ async fn concurrent_removal_conflict() {
     // Alice: Create Space with themselves and bob
     // ~~~~~~~~~~~~
 
-    let (space, message_01) = alice_manager
+    let (space, messages) = alice_manager
         .create_space(&[(bob_id, Access::manage())])
         .await
         .unwrap();
     let space_id = space.id();
     drop(space);
 
-    // Bob: Receive alice's message
+    // There are two messages (one auth, and one space)
+    assert_eq!(messages.len(), 2);
+    let message_01 = messages[0].clone();
+    let message_02 = messages[1].clone();
+
+    // Bob: Receive alice's messages
     // ~~~~~~~~~~~~
 
     bob_manager.process(&message_01).await.unwrap();
+    bob_manager.process(&message_02).await.unwrap();
 
-    // Alice: Removes bob
+    // Alice: Removes bob (concurrently)
     // ~~~~~~~~~~~~
 
-    let space = alice_manager.space(&space_id).await.unwrap().unwrap();
-    let _ = space.remove(GroupMember::Individual(bob_id)).await.unwrap();
-
+    let space = alice_manager.space(space_id).await.unwrap().unwrap();
+    let _ = space.remove(bob_id).await.unwrap();
     drop(space);
 
-    // Bob: Adds claire
+    // Bob: Adds claire (concurrently)
     // ~~~~~~~~~~~~
 
-    let space = bob_manager.space(&space_id).await.unwrap().unwrap();
-    let message_02_b = space
-        .add(GroupMember::Individual(claire_id), Access::read())
-        .await
-        .unwrap();
-
+    let space = bob_manager.space(space_id).await.unwrap().unwrap();
+    let messages = space.add(claire_id, Access::read()).await.unwrap();
     drop(space);
+
+    // There are two messages (one auth, and one space)
+    assert_eq!(messages.len(), 2);
+    let message_03 = messages[0].clone();
+    let message_04 = messages[1].clone();
 
     // Alice: process bobs' message
     // ~~~~~~~~~~~~
 
-    alice_manager.process(&message_02_b).await.unwrap();
+    alice_manager.process(&message_03).await.unwrap();
+    alice_manager.process(&message_04).await.unwrap();
 
     // Alice: Adds dave
     // ~~~~~~~~~~~~
 
-    let space = alice_manager.space(&space_id).await.unwrap().unwrap();
-    let message_03 = space
-        .add(GroupMember::Individual(dave_id), Access::read())
-        .await
-        .unwrap();
+    let space = alice_manager.space(space_id).await.unwrap().unwrap();
+    let messages = space.add(dave_id, Access::read()).await.unwrap();
 
-    let SpacesArgs::ControlMessage {
-        direct_messages, ..
-    } = message_03.args()
+    assert_eq!(messages.len(), 2);
+    let message_05 = messages[0].clone();
+    let message_06 = messages[1].clone();
+
+    let SpacesArgs::Auth {
+        control_message: auth_control_message,
+        ..
+    } = message_05.args()
+    else {
+        panic!("expected auth message");
+    };
+
+    let SpacesArgs::SpaceMembership {
+        group_id,
+        control_messages: space_control_messages,
+        ..
+    } = message_06.args()
     else {
         panic!("expected system message");
     };
 
+    // Auth control message contains "remove".
+    assert_eq!(
+        auth_control_message.to_owned(),
+        AuthControlMessage {
+            group_id: *group_id,
+            action: AuthGroupAction::Add {
+                member: GroupMember::Individual(dave_id),
+                access: Access::read()
+            }
+        },
+    );
+
+    // There is one encryption control message.
+    assert_eq!(space_control_messages.len(), 1);
+    let space_control_message = space_control_messages[0].clone();
+
+    // The encryption control message is an "add" of dave.
+    assert_eq!(
+        space_control_message.encryption_control_message(),
+        EncryptionControlMessage::Add { added: dave_id }
+    );
+
     // There is one direct message and it's for dave.
+    let direct_messages = space_control_message.direct_messages();
     assert_eq!(direct_messages.len(), 1);
     let message = direct_messages.to_owned().pop().unwrap();
     assert!(matches!(
@@ -796,4 +971,373 @@ async fn concurrent_removal_conflict() {
             ..
         } if recipient == dave_id
     ))
+}
+
+#[tokio::test]
+async fn space_from_existing_auth_state() {
+    let alice = TestPeer::new(0);
+    let bob = TestPeer::new(1);
+    let claire = TestPeer::new(2);
+
+    let alice_id = alice.manager.id().await;
+    let bob_id = bob.manager.id().await;
+    let claire_id = claire.manager.id().await;
+
+    let alice_manager = alice.manager.clone();
+    let bob_manager = bob.manager.clone();
+    let claire_manager = claire.manager.clone();
+
+    // Manually register all key bundles on alice.
+
+    alice_manager
+        .register_member(&bob_manager.me().await.unwrap())
+        .await
+        .unwrap();
+
+    alice_manager
+        .register_member(&claire_manager.me().await.unwrap())
+        .await
+        .unwrap();
+
+    // Create Group with bob and claire as managers.
+    // ~~~~~~~~~~~~
+
+    let (group, message_01) = alice_manager
+        .create_group(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
+        .await
+        .unwrap();
+    let member_group_id = group.id();
+
+    // Create Space with group as member
+    // ~~~~~~~~~~~~
+
+    let (space, messages) = alice_manager
+        .create_space(&[(member_group_id, Access::read())])
+        .await
+        .unwrap();
+
+    // There are 3 messages:
+    // 1) auth message containing "create" for the space group
+    // 2) space message containing reference to auth "create" message for the member group
+    // 3) space message containing reference to auth "create" message for the space
+    assert_eq!(messages.len(), 3);
+    let message_02 = messages[0].clone();
+    let message_03 = messages[1].clone();
+    let message_04 = messages[2].clone();
+
+    let SpacesArgs::Auth {
+        control_message: auth_control_message,
+        ..
+    } = message_02.args()
+    else {
+        panic!("expected auth message");
+    };
+
+    // Auth control message contains "create" for the space group.
+    assert_eq!(
+        auth_control_message.to_owned(),
+        AuthControlMessage {
+            group_id: space.group_id().await.unwrap(),
+            action: AuthGroupAction::Create {
+                initial_members: vec![
+                    (GroupMember::Group(member_group_id), Access::read()),
+                    (GroupMember::Individual(alice_id), Access::manage()),
+                ],
+            }
+        },
+    );
+
+    let SpacesArgs::SpaceMembership {
+        control_messages: space_control_messages,
+        auth_message_id,
+        ..
+    } = message_03.args()
+    else {
+        panic!("expected system message");
+    };
+
+    // Space message references auth "create" message for the member group.
+    assert_eq!(*auth_message_id, message_01.id());
+
+    // There are no encryption control message.
+    assert_eq!(space_control_messages.len(), 0);
+
+    let SpacesArgs::SpaceMembership {
+        control_messages: space_control_messages,
+        auth_message_id,
+        ..
+    } = message_04.args()
+    else {
+        panic!("expected system message");
+    };
+
+    // Space message references auth "create" message for space group.
+    assert_eq!(*auth_message_id, message_02.id());
+
+    // There is one encryption control message.
+    assert_eq!(space_control_messages.len(), 1);
+    let space_control_message = space_control_messages[0].clone();
+
+    // The encryption control message is a "create" with alice, bob and claire as initial members.
+    assert!(matches!(space_control_message.encryption_control_message(),
+    EncryptionControlMessage::Create {
+        initial_members
+    } if {
+        let mut initial_members = initial_members.clone();
+        initial_members.sort();
+        initial_members == vec![alice_id, bob_id, claire_id]
+    }));
+
+    // There are two direct messages.
+    let direct_messages = space_control_message.direct_messages();
+    assert_eq!(direct_messages.len(), 2);
+
+    // The messages are for bob and claire.
+    let result = direct_messages.iter().all(|message| {
+        matches!(
+            message,
+            DirectMessage {
+                recipient,
+                ..
+            } if recipient == &bob_id || recipient == &claire_id
+        )
+    });
+    assert!(result, "{:?}", direct_messages);
+
+    // Space members are correct.
+    let mut members = space.members().await.unwrap();
+    members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(actor_b));
+    assert_eq!(
+        members,
+        vec![
+            (alice_id, Access::manage()),
+            (bob_id, Access::read()),
+            (claire_id, Access::read()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn create_group() {
+    let alice = TestPeer::new(0);
+    let bob = TestPeer::new(1);
+
+    let alice_id = alice.manager.id().await;
+    let bob_id = bob.manager.id().await;
+    let manager = alice.manager.clone();
+
+    // Create Group
+    // ~~~~~~~~~~~~
+
+    let (group, message_01) = manager
+        .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
+        .await
+        .unwrap();
+
+    let mut members = group.members().await.unwrap();
+    members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(actor_b));
+    assert_eq!(
+        members,
+        vec![(alice_id, Access::manage()), (bob_id, Access::manage())]
+    );
+
+    // There is one auth message.
+    let SpacesArgs::Auth {
+        control_message,
+        auth_dependencies,
+    } = message_01.args()
+    else {
+        panic!("expected auth message");
+    };
+
+    // Dependencies are empty.
+    assert_eq!(auth_dependencies, &vec![]);
+
+    // Control message contains "create".
+    assert_eq!(
+        control_message.to_owned(),
+        AuthControlMessage {
+            group_id: group.id(),
+            action: AuthGroupAction::Create {
+                initial_members: vec![
+                    (GroupMember::Individual(alice_id), Access::manage()),
+                    (GroupMember::Individual(bob_id), Access::manage())
+                ]
+            }
+        },
+    );
+
+    // Orderer state has been updated.
+    let manager_ref = manager.inner.read().await;
+    let auth_y = manager_ref.store.auth().await.unwrap();
+    assert_eq!(vec![message_01.id()], auth_y.orderer_y.heads());
+}
+
+#[tokio::test]
+async fn add_member_to_group() {
+    let alice = TestPeer::new(0);
+    let bob = TestPeer::new(1);
+    let claire = TestPeer::new(2);
+
+    let alice_id = alice.manager.id().await;
+    let bob_id = bob.manager.id().await;
+    let claire_id = claire.manager.id().await;
+    let manager = alice.manager.clone();
+
+    // Create Group
+    // ~~~~~~~~~~~~
+
+    let (group, message_01) = manager
+        .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
+        .await
+        .unwrap();
+
+    let message_02 = group.add(claire_id, Access::read()).await.unwrap();
+
+    let mut members = group.members().await.unwrap();
+    members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(actor_b));
+    assert_eq!(
+        members,
+        vec![
+            (alice_id, Access::manage()),
+            (bob_id, Access::manage()),
+            (claire_id, Access::read())
+        ]
+    );
+
+    // There is one auth message.
+    let SpacesArgs::Auth {
+        control_message,
+        auth_dependencies,
+    } = message_02.args()
+    else {
+        panic!("expected auth message");
+    };
+
+    // Dependencies contain message_01.
+    assert_eq!(auth_dependencies, &vec![message_01.id()]);
+
+    // Control message contains "add" of claire.
+    assert_eq!(
+        control_message.to_owned(),
+        AuthControlMessage {
+            group_id: group.id(),
+            action: AuthGroupAction::Add {
+                member: GroupMember::Individual(claire_id),
+                access: Access::read()
+            }
+        },
+    );
+
+    // Orderer state has been updated.
+    let manager_ref = manager.inner.read().await;
+    let auth_y = manager_ref.store.auth().await.unwrap();
+    assert_eq!(vec![message_02.id()], auth_y.orderer_y.heads());
+}
+
+#[tokio::test]
+async fn remove_member_from_group() {
+    let alice = TestPeer::new(0);
+    let bob = TestPeer::new(1);
+
+    let alice_id = alice.manager.id().await;
+    let bob_id = bob.manager.id().await;
+    let manager = alice.manager.clone();
+
+    // Create Group
+    // ~~~~~~~~~~~~
+
+    let (group, message_01) = manager
+        .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
+        .await
+        .unwrap();
+
+    // Remove bob from group
+    // ~~~~~~~~~~~~
+
+    let message_02 = group.remove(bob_id).await.unwrap();
+
+    let members = group.members().await.unwrap();
+    assert_eq!(members, vec![(alice_id, Access::manage()),]);
+
+    // There is one auth message.
+    let SpacesArgs::Auth {
+        control_message,
+        auth_dependencies,
+    } = message_02.args()
+    else {
+        panic!("expected auth message");
+    };
+
+    // Dependencies contain message_01.
+    assert_eq!(auth_dependencies, &vec![message_01.id()]);
+
+    // Control message contains "remove" of bob.
+    assert_eq!(
+        control_message.to_owned(),
+        AuthControlMessage {
+            group_id: group.id(),
+            action: AuthGroupAction::Remove {
+                member: GroupMember::Individual(bob_id),
+            }
+        },
+    );
+
+    // Orderer state has been updated.
+    let manager_ref = manager.inner.read().await;
+    let auth_y = manager_ref.store.auth().await.unwrap();
+    assert_eq!(vec![message_02.id()], auth_y.orderer_y.heads());
+}
+
+#[tokio::test]
+async fn receive_auth_messages() {
+    let alice = TestPeer::new(0);
+    let bob = TestPeer::new(1);
+    let claire = TestPeer::new(2);
+
+    let alice_id = alice.manager.id().await;
+    let bob_id = bob.manager.id().await;
+    let claire_id = claire.manager.id().await;
+
+    let alice_manager = alice.manager.clone();
+    let bob_manager = bob.manager.clone();
+
+    // Create Group
+    // ~~~~~~~~~~~~
+
+    let (group, message_01) = alice_manager
+        .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
+        .await
+        .unwrap();
+    let group_id = group.id();
+
+    // Add claire
+    // ~~~~~~~~~~~~
+
+    let message_02 = group.add(claire_id, Access::read()).await.unwrap();
+    drop(group);
+
+    // Bob receives message 01 & 02
+    // ~~~~~~~~~~~~
+
+    let _events = bob_manager.process(&message_01).await.unwrap();
+    let _events = bob_manager.process(&message_02).await.unwrap();
+
+    let group = bob_manager.group(group_id).await.unwrap().unwrap();
+    let mut members = group.members().await.unwrap();
+    members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(actor_b));
+    assert_eq!(
+        members,
+        vec![
+            (alice_id, Access::manage()),
+            (bob_id, Access::manage()),
+            (claire_id, Access::read())
+        ]
+    );
+    drop(group);
+
+    // Orderer state has been updated.
+    let manager_ref = bob_manager.inner.read().await;
+    let auth_y = manager_ref.store.auth().await.unwrap();
+    assert_eq!(vec![message_02.id()], auth_y.orderer_y.heads());
 }

--- a/p2panda-spaces/src/traits.rs
+++ b/p2panda-spaces/src/traits.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt::Debug;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+/// Trait representing the identifier of a space.
+pub trait SpaceId: Debug + Copy + Eq + PartialEq + DeserializeOwned + Serialize {}

--- a/p2panda-spaces/src/utils.rs
+++ b/p2panda-spaces/src/utils.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use p2panda_auth::traits::Conditions;
+use p2panda_auth::{Access, group::GroupMember};
+
+use crate::manager::Manager;
+use crate::store::AuthStore;
+use crate::{ActorId, types::AuthGroupState};
+
+/// Assign a GroupMember type to passed actor based on looking up if the actor is a group in the
+/// auth state.
+pub(crate) fn typed_member<C: Conditions>(
+    auth_y: &AuthGroupState<C>,
+    member: ActorId,
+) -> GroupMember<ActorId> {
+    if auth_y.members(member).is_empty() {
+        GroupMember::Individual(member)
+    } else {
+        GroupMember::Group(member)
+    }
+}
+
+/// Assign GroupMember type to every actor based on looking up if the actor is a group in the auth
+/// state.
+pub(crate) async fn typed_members<ID, S, F, M, C, RS>(
+    manager_ref: Manager<ID, S, F, M, C, RS>,
+    members: Vec<(ActorId, Access<C>)>,
+) -> Result<Vec<(GroupMember<ActorId>, Access<C>)>, <S as AuthStore<C>>::Error>
+where
+    S: AuthStore<C>,
+    C: Conditions,
+{
+    let manager = manager_ref.inner.read().await;
+    let auth_y = manager.store.auth().await?;
+    Ok(members
+        .into_iter()
+        .map(|(member, access)| (typed_member(&auth_y, member), access))
+        .collect())
+}


### PR DESCRIPTION
There is one global auth state which is shared by all spaces. This allows for groups to be re-used across multiple spaces. Keeping spaces in sync with the global auth state poses several challenges considering the auth state itself will be mutated concurrently by multiple actors.

Another property we need to uphold is per-space atomicity, meaning that any encryption message must be processed along with it's accompanying auth message, or not at all.

These two requirements can be satisfied if whenever an auth group membership change occurs, an auth message is forged and published towards a global auth state _and_ a space message (containing the encryption messages) is forged and published to all known spaces referencing this message.

With this approach all spaces are effected when the global state changes, and per-space atomicity is retained as encryption state changes will always occur along with their related auth state change.

There are special concurrency cases which need to be handled (auth state changes needing to be retroactively applied to concurrently created spaces), these will be dealt with in further PRs.

<img width="1410" height="795" alt="image" src="https://github.com/user-attachments/assets/baa6a990-e22c-4f30-b460-be80ebeb51df" />

<img width="958" height="599" alt="image" src="https://github.com/user-attachments/assets/71051856-9670-4b16-91d2-d4caf3bdef47" />
_EDIT: space id is generic now, not the operation hash as stated in the above design._

### Tasks
- [x] share auth state across all spaces
   - [x] update message types
   - [x] update spaces API logic
   - [x] introduce `MessageStore`
   - [x] sync local auth changes with all spaces (we know of)
- [x] implement basic groups API
  - [x] create
  - [x] add
  - [x] remove
- [x] generic space id
- [x] tests

### Next steps
- keep spaces in sync with _concurrent_ shared auth state changes too 

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
