### PR TITLE
Replace sink adaptor chain with custom wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Highlights are marked with a pancake 🥞
 ### Fixed
 
 - Fix Drop impl causing premature gossip unsubscribe [#968](https://github.com/p2panda/p2panda/pull/968)
+- Fix panic on sink closure after error during sync session [#972](https://github.com/p2panda/p2panda/pull/972)
 
 ## [0.5.0] - 21/01/2026
 

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -92,5 +92,6 @@ clap = { version = "4.5.54", features = ["derive"] }
 futures-test = "0.3.31"
 mock_instant = "0.6.0"
 p2panda-net = { path = ".", features = ["test_utils"] }
+p2panda-sync = { path = "../p2panda-sync", features = ["test_utils"] }
 tokio = { version = "1.47.1", features = ["rt", "sync", "time"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }

--- a/p2panda-net/src/sync/log_sync/tests.rs
+++ b/p2panda-net/src/sync/log_sync/tests.rs
@@ -3,9 +3,15 @@
 use std::collections::HashMap;
 
 use assert_matches::assert_matches;
+use iroh::endpoint::Connection;
+use iroh::protocol::{AcceptError, ProtocolHandler};
+use iroh::{Endpoint, protocol::Router};
 use p2panda_core::Operation;
+use p2panda_net::cbor::{into_cbor_sink, into_cbor_stream};
 use p2panda_sync::FromSync;
-use p2panda_sync::protocols::TopicLogSyncEvent as Event;
+use p2panda_sync::protocols::{Logs, TopicLogSyncEvent as Event};
+use p2panda_sync::test_utils::{Peer, TestTopic, TestTopicSyncMessage};
+use p2panda_sync::traits::Protocol;
 use tokio_stream::StreamExt;
 
 use crate::test_utils::{TestNode, setup_logging};
@@ -604,4 +610,62 @@ async fn unsubscribe_from_gossip_after_drop() {
             break;
         }
     }
+}
+
+const ALPN: &[u8] = b"iroh/smol/0";
+
+#[derive(Debug, Clone, Default)]
+struct TestProtocol {}
+
+impl ProtocolHandler for TestProtocol {
+    async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
+        let _ = connection.accept_bi().await;
+        // No need to do anything else here as we expect the connection to immediately close.
+        Ok(())
+    }
+
+    async fn shutdown(&self) {}
+}
+
+#[tokio::test]
+async fn panic_on_sink_closure_after_error_regression() {
+    // This is a regression test for an issue where chaining adaptors on the message sink in
+    // TopicLogSync was causing a panic under certain error conditions:
+    // https://github.com/p2panda/p2panda/issues/970
+    //
+    // The issue could only be reproduced when using an actual QUIC stream as the underlying
+    // transport. Here we use a connection between two iroh endpoints.
+    setup_logging();
+
+    let topic = TestTopic::new("messages");
+    let mut peer = Peer::new(0);
+    peer.insert_topic(&topic, &Logs::default());
+
+    let (session, _events_rx, _live_tx) = peer.topic_sync_protocol(topic.clone(), true);
+
+    let acceptor = Endpoint::bind().await.unwrap();
+    let acceptor_router = Router::builder(acceptor)
+        .accept(ALPN, TestProtocol::default())
+        .spawn();
+    let addr = acceptor_router.endpoint().addr();
+
+    let initiator = Endpoint::bind().await.unwrap();
+    let connection = initiator.connect(addr, ALPN).await.unwrap();
+    let (tx, rx) = connection.open_bi().await.unwrap();
+    let mut tx = into_cbor_sink::<TestTopicSyncMessage, _>(tx);
+    let mut rx = into_cbor_stream::<TestTopicSyncMessage, _>(rx);
+
+    let handle = tokio::spawn(async move { session.run(&mut tx, &mut rx).await });
+
+    // Unexpectedly closing the connection here on the "initiator" side causes the initial sync
+    // protocol (before live-mode) to end with an error. After the error is correctly handled
+    // sink.close() is called and _this_ causes a panic in the underlying message sink due to the
+    // way it was wrapped in both a .with() and .sink_map_err() adaptor. The panic is caused
+    // because both these wrappers end up calling poll_close() and doing this after the sink is
+    // already in a closed state causes an error. The fix is to introduce a custom Sink wrapper
+    // instead of chaining adaptors.
+    connection.close(0u32.into(), b"testing");
+
+    let result = handle.await.unwrap();
+    assert!(result.is_err());
 }

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 p2panda-core = { path = "../p2panda-core", version = "0.5.0" }
 p2panda-store = { path = "../p2panda-store", version = "0.5.0" }
+pin-project-lite = "0.2.16"
 rand = { version = "0.9.2", optional = true }
 serde = "1.0.228"
 thiserror = "2.0.17"


### PR DESCRIPTION
Under certain conditions an error occuring during a sync session would cause a panic when the sink was closed. This was due to the .with() and .sink_map_err() adapters being chained and when the underlying sink transport has particular closure semantics it could cause the sink to be polled twice on closure. This behavior was reproducable using a QUIC stream between two iroh endpoints for the transport and closing the initiator end immediately after connection was established.

The fix is to implement a custom Sink wrapper which avoids the need for the chained adaptors.

A regression test is included in this change which failed with the previous code.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
