### PR TITLE
Add missing relay url in user data during mDNS discovery

### DIFF
--- a/p2panda-net-next/src/actors/iroh/mdns.rs
+++ b/p2panda-net-next/src/actors/iroh/mdns.rs
@@ -192,9 +192,19 @@ impl ThreadLocalActor for Mdns {
                         let transport_info = AuthenticatedTransportInfo {
                             timestamp: txt.timestamp,
                             signature: txt.signature,
-                            addresses: endpoint_addr
-                                .map(|addr| vec![addr.into()])
-                                .unwrap_or(vec![]),
+                            addresses: {
+                                endpoint_addr
+                                    .clone()
+                                    .map(|mut addr| {
+                                        // Optionally add relay url if it was delivered via user
+                                        // data as well.
+                                        if let Some(relay_url) = txt.relay_url {
+                                            addr = addr.with_relay_url(relay_url);
+                                        }
+                                        vec![addr.into()]
+                                    })
+                                    .unwrap_or(vec![])
+                            },
                         };
 
                         // Check authenticity.

--- a/p2panda-net-next/src/actors/iroh/user_data.rs
+++ b/p2panda-net-next/src/actors/iroh/user_data.rs
@@ -7,8 +7,8 @@ use iroh::endpoint_info::MaxLengthExceededError;
 use p2panda_core::{IdentityError, Signature};
 use thiserror::Error;
 
-use crate::AuthenticatedTransportInfo;
 use crate::timestamp::{HybridTimestamp, HybridTimestampError};
+use crate::{AuthenticatedTransportInfo, NodeTransportInfo, TransportAddress};
 
 /// Helper to bring additional transport info (signature and timestamp) into iroh's user data
 /// struct.
@@ -18,6 +18,13 @@ use crate::timestamp::{HybridTimestamp, HybridTimestampError};
 pub struct UserDataTransportInfo {
     pub signature: Signature,
     pub timestamp: HybridTimestamp,
+    // TODO: We're including the endpoints "home relay url" in the user data as well as this is
+    // currently not supported by iroh for mDNS discovery.
+    //
+    // Without the relay url being part of the transport info we would break the signature.
+    //
+    // See related issue: https://github.com/n0-computer/iroh/issues/3682
+    pub relay_url: Option<iroh::RelayUrl>,
 }
 
 impl UserDataTransportInfo {
@@ -25,6 +32,9 @@ impl UserDataTransportInfo {
         Self {
             signature: info.signature,
             timestamp: info.timestamp,
+            relay_url: info.addresses().iter().find_map(|addr| match addr {
+                TransportAddress::Iroh(addr) => addr.relay_urls().next().cloned(),
+            }),
         }
     }
 }
@@ -37,7 +47,7 @@ impl TryFrom<AuthenticatedTransportInfo> for UserData {
     }
 }
 
-const INFO_SEPARATOR: char = '.';
+const INFO_SEPARATOR: char = '|';
 
 impl TryFrom<UserDataTransportInfo> for UserData {
     type Error = MaxLengthExceededError;
@@ -50,8 +60,12 @@ impl TryFrom<UserDataTransportInfo> for UserData {
         // NOTE: This will currently fail if the u64 integer gets too large .. we can't "remote
         // crash" nodes because of that at least.
         UserData::try_from(format!(
-            "{}{INFO_SEPARATOR}{}",
-            info.signature, info.timestamp
+            "{}{INFO_SEPARATOR}{}{}",
+            info.signature,
+            info.timestamp,
+            info.relay_url
+                .map(|url| format!("{INFO_SEPARATOR}{url}"))
+                .unwrap_or_default()
         ))
     }
 }
@@ -64,7 +78,7 @@ impl TryFrom<UserData> for UserDataTransportInfo {
 
         // Try to split string by separator into two halfs.
         let parts: Vec<_> = user_data.split(INFO_SEPARATOR).collect();
-        if parts.len() != 2 {
+        if parts.len() != 2 && parts.len() != 3 {
             return Err(UserDataInfoError::Size(parts.len()));
         }
 
@@ -76,16 +90,24 @@ impl TryFrom<UserData> for UserDataTransportInfo {
         let signature = Signature::from_str(signature_str)?;
         let timestamp = HybridTimestamp::from_str(timestamp_str)?;
 
+        // Try to parse optional relay url.
+        let relay_url = if let Some(relay_url_str) = parts.next() {
+            Some(iroh::RelayUrl::from_str(relay_url_str)?)
+        } else {
+            None
+        };
+
         Ok(Self {
             signature,
             timestamp,
+            relay_url,
         })
     }
 }
 
 #[derive(Debug, Error)]
 pub enum UserDataInfoError {
-    #[error("invalid size of separated info parts, expected 2, given: {0}")]
+    #[error("invalid size of separated info parts, expected 2-3, given: {0}")]
     Size(usize),
 
     #[error(transparent)]
@@ -93,12 +115,17 @@ pub enum UserDataInfoError {
 
     #[error(transparent)]
     Timestamp(#[from] HybridTimestampError),
+
+    #[error(transparent)]
+    RelayUrl(#[from] iroh::RelayUrlParseError),
 }
 
 #[cfg(test)]
 mod tests {
     use iroh::discovery::UserData;
     use p2panda_core::PrivateKey;
+
+    use crate::utils::from_public_key;
 
     use super::{AuthenticatedTransportInfo, UserDataTransportInfo};
 
@@ -109,6 +136,33 @@ mod tests {
         let transport_info = AuthenticatedTransportInfo::new_unsigned()
             .sign(&private_key)
             .unwrap();
+
+        // Extract information we want for our TXT record.
+        let txt_info = UserDataTransportInfo::from_transport_info(transport_info);
+
+        // Convert it into iroh data type.
+        let user_data = UserData::try_from(txt_info.clone()).unwrap();
+
+        // .. and back!
+        let txt_info_again = UserDataTransportInfo::try_from(user_data).unwrap();
+        assert_eq!(txt_info, txt_info_again);
+    }
+
+    #[test]
+    fn transport_info_to_user_data_with_relay_url() {
+        let private_key = PrivateKey::new();
+        let mut transport_info = AuthenticatedTransportInfo::new_unsigned();
+        transport_info.add_addr(
+            iroh::EndpointAddr::new(from_public_key(private_key.public_key()))
+                .with_ip_addr("127.0.0.1:8080".parse().unwrap())
+                .with_relay_url(
+                    "https://euc1-1.relay.n0.iroh-canary.iroh.link./"
+                        .parse()
+                        .unwrap(),
+                )
+                .into(),
+        );
+        let transport_info = transport_info.sign(&private_key).unwrap();
 
         // Extract information we want for our TXT record.
         let txt_info = UserDataTransportInfo::from_transport_info(transport_info);


### PR DESCRIPTION
This PR fixes a bug where the signature of transport info was invalid in mDNS discovery if the info was signed with a home relay url inside the endpoint addresses.

The relay url is omitted during mDNS breaking the verification for the receiver. We're manually adding it as part of the user data object.

Later this should become a feature as part of iroh. See related issue: https://github.com/n0-computer/iroh/issues/3682

Note: This doesn't fail if the info was signed with _no_ relay url inside. This is why the current mdns discovery test passes.