### PR TITLE
Remove patch note for iroh-gossip from p2panda-net docs

### DIFF
--- a/p2panda-net/README.md
+++ b/p2panda-net/README.md
@@ -29,19 +29,6 @@ these modules solve the problem of event delivery.
 Applications subscribe to any topic they are interested in and `p2panda-net`
 will automatically discover similar peers and exchange messages between them.
 
-> [!IMPORTANT]
-> `p2panda-net` depends on a fixed version
-> ([`#117`](https://github.com/n0-computer/iroh-gossip/pull/117)) of
-> `iroh-gossip` which has not been published yet.
->
-> Please patch your build with the fixed crate for now until this is handled
-> upstream by adding the following lines to your root `Cargo.toml`:
->
-> ```toml
-> [patch.crates-io]
-> iroh-gossip = { git = "https://github.com/p2panda/iroh-gossip", rev = "533c34a2758518ece19c1de9f21bc40d61f9b5a5" }
-> ```
-
 ## Features
 
 - [Publish & Subscribe] for ephemeral messages (gossip protocol)

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -16,20 +16,6 @@
 //!   [Supervision Trees])
 //! - Modular API allowing users to choose or replace the layers they want to use
 //!
-//! ## Important note
-//!
-//! `p2panda-net` depends on a fixed version
-//! ([`#117`](https://github.com/n0-computer/iroh-gossip/pull/117)) of `iroh-gossip` which has not
-//! been published yet.
-//!
-//! Please patch your build with the fixed crate for now until this is handled upstream by adding
-//! the following lines to your root `Cargo.toml`:
-//!
-//! ```toml
-//! [patch.crates-io]
-//! iroh-gossip = { git = "https://github.com/p2panda/iroh-gossip", rev = "533c34a2758518ece19c1de9f21bc40d61f9b5a5" }
-//! ```
-//!
 //! ## Getting Started
 //!
 //! Install the Rust crate using `cargo add p2panda-net`.


### PR DESCRIPTION
Addresses https://github.com/p2panda/p2panda/issues/983

This is the original PR that added the note(s): https://github.com/p2panda/p2panda/pull/962

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
