### PR TITLE
Gracefully handle concurrently pruned operations in log sync protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Highlights are marked with a pancake 🥞
 
 - Fix Drop impl causing premature gossip unsubscribe [#968](https://github.com/p2panda/p2panda/pull/968)
 - Fix panic on sink closure after error during sync session [#972](https://github.com/p2panda/p2panda/pull/972)
+- Gracefully handle concurrently deleted operations during sync [#974](https://github.com/p2panda/p2panda/pull/974)
 
 ## [0.5.0] - 21/01/2026
 

--- a/p2panda-store/src/memory.rs
+++ b/p2panda-store/src/memory.rs
@@ -276,7 +276,7 @@ where
         public_key: &PublicKey,
         log_id: &L,
         from: Option<u64>,
-    ) -> Result<Option<Vec<Hash>>, Self::Error> {
+    ) -> Result<Option<Vec<(u64, Hash)>>, Self::Error> {
         let store = self.read_store();
         match store.logs.get(&(*public_key, log_id.to_owned())) {
             Some(log) => {
@@ -286,14 +286,14 @@ where
                         if *seq_num >= from {
                             let (_, header, _, _) =
                                 store.operations.get(hash).expect("exists in hash map");
-                            hashes.push(header.hash());
+                            hashes.push((header.seq_num, header.hash()));
                         }
                     });
                 } else {
                     log.iter().for_each(|(_, _, hash)| {
                         let (_, header, _, _) =
                             store.operations.get(hash).expect("exists in hash map");
-                        hashes.push(header.hash());
+                        hashes.push((header.seq_num, header.hash()));
                     });
                 }
                 Ok(Some(hashes))
@@ -701,9 +701,9 @@ mod tests {
             .expect("log should exist");
 
         assert_eq!(hashes.len(), 3);
-        assert_eq!(hashes[0], hash_0);
-        assert_eq!(hashes[1], hash_1);
-        assert_eq!(hashes[2], hash_2);
+        assert_eq!(hashes[0], (0, hash_0));
+        assert_eq!(hashes[1], (1, hash_1));
+        assert_eq!(hashes[2], (2, hash_2));
 
         // Get sum of log byte lengths.
         let size = store
@@ -728,8 +728,8 @@ mod tests {
             .expect("log should exist");
 
         assert_eq!(hashes.len(), 2);
-        assert_eq!(hashes[0], hash_1);
-        assert_eq!(hashes[1], hash_2);
+        assert_eq!(hashes[0], (1, hash_1));
+        assert_eq!(hashes[1], (2, hash_2));
 
         // Get sum of log byte lengths from sequence number 1.
         let size = store

--- a/p2panda-store/src/operations.rs
+++ b/p2panda-store/src/operations.rs
@@ -140,7 +140,7 @@ pub trait LocalLogStore<LogId, Extensions> {
         public_key: &PublicKey,
         log_id: &LogId,
         from: Option<u64>,
-    ) -> Result<Option<Vec<Hash>>, Self::Error>;
+    ) -> Result<Option<Vec<(u64, Hash)>>, Self::Error>;
 
     /// Get the log heights of all logs, by any author, which are stored under the passed log id.
     async fn get_log_heights(&self, log_id: &LogId) -> Result<Vec<(PublicKey, u64)>, Self::Error>;

--- a/p2panda-store/src/sqlite/models.rs
+++ b/p2panda-store/src/sqlite/models.rs
@@ -36,7 +36,10 @@ pub struct OperationRow {
 
 /// Database representation of a single hash.
 #[derive(FromRow, Debug, Clone, PartialEq, Eq)]
-pub struct HashValue(String);
+pub struct SeqAndHash {
+    seq_num: String,
+    hash: String,
+}
 
 /// Database representation of the sum of all header and body byte size.
 #[derive(FromRow, Debug, Clone, PartialEq, Eq)]
@@ -80,9 +83,9 @@ impl From<RawOperationRow> for RawOperation {
     }
 }
 
-impl From<HashValue> for Hash {
-    fn from(value: HashValue) -> Hash {
-        value.0.parse().unwrap()
+impl From<SeqAndHash> for (u64, Hash) {
+    fn from(value: SeqAndHash) -> (u64, Hash) {
+        (value.seq_num.parse().unwrap(), value.hash.parse().unwrap())
     }
 }
 

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -458,7 +458,7 @@ mod tests {
 
     #[tokio::test]
     async fn live_mode_three_peer_forwarding() {
-        use std::collections::HashMap;
+        setup_logging();
 
         const TOPIC_NAME: &str = "chat";
         const LOG_ID: u64 = 0;


### PR DESCRIPTION
It is possible that operations are pruned from a log after a sync session has started and hashes of all operations a remote needs calculated, but before the operations themselves were retrieved from the store. Prior to this change this caused a panic in the log sync protocol as it expected all operations to be still present in the store. With this change we gracefully handle the case where an operation is no longer present, logging the fact that it is missing.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
