### PR TITLE
Update iroh to `v0.96.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
+### Changed
+
+- Update iroh to v0.96.1 [#978](https://github.com/p2panda/p2panda/pull/978)
+
 ### Fixed
 
 - Fix Drop impl causing premature gossip unsubscribe [#968](https://github.com/p2panda/p2panda/pull/968)

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -38,7 +38,7 @@ iroh_endpoint = [
 ]
 iroh_mdns = [
   "iroh_endpoint",
-  "iroh/discovery-local-network",
+  "iroh/address-lookup-mdns",
 ]
 discovery = [
   "address_book",
@@ -67,9 +67,9 @@ ciborium = "0.2.2"
 futures-channel = "0.3.31"
 futures-util = "0.3.31"
 hex = "0.4.3"
-iroh = { version = "0.95.1", default-features = false, optional = true }
-iroh-base = { version = "0.95.1", optional = true }
-iroh-gossip = { version = "0.95.0", optional = true }
+iroh = { version = "0.96.1", default-features = false, optional = true }
+iroh-base = { version = "0.96.1", optional = true }
+iroh-gossip = { version = "0.96.0", optional = true }
 p2panda-core = { path = "../p2panda-core", version = "0.5.0" }
 p2panda-discovery = { path = "../p2panda-discovery", version = "0.5.0", features = ["test_utils"], optional = true }
 p2panda-store = { path = "../p2panda-store", version = "0.5.0", optional = true }

--- a/p2panda-net/src/gossip/api.rs
+++ b/p2panda-net/src/gossip/api.rs
@@ -217,6 +217,11 @@ impl Gossip {
 
 impl Drop for Inner {
     fn drop(&mut self) {
+        trace!(
+            actor_id = %self.actor_ref.get_id(),
+            "drop gossip actor reference"
+        );
+
         // Stop actor after all references (Gossip, GossipHandle, GossipSubscription) have dropped.
         self.actor_ref.stop(None);
     }
@@ -290,6 +295,7 @@ impl GossipHandle {
 /// A handle to an ephemeral messaging stream subscription.
 ///
 /// The stream can be used to receive messages from the stream.
+#[derive(Debug)]
 pub struct GossipSubscription {
     topic: TopicId,
     from_topic_rx: BroadcastStream<Vec<u8>>,
@@ -331,6 +337,7 @@ impl Stream for GossipSubscription {
 ///
 /// Check if we can unsubscribe from topic if all handles and subscriptions have been dropped for
 /// it. The gossip overlay will be left then for this topic.
+#[derive(Debug)]
 struct TopicDropGuard {
     topic: TopicId,
     counter: Arc<AtomicUsize>,

--- a/p2panda-net/src/iroh_endpoint/actors/connection.rs
+++ b/p2panda-net/src/iroh_endpoint/actors/connection.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::sync::Arc;
-
-use iroh::endpoint::{ConnectOptions, TransportConfig};
+use iroh::endpoint::{ConnectOptions, QuicTransportConfig};
 use ractor::thread_local::ThreadLocalActor;
 use ractor::{ActorProcessingErr, ActorRef, RpcReplyPort};
 use thiserror::Error;
@@ -24,7 +22,7 @@ pub enum IrohConnectionArgs {
         endpoint: iroh::endpoint::Endpoint,
         endpoint_addr: iroh::EndpointAddr,
         alpn: ProtocolId,
-        transport_config: Option<Arc<TransportConfig>>,
+        quic_transport_config: Option<QuicTransportConfig>,
         reply: ConnectReplyPort,
     },
     Accept {
@@ -97,14 +95,14 @@ async fn establish_connection(
             endpoint,
             endpoint_addr,
             alpn,
-            transport_config,
+            quic_transport_config,
             reply,
         } => {
             tracing::Span::current().record("alpn", alpn.fmt_short());
             let remote_node_id = to_public_key(endpoint_addr.id);
 
             let mut connect_options = ConnectOptions::default();
-            if let Some(config) = transport_config {
+            if let Some(config) = quic_transport_config {
                 connect_options = connect_options.with_transport_config(config);
             }
 

--- a/p2panda-net/src/iroh_endpoint/api.rs
+++ b/p2panda-net/src/iroh_endpoint/api.rs
@@ -168,7 +168,7 @@ impl Endpoint {
         &self,
         node_id: NodeId,
         protocol_id: impl AsRef<[u8]>,
-        transport_config: Arc<iroh::endpoint::TransportConfig>,
+        quic_transport_config: iroh::endpoint::QuicTransportConfig,
     ) -> Result<iroh::endpoint::Connection, EndpointError> {
         let inner = self.inner.read().await;
         let result = call!(
@@ -176,7 +176,7 @@ impl Endpoint {
             ToIrohEndpoint::Connect,
             node_id,
             protocol_id.as_ref().to_vec(),
-            Some(transport_config)
+            Some(quic_transport_config)
         )
         .map_err(Box::new)??;
         Ok(result)

--- a/p2panda-net/src/iroh_endpoint/user_data.rs
+++ b/p2panda-net/src/iroh_endpoint/user_data.rs
@@ -2,7 +2,7 @@
 
 use std::str::FromStr;
 
-use iroh::discovery::UserData;
+use iroh::address_lookup::UserData;
 use iroh::endpoint_info::MaxLengthExceededError;
 use p2panda_core::{IdentityError, Signature};
 use thiserror::Error;
@@ -122,7 +122,7 @@ pub enum UserDataInfoError {
 
 #[cfg(test)]
 mod tests {
-    use iroh::discovery::UserData;
+    use iroh::address_lookup::UserData;
     use p2panda_core::PrivateKey;
 
     use crate::iroh_endpoint::from_public_key;

--- a/p2panda-net/src/iroh_mdns/actor.rs
+++ b/p2panda-net/src/iroh_mdns/actor.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use futures_util::StreamExt;
-use iroh::discovery::mdns::{DiscoveryEvent, MdnsDiscovery};
-use iroh::discovery::{Discovery, EndpointData, UserData};
+use iroh::address_lookup::mdns::DiscoveryEvent;
+use iroh::address_lookup::{AddressLookup, EndpointData, MdnsAddressLookup, UserData};
 use ractor::thread_local::ThreadLocalActor;
 use ractor::{ActorProcessingErr, ActorRef};
 use tokio::task::JoinHandle;
@@ -39,7 +39,7 @@ pub enum ToMdns {
 pub struct MdnsState {
     my_node_id: NodeId,
     address_book: AddressBook,
-    service: Option<MdnsDiscovery>,
+    service: Option<MdnsAddressLookup>,
     handle: Option<JoinHandle<()>>,
 }
 
@@ -104,7 +104,7 @@ impl ThreadLocalActor for MdnsActor {
                 // resolving interface) as we're already handling that ourselves with checked and
                 // authenticated addresses.
 
-                let mdns = MdnsDiscovery::builder()
+                let mdns = MdnsAddressLookup::builder()
                     // Do not advertise our own endpoint address if in "passive" mode.
                     .advertise(mode.is_active())
                     .service_name(MDNS_SERVICE_NAME)


### PR DESCRIPTION
Introduces updated API naming changes for iroh.

Patch release `v0.96.1` was released in the process of making this PR.

https://github.com/p2panda/p2panda/issues/960

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
