### PR TITLE
Improve sync session logging in `p2panda-sync` and `p2panda-net`

### DIFF
--- a/p2panda-net/src/sync/actors/topic_manager.rs
+++ b/p2panda-net/src/sync/actors/topic_manager.rs
@@ -190,12 +190,13 @@ where
                     state.pool.clone(),
                 )
                 .await?;
-                let protocol =
+                let (session_id, protocol) =
                     Self::new_session(state, actor_ref.get_id(), node_id, topic, config).await;
 
                 actor_ref.send_message(SyncSessionMessage::Initiate {
                     node_id,
                     topic,
+                    session_id,
                     protocol,
                     protocol_id: state.protocol_id.clone(),
                 })?;
@@ -249,13 +250,14 @@ where
                 )
                 .await?;
 
-                let protocol =
+                let (session_id, protocol) =
                     Self::new_session(state, actor_ref.get_id(), node_id, state.topic, config)
                         .await;
 
                 actor_ref.send_message(SyncSessionMessage::Initiate {
                     node_id,
                     topic: state.topic,
+                    session_id,
                     protocol,
                     protocol_id: state.protocol_id.clone(),
                 })?;
@@ -285,11 +287,13 @@ where
                     state.pool.clone(),
                 )
                 .await?;
-                let protocol =
+                let (session_id, protocol) =
                     Self::new_session(state, actor_ref.get_id(), node_id, topic, config).await;
 
                 actor_ref.send_message(SyncSessionMessage::Accept {
                     connection,
+                    topic,
+                    session_id,
                     protocol,
                 })?;
             }
@@ -476,7 +480,7 @@ where
         node_id: NodeId,
         topic: TopicId,
         config: SessionConfig<TopicId>,
-    ) -> <M as SyncManagerTrait<TopicId>>::Protocol {
+    ) -> (u64, <M as SyncManagerTrait<TopicId>>::Protocol) {
         let session_id: SyncSessionId = state.next_session_id;
         state.next_session_id += 1;
 
@@ -505,7 +509,7 @@ where
 
         state.actor_session_id_map.insert(actor_id, session_id);
 
-        session
+        (session_id, session)
     }
 
     /// Remove a session from all manager state mappings.

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -128,7 +128,7 @@ where
             .insert_with_topic(session_id, config.topic.clone(), live_tx.clone());
 
         for manager_tx in self.manager_tx.iter_mut() {
-            if manager_tx
+            if let Err(err) = manager_tx
                 .send(SessionStream {
                     session_id,
                     topic: config.topic.clone(),
@@ -137,9 +137,8 @@ where
                     live_tx: live_tx.clone(),
                 })
                 .await
-                .is_err()
             {
-                debug!("manager handle dropped");
+                debug!("manager handle dropped: {err:?}");
             };
         }
 


### PR DESCRIPTION
Improvements to sync session logging in both p2panda-net and p2panda-sync. The logs now provide contextual information relating to the session by using trace spans, as well more concisely expressing sync lifetime events at debug level. For logging of all sync events coming from all running sessions, trace level logging can be enabled.

## Example Logs

_all examples here include logging from both parties in the sync session, normally you'd only see one side_

## Debug

command: `RUST_LOG=p2panda_net[sync]=debug,p2panda_sync[sync]=debug cargo test e2e_log_sync`

```
2026-02-04T12:51:02.121823Z DEBUG sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: start sync session live_mode=true
2026-02-04T12:51:02.121882Z DEBUG sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: local topic logs retrieved logs={"166574f515": 1}
2026-02-04T12:51:02.123122Z DEBUG sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: start sync session live_mode=true
2026-02-04T12:51:02.123209Z DEBUG sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: local topic logs retrieved logs={"053f155a33": 1}
2026-02-04T12:51:02.123928Z DEBUG sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::log_sync: sync metrics received local_ops=1 remote_ops=1 local_bytes=155 remote_bytes=157
2026-02-04T12:51:02.123961Z DEBUG sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::log_sync: sync metrics received local_ops=1 remote_ops=1 local_bytes=157 remote_bytes=155
2026-02-04T12:51:02.125637Z DEBUG sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: closing sync session
2026-02-04T12:51:02.126033Z DEBUG sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: received close message from remote
2026-02-04T12:51:02.126089Z DEBUG sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: sync session closed sent_ops=1 sent_bytes=155 received_ops=2 received_bytes=355
2026-02-04T12:51:02.126431Z DEBUG sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: sync session closed sent_ops=2 sent_bytes=355 received_ops=1 received_bytes=155

```

### Trace

command: `RUST_LOG=p2panda_net[sync]=trace,p2panda_sync[sync]=trace cargo test e2e_log_sync`

```
2026-02-04T12:51:43.454082Z DEBUG sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: start sync session live_mode=true
2026-02-04T12:51:43.454137Z DEBUG sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: local topic logs retrieved logs={"166574f515": 1}
2026-02-04T12:51:43.454164Z TRACE sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: local topic logs retrieved logs=[("166574f515", [0])]
2026-02-04T12:51:43.454333Z TRACE sync{responder=9898b46f14 topic=0000000000 session_id=0}: iroh_quinn_proto::connection::streams: wrote 74 bytes stream=client bidirectional stream 1
2026-02-04T12:51:43.454686Z DEBUG sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: start sync session live_mode=true
2026-02-04T12:51:43.454734Z DEBUG sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: local topic logs retrieved logs={"053f155a33": 1}
2026-02-04T12:51:43.454757Z TRACE sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: local topic logs retrieved logs=[("053f155a33", [0])]
2026-02-04T12:51:43.454849Z TRACE sync{requester=6df30e3c76 topic=0000000000 session_id=0}: iroh_quinn_proto::connection::streams: wrote 74 bytes stream=client bidirectional stream 1
2026-02-04T12:51:43.455224Z TRACE sync{requester=6df30e3c76 topic=0000000000 session_id=0}: iroh_quinn_proto::connection::streams: wrote 70 bytes stream=client bidirectional stream 1
2026-02-04T12:51:43.455319Z TRACE sync{responder=9898b46f14 topic=0000000000 session_id=0}: iroh_quinn_proto::connection::streams: wrote 70 bytes stream=client bidirectional stream 1
2026-02-04T12:51:43.455524Z DEBUG sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::log_sync: sync metrics received local_ops=1 remote_ops=1 local_bytes=157 remote_bytes=155
2026-02-04T12:51:43.455607Z TRACE sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::log_sync: send operation phase="sync" public_key=166574f515 log_id=0 seq_num=0 id=29010 sent_ops=1 sent_bytes=157
2026-02-04T12:51:43.455622Z DEBUG sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::log_sync: sync metrics received local_ops=1 remote_ops=1 local_bytes=155 remote_bytes=157
2026-02-04T12:51:43.455671Z TRACE sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::log_sync: send operation phase="sync" public_key=053f155a33 log_id=0 seq_num=0 id=e31db sent_ops=1 sent_bytes=155
2026-02-04T12:51:43.455677Z TRACE sync{responder=9898b46f14 topic=0000000000 session_id=0}: iroh_quinn_proto::connection::streams: wrote 346 bytes stream=client bidirectional stream 1
2026-02-04T12:51:43.455707Z TRACE sync{requester=6df30e3c76 topic=0000000000 session_id=0}: iroh_quinn_proto::connection::streams: wrote 333 bytes stream=client bidirectional stream 1
2026-02-04T12:51:43.455732Z TRACE sync{requester=6df30e3c76 topic=0000000000 session_id=0}: iroh_quinn_proto::connection::streams: wrote 28 bytes stream=client bidirectional stream 1
2026-02-04T12:51:43.455728Z TRACE sync{responder=9898b46f14 topic=0000000000 session_id=0}: iroh_quinn_proto::connection::streams: wrote 28 bytes stream=client bidirectional stream 1
2026-02-04T12:51:43.456029Z TRACE sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::log_sync: received operation phase="sync" id="e31db" received_ops=1 received_bytes=155
2026-02-04T12:51:43.456091Z TRACE sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::log_sync: received operation phase="sync" id="29010" received_ops=1 received_bytes=157
2026-02-04T12:51:43.456575Z TRACE sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: sent operation phase="live" id="f7a7d" sent_ops=2 sent_bytes=355
2026-02-04T12:51:43.456641Z TRACE sync{responder=9898b46f14 topic=0000000000 session_id=0}: iroh_quinn_proto::connection::streams: wrote 217 bytes stream=client bidirectional stream 1
2026-02-04T12:51:43.457142Z TRACE sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: received operation phase="live" operation_id="f7a7d" received_ops=2 received_bytes=355
2026-02-04T12:51:43.457407Z DEBUG sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: closing sync session
2026-02-04T12:51:43.457451Z TRACE sync{responder=9898b46f14 topic=0000000000 session_id=0}: iroh_quinn_proto::connection::streams: wrote 12 bytes stream=client bidirectional stream 1
2026-02-04T12:51:43.457870Z DEBUG sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: received close message from remote
2026-02-04T12:51:43.457910Z DEBUG sync{requester=6df30e3c76 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: sync session closed sent_ops=1 sent_bytes=155 received_ops=2 received_bytes=355
2026-02-04T12:51:43.458236Z DEBUG sync{responder=9898b46f14 topic=0000000000 session_id=0}: p2panda_sync::protocols::topic_log_sync: sync session closed sent_ops=2 sent_bytes=355 received_ops=1 received_bytes=155

```

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
