### PR TITLE
Add clone trait on GossipHandle

### DIFF
--- a/p2panda-net/src/gossip/api.rs
+++ b/p2panda-net/src/gossip/api.rs
@@ -167,6 +167,7 @@ pub enum GossipError {
 /// received if they were published after the subscription was created.
 ///
 /// Use the sync stream if you wish to receive past state for eventual consistency.
+#[derive(Clone)]
 pub struct GossipHandle {
     topic: TopicId,
     to_topic_tx: mpsc::Sender<Vec<u8>>,


### PR DESCRIPTION
Since all fields of GossipHandle already implement the Clone trait, adding #[derive(Clone)] to GossipHandle was sufficient to make it cloneable.
Fixes issue : #953 