### PR TITLE
Note on patching fixed iroh-gossip

### DIFF
--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -69,8 +69,7 @@ futures-util = "0.3.31"
 hex = "0.4.3"
 iroh = { version = "0.95.1", default-features = false, optional = true }
 iroh-base = { version = "0.95.1", optional = true }
-# TODO: Temporary fix. See related issue: https://github.com/n0-computer/iroh-gossip/pull/117
-iroh-gossip = { git = "https://github.com/p2panda/iroh-gossip", rev = "6fad0f740c031876dbb412c7b8237776314d763e", optional = true }
+iroh-gossip = { version = "0.95.0", optional = true }
 p2panda-core = { path = "../p2panda-core", version = "0.4.0" }
 p2panda-discovery = { path = "../p2panda-discovery", version = "0.4.0", features = ["test_utils"], optional = true }
 p2panda-store = { path = "../p2panda-store", version = "0.4.0", optional = true }

--- a/p2panda-net/README.md
+++ b/p2panda-net/README.md
@@ -29,6 +29,19 @@ these modules solve the problem of event delivery.
 Applications subscribe to any topic they are interested in and `p2panda-net`
 will automatically discover similar peers and exchange messages between them.
 
+> [!IMPORTANT]
+> `p2panda-net` depends on a fixed version
+> ([`#117`](https://github.com/n0-computer/iroh-gossip/pull/117)) of
+> `iroh-gossip` which has not been published yet.
+>
+> Please patch your build with the fixed crate for now until this is handled
+> upstream by adding the following lines to your root `Cargo.toml`:
+>
+> ```toml
+> [patch.crates-io]
+> iroh-gossip = { git = "https://github.com/p2panda/iroh-gossip", rev = "533c34a2758518ece19c1de9f21bc40d61f9b5a5" }
+> ```
+
 ## Features
 
 - [Publish & Subscribe] for ephemeral messages (gossip protocol)

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -16,6 +16,20 @@
 //!   [Supervision Trees])
 //! - Modular API allowing users to choose or replace the layers they want to use
 //!
+//! ## Important note
+//!
+//! `p2panda-net` depends on a fixed version
+//! ([`#117`](https://github.com/n0-computer/iroh-gossip/pull/117)) of `iroh-gossip` which has not
+//! been published yet.
+//!
+//! Please patch your build with the fixed crate for now until this is handled upstream by adding
+//! the following lines to your root `Cargo.toml`:
+//!
+//! ```toml
+//! [patch.crates-io]
+//! iroh-gossip = { git = "https://github.com/p2panda/iroh-gossip", rev = "533c34a2758518ece19c1de9f21bc40d61f9b5a5" }
+//! ```
+//!
 //! ## Getting Started
 //!
 //! Install the Rust crate using `cargo add p2panda-net`.


### PR DESCRIPTION
p2panda-net depends on a fixed version
(https://github.com/n0-computer/iroh-gossip/pull/117) of `iroh-gossip` which has not been published yet.

This commit adds a note to the README.md and crate-level documentation to inform users about a dependency patch they need to apply manually to work with the fixed version.

When releasing p2panda-net with the fixed, upstream iroh version, this note can be removed.