### PR TITLE
Generate NeighborUp events when we join the gossip overlay

### DIFF
--- a/p2panda-net-next/src/actors/gossip/mod.rs
+++ b/p2panda-net-next/src/actors/gossip/mod.rs
@@ -360,10 +360,18 @@ where
                     warn!("oneshot gossip joined receiver dropped")
                 }
 
-                let peer_set = HashSet::from_iter(peers);
-
-                // Store the neighbours with whom we have joined the topic.
+                // Generate an empty set of neighbours.
+                // This will be populated with joined peers in the `NeighborUp` event handler.
+                let peer_set = HashSet::new();
                 state.neighbours.insert(topic, peer_set);
+
+                // Generate `NeighborUp` events. These are required to initiate sync.
+                peers.iter().for_each(|peer| {
+                    let _ = myself.cast(ToGossip::NeighborUp {
+                        node_id: *peer,
+                        session_id,
+                    });
+                });
 
                 Ok(())
             }


### PR DESCRIPTION
The gossip receiver actor is notified (by iroh) when we first join a gossip overlay. That results in an `ToGossipSession::ProcessJoined` event being sent. The gossip session informs the root gossip actor by sending `ToGossip::Joined`. This PR updates the `ToGossip::Joined` handler in order to trigger `ToGossip::NeighborUp` events which then initiate sync sessions.

We need to add this work around because we do not receive a `NeighborUp` event from iroh when we first join the overlay; it is consumed in the act of receiving the `joined()` result.
