### PR TITLE
Fix: dropped "joined" event results in no sync session being started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix missing gossip events in sync manager [#988](https://github.com/p2panda/p2panda/pull/988)
+
 ## [0.5.1] - 09/02/2026
 
 ### Changed

--- a/p2panda-net/src/gossip/api.rs
+++ b/p2panda-net/src/gossip/api.rs
@@ -208,6 +208,9 @@ impl Gossip {
     }
 
     /// Subscribe to system events.
+    ///
+    /// NOTE: only events emitted _after_ calling this method will be received on the returned
+    /// channel.
     pub async fn events(&self) -> Result<broadcast::Receiver<GossipEvent>, GossipError> {
         let inner = self.inner.read().await;
         let result = call!(inner.actor_ref, ToGossipManager::Events).map_err(Box::new)?;

--- a/p2panda-net/src/sync/actors/manager.rs
+++ b/p2panda-net/src/sync/actors/manager.rs
@@ -145,6 +145,9 @@ where
             "join gossip overlay for peer-sampling",
         );
 
+        // Subscribe to events coming from the gossip actor.
+        let mut events = self.gossip.events().await?;
+
         // Join gossip overlay to use HyParView membership algorithm for peer sampling.
         //
         // This will subscribe us to the gossip topic and add it to the address book.
@@ -153,7 +156,6 @@ where
         // Listen for events of HyParView who entered or left the "active view". This informs with
         // whom we're running sync sessions with.
         let gossip_events_handle = {
-            let mut events = self.gossip.events().await?;
             let myself = myself.clone();
             let gossip_topics = self.gossip_topics.clone();
 


### PR DESCRIPTION
When subscribing to the event stream on the gossip API only events emitted after the channel was created will be received. An error was introduced as a result of this because of joining a gossip overlay in the sync manager and then subscribing to the event channel meant we missed a critical "joined" event which would kick of sync. Moving the event stream subscription to before the call to join the overlay solved this particular issue.

Additionally a note has been added to the event() doc string to highlight this behavior.

closes: https://github.com/p2panda/reflection/issues/205

## 📋 Checklist

- [ ] ~~Add tests that cover your changes~~
- [ ] ~~Add this PR to the _Unreleased_ section in `CHANGELOG.md`~~
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
