### PR TITLE
Allow endpoint to gracefully shut down on drop

### DIFF
--- a/p2panda-net-next/src/actors/endpoint_supervisor.rs
+++ b/p2panda-net-next/src/actors/endpoint_supervisor.rs
@@ -202,12 +202,19 @@ where
         _myself: ActorRef<Self::Msg>,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
+        trace!("endpoint supervisor shutting down");
         let reason = Some("endpoint supervisor is shutting down".to_string());
 
         // Stop all the actors which are directly supervised by this actor.
-        state.iroh_endpoint_actor.stop(reason.clone());
-        state.discovery_manager_actor.stop(reason.clone());
-        state.stream_supervisor.stop(reason);
+        state
+            .iroh_endpoint_actor
+            .stop_and_wait(reason.clone(), None)
+            .await?;
+        state
+            .discovery_manager_actor
+            .stop_and_wait(reason.clone(), None)
+            .await?;
+        state.stream_supervisor.stop_and_wait(reason, None).await?;
 
         Ok(())
     }

--- a/p2panda-net-next/src/actors/supervisor.rs
+++ b/p2panda-net-next/src/actors/supervisor.rs
@@ -126,12 +126,23 @@ where
         _myself: ActorRef<Self::Msg>,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
+        trace!("supervisor shutting down");
+
         let reason = Some("network system is shutting down".to_string());
 
         // Stop all the actors which are directly supervised by this actor.
-        state.events_actor.stop(reason.clone());
-        state.address_book_actor.stop(reason.clone());
-        state.endpoint_supervisor.stop(reason.clone());
+        state
+            .events_actor
+            .stop_and_wait(reason.clone(), None)
+            .await?;
+        state
+            .address_book_actor
+            .stop_and_wait(reason.clone(), None)
+            .await?;
+        state
+            .endpoint_supervisor
+            .stop_and_wait(reason.clone(), None)
+            .await?;
 
         Ok(())
     }

--- a/p2panda-net-next/src/network.rs
+++ b/p2panda-net-next/src/network.rs
@@ -139,11 +139,12 @@ impl NetworkBuilder {
 }
 
 #[derive(Debug)]
-#[allow(unused)]
 pub struct Network<M> {
     actor_namespace: ActorNamespace,
     supervisor_actor: ActorRef<()>,
+    #[allow(unused)]
     supervisor_actor_handle: JoinHandle<()>,
+    #[allow(unused)]
     root_thread_pool: ThreadLocalActorSpawner,
     _marker: PhantomData<M>,
 }

--- a/p2panda-net-next/src/tests/relay_url.rs
+++ b/p2panda-net-next/src/tests/relay_url.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use p2panda_core::PrivateKey;
 use p2panda_discovery::address_book::memory::MemoryStore;
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
 
 use crate::events::{NetworkEvent, RelayStatus};
 use crate::test_utils::{DummySyncConfig, DummySyncManager, setup_logging};
@@ -16,11 +17,37 @@ const RELAY_URL: &str = "https://euc1-1.relay.n0.iroh-canary.iroh.link.";
 async fn learns_about_home_relay() {
     setup_logging();
 
-    let address_book = MemoryStore::new(rand_chacha::ChaCha20Rng::from_os_rng());
+    let mut rng = rand_chacha::ChaCha20Rng::from_seed([1; 32]);
+    let address_book = MemoryStore::new(rng.clone());
+    let private_key = PrivateKey::from_bytes(&{
+        let bytes: [u8; 32] = rng.random();
+        bytes
+    });
     let (sync_config, _) = DummySyncConfig::new();
 
     let network: Network<DummySyncManager> = NetworkBuilder::new([1; 32])
         .relay(RELAY_URL.parse().unwrap())
+        .private_key(private_key.clone())
+        .build(address_book.clone(), sync_config.clone())
+        .await
+        .unwrap();
+
+    let mut events = network.events().await.unwrap();
+    loop {
+        if let NetworkEvent::Relay(RelayStatus::Connected(_)) = events.recv().await.unwrap() {
+            break;
+        }
+    }
+
+    // Drop the whole network instance and test if we're coming back online with a relay connection
+    // after launching a new instance with the same node id / private key.
+    //
+    // Read more here: https://github.com/n0-computer/iroh/issues/3798
+    drop(network);
+
+    let network: Network<DummySyncManager> = NetworkBuilder::new([1; 32])
+        .relay(RELAY_URL.parse().unwrap())
+        .private_key(private_key)
         .build(address_book, sync_config)
         .await
         .unwrap();


### PR DESCRIPTION
Allows all instances where we use iroh's `Endpoint` to gracefully close connections and sockets to not run into the issue where we can't re-connect to a relay after restarting (see https://github.com/n0-computer/iroh/issues/3798).

To make this work we need to spawn tasks on the `post_stop` handlers which allow the endpoint instance to wind down, independent of when the actors are actually dropped.

Lastly I've needed to change the methods from `stop` to `stop_and_wait` in ractor, as otherwise the `post_stop` handler was actually never called (at least for nested actors).