### PR TITLE
`p2panda-spaces`: events for group and space membership changes 

### DIFF
--- a/p2panda-spaces/Cargo.toml
+++ b/p2panda-spaces/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.46.1", features = ["sync"] }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 p2panda-auth = { path = "../p2panda-auth", version = "0.4.0", features = ["test_utils"], default-features = false }
 p2panda-encryption = { path = "../p2panda-encryption", version = "0.4.0", features = ["test_utils"], default-features = false }
 tokio = { version = "1.46.1", features = ["rt", "macros"] }

--- a/p2panda-spaces/src/encryption/message.rs
+++ b/p2panda-spaces/src/encryption/message.rs
@@ -87,8 +87,8 @@ impl EncryptionMessage {
         space_message: &M,
         my_id: ActorId,
         auth_message: &AuthMessage<C>,
-        current_members: Vec<ActorId>,
-        next_members: Vec<ActorId>,
+        current_members: &Vec<ActorId>,
+        next_members: &Vec<ActorId>,
     ) -> Self
     where
         ID: SpaceId,
@@ -118,7 +118,7 @@ impl EncryptionMessage {
             // message is constructed containing only the next secret members.
             AuthGroupAction::Create { .. } => {
                 let control_message = EncryptionControlMessage::Create {
-                    initial_members: next_members,
+                    initial_members: next_members.to_owned(),
                 };
                 EncryptionArgs::System {
                     dependencies: space_dependencies.to_owned(),
@@ -147,7 +147,7 @@ impl EncryptionMessage {
             // removed member, otherwise use the ActorId of the actual removed member (which may
             // be an individual or group).
             AuthGroupAction::Remove { member } => {
-                let removed = removed_members(current_members, next_members);
+                let removed = removed_members(current_members.to_owned(), next_members.to_owned());
                 let control_message = if removed.contains(&my_id) {
                     EncryptionControlMessage::Remove { removed: my_id }
                 } else {

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -193,7 +193,7 @@ where
             }
             // A removal of the local actor from a space could also be detected from observing
             // changes to the auth group state, we hook into the encryption output here though to
-            // improve observability of the internal encryption state. 
+            // improve observability of the internal encryption state.
             GroupOutput::Removed => Some(Event::Space(SpaceEvent::Ejected {
                 space_id: *space_id,
             })),

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -1,6 +1,282 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-pub enum Event<ID> {
+use p2panda_auth::Access;
+use p2panda_auth::group::GroupMember;
+use p2panda_auth::traits::Conditions;
+use p2panda_encryption::data_scheme::{ControlMessage, GroupOutput};
+
+use crate::ActorId;
+use crate::auth::message::AuthMessage;
+use crate::encryption::message::{EncryptionArgs, EncryptionMessage};
+use crate::traits::SpaceId;
+use crate::types::{AuthGroupAction, AuthGroupState, EncryptionGroupOutput};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Member {
+    id: ActorId,
+    is_group: bool,
+}
+
+impl Member {
+    pub fn individual(id: ActorId) -> Self {
+        Self {
+            id,
+            is_group: false,
+        }
+    }
+
+    pub fn group(id: ActorId) -> Self {
+        Self { id, is_group: true }
+    }
+
+    pub fn from_group_member(group_member: GroupMember<ActorId>) -> Self {
+        match group_member {
+            GroupMember::Individual(id) => Member::individual(id),
+            GroupMember::Group(id) => Member::group(id),
+        }
+    }
+
+    pub fn id(&self) -> ActorId {
+        self.id
+    }
+
+    pub fn is_group(&self) -> bool {
+        self.is_group
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Event<ID, C> {
     Application { space_id: ID, data: Vec<u8> },
-    Removed { space_id: ID },
+    Group(GroupEvent<C>),
+    Space(SpaceEvent<ID>),
+}
+
+/// Events emitted on auth group membership change.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GroupEvent<C> {
+    /// A group was created.
+    Created {
+        /// Group id.
+        group_id: ActorId,
+
+        /// Root members, can be individuals or groups.
+        members: Vec<(Member, Access<C>)>,
+
+        /// Transitive members, can only be individuals.
+        transitive_members: Vec<(Member, Access<C>)>,
+    },
+    /// A member was added to a group.
+    Added {
+        /// Group id.
+        group_id: ActorId,
+
+        /// Member that was added, can be individual or group.
+        added: Member,
+
+        /// Access level assigned to the added members.
+        access: Access<C>,
+
+        /// Root members, can be individuals or groups.
+        members: Vec<(Member, Access<C>)>,
+
+        /// Transitive members, can only be individuals.
+        transitive_members: Vec<(Member, Access<C>)>,
+    },
+    /// A member was removed from a group.
+    Removed {
+        /// Group id.
+        group_id: ActorId,
+
+        /// Member that was removed, can be individual or group.
+        removed: Member,
+
+        /// Root members, can be individuals or groups.
+        members: Vec<(Member, Access<C>)>,
+
+        /// Transitive members, can only be individuals.
+        transitive_members: Vec<(Member, Access<C>)>,
+    },
+}
+
+/// Events emitted on space encryption group membership change.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SpaceEvent<ID> {
+    /// A space was created.
+    Created {
+        /// Space id.
+        space_id: ID,
+
+        /// Id of the group associated with this space.
+        group_id: ActorId,
+
+        /// Individual in the spaces' encryption context.
+        members: Vec<ActorId>,
+    },
+    /// An individual was added to the space.
+    Added {
+        /// Space id.
+        space_id: ID,
+
+        /// Id of the group associated with this space.
+        group_id: ActorId,
+
+        /// Individual added to the encryption context.
+        added: ActorId,
+
+        /// Individual in the spaces' encryption context.
+        members: Vec<ActorId>,
+    },
+    /// An individual was removed from the space.
+    Removed {
+        /// Space id.
+        space_id: ID,
+
+        /// Id of the group associated with this space.
+        group_id: ActorId,
+
+        /// Individual removed from the encryption context.
+        removed: ActorId,
+
+        /// Individual in the spaces' encryption context.
+        members: Vec<ActorId>,
+    },
+    /// Local actor was removed from the space.
+    Ejected {
+        /// Space id.
+        space_id: ID,
+    },
+}
+
+pub(crate) fn encryption_output_to_space_events<ID, M, C>(
+    space_id: &ID,
+    encryption_output: Vec<EncryptionGroupOutput<M>>,
+) -> Vec<Event<ID, C>>
+where
+    ID: SpaceId,
+    C: Conditions,
+{
+    encryption_output
+        .into_iter()
+        .filter_map(|event| match event {
+            EncryptionGroupOutput::Application { plaintext } => Some(Event::Application {
+                space_id: space_id.clone(),
+                data: plaintext,
+            }),
+            GroupOutput::Control(_control_message) => {
+                // @TODO: when do control messages get emitted in group output?
+                todo!()
+            }
+            GroupOutput::Removed => Some(Event::Space(SpaceEvent::Ejected {
+                space_id: space_id.clone(),
+            })),
+        })
+        .collect()
+}
+
+pub(crate) fn encryption_message_to_space_event<ID, C>(
+    space_id: &ID,
+    group_id: ActorId,
+    current_members: &mut Vec<ActorId>,
+    encryption_message: &EncryptionMessage,
+) -> Option<Event<ID, C>>
+where
+    ID: SpaceId,
+    C: Conditions,
+{
+    let args = match encryption_message {
+        EncryptionMessage::Args(auth_args) => auth_args,
+        EncryptionMessage::Forged { args, .. } => args,
+    };
+
+    if let EncryptionArgs::System {
+        control_message, ..
+    } = args
+    {
+        let event = match control_message {
+            ControlMessage::Create { initial_members } => SpaceEvent::Created {
+                space_id: space_id.clone(),
+                group_id,
+                members: initial_members.to_owned(),
+            },
+            ControlMessage::Remove { removed } => SpaceEvent::Removed {
+                space_id: space_id.clone(),
+                group_id,
+                removed: *removed,
+                members: {
+                    let (idx, _) = current_members
+                        .iter()
+                        .enumerate()
+                        .find(|(_, member)| **member == *removed)
+                        .expect("member exists");
+                    current_members.remove(idx);
+                    current_members.clone()
+                },
+            },
+            ControlMessage::Add { added } => SpaceEvent::Added {
+                space_id: space_id.clone(),
+                group_id,
+                added: *added,
+                members: {
+                    current_members.push(*added);
+                    current_members.clone()
+                },
+            },
+            ControlMessage::Update => unimplemented!(),
+        };
+        return Some(Event::Space(event));
+    }
+    None
+}
+
+pub(crate) fn auth_message_to_group_event<ID, C>(
+    auth_y: &AuthGroupState<C>,
+    auth_message: &AuthMessage<C>,
+) -> Event<ID, C>
+where
+    C: Conditions,
+{
+    let args = match auth_message {
+        AuthMessage::Args(auth_args) => auth_args,
+        AuthMessage::Forged { args, .. } => args,
+    };
+
+    let group_id = args.control_message.group_id();
+    let members = auth_y
+        .root_members(group_id)
+        .into_iter()
+        .map(|(member, access)| (Member::from_group_member(member), access))
+        .collect();
+    let transitive_members = auth_y
+        .members(group_id)
+        .into_iter()
+        .map(|(member, access)| (Member::individual(member), access))
+        .collect();
+    let group_event = match args.control_message.action.clone() {
+        AuthGroupAction::Create { initial_members } => GroupEvent::Created {
+            group_id,
+            members: initial_members
+                .into_iter()
+                .map(|(member, access)| (Member::from_group_member(member), access))
+                .collect(),
+            transitive_members,
+        },
+        AuthGroupAction::Add { member, access } => GroupEvent::Added {
+            group_id,
+            added: Member::from_group_member(member),
+            access,
+            members,
+            transitive_members,
+        },
+        AuthGroupAction::Remove { member } => GroupEvent::Removed {
+            group_id,
+            removed: Member::from_group_member(member),
+            members,
+            transitive_members,
+        },
+        AuthGroupAction::Promote { .. } => unimplemented!(),
+        AuthGroupAction::Demote { .. } => unimplemented!(),
+    };
+
+    Event::Group(group_event)
 }

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -160,7 +160,7 @@ where
         .into_iter()
         .filter_map(|event| match event {
             EncryptionGroupOutput::Application { plaintext } => Some(Event::Application {
-                space_id: space_id.clone(),
+                space_id: *space_id,
                 data: plaintext,
             }),
             GroupOutput::Control(_control_message) => {
@@ -168,7 +168,7 @@ where
                 todo!()
             }
             GroupOutput::Removed => Some(Event::Space(SpaceEvent::Ejected {
-                space_id: space_id.clone(),
+                space_id: *space_id,
             })),
         })
         .collect()
@@ -195,12 +195,12 @@ where
     {
         let event = match control_message {
             ControlMessage::Create { initial_members } => SpaceEvent::Created {
-                space_id: space_id.clone(),
+                space_id: *space_id,
                 group_id,
                 members: initial_members.to_owned(),
             },
             ControlMessage::Remove { removed } => SpaceEvent::Removed {
-                space_id: space_id.clone(),
+                space_id: *space_id,
                 group_id,
                 removed: *removed,
                 members: {
@@ -214,7 +214,7 @@ where
                 },
             },
             ControlMessage::Add { added } => SpaceEvent::Added {
-                space_id: space_id.clone(),
+                space_id: *space_id,
                 group_id,
                 added: *added,
                 members: {

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -189,8 +189,7 @@ where
                 data: plaintext,
             }),
             GroupOutput::Control(_control_message) => {
-                // @TODO: when do control messages get emitted in group output?
-                unimplemented!()
+                unreachable!()
             }
             GroupOutput::Removed => Some(Event::Space(SpaceEvent::Ejected {
                 space_id: *space_id,

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -191,6 +191,9 @@ where
             GroupOutput::Control(_control_message) => {
                 unreachable!()
             }
+            // A removal of the local actor from a space could also be detected from observing
+            // changes to the auth group state, we hook into the encryption output here though to
+            // improve observability of the internal encryption state. 
             GroupOutput::Removed => Some(Event::Space(SpaceEvent::Ejected {
                 space_id: *space_id,
             })),

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 use crate::OperationId;
 use crate::auth::message::AuthMessage;
-use crate::event::Event;
+use crate::event::{Event, auth_message_to_group_event};
 use crate::forge::Forge;
 use crate::manager::Manager;
 use crate::message::{AuthoredMessage, SpacesArgs, SpacesMessage};
@@ -160,7 +160,7 @@ where
     pub(crate) async fn process(
         manager_ref: Manager<ID, S, F, M, C, RS>,
         message: &M,
-    ) -> Result<Vec<Event<ID>>, GroupError<ID, S, F, M, C, RS>> {
+    ) -> Result<Event<ID, C>, GroupError<ID, S, F, M, C, RS>> {
         let auth_message = AuthMessage::from_forged(message);
 
         let mut auth_y = {
@@ -184,7 +184,7 @@ where
             .await
             .map_err(GroupError::MessageStore)?;
 
-        Ok(vec![])
+        Ok(auth_message_to_group_event(&auth_y, &auth_message))
     }
 
     /// Process a local control message.

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -211,7 +211,7 @@ where
     pub async fn process(
         &self,
         message: &M,
-    ) -> Result<Vec<Event<ID>>, ManagerError<ID, S, F, M, C, RS>> {
+    ) -> Result<Vec<Event<ID, C>>, ManagerError<ID, S, F, M, C, RS>> {
         // Route message to the regarding member-, group- or space processor.
         let events = match message.args() {
             // Received key bundle from a member.
@@ -222,9 +222,10 @@ where
                 todo!()
             }
             SpacesArgs::Auth { .. } => {
-                Group::process(self.clone(), message)
+                let event = Group::process(self.clone(), message)
                     .await
-                    .map_err(ManagerError::Group)?
+                    .map_err(ManagerError::Group)?;
+                vec![event]
 
                 // @TODO: check that this message was applied to all spaces and apply it ourselves
                 // if not.
@@ -290,7 +291,7 @@ where
     async fn handle_space_membership_message(
         &self,
         message: &M,
-    ) -> Result<Vec<Event<ID>>, ManagerError<ID, S, F, M, C, RS>> {
+    ) -> Result<Vec<Event<ID, C>>, ManagerError<ID, S, F, M, C, RS>> {
         let SpacesArgs::SpaceMembership {
             space_id,
             auth_message_id,

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -1593,11 +1593,13 @@ async fn events() {
             0 => {
                 assert_eq!(events.len(), 1);
                 assert_matches!(events[0].clone(), Event::Group(GroupEvent::Created { group_id, .. }) if group_id == group.id());
+                assert_matches!(events[0].clone(), Event::Group(GroupEvent::Created { context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             // Space auth group created.
             1 => {
                 assert_eq!(events.len(), 1);
-                assert_matches!(events[0].clone(), Event::Group(GroupEvent::Created {group_id, .. }) if group_id == space_group_id);
+                assert_matches!(events[0].clone(), Event::Group(GroupEvent::Created { group_id, .. }) if group_id == space_group_id);
+                assert_matches!(events[0].clone(), Event::Group(GroupEvent::Created { context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             // Both previous auth messages published to newly created space, initial members added
             // to encryption context.
@@ -1605,29 +1607,35 @@ async fn events() {
             3 => {
                 assert_eq!(events.len(), 1);
                 assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Created { space_id, context: SpaceContext{group_id, ..}, .. }) if space_id == space.id() && group_id == space_group_id);
+                assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Created { context: SpaceContext{ auth_author, spaces_author, ..}, .. }) if auth_author == alice_id && spaces_author == alice_id);
             }
             // Dave added to space auth group and encryption context.
             4 => {
                 assert_eq!(events.len(), 1);
                 assert_matches!(events[0].clone(), Event::Group(GroupEvent::Added { added, group_id, .. }) if added == GroupActor::individual(dave_id) && group_id == space_group_id);
+                assert_matches!(events[0].clone(), Event::Group(GroupEvent::Added { context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             5 => {
                 assert_eq!(events.len(), 1);
                 assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Added { added, .. }) if added == vec![dave_id]);
+                assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Added { context: SpaceContext{ auth_author, spaces_author, ..}, .. }) if auth_author == alice_id && spaces_author == alice_id);
             }
             // Dave removed from space auth group and encryption context.
             6 => {
                 assert_eq!(events.len(), 1);
                 assert_matches!(events[0].clone(), Event::Group(GroupEvent::Removed { removed, .. }) if removed == GroupActor::individual(dave_id));
+                assert_matches!(events[0].clone(), Event::Group(GroupEvent::Removed { context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             7 => {
                 assert_eq!(events.len(), 1);
                 assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Removed { removed, .. }) if removed == vec![dave_id]);
+                assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Removed { context: SpaceContext{ auth_author, spaces_author, ..}, .. }) if auth_author == alice_id && spaces_author == alice_id);
             }
             // Dave added to auth group with pull access and no resulting encryption context change.
             8 => {
                 assert_eq!(events.len(), 1);
                 assert_matches!(events[0].clone(), Event::Group(GroupEvent::Added { added, .. }) if added == GroupActor::individual(dave_id));
+                assert_matches!(events[0].clone(), Event::Group(GroupEvent::Added { context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             9 => assert_eq!(events.len(), 0, "{:?}", events),
             // Remove member group from space auth group, both bob and claire removed from space
@@ -1635,10 +1643,12 @@ async fn events() {
             10 => {
                 assert_eq!(events.len(), 1);
                 assert_matches!(events[0].clone(), Event::Group(GroupEvent::Removed { removed, .. }) if removed == GroupActor::group(group.id()));
+                assert_matches!(events[0].clone(), Event::Group(GroupEvent::Removed { context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             11 => {
                 assert_eq!(events.len(), 2);
                 assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Removed { removed, .. }) if removed == vec![bob_id, claire_id]);
+                assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Removed { context: SpaceContext{ auth_author, spaces_author, ..}, .. }) if auth_author == alice_id && spaces_author == alice_id);
                 assert_matches!(events[1].clone(), Event::Space(SpaceEvent::Ejected { .. }));
             }
             _ => panic!(),
@@ -1656,6 +1666,7 @@ async fn events() {
                         GroupContext {
                             mut group_actors,
                             mut members,
+                            ..
                         },
                     ..
                 }) = events[0].clone()
@@ -1683,6 +1694,7 @@ async fn events() {
                         GroupContext {
                             mut group_actors,
                             mut members,
+                            ..
                         },
                     ..
                 }) = events[0].clone()
@@ -1729,6 +1741,7 @@ async fn events() {
                         GroupContext {
                             mut group_actors,
                             mut members,
+                            ..
                         },
                     ..
                 }) = events[0].clone()
@@ -1776,6 +1789,7 @@ async fn events() {
                         GroupContext {
                             mut group_actors,
                             mut members,
+                            ..
                         },
                     ..
                 }) = events[0].clone()
@@ -1821,6 +1835,7 @@ async fn events() {
                         GroupContext {
                             mut group_actors,
                             mut members,
+                            ..
                         },
                     ..
                 }) = events[0].clone()
@@ -1856,6 +1871,7 @@ async fn events() {
                         GroupContext {
                             mut group_actors,
                             mut members,
+                            ..
                         },
                     ..
                 }) = events[0].clone()

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -1609,7 +1609,7 @@ async fn events() {
             }
             5 => {
                 assert_eq!(events.len(), 1);
-                assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Added { added, .. }) if added == dave_id);
+                assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Added { added, .. }) if added == vec![dave_id]);
             }
             // Dave removed from space auth group and encryption context.
             6 => {
@@ -1618,14 +1618,14 @@ async fn events() {
             }
             7 => {
                 assert_eq!(events.len(), 1);
-                assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Removed { removed, .. }) if removed == dave_id);
+                assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Removed { removed, .. }) if removed == vec![dave_id]);
             }
             // Dave added to auth group with pull access and no resulting encryption context change.
             8 => {
                 assert_eq!(events.len(), 1);
                 assert_matches!(events[0].clone(), Event::Group(GroupEvent::Added { added, .. }) if added == Member::individual(dave_id));
             }
-            9 => assert_eq!(events.len(), 0),
+            9 => assert_eq!(events.len(), 0, "{:?}", events),
             // Remove member group from space auth group, both bob and claire removed from space
             // encryption context.
             10 => {
@@ -1633,14 +1633,9 @@ async fn events() {
                 assert_matches!(events[0].clone(), Event::Group(GroupEvent::Removed { removed, .. }) if removed == Member::group(group.id()));
             }
             11 => {
-                assert_eq!(events.len(), 4);
-                assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Removed { removed, .. }) if removed == bob_id || removed == claire_id);
+                assert_eq!(events.len(), 2);
+                assert_matches!(events[0].clone(), Event::Space(SpaceEvent::Removed { removed, .. }) if removed == vec![bob_id, claire_id]);
                 assert_matches!(events[1].clone(), Event::Space(SpaceEvent::Ejected { .. }));
-                assert_matches!(events[2].clone(), Event::Space(SpaceEvent::Removed { removed, .. }) if removed == bob_id || removed == claire_id);
-                // @TODO: unexpected second "ejected" received here, believe it's due to how
-                // "is_removed" flag is computed inside EncryptionGroup::receive(..) and the fact
-                // that multiple members can be removed in one go now.
-                assert_matches!(events[3].clone(), Event::Space(SpaceEvent::Ejected { .. }));
             }
             _ => panic!(),
         }
@@ -1851,16 +1846,6 @@ async fn events() {
             }
             11 => {
                 let Event::Space(SpaceEvent::Removed { mut members, .. }) = events[0].clone()
-                else {
-                    panic!()
-                };
-
-                let mut expected_members = vec![alice_id, bob_id];
-                expected_members.sort();
-                members.sort();
-                assert_eq!(members, expected_members);
-
-                let Event::Space(SpaceEvent::Removed { mut members, .. }) = events[2].clone()
                 else {
                     panic!()
                 };


### PR DESCRIPTION
This PR introduces events which are emitted when group and/or space membership changes occur due to processing remote messages.

The two event variants for "groups" and "spaces" have slightly different semantics. Group events contain member changes where the members can be a group or an individual and all members have a corresponding access levels. Space events contain only changes which occurred to the "secret" member set (members with >= "read" access) and access levels are not given. 

Both event variants are enriched with additional state information which may be useful for consumers. Group events contain both `members` (the direct group members, can be groups or individuals) and `transitive_members` (the resolved member set, only contains individuals). Space events contain only `members` which is the set of individuals in the space encryption context (resolved members with >= "read" access). 

```rust

#[derive(Clone, Debug, PartialEq, Eq)]
#[allow(clippy::large_enum_variant)]
pub enum Event<ID, C> {
    Application { space_id: ID, data: Vec<u8> },
    Group(GroupEvent<C>),
    Space(SpaceEvent<ID>),
}

#[derive(Clone, Debug, PartialEq, Eq)]
pub struct GroupContext<C> {
    /// The actor who authored this action.
    pub author: ActorId,

    /// Root group actors, can be individuals or groups.
    pub group_actors: Vec<(GroupActor, Access<C>)>,

    /// Members of this group.
    pub members: Vec<(ActorId, Access<C>)>,
}

#[derive(Clone, Debug, PartialEq, Eq)]
pub struct SpaceContext {
    /// The actor who authored this group change action.
    pub auth_author: ActorId,

    /// The actor who applied this action to the spaces state.
    ///
    /// Note: this can be different to the auth_actor in cases where concurrent auth changes which
    /// effect a space are applied later.
    pub spaces_author: ActorId,

    /// Id of the group associated with this space.
    pub group_id: ActorId,

    /// Members in the spaces' encryption context.
    pub members: Vec<ActorId>,
}

/// Events emitted on auth group membership change.
#[derive(Clone, Debug, PartialEq, Eq)]
pub enum GroupEvent<C> {
    /// A group was created.
    Created {
        /// Group id.
        group_id: ActorId,

        /// Initial group members.
        initial_members: Vec<(GroupActor, Access<C>)>,

        /// Additional event context and group state after any change occurred.
        context: GroupContext<C>,
    },

    /// A member was added to a group.
    Added {
        /// Group id.
        group_id: ActorId,

        /// Group actor that was added, can be individual or group.
        added: GroupActor,

        /// Access level assigned to the added members.
        access: Access<C>,

        /// Additional event context and group state after any change occurred.
        context: GroupContext<C>,
    },

    /// A member was removed from a group.
    Removed {
        /// Group id.
        group_id: ActorId,

        /// Group actor that was removed, can be individual or group.
        removed: GroupActor,

        /// Additional event context and group state after any change occurred.
        context: GroupContext<C>,
    },
}

/// Events emitted on space encryption group membership change.
#[derive(Clone, Debug, PartialEq, Eq)]
pub enum SpaceEvent<ID> {
    /// A space was created.
    Created {
        /// Space id.
        space_id: ID,

        /// Initial members in the encryption context.
        initial_members: Vec<ActorId>,

        /// Additional event context and space state after any change occurred.
        context: SpaceContext,
    },

    /// One or many individuals were added to the space.
    Added {
        /// Space id.
        space_id: ID,

        /// Members added to the encryption context.
        added: Vec<ActorId>,

        /// Additional event context and space state after any change occurred.
        context: SpaceContext,
    },

    /// One or many individuals were removed from the space.
    Removed {
        /// Space id.
        space_id: ID,

        /// Members removed from the encryption context.
        removed: Vec<ActorId>,

        /// Additional event context and space state after any change occurred.
        context: SpaceContext,
    },

    /// Local actor was removed from the space.
    Ejected {
        /// Space id.
        space_id: ID,
    },
}
```

## Next steps
- ~~emit all events from a  channel `rx` which can be subscribed to on manager~~
- also emit events for state changes _we_ triggered by calling create, add, remove etc...

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
