### PR TITLE
Avoid leaking low-level p2panda-sync types in p2panda-net API 

### DIFF
--- a/p2panda-net/src/gossip/mod.rs
+++ b/p2panda-net/src/gossip/mod.rs
@@ -10,7 +10,7 @@ mod events;
 #[cfg(test)]
 mod tests;
 
-pub use api::{Gossip, GossipError, GossipHandle, GossipHandleError, GossipSubscription};
+pub use api::{Gossip, GossipError, GossipHandle, GossipSubscription};
 pub use builder::Builder;
 pub use config::{DEFAULT_MAX_MESSAGE_SIZE, GossipConfig, HyParViewConfig, PlumTreeConfig};
 pub use events::GossipEvent;

--- a/p2panda-net/src/sync/log_sync/api.rs
+++ b/p2panda-net/src/sync/log_sync/api.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::sync::Arc;
 
-use p2panda_core::Extensions;
+use p2panda_core::{Extensions, Operation};
 use p2panda_store::{LogId, LogStore, OperationStore};
-use p2panda_sync::manager::TopicSyncManager;
-use p2panda_sync::protocols::Logs;
-use p2panda_sync::traits::{Manager as SyncManagerTrait, TopicMap};
+use p2panda_sync::protocols::{Logs, TopicLogSyncEvent};
+use p2panda_sync::traits::TopicMap;
 use ractor::{ActorRef, call};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -47,18 +47,16 @@ where
     E: Extensions + Send + 'static,
     TM: TopicMap<TopicId, Logs<L>> + Send + 'static,
 {
-    inner: Arc<RwLock<Inner<S, L, E, TM>>>,
+    inner: Arc<RwLock<Inner<E>>>,
+    _phantom: PhantomData<(S, L, TM)>,
 }
 
-struct Inner<S, L, E, TM>
+struct Inner<E>
 where
-    S: OperationStore<L, E> + LogStore<L, E> + Send + 'static,
-    L: LogId + Serialize + for<'de> Deserialize<'de> + Send + 'static,
     E: Extensions + Send + 'static,
-    TM: TopicMap<TopicId, Logs<L>> + Send + 'static,
 {
     #[allow(clippy::type_complexity)]
-    actor_ref: ActorRef<ToSyncManager<TopicSyncManager<TopicId, S, TM, L, E>>>,
+    actor_ref: ActorRef<ToSyncManager<Operation<E>, TopicLogSyncEvent<E>>>,
 }
 
 impl<S, L, E, TM> LogSync<S, L, E, TM>
@@ -70,10 +68,11 @@ where
 {
     #[allow(clippy::type_complexity)]
     pub(crate) fn new(
-        actor_ref: ActorRef<ToSyncManager<TopicSyncManager<TopicId, S, TM, L, E>>>,
+        actor_ref: ActorRef<ToSyncManager<Operation<E>, TopicLogSyncEvent<E>>>,
     ) -> Self {
         Self {
             inner: Arc::new(RwLock::new(Inner { actor_ref })),
+            _phantom: PhantomData,
         }
     }
 
@@ -91,10 +90,7 @@ where
         &self,
         topic: TopicId,
         live_mode: bool,
-    ) -> Result<
-        SyncHandle<TopicSyncManager<TopicId, S, TM, L, E>>,
-        LogSyncError<TopicSyncManager<TopicId, S, TM, L, E>>,
-    > {
+    ) -> Result<SyncHandle<Operation<E>, TopicLogSyncEvent<E>>, LogSyncError<E>> {
         let inner = self.inner.read().await;
         let sync_manager_ref =
             call!(inner.actor_ref, ToSyncManager::Create, topic, live_mode).map_err(Box::new)?;
@@ -107,12 +103,9 @@ where
     }
 }
 
-impl<S, L, E, TM> Drop for Inner<S, L, E, TM>
+impl<E> Drop for Inner<E>
 where
-    S: OperationStore<L, E> + LogStore<L, E> + Send + 'static,
-    L: LogId + Serialize + for<'de> Deserialize<'de> + Send + 'static,
     E: Extensions + Send + 'static,
-    TM: TopicMap<TopicId, Logs<L>> + Send + 'static,
 {
     fn drop(&mut self) {
         self.actor_ref.stop(None);
@@ -120,15 +113,12 @@ where
 }
 
 #[derive(Debug, Error)]
-pub enum LogSyncError<M>
-where
-    M: SyncManagerTrait<TopicId> + Send + 'static,
-{
+pub enum LogSyncError<E> {
     /// Spawning the internal actor failed.
     #[error(transparent)]
     ActorSpawn(#[from] ractor::SpawnErr),
 
     /// Messaging with internal actor via RPC failed.
     #[error(transparent)]
-    ActorRpc(#[from] Box<ractor::RactorErr<ToSyncManager<M>>>),
+    ActorRpc(#[from] Box<ractor::RactorErr<ToSyncManager<Operation<E>, TopicLogSyncEvent<E>>>>),
 }

--- a/p2panda-net/src/sync/log_sync/builder.rs
+++ b/p2panda-net/src/sync/log_sync/builder.rs
@@ -47,9 +47,7 @@ where
         }
     }
 
-    pub async fn spawn(
-        self,
-    ) -> Result<LogSync<S, L, E, TM>, LogSyncError<TopicSyncManager<TopicId, S, TM, L, E>>> {
+    pub async fn spawn(self) -> Result<LogSync<S, L, E, TM>, LogSyncError<E>> {
         let (actor_ref, _) = {
             let thread_pool = ThreadLocalActorSpawner::new();
 

--- a/p2panda-net/src/sync/tests.rs
+++ b/p2panda-net/src/sync/tests.rs
@@ -29,7 +29,7 @@ const TEST_PROTOCOL_ID: [u8; 32] = [101; 32];
 
 struct FailingNode {
     args: ApplicationArguments,
-    sync_ref: ActorRef<ToSyncManager<DummySyncManager<FailingSyncArgs, FailingSyncProtocol>>>,
+    sync_ref: ActorRef<ToSyncManager<DummySyncMessage, DummySyncEvent>>,
 }
 
 impl FailingNode {
@@ -175,7 +175,7 @@ impl SyncManagerTrait<TopicId> for DummySyncManager<FailingSyncArgs, FailingSync
     type Protocol = FailingSyncProtocol;
     type Event = DummySyncEvent;
     type Args = FailingSyncArgs;
-    type Message = ();
+    type Message = DummySyncMessage;
     type Error = SendError;
 
     fn from_args(args: Self::Args) -> Self {


### PR DESCRIPTION
This fixes the fact that the `SyncManager` trait was being leaked due to it being a requirement
on a generic parameter in error types and the sync stream handle.

With this change error types and the SyncHandle now have generic parameters for the concrete
message and event types defined at application level, rather than requiring the concrete manager
type to be defined. Some minor improvements to generic parameters in p2panda-sync have also
been included.

Additionally a BroadcastStreamRecvError is returned directly from SyncSubscription and
GossipSubscription streams which avoids unnecessary error unwrapping.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
