### PR TITLE
Fix tests: Subscribe to events before topic stream creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Highlights are marked with a pancake 🥞
 - Gracefully handle concurrently deleted operations during sync [#974](https://github.com/p2panda/p2panda/pull/974)
 - Cleanup state in gossip unsubscribe handler [#973](https://github.com/p2panda/p2panda/pull/973)
 - Fix bind conflict with unique argument seed [#980](https://github.com/p2panda/p2panda/pull/980)
+- Fix tests: Subscribe to events before topic stream creation [#981](https://github.com/p2panda/p2panda/pull/981)
 
 ## [0.5.0] - 21/01/2026
 


### PR DESCRIPTION
Events can be missed if they are published into the channel before the subscription has occurred via the high-level API.

This behaviour resulted in flaky gossip tests.

Related: https://github.com/p2panda/p2panda/issues/926

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any relevant issue