### PR TITLE
`test_args()` seeded from random bytes

### DIFF
--- a/p2panda-net-next/src/actors/supervisor.rs
+++ b/p2panda-net-next/src/actors/supervisor.rs
@@ -243,8 +243,7 @@ mod tests {
     use crate::actors::events::EVENTS;
     use crate::actors::{generate_actor_namespace, with_namespace};
     use crate::args::ArgsBuilder;
-    use crate::test_utils::NoSyncManager;
-    use crate::test_utils::test_args;
+    use crate::test_utils::{NoSyncManager, test_args};
 
     use super::{SUPERVISOR, Supervisor};
 

--- a/p2panda-net-next/src/test_utils.rs
+++ b/p2panda-net-next/src/test_utils.rs
@@ -26,7 +26,7 @@ pub fn test_args() -> (
     MemoryStore<ChaCha20Rng, TopicId, NodeId, NodeInfo>,
     NoSyncConfig,
 ) {
-    test_args_from_seed([1; 32])
+    test_args_from_seed(rand::random())
 }
 
 pub fn test_args_from_seed(
@@ -66,8 +66,8 @@ pub fn setup_logging() {
 
 #[test]
 fn deterministic_args() {
-    let (args_1, _, _) = test_args();
-    let (args_2, _, _) = test_args();
+    let (args_1, _, _) = test_args_from_seed([0; 32]);
+    let (args_2, _, _) = test_args_from_seed([0; 32]);
     assert_eq!(args_1.public_key, args_2.public_key);
     assert_eq!(args_1.iroh_config, args_2.iroh_config);
 }


### PR DESCRIPTION
Arguments generated via `test_args()` are seeded from random bytes in order to avoid cross-test collisions. If deterministic arguments are required then `test_args_from_seed` should be used.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
