### PR TITLE
Cleanup state in gossip unsubscribe handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Highlights are marked with a pancake 🥞
 - Fix Drop impl causing premature gossip unsubscribe [#968](https://github.com/p2panda/p2panda/pull/968)
 - Fix panic on sink closure after error during sync session [#972](https://github.com/p2panda/p2panda/pull/972)
 - Gracefully handle concurrently deleted operations during sync [#974](https://github.com/p2panda/p2panda/pull/974)
+- Cleanup state in gossip unsubscribe handler [#973](https://github.com/p2panda/p2panda/pull/973)
 
 ## [0.5.0] - 21/01/2026
 


### PR DESCRIPTION
The `ActorTerminated` event cannot be relied upon to fire when a child actor is stopped by the parent. Since we were cleaning up some gossip session state and sending the `Left` event from the termination handler, this resulted in the event not being sent on some occasions.

The cleanup logic has been moved into the `Unsubscribe` handler and the `ActorTerminated` event handler has been removed completely to avoid further confusion in the future.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`