### PR TITLE
`p2panda-spaces`: expect `Forge` implementations to persist messages

### DIFF
--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -220,8 +220,7 @@ where
 
         let message = {
             let mut manager = manager_ref.inner.write().await;
-            let message = manager.identity.forge(args).await?;
-            message
+            manager.identity.forge(args).await?
         };
 
         {

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -192,11 +192,6 @@ where
             .set_auth(&auth_y)
             .await
             .map_err(GroupError::AuthStore)?;
-        manager
-            .spaces_store
-            .set_message(&message.id(), message)
-            .await
-            .map_err(GroupError::MessageStore)?;
 
         Ok(auth_message_to_group_event(&auth_y, &auth_message))
     }
@@ -226,11 +221,6 @@ where
         let message = {
             let mut manager = manager_ref.inner.write().await;
             let message = manager.identity.forge(args).await?;
-            manager
-                .spaces_store
-                .set_message(&message.id(), &message)
-                .await
-                .map_err(GroupError::MessageStore)?;
             message
         };
 

--- a/p2panda-spaces/src/identity.rs
+++ b/p2panda-spaces/src/identity.rs
@@ -267,7 +267,7 @@ mod tests {
 
     use crate::identity::IdentityError;
     use crate::message::SpacesArgs;
-    use crate::test_utils::TestKeyStore;
+    use crate::test_utils::{TestKeyStore, TestSpacesStore};
     use crate::traits::message::{AuthoredMessage, SpacesMessage};
     use crate::{ActorId, Config, Credentials};
 
@@ -278,7 +278,9 @@ mod tests {
         let rng = Rng::from_seed([1; 32]);
         let mut credentials = Credentials::from_rng(&rng).unwrap();
         let config = Config::default();
-        let key_store: TestKeyStore<i32> = TestKeyStore::new(&credentials, &config, &rng).unwrap();
+        let spaces_store = TestSpacesStore::new();
+        let key_store: TestKeyStore<i32> =
+            TestKeyStore::new(spaces_store, &credentials, &config, &rng).unwrap();
 
         // Rotate identity secret
         credentials.identity_secret = SecretKey::from_rng(&rng).unwrap();
@@ -294,7 +296,9 @@ mod tests {
         let rng = Rng::from_seed([1; 32]);
         let mut credentials = Credentials::from_rng(&rng).unwrap();
         let config = Config::default();
-        let key_store: TestKeyStore<i32> = TestKeyStore::new(&credentials, &config, &rng).unwrap();
+        let spaces_store = TestSpacesStore::new();
+        let key_store: TestKeyStore<i32> =
+            TestKeyStore::new(spaces_store, &credentials, &config, &rng).unwrap();
 
         // Rotate private key
         let private_key = PrivateKey::from_bytes(&rng.random_array().unwrap());
@@ -311,7 +315,9 @@ mod tests {
         let rng = Rng::from_seed([1; 32]);
         let credentials = Credentials::from_rng(&rng).unwrap();
         let config = Config::default();
-        let key_store: TestKeyStore<i32> = TestKeyStore::new(&credentials, &config, &rng).unwrap();
+        let spaces_store = TestSpacesStore::new();
+        let key_store: TestKeyStore<i32> =
+            TestKeyStore::new(spaces_store, &credentials, &config, &rng).unwrap();
         let mut identity_manager = IdentityManager::new(key_store, &credentials, &config, &rng)
             .await
             .unwrap();
@@ -329,7 +335,9 @@ mod tests {
         let rng = Rng::from_seed([1; 32]);
         let credentials = Credentials::from_rng(&rng).unwrap();
         let config = Config::default();
-        let key_store: TestKeyStore<i32> = TestKeyStore::new(&credentials, &config, &rng).unwrap();
+        let spaces_store = TestSpacesStore::new();
+        let key_store: TestKeyStore<i32> =
+            TestKeyStore::new(spaces_store, &credentials, &config, &rng).unwrap();
         let mut identity_manager = IdentityManager::new(key_store, &credentials, &config, &rng)
             .await
             .unwrap();
@@ -351,8 +359,13 @@ mod tests {
         let alice_rng = Rng::from_seed([1; 32]);
         let alice_credentials = Credentials::from_rng(&alice_rng).unwrap();
         let alice_config = Config::default();
-        let alice_key_store: TestKeyStore<i32> =
-            TestKeyStore::new(&alice_credentials, &alice_config, &alice_rng).unwrap();
+        let alice_key_store: TestKeyStore<i32> = TestKeyStore::new(
+            TestSpacesStore::new(),
+            &alice_credentials,
+            &alice_config,
+            &alice_rng,
+        )
+        .unwrap();
         let mut alice_identity_manager = IdentityManager::new(
             alice_key_store,
             &alice_credentials,
@@ -365,8 +378,13 @@ mod tests {
         let bob_rng = Rng::from_seed([2; 32]);
         let bob_credentials = Credentials::from_rng(&bob_rng).unwrap();
         let bob_config = Config::default();
-        let bob_key_store: TestKeyStore<i32> =
-            TestKeyStore::new(&bob_credentials, &bob_config, &bob_rng).unwrap();
+        let bob_key_store: TestKeyStore<i32> = TestKeyStore::new(
+            TestSpacesStore::new(),
+            &bob_credentials,
+            &bob_config,
+            &bob_rng,
+        )
+        .unwrap();
         let mut bob_identity_manager =
             IdentityManager::new(bob_key_store, &bob_credentials, &bob_config, &bob_rng)
                 .await
@@ -398,7 +416,7 @@ mod tests {
         let alice_credentials = Credentials::from_rng(&alice_rng).unwrap();
         let alice_config = Config::default();
         let alice_key_store: TestKeyStore<i32> =
-            TestKeyStore::new(&alice_credentials, &alice_config, &alice_rng).unwrap();
+            TestKeyStore::new(TestSpacesStore::new(), &alice_credentials, &alice_config, &alice_rng).unwrap();
         let mut alice_identity_manager = IdentityManager::new(
             alice_key_store,
             &alice_credentials,

--- a/p2panda-spaces/src/identity.rs
+++ b/p2panda-spaces/src/identity.rs
@@ -415,8 +415,13 @@ mod tests {
         let alice_rng = Rng::from_seed([1; 32]);
         let alice_credentials = Credentials::from_rng(&alice_rng).unwrap();
         let alice_config = Config::default();
-        let alice_key_store: TestKeyStore<i32> =
-            TestKeyStore::new(TestSpacesStore::new(), &alice_credentials, &alice_config, &alice_rng).unwrap();
+        let alice_key_store: TestKeyStore<i32> = TestKeyStore::new(
+            TestSpacesStore::new(),
+            &alice_credentials,
+            &alice_config,
+            &alice_rng,
+        )
+        .unwrap();
         let mut alice_identity_manager = IdentityManager::new(
             alice_key_store,
             &alice_credentials,

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -197,12 +197,6 @@ where
 
             let mut manager = manager_ref.inner.write().await;
             let message = manager.identity.forge(args).await?;
-            manager
-                .spaces_store
-                .set_message(&message.id(), &message)
-                .await
-                .map_err(SpaceError::MessageStore)?;
-
             message
         };
 
@@ -288,13 +282,6 @@ where
                 space_dependencies,
             };
             let message = manager.identity.forge(args).await?;
-
-            manager
-                .spaces_store
-                .set_message(&message.id(), &message)
-                .await
-                .map_err(SpaceError::MessageStore)?;
-
             space_dependencies = vec![message.id()];
             messages.push(message);
         }
@@ -678,7 +665,6 @@ where
 
         // Forge message.
         let message = manager.identity.forge(args).await?;
-        // @TODO: persist message.
 
         // Update dependencies.
         y.encryption_y

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -196,8 +196,7 @@ where
             };
 
             let mut manager = manager_ref.inner.write().await;
-            let message = manager.identity.forge(args).await?;
-            message
+            manager.identity.forge(args).await?
         };
 
         // Update space state and persist it.

--- a/p2panda-spaces/src/test_utils/mod.rs
+++ b/p2panda-spaces/src/test_utils/mod.rs
@@ -70,7 +70,7 @@ where
         rng: Rng,
     ) -> Self {
         let store = TestSpacesStore::new();
-        let key_store = TestKeyStore::new(credentials, &config, &rng).unwrap();
+        let key_store = TestKeyStore::new(store.clone(), credentials, &config, &rng).unwrap();
         let manager = TestManager::new_with_config(store, key_store, credentials, config, rng)
             .await
             .unwrap();

--- a/p2panda-spaces/src/test_utils/spaces_store.rs
+++ b/p2panda-spaces/src/test_utils/spaces_store.rs
@@ -3,8 +3,10 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::hash::Hash;
+use std::sync::Arc;
 
 use p2panda_auth::traits::Conditions;
+use tokio::sync::RwLock;
 
 use crate::OperationId;
 use crate::auth::orderer::AuthOrderer;
@@ -17,13 +19,21 @@ use crate::types::AuthGroupState;
 pub type TestSpacesStore<ID> = MemoryStore<ID, TestMessage<ID>, TestConditions>;
 
 #[derive(Debug)]
-pub struct MemoryStore<ID, M, C>
+pub struct MemoryStoreInner<ID, M, C>
 where
     C: Conditions,
 {
     auth: AuthGroupState<C>,
     spaces: HashMap<ID, SpaceState<ID, M, C>>,
     messages: HashMap<OperationId, M>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MemoryStore<ID, M, C>
+where
+    C: Conditions,
+{
+    pub(crate) inner: Arc<RwLock<MemoryStoreInner<ID, M, C>>>,
 }
 
 impl<ID, M, C> MemoryStore<ID, M, C>
@@ -34,11 +44,13 @@ where
     pub fn new() -> Self {
         let orderer_y = AuthOrderer::init();
         let auth_y = AuthGroupState::new(orderer_y);
-
-        Self {
+        let inner = MemoryStoreInner {
             auth: auth_y,
             spaces: HashMap::new(),
             messages: HashMap::new(),
+        };
+        Self {
+            inner: Arc::new(RwLock::new(inner)),
         }
     }
 }
@@ -52,19 +64,23 @@ where
     type Error = Infallible;
 
     async fn space(&self, id: &ID) -> Result<Option<SpaceState<ID, M, C>>, Self::Error> {
-        Ok(self.spaces.get(id).cloned())
+        let inner = self.inner.read().await;
+        Ok(inner.spaces.get(id).cloned())
     }
 
     async fn has_space(&self, id: &ID) -> Result<bool, Self::Error> {
-        Ok(self.spaces.contains_key(id))
+        let inner = self.inner.read().await;
+        Ok(inner.spaces.contains_key(id))
     }
 
     async fn spaces_ids(&self) -> Result<Vec<ID>, Self::Error> {
-        Ok(self.spaces.keys().cloned().collect())
+        let inner = self.inner.read().await;
+        Ok(inner.spaces.keys().cloned().collect())
     }
 
     async fn set_space(&mut self, id: &ID, y: SpaceState<ID, M, C>) -> Result<(), Self::Error> {
-        self.spaces.insert(*id, y);
+        let mut inner = self.inner.write().await;
+        inner.spaces.insert(*id, y);
         Ok(())
     }
 }
@@ -77,11 +93,13 @@ where
     type Error = Infallible;
 
     async fn auth(&self) -> Result<AuthGroupState<C>, Self::Error> {
-        Ok(self.auth.clone())
+        let inner = self.inner.read().await;
+        Ok(inner.auth.clone())
     }
 
     async fn set_auth(&mut self, y: &AuthGroupState<C>) -> Result<(), Self::Error> {
-        self.auth = y.clone();
+        let mut inner = self.inner.write().await;
+        inner.auth = y.clone();
         Ok(())
     }
 }
@@ -95,11 +113,13 @@ where
     type Error = Infallible;
 
     async fn message(&self, id: &OperationId) -> Result<Option<M>, Self::Error> {
-        Ok(self.messages.get(id).cloned())
+        let inner = self.inner.read().await;
+        Ok(inner.messages.get(id).cloned())
     }
 
     async fn set_message(&mut self, id: &OperationId, message: &M) -> Result<(), Self::Error> {
-        self.messages.insert(*id, message.clone());
+        let mut inner = self.inner.write().await;
+        inner.messages.insert(*id, message.clone());
         Ok(())
     }
 }

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -148,6 +148,7 @@ async fn send_and_receive() {
     // Bob processes Alice's messages.
 
     for message in alice_messages {
+        bob.manager.persist_message(&message).await.unwrap();
         bob.manager.process(&message).await.unwrap();
     }
 
@@ -169,6 +170,7 @@ async fn send_and_receive() {
 
     // Alice processes Bob's encrypted message.
 
+    alice.manager.persist_message(&message).await.unwrap();
     let events = alice.manager.process(&message).await.unwrap();
     assert_eq!(events.len(), 1);
 
@@ -370,10 +372,15 @@ async fn send_and_receive_after_add() {
 
     // Bob processes all of Alice's messages.
 
+    bob.manager.persist_message(&message_01).await.unwrap();
     bob.manager.process(&message_01).await.unwrap();
+    bob.manager.persist_message(&message_02).await.unwrap();
     bob.manager.process(&message_02).await.unwrap();
+    bob.manager.persist_message(&message_03).await.unwrap();
     bob.manager.process(&message_03).await.unwrap();
+    bob.manager.persist_message(&message_04).await.unwrap();
     bob.manager.process(&message_04).await.unwrap();
+    bob.manager.persist_message(&message_05).await.unwrap();
     let events = bob.manager.process(&message_05).await.unwrap();
     assert_eq!(events.len(), 1);
 }
@@ -520,7 +527,9 @@ async fn receive_control_messages() {
 
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
-    bob.manager.process(&message_01).await.unwrap();
+
+    bob_manager.persist_message(&message_01).await.unwrap();
+    bob_manager.process(&message_01).await.unwrap();
 
     // Global auth state has been updated.
     {
@@ -531,7 +540,8 @@ async fn receive_control_messages() {
         assert_eq!(vec![message_01.id()], auth_y.orderer_y.heads());
     }
 
-    bob.manager.process(&message_02).await.unwrap();
+    bob_manager.persist_message(&message_02).await.unwrap();
+    bob_manager.process(&message_02).await.unwrap();
     let space = bob_manager.space(space_id).await.unwrap().unwrap();
 
     // Alice is the only group member.
@@ -572,10 +582,13 @@ async fn receive_control_messages() {
     // Bob: Receive Message 03, 04 and 05
     // ~~~~~~~~~~~~
 
+    bob_manager.persist_message(&message_03).await.unwrap();
     let events = bob.manager.process(&message_03).await.unwrap();
     assert!(events.is_empty());
+    bob_manager.persist_message(&message_04).await.unwrap();
     let _ = bob.manager.process(&message_04).await.unwrap();
     assert!(events.is_empty());
+    bob_manager.persist_message(&message_05).await.unwrap();
     let events = bob.manager.process(&message_05).await.unwrap();
     // The application message arrives only after bob is welcomed.
     assert_eq!(events.len(), 2);
@@ -648,8 +661,10 @@ async fn remove_member() {
     // Bob: Receive Message 01 & 02
     // ~~~~~~~~~~~~
 
+    bob_manager.persist_message(&message_01).await.unwrap();
     let events = bob_manager.process(&message_01).await.unwrap();
     assert_eq!(events.len(), 1);
+    bob_manager.persist_message(&message_02).await.unwrap();
     let events = bob_manager.process(&message_02).await.unwrap();
     assert_eq!(events.len(), 1);
 
@@ -698,8 +713,10 @@ async fn remove_member() {
     // Bob: Receive Message 03 & 04
     // ~~~~~~~~~~~~
 
+    bob_manager.persist_message(&message_03).await.unwrap();
     let events = bob_manager.process(&message_03).await.unwrap();
     assert_eq!(events.len(), 1);
+    bob_manager.persist_message(&message_04).await.unwrap();
     let events = bob_manager.process(&message_04).await.unwrap();
     assert_eq!(events.len(), 2);
     assert!(matches!(
@@ -754,7 +771,9 @@ async fn concurrent_removal_conflict() {
     // Bob: Receive alice's messages
     // ~~~~~~~~~~~~
 
+    bob_manager.persist_message(&message_01).await.unwrap();
     bob_manager.process(&message_01).await.unwrap();
+    bob_manager.persist_message(&message_02).await.unwrap();
     bob_manager.process(&message_02).await.unwrap();
 
     // Alice: Removes bob (concurrently)
@@ -779,7 +798,9 @@ async fn concurrent_removal_conflict() {
     // Alice: process bobs' message
     // ~~~~~~~~~~~~
 
+    alice_manager.persist_message(&message_03).await.unwrap();
     alice_manager.process(&message_03).await.unwrap();
+    alice_manager.persist_message(&message_04).await.unwrap();
     alice_manager.process(&message_04).await.unwrap();
 
     // Alice: Adds dave
@@ -1376,6 +1397,7 @@ async fn events() {
 
     // Test basic expected event types.
     for (idx, message) in all_messages.iter().enumerate() {
+        bob_manager.persist_message(&message).await.unwrap();
         let events = bob_manager.process(&message).await.unwrap();
         match idx {
             // Member auth group created.
@@ -1446,6 +1468,7 @@ async fn events() {
 
     // Test expected members.
     for (idx, message) in all_messages.iter().enumerate() {
+        claire_manager.persist_message(&message).await.unwrap();
         let events = claire_manager.process(&message).await.unwrap();
         match idx {
             // Member auth group created.

--- a/p2panda-spaces/src/traits/key_store.rs
+++ b/p2panda-spaces/src/traits/key_store.rs
@@ -12,8 +12,10 @@ use crate::message::SpacesArgs;
 pub trait Forge<ID, M, C> {
     type Error: Debug;
 
+    /// Public key of the local peer.
     fn public_key(&self) -> PublicKey;
 
+    /// Forge and persist a new message.
     fn forge(&self, args: SpacesArgs<ID, C>) -> impl Future<Output = Result<M, Self::Error>>;
 }
 


### PR DESCRIPTION
Introduces a requirement of any `Forge` implementations that forged messages are also persisted to the global message store. This means we no longer persist forged messages ourselves within the p2panda-spaces code.

Note: `MessageStore` will be replaced with `OperationStore` from p2panda-core / p2panda-store when that's ready.

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
