### PR TITLE
Re-export useful EndpointAddr iroh type in p2panda-net

### DIFF
--- a/p2panda-net/src/iroh_endpoint/mod.rs
+++ b/p2panda-net/src/iroh_endpoint/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod user_data;
 
 // Re-export useful iroh types.
 pub use iroh::RelayUrl;
+pub use iroh::EndpointAddr;
 
 pub use api::{Endpoint, EndpointError};
 pub use builder::Builder;


### PR DESCRIPTION
To construct a `NodeInfo` backed by iroh the `EndpointAddr` type is
needed. Therefore it should be reexported.