### PR TITLE
Fix: Gossip handles address book for sync topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Highlights are marked with a pancake 🥞
 - Remove uni-streams limit, additional tests for gossip [#874](https://github.com/p2panda/p2panda/pull/874)
 - Do not overwrite serde errors during deserialization of `Header` [#886](https://github.com/p2panda/p2panda/pull/886)
 - Handle outdated operations which got processed while being pruned, fix overflow substraction bug [#894](https://github.com/p2panda/p2panda/pull/894)
+- Gossip handles address book for sync topic [#942](https://github.com/p2panda/p2panda/pull/942)
 
 ## [0.4.0] - 07/07/2025
 

--- a/p2panda-net/src/gossip/api.rs
+++ b/p2panda-net/src/gossip/api.rs
@@ -301,7 +301,7 @@ impl Drop for TopicDropGuard {
             .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
 
         // If this is 1 the last instance of the guard was dropped and the counter is now at zero.
-        if previous_counter == 1 {
+        if previous_counter <= 1 {
             // Ignore this error, it could be that the actor has already stopped.
             let _ = actor_ref.send_message(ToGossipManager::Unsubscribe(self.topic));
         }

--- a/p2panda-net/src/sync/log_sync/api.rs
+++ b/p2panda-net/src/sync/log_sync/api.rs
@@ -13,7 +13,6 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 
 use crate::TopicId;
-use crate::address_book::AddressBook;
 use crate::gossip::Gossip;
 use crate::iroh_endpoint::Endpoint;
 use crate::sync::actors::ToSyncManager;
@@ -61,11 +60,10 @@ where
     pub fn builder(
         store: S,
         topic_map: TM,
-        address_book: AddressBook,
         endpoint: Endpoint,
         gossip: Gossip,
     ) -> Builder<S, L, E, TM> {
-        Builder::<S, L, E, TM>::new(store, topic_map, address_book, endpoint, gossip)
+        Builder::<S, L, E, TM>::new(store, topic_map, endpoint, gossip)
     }
 
     // TODO: Extensions should be generic over a stream handle, not over this struct.

--- a/p2panda-net/src/sync/log_sync/builder.rs
+++ b/p2panda-net/src/sync/log_sync/builder.rs
@@ -10,7 +10,6 @@ use ractor::thread_local::{ThreadLocalActor, ThreadLocalActorSpawner};
 use serde::{Deserialize, Serialize};
 
 use crate::TopicId;
-use crate::address_book::AddressBook;
 use crate::gossip::Gossip;
 use crate::iroh_endpoint::Endpoint;
 use crate::sync::actors::SyncManager;
@@ -25,7 +24,6 @@ where
 {
     store: S,
     topic_map: TM,
-    address_book: AddressBook,
     endpoint: Endpoint,
     gossip: Gossip,
     _marker: PhantomData<(L, E)>,
@@ -38,17 +36,10 @@ where
     E: Extensions + Send + 'static,
     TM: TopicLogMap<TopicId, L> + Send + 'static,
 {
-    pub fn new(
-        store: S,
-        topic_map: TM,
-        address_book: AddressBook,
-        endpoint: Endpoint,
-        gossip: Gossip,
-    ) -> Self {
+    pub fn new(store: S, topic_map: TM, endpoint: Endpoint, gossip: Gossip) -> Self {
         Self {
             store,
             topic_map,
-            address_book,
             endpoint,
             gossip,
             _marker: PhantomData,
@@ -69,7 +60,6 @@ where
             let args = (
                 LOG_SYNC_PROTOCOL_ID.to_vec(),
                 config,
-                self.address_book,
                 self.endpoint,
                 self.gossip,
             );

--- a/p2panda-net/src/sync/tests.rs
+++ b/p2panda-net/src/sync/tests.rs
@@ -67,13 +67,7 @@ impl FailingNode {
         let (sync_ref, _) =
             SyncManager::<DummySyncManager<FailingSyncConfig, FailingSyncProtocol>>::spawn(
                 None,
-                (
-                    TEST_PROTOCOL_ID.to_vec(),
-                    sync_config,
-                    address_book,
-                    endpoint,
-                    gossip,
-                ),
+                (TEST_PROTOCOL_ID.to_vec(), sync_config, endpoint, gossip),
                 thread_pool,
             )
             .await

--- a/p2panda-net/src/test_utils.rs
+++ b/p2panda-net/src/test_utils.rs
@@ -230,16 +230,11 @@ impl TestNode {
 
         let (operation_store, topic_map) = client.sync_config();
 
-        let log_sync = LogSync::builder(
-            operation_store,
-            topic_map,
-            address_book.clone(),
-            endpoint.clone(),
-            gossip.clone(),
-        )
-        .spawn()
-        .await
-        .unwrap();
+        let log_sync =
+            LogSync::builder(operation_store, topic_map, endpoint.clone(), gossip.clone())
+                .spawn()
+                .await
+                .unwrap();
 
         Self {
             args,

--- a/p2panda-net/tests/api.rs
+++ b/p2panda-net/tests/api.rs
@@ -30,7 +30,7 @@ async fn modular_api() {
         .await
         .unwrap();
 
-    let gossip = Gossip::builder(address_book.clone(), endpoint.clone())
+    let gossip = Gossip::builder(address_book, endpoint.clone())
         .spawn()
         .await
         .unwrap();
@@ -48,7 +48,7 @@ async fn modular_api() {
     let store = TestMemoryStore::new();
     let topic_map = TestTopicMap::new();
 
-    let sync = LogSync::builder(store, topic_map, address_book, endpoint, gossip)
+    let sync = LogSync::builder(store, topic_map, endpoint, gossip)
         .spawn()
         .await
         .unwrap();


### PR DESCRIPTION
This fixes a bug where sync would add it's topic to the address book even though gossip already managed this. Since we're deriving the topic used for gossip / membership clustering / HyParView from the given sync topic this bug caused _both_ representations to exist in the address book ("sync topic" and derived "gossip topic").

The same goes for topic removal from the address book which shouldn't be handled by sync but only by gossip, as soon as all handles have been dropped. This didn't work as intended due to a off-by-one bug in the drop logic (which occurs only in specific cases we didn't test against yet).

I've added a test which should take care of both of these issues.

Lastly I've added some more DEBUG-level logs for sync for easier troubleshooting in the future (it helped finding this bug) and did some minor variable renaming changes, to separate clearer from "sync-" and "gossip topics" (instead of calling it a "mixed topic").

This change causes a breaking change in the `LogSync` API, the address book argument is _not_ needed anymore (which is nice).

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] New files contain a SPDX license header
