### PR TITLE
Bump Rust version to 1.89.0 in GitHub CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on: push
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: 1.88.0
+  RUST_TOOLCHAIN: 1.89.0
 
 jobs:
   test:


### PR DESCRIPTION
This is required by iroh v0.96.0 crates.