### PR TITLE
`p2panda-spaces`: return events on local method calls which mutate state

### DIFF
--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -12,6 +12,7 @@ use crate::space::{added_members, removed_members};
 use crate::traits::SpaceId;
 use crate::traits::message::{AuthoredMessage, SpacesMessage};
 use crate::types::{AuthGroupAction, AuthGroupState, EncryptionGroupOutput};
+use crate::utils::sort_members;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GroupActor {
@@ -217,12 +218,14 @@ where
     };
 
     let group_id = args.control_message.group_id();
-    let group_actors = auth_y
+    let mut group_actors: Vec<_> = auth_y
         .root_members(group_id)
         .into_iter()
         .map(|(member, access)| (GroupActor::from_group_member(member), access))
         .collect();
-    let members = auth_y.members(group_id);
+    sort_members(&mut group_actors);
+    let mut members = auth_y.members(group_id);
+    sort_members(&mut members);
 
     let context = GroupContext {
         author: auth_message.author(),

--- a/p2panda-spaces/src/utils.rs
+++ b/p2panda-spaces/src/utils.rs
@@ -46,3 +46,7 @@ pub(crate) fn now() -> u64 {
         .expect("system time before unix epoch")
         .as_secs()
 }
+
+pub(crate) fn sort_members<ID: Ord, C>(members: &mut [(ID, Access<C>)]) {
+    members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(actor_b));
+}


### PR DESCRIPTION
When a user calls methods on the manager, a space or a group, we now return state change events.

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
