### PR TITLE
Make test fail by changing order of `create_space` and `register_member`

### DIFF
--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -352,12 +352,6 @@ async fn add_member_to_space() {
 
     // Manually register bobs key bundle.
 
-    alice
-        .manager
-        .register_member(&bob.manager.me().await.unwrap())
-        .await
-        .unwrap();
-
     let alice_id = alice.manager.id().await;
     let bob_id = bob.manager.id().await;
 
@@ -368,6 +362,12 @@ async fn add_member_to_space() {
 
     let space_id = 0;
     let (space, messages) = manager.create_space(space_id, &[]).await.unwrap();
+
+    alice
+        .manager
+        .register_member(&bob.manager.me().await.unwrap())
+        .await
+        .unwrap();
 
     // There are two messages (one auth, and one space)
     assert_eq!(messages.len(), 2);


### PR DESCRIPTION
This reproduces an error I've been having. This test seems to show that keybundles have to be registered before the space is created, because if I do registration after creating the group instead of before, trying to add the member with that keybundle fails with `MissingPreKeys`. Is this a bug or a misuse of spaces?

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
