### PR TITLE
Method to configure relay urls in Endpoint builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Highlights are marked with a pancake 🥞
   - Add missing relay url in user data during mDNS discovery [#907](https://github.com/p2panda/p2panda/pull/907)
   - Allow endpoint to gracefully shut down on drop [#908](https://github.com/p2panda/p2panda/pull/908)
   - Modular API for new `p2panda-net` [#909](https://github.com/p2panda/p2panda/pull/909) 🥞
+  - Method to configure relay urls in Endpoint builder [#948](https://github.com/p2panda/p2panda/pull/948)
 
 ### Changed
 

--- a/p2panda-net/src/iroh_endpoint/builder.rs
+++ b/p2panda-net/src/iroh_endpoint/builder.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::HashSet;
+
 use p2panda_core::PrivateKey;
 use ractor::thread_local::{ThreadLocalActor, ThreadLocalActorSpawner};
 
@@ -18,6 +20,7 @@ pub struct Builder {
     network_id: Option<NetworkId>,
     private_key: Option<PrivateKey>,
     config: Option<IrohConfig>,
+    relay_urls: HashSet<iroh::RelayUrl>,
     address_book: AddressBook,
 }
 
@@ -28,6 +31,7 @@ impl Builder {
             private_key: None,
             config: None,
             address_book,
+            relay_urls: HashSet::new(),
         }
     }
 
@@ -46,11 +50,41 @@ impl Builder {
         self
     }
 
+    /// Adds iroh relay server to assist in establishing direct connections.
+    ///
+    /// Multiple relays can be added, iroh will automatically choose a "home relay" based on
+    /// latency.
+    ///
+    /// Relays fullfil multiple functions:
+    ///
+    /// 1. The relay server helps establish connections by temporarily routing encrypted traffic
+    ///    until a direct, P2P connection is feasible. This allows nodes to immediately get
+    ///    started, without waiting for holepunching / STUN to complete first.
+    /// 2. Handle learning a node's public addresses (via QUIC address discovery), signalling and
+    ///    hole-punching to establish direct connections between two nodes. This set of methods is
+    ///    also understood as STUN. After this point the relay is not required anymore.
+    /// 3. Relayed and encrypted fallback using the server when establishing a direct connection
+    ///    failed (TURN).
+    ///
+    /// If no relay is given we can only connect to a node knowing it's directly reachable IP
+    /// address.
+    pub fn relay_url(mut self, url: iroh::RelayUrl) -> Self {
+        self.relay_urls.insert(url);
+        self
+    }
+
     pub(crate) fn build_args(self) -> IrohEndpointArgs {
         let network_id = self.network_id.unwrap_or(DEFAULT_NETWORK_ID);
         let private_key = self.private_key.unwrap_or_default();
         let config = self.config.unwrap_or_default();
-        (network_id, private_key, config, self.address_book)
+        let relay_map = iroh::RelayMap::from_iter(self.relay_urls);
+        (
+            network_id,
+            private_key,
+            config,
+            relay_map,
+            self.address_book,
+        )
     }
 
     pub async fn spawn(self) -> Result<Endpoint, EndpointError> {

--- a/p2panda-net/src/iroh_endpoint/config.rs
+++ b/p2panda-net/src/iroh_endpoint/config.rs
@@ -24,12 +24,6 @@ pub struct IrohConfig {
     /// Setting the port to `0` will use a random port. If the port specified is already in use, it
     /// will fallback to choosing a random port.
     pub bind_port_v6: u16,
-
-    /// Sets the relay servers to assist in establishing connectivity.
-    ///
-    /// Relay servers are used to establish initial connection with another iroh endpoint. They
-    /// also perform various functions related to hole punching.
-    pub relay_urls: Vec<iroh::RelayUrl>,
 }
 
 impl Default for IrohConfig {
@@ -39,7 +33,6 @@ impl Default for IrohConfig {
             bind_port_v4: DEFAULT_BIND_PORT,
             bind_ip_v6: Ipv6Addr::UNSPECIFIED,
             bind_port_v6: DEFAULT_BIND_PORT + 2,
-            relay_urls: Vec::new(),
         }
     }
 }

--- a/p2panda-net/src/test_utils.rs
+++ b/p2panda-net/src/test_utils.rs
@@ -144,7 +144,6 @@ pub fn test_args_from_seed(
                 bind_port_v4: rng.random_range(49152..65535),
                 bind_ip_v6: Ipv6Addr::LOCALHOST,
                 bind_port_v6: rng.random_range(49152..65535),
-                ..Default::default()
             })
             .with_rng(rng)
             .with_mdns_mode(MdnsDiscoveryMode::Disabled)


### PR DESCRIPTION
Users can now call `relay_url` on the Endpoint builder to configure relay urls instead of passing them in via the `IrohConfig` object which felt cumbersome:

```rust
let endpoint = Endpoint::builder(address_book)
    .relay_url(url)
    .spawn()
    .await?;
```

This removes iroh's relay urls from `IrohConfig` and instead makes it an explicit argument which needs to be passed into the Endpoint actor.

I prefer configs being always "optional" as the defaults already guarantee you a fully working system. Relay urls feel a bit outside of that definition as without them many things would _not_ work and the default is not enough.

Closes: https://github.com/p2panda/p2panda/issues/940

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
