### PR TITLE
`LogStore` SQLite implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
+- Add `LogStore` trait and SQLite implementation [#1004](https://github.com/p2panda/p2panda/pull/1004)
 - Add `TopicStore` trait and SQLite implementation [#1011](https://github.com/p2panda/p2panda/pull/1011)
 
 ### Changed

--- a/p2panda-core/src/test_utils.rs
+++ b/p2panda-core/src/test_utils.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::{Body, Extensions, Hash, Header, Operation, PrivateKey, Topic};
+use crate::{Body, Extensions, Hash, Header, Operation, PrivateKey, PublicKey, Topic};
 
 #[derive(Clone, Default)]
 pub struct TestLog {
@@ -24,8 +24,18 @@ impl TestLog {
         }
     }
 
+    pub fn from_private_key(private_key: PrivateKey) -> Self {
+        let mut log = TestLog::new();
+        log.private_key = private_key;
+        log
+    }
+
     pub fn id(&self) -> Topic {
         self.log_id
+    }
+
+    pub fn author(&self) -> PublicKey {
+        self.private_key.public_key()
     }
 
     pub fn operation<E: Extensions>(&self, body: &[u8], extensions: E) -> Operation<E> {

--- a/p2panda-store-next/migrations/20250928132835_create_operations.sql
+++ b/p2panda-store-next/migrations/20250928132835_create_operations.sql
@@ -11,7 +11,9 @@ CREATE TABLE IF NOT EXISTS operations_v1 (
     payload_size            TEXT            NOT NULL,
     payload_hash            TEXT            NULL,
     timestamp               TEXT            NOT NULL,
+    seq_num                 TEXT            NOT NULL,
     header                  BLOB            NOT NULL,
+    header_size             TEXT            NOT NULL,
     body                    BLOB            NULL,
     extensions              BLOB            NULL
 );

--- a/p2panda-store-next/src/lib.rs
+++ b/p2panda-store-next/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 pub mod address_book;
+pub mod logs;
 #[cfg(feature = "macros")]
 pub mod macros;
 pub mod operations;

--- a/p2panda-store-next/src/logs/mod.rs
+++ b/p2panda-store-next/src/logs/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cfg(feature = "sqlite")]
+mod sqlite;
+mod traits;
+
+pub use traits::LogStore;

--- a/p2panda-store-next/src/logs/sqlite/mod.rs
+++ b/p2panda-store-next/src/logs/sqlite/mod.rs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+mod models;
+#[cfg(test)]
+mod tests;
+
+use std::collections::HashMap;
+
+use p2panda_core::cbor::encode_cbor;
+use p2panda_core::{Extensions, Hash, LogId, Operation, PublicKey};
+use sqlx::{query, query_as};
+
+use crate::logs::LogStore;
+use crate::logs::sqlite::models::{LatestEntryRow, LogHeightRow, LogMetaRow};
+use crate::operations::OperationRow;
+use crate::sqlite::{SqliteError, SqliteStore};
+
+pub type SeqNum = u64;
+
+impl<'a, L, E> LogStore<Operation<E>, PublicKey, L, SeqNum, Hash> for SqliteStore<'a>
+where
+    E: Extensions,
+    L: LogId,
+{
+    type Error = SqliteError;
+
+    /// Retrieve the hash and sequence number of the latest entry in an author's log.
+    async fn get_latest_entry(
+        &self,
+        author: &PublicKey,
+        log_id: &L,
+    ) -> Result<Option<(Hash, SeqNum)>, Self::Error> {
+        if let Some(latest_entry) = query_as::<_, LatestEntryRow>(
+            "
+            SELECT
+                hash,
+                seq_num
+            FROM
+                operations_v1
+            WHERE
+                public_key = ?
+                AND log_id = ?
+            ORDER BY
+                CAST(seq_num AS NUMERIC) DESC LIMIT 1
+            ",
+        )
+        .bind(author.to_string())
+        .bind(encode_cbor(&log_id).map_err(|err| SqliteError::Encode("log id".to_string(), err))?)
+        .fetch_optional(&self.pool)
+        .await?
+        {
+            let hash_seq_num = latest_entry.try_into()?;
+
+            Ok(Some(hash_seq_num))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Retrieve the latest sequence number for a set of author's logs.
+    async fn get_log_heights(
+        &self,
+        author: &PublicKey,
+        logs: &[L],
+    ) -> Result<Option<HashMap<L, SeqNum>>, Self::Error> {
+        let mut encoded_log_ids = Vec::new();
+        for log in logs {
+            let encoded_log_id =
+                encode_cbor(&log).map_err(|err| SqliteError::Encode("log id".to_string(), err))?;
+            encoded_log_ids.push(encoded_log_id);
+        }
+
+        // This query formation approach is required since there is currently no
+        // way to directly bind arrays as comma-separated lists in sqlx.
+        let params = format!("?{}", ", ?".repeat(encoded_log_ids.len() - 1));
+        let query_str = format!(
+            "
+            SELECT
+                log_id,
+                CAST(MAX(CAST(seq_num AS NUMERIC)) AS TEXT) as seq_num
+            FROM
+                operations_v1
+            WHERE
+                public_key = ?
+                AND log_id IN ( {} )
+            GROUP BY
+                log_id
+            ",
+            params
+        );
+
+        let mut query = query_as::<_, LogHeightRow>(&query_str).bind(author.to_string());
+
+        for log_id in encoded_log_ids {
+            query = query.bind(log_id)
+        }
+
+        let log_heights_query = query.fetch_all(&self.pool).await?;
+
+        let log_heights = if log_heights_query.is_empty() {
+            None
+        } else {
+            let mut log_heights = HashMap::new();
+
+            for row in log_heights_query {
+                let (log_id, seq_num) = row.try_into()?;
+                log_heights.insert(log_id, seq_num);
+            }
+
+            Some(log_heights)
+        };
+
+        Ok(log_heights)
+    }
+
+    /// Retrieve the count and total byte size of all operations in an author's log.
+    async fn get_log_size(
+        &self,
+        author: &PublicKey,
+        log_id: &L,
+        after: Option<SeqNum>,
+        until: Option<SeqNum>,
+    ) -> Result<Option<(u64, u64)>, Self::Error> {
+        // We need to use an inclusive greater-than to ensure our
+        // query includes the operation with sequence number 0.
+        let after_operator = if after.is_none() { ">=" } else { ">" };
+        let query_str = format!(
+            "
+            SELECT
+                CAST(SUM(CAST(header_size AS NUMERIC)) AS TEXT) AS total_header_bytes,
+                CAST(SUM(CAST(payload_size AS NUMERIC)) AS TEXT) AS total_payload_bytes,
+                CAST(COUNT(*) AS TEXT) AS total_operation_count
+            FROM
+                operations_v1
+            WHERE
+                public_key = ?
+                AND log_id = ?
+                AND CAST(seq_num AS NUMERIC) {} CAST(? as NUMERIC)
+                AND CAST(seq_num AS NUMERIC) <= CAST(? as NUMERIC)
+            ",
+            after_operator
+        );
+
+        let log_meta: Option<LogMetaRow> = query_as::<_, LogMetaRow>(&query_str)
+            .bind(author.to_string())
+            .bind(
+                encode_cbor(&log_id)
+                    .map_err(|err| SqliteError::Encode("log id".to_string(), err))?,
+            )
+            .bind(after.unwrap_or(0).to_string())
+            .bind(until.unwrap_or(u64::MAX).to_string())
+            .fetch_optional(&self.pool)
+            .await?;
+
+        if let Some(row) = log_meta {
+            let (total_header_bytes, total_payload_bytes, total_operation_count) =
+                row.try_into()?;
+
+            return Ok(Some((
+                total_operation_count,
+                total_header_bytes + total_payload_bytes,
+            )));
+        }
+
+        Ok(None)
+    }
+
+    /// Retrieve log entries representing operations from an author's log.
+    async fn get_log_entries(
+        &self,
+        author: &PublicKey,
+        log_id: &L,
+        after: Option<SeqNum>,
+        until: Option<SeqNum>,
+    ) -> Result<Option<Vec<(Operation<E>, Vec<u8>)>>, Self::Error> {
+        // We need to use an inclusive greater-than to ensure our
+        // query includes the operation with sequence number 0.
+        let after_operator = if after.is_none() { ">=" } else { ">" };
+
+        let query_str = format!(
+            "
+            SELECT
+                hash,
+                header,
+                body
+            FROM
+                operations_v1
+            WHERE
+                public_key = ?
+                AND log_id = ?
+                AND CAST(seq_num AS NUMERIC) {} CAST(? as NUMERIC)
+                AND CAST(seq_num AS NUMERIC) <= CAST(? as NUMERIC)
+            ORDER BY
+                CAST(seq_num AS NUMERIC)
+            ",
+            after_operator
+        );
+
+        let operations = query_as::<_, OperationRow>(&query_str)
+            .bind(author.to_string())
+            .bind(
+                encode_cbor(&log_id)
+                    .map_err(|err| SqliteError::Encode("log id".to_string(), err))?,
+            )
+            .bind(after.unwrap_or(0).to_string())
+            .bind(until.unwrap_or(u64::MAX).to_string())
+            .fetch_all(&self.pool)
+            .await?;
+
+        let mut entries = Vec::new();
+        for operation in operations {
+            entries.push((operation.clone().try_into()?, operation.header))
+        }
+
+        if entries.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(entries))
+        }
+    }
+
+    /// Prune entries from an author's log.
+    ///
+    /// Pruning involves deletion of the entry bodies (ie. payloads) from the database.
+    async fn prune_entries(
+        &self,
+        author: &PublicKey,
+        log_id: &L,
+        until: &SeqNum,
+    ) -> Result<u64, Self::Error> {
+        let result = query(
+            "
+            DELETE
+            FROM
+                operations_v1
+            WHERE
+                public_key = ?
+                AND log_id = ?
+                AND CAST(seq_num AS NUMERIC) < CAST(? as NUMERIC)
+            ",
+        )
+        .bind(author.to_string())
+        .bind(encode_cbor(&log_id).map_err(|err| SqliteError::Encode("log id".to_string(), err))?)
+        .bind(until.to_string())
+        .execute(&self.pool)
+        .await?;
+
+        let pruned_entries_num = result.rows_affected();
+
+        Ok(pruned_entries_num)
+    }
+}

--- a/p2panda-store-next/src/logs/sqlite/models.rs
+++ b/p2panda-store-next/src/logs/sqlite/models.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use p2panda_core::cbor::decode_cbor;
+use p2panda_core::{Hash, HashError, LogId};
+use sqlx::FromRow;
+
+use crate::logs::sqlite::SeqNum;
+use crate::sqlite::{DecodeError, SqliteError};
+
+/// Database representation of the sum of all header and body byte size.
+#[derive(FromRow, Debug, Clone, PartialEq, Eq)]
+pub struct LogMetaRow {
+    pub total_header_bytes: String,
+    pub total_payload_bytes: String,
+    pub total_operation_count: String,
+}
+
+impl TryFrom<LogMetaRow> for (u64, u64, u64) {
+    type Error = SqliteError;
+
+    fn try_from(row: LogMetaRow) -> Result<Self, Self::Error> {
+        let total_header_bytes: u64 = row
+            .total_header_bytes
+            .parse()
+            .map_err(|_| SqliteError::Decode("header size".to_string(), DecodeError::FromStr))?;
+        let total_payload_bytes: u64 = row
+            .total_payload_bytes
+            .parse()
+            .map_err(|_| SqliteError::Decode("payload size".to_string(), DecodeError::FromStr))?;
+        let total_operation_count: u64 = row.total_operation_count.parse().map_err(|_| {
+            SqliteError::Decode("operation count".to_string(), DecodeError::FromStr)
+        })?;
+
+        Ok((
+            total_header_bytes,
+            total_payload_bytes,
+            total_operation_count,
+        ))
+    }
+}
+
+/// Database representation of the hash and sequence number of the latest
+/// operation in a log.
+#[derive(FromRow, Debug, Clone, PartialEq, Eq)]
+pub struct LatestEntryRow {
+    hash: String,
+    seq_num: String,
+}
+
+impl TryFrom<LatestEntryRow> for (Hash, SeqNum) {
+    type Error = SqliteError;
+
+    fn try_from(row: LatestEntryRow) -> Result<Self, Self::Error> {
+        let hash = row
+            .hash
+            .parse()
+            .map_err(|err: HashError| SqliteError::Decode("hash".to_string(), err.into()))?;
+        let seq_num = row
+            .seq_num
+            .parse()
+            .map_err(|_| SqliteError::Decode("seq num".to_string(), DecodeError::FromStr))?;
+
+        Ok((hash, seq_num))
+    }
+}
+
+/// Database representation of a log ID and sequence number for a single operation.
+#[derive(FromRow, Debug, Clone, PartialEq, Eq)]
+pub struct LogHeightRow {
+    pub(crate) log_id: Vec<u8>,
+    pub(crate) seq_num: String,
+}
+
+impl<L> TryFrom<LogHeightRow> for (L, SeqNum)
+where
+    L: LogId,
+{
+    type Error = SqliteError;
+
+    fn try_from(row: LogHeightRow) -> Result<Self, Self::Error> {
+        let log_id = decode_cbor(&row.log_id[..])
+            .map_err(|err| SqliteError::Decode("log id".to_string(), err.into()))?;
+        let seq_num = row
+            .seq_num
+            .parse()
+            .map_err(|_| SqliteError::Decode("seq num".to_string(), DecodeError::FromStr))?;
+
+        Ok((log_id, seq_num))
+    }
+}

--- a/p2panda-store-next/src/logs/sqlite/tests.rs
+++ b/p2panda-store-next/src/logs/sqlite/tests.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashMap;
+
+use p2panda_core::test_utils::TestLog;
+use p2panda_core::{Operation, PrivateKey};
+
+use crate::logs::LogStore;
+use crate::operations::OperationStore;
+use crate::sqlite::{SqliteStore, SqliteStoreBuilder};
+use crate::traits::Transaction;
+
+#[tokio::test]
+async fn get_latest_entry() {
+    let store = SqliteStoreBuilder::new()
+        .random_memory_url()
+        .max_connections(1)
+        .build()
+        .await
+        .unwrap();
+
+    let log = TestLog::new();
+
+    let operation_1 = log.operation(b"first", ());
+    let operation_2 = log.operation(b"second", ());
+
+    let permit = store.begin().await.unwrap();
+
+    assert!(
+        store
+            .insert_operation(&operation_1.hash.clone(), operation_1.clone(), log.id())
+            .await
+            .unwrap()
+    );
+
+    assert!(
+        store
+            .insert_operation(&operation_2.hash.clone(), operation_2.clone(), log.id())
+            .await
+            .unwrap()
+    );
+
+    store.commit(permit).await.unwrap();
+
+    let result = <SqliteStore<'_> as LogStore<Operation, _, _, _, _>>::get_latest_entry(
+        &store,
+        &log.author(),
+        &log.id(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, Some((operation_2.hash, operation_2.header.seq_num)));
+}
+
+#[tokio::test]
+async fn get_log_heights() {
+    let store = SqliteStoreBuilder::new()
+        .random_memory_url()
+        .max_connections(1)
+        .build()
+        .await
+        .unwrap();
+
+    let private_key = PrivateKey::new();
+
+    // Create two separate logs which share the same author.
+    let log_1 = TestLog::from_private_key(private_key.clone());
+    let log_2 = TestLog::from_private_key(private_key.clone());
+
+    let operation_1 = log_1.operation(b"first", ());
+    let operation_2 = log_1.operation(b"second", ());
+    let operation_3 = log_2.operation(b"third", ());
+
+    let permit = store.begin().await.unwrap();
+
+    assert!(
+        store
+            .insert_operation(&operation_1.hash.clone(), operation_1.clone(), log_1.id())
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .insert_operation(&operation_2.hash.clone(), operation_2.clone(), log_1.id())
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .insert_operation(&operation_3.hash.clone(), operation_3.clone(), log_2.id())
+            .await
+            .unwrap()
+    );
+
+    store.commit(permit).await.unwrap();
+
+    let result = <SqliteStore<'_> as LogStore<Operation, _, _, _, _>>::get_log_heights(
+        &store,
+        &private_key.public_key(),
+        &[log_1.id(), log_2.id()],
+    )
+    .await
+    .unwrap();
+
+    let mut expected_result = HashMap::new();
+    expected_result.insert(log_1.id(), 1);
+    expected_result.insert(log_2.id(), 0);
+
+    assert_eq!(result, Some(expected_result));
+}
+
+#[tokio::test]
+async fn get_log_size() {
+    let store = SqliteStoreBuilder::new()
+        .random_memory_url()
+        .max_connections(1)
+        .build()
+        .await
+        .unwrap();
+
+    let log = TestLog::new();
+
+    let operation_1 = log.operation(b"first", ());
+    let operation_2 = log.operation(b"second", ());
+
+    let permit = store.begin().await.unwrap();
+
+    assert!(
+        store
+            .insert_operation(&operation_1.hash.clone(), operation_1.clone(), log.id())
+            .await
+            .unwrap()
+    );
+
+    assert!(
+        store
+            .insert_operation(&operation_2.hash.clone(), operation_2.clone(), log.id())
+            .await
+            .unwrap()
+    );
+
+    store.commit(permit).await.unwrap();
+
+    let (operations_num, size) =
+        <SqliteStore<'_> as LogStore<Operation, _, _, _, _>>::get_log_size(
+            &store,
+            &log.author(),
+            &log.id(),
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(operations_num, 2);
+
+    let expected_size = operation_1.header.to_bytes().len() as u64
+        + operation_1.header.payload_size
+        + operation_2.header.to_bytes().len() as u64
+        + operation_2.header.payload_size;
+    assert_eq!(size, expected_size);
+}
+
+#[tokio::test]
+async fn get_log_entries() {
+    let store = SqliteStoreBuilder::new()
+        .random_memory_url()
+        .max_connections(1)
+        .build()
+        .await
+        .unwrap();
+
+    let log = TestLog::new();
+
+    let operation_1 = log.operation(b"first", ());
+    let operation_2 = log.operation(b"second", ());
+    let operation_3 = log.operation(b"third", ());
+    let operation_4 = log.operation(b"fourth", ());
+    let operation_5 = log.operation(b"fifth", ());
+
+    let permit = store.begin().await.unwrap();
+
+    assert!(
+        store
+            .insert_operation(&operation_1.hash.clone(), operation_1.clone(), log.id())
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .insert_operation(&operation_2.hash.clone(), operation_2.clone(), log.id())
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .insert_operation(&operation_3.hash.clone(), operation_3.clone(), log.id())
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .insert_operation(&operation_4.hash.clone(), operation_4.clone(), log.id())
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .insert_operation(&operation_5.hash.clone(), operation_5.clone(), log.id())
+            .await
+            .unwrap()
+    );
+
+    store.commit(permit).await.unwrap();
+
+    let log_entries = <SqliteStore<'_> as LogStore<Operation, _, _, _, _>>::get_log_entries(
+        &store,
+        &log.author(),
+        &log.id(),
+        None,
+        None,
+    )
+    .await
+    .expect("no errors");
+
+    assert!(log_entries.is_some());
+    let log_entries = log_entries.unwrap();
+
+    assert_eq!(log_entries.len(), 5);
+
+    assert_eq!(log_entries[0].0, operation_1);
+    assert_eq!(log_entries[1].0, operation_2);
+    assert_eq!(log_entries[2].0, operation_3);
+    assert_eq!(log_entries[3].0, operation_4);
+    assert_eq!(log_entries[4].0, operation_5);
+}
+
+#[tokio::test]
+async fn prune_entries() {
+    let store = SqliteStoreBuilder::new()
+        .random_memory_url()
+        .max_connections(1)
+        .build()
+        .await
+        .unwrap();
+
+    let log = TestLog::new();
+
+    let operation_1 = log.operation(b"first", ());
+    let operation_2 = log.operation(b"second", ());
+    let operation_3 = log.operation(b"third", ());
+    let operation_4 = log.operation(b"fourth", ());
+    let operation_5 = log.operation(b"fifth", ());
+
+    let permit = store.begin().await.unwrap();
+
+    assert!(
+        store
+            .insert_operation(&operation_1.hash.clone(), operation_1.clone(), log.id())
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .insert_operation(&operation_2.hash.clone(), operation_2.clone(), log.id())
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .insert_operation(&operation_3.hash.clone(), operation_3.clone(), log.id())
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .insert_operation(&operation_4.hash.clone(), operation_4.clone(), log.id())
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .insert_operation(&operation_5.hash.clone(), operation_5.clone(), log.id())
+            .await
+            .unwrap()
+    );
+
+    store.commit(permit).await.unwrap();
+
+    let prune_entries_num = <SqliteStore<'_> as LogStore<Operation, _, _, _, _>>::prune_entries(
+        &store,
+        &log.author(),
+        &log.id(),
+        &3,
+    )
+    .await
+    .expect("no errors");
+
+    assert_eq!(prune_entries_num, 3);
+
+    let log_entries = <SqliteStore<'_> as LogStore<Operation, _, _, _, _>>::get_log_entries(
+        &store,
+        &log.author(),
+        &log.id(),
+        None,
+        None,
+    )
+    .await
+    .expect("no errors");
+
+    assert!(log_entries.is_some());
+    let log_entries = log_entries.unwrap();
+
+    // Three entries were pruned; the two most recently published entries should
+    // remain.
+    assert_eq!(log_entries.len(), 2);
+    assert_eq!(log_entries[0].0, operation_4);
+    assert_eq!(log_entries[1].0, operation_5);
+}

--- a/p2panda-store-next/src/logs/traits.rs
+++ b/p2panda-store-next/src/logs/traits.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashMap;
+use std::error::Error;
+
+type LogEntries<T> = Vec<(T, Vec<u8>)>;
+
+/// Store methods for aiding efficient comparison of log-based data types.
+///
+/// The concrete message type contained on each log "entry" is not known in this API. It is
+/// assumed there is another store for retrieving these during sync (eg. OperationStore).
+pub trait LogStore<T, A, L, S, ID> {
+    type Error: Error;
+
+    /// Get the ID and sequence number of the latest entry in a log.
+    ///
+    /// Returns None when the author or a log with the requested id was not found.
+    fn get_latest_entry(
+        &self,
+        author: &A,
+        log_id: &L,
+    ) -> impl Future<Output = Result<Option<(ID, S)>, Self::Error>>;
+
+    /// Get current heights for a set of logs.
+    ///
+    /// Returns the sequence number for the latest entry in every requested log.
+    ///
+    /// Returns None when the author or a log with the requested id was not found.
+    fn get_log_heights(
+        &self,
+        author: &A,
+        logs: &[L],
+    ) -> impl Future<Output = Result<Option<HashMap<L, S>>, Self::Error>>;
+
+    /// Get the byte and operation count of the entries in a log.
+    ///
+    /// `after` and `until` fields can be provided to select only a range of the log.
+    fn get_log_size(
+        &self,
+        author: &A,
+        log_id: &L,
+        after: Option<S>,
+        until: Option<S>,
+    ) -> impl Future<Output = Result<Option<(u64, u64)>, Self::Error>>;
+
+    /// Get all entries in a log after an optional starting point.
+    ///
+    /// `after` and `to` fields can be provided to select only a range of the log.
+    fn get_log_entries(
+        &self,
+        author: &A,
+        log_id: &L,
+        after: Option<S>,
+        until: Option<S>,
+    ) -> impl Future<Output = Result<Option<LogEntries<T>>, Self::Error>>;
+
+    /// Prune all entries in a log until the provided sequence number.
+    ///
+    /// Returns the number of entries which were pruned.
+    fn prune_entries(
+        &self,
+        author: &A,
+        log_id: &L,
+        until: &S,
+    ) -> impl Future<Output = Result<u64, Self::Error>>;
+}

--- a/p2panda-store-next/src/operations/mod.rs
+++ b/p2panda-store-next/src/operations/mod.rs
@@ -7,3 +7,6 @@ mod tests;
 mod traits;
 
 pub use traits::OperationStore;
+
+#[cfg(feature = "sqlite")]
+pub(crate) use sqlite::OperationRow;

--- a/p2panda-store-next/src/operations/sqlite.rs
+++ b/p2panda-store-next/src/operations/sqlite.rs
@@ -36,12 +36,14 @@ where
                             payload_size,
                             payload_hash,
                             timestamp,
+                            seq_num,
                             header,
+                            header_size,
                             body,
                             extensions
                         )
                     VALUES
-                        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ",
                 )
                 .bind(id.to_hex())
@@ -55,10 +57,12 @@ where
                 .bind(operation.header.payload_size.to_string())
                 .bind(operation.header.payload_hash.map(|hash| hash.to_hex()))
                 .bind(operation.header.timestamp.to_string())
+                .bind(operation.header.seq_num.to_string())
                 .bind(
                     encode_cbor(&operation.header)
                         .map_err(|err| SqliteError::Encode("header".to_string(), err))?,
                 )
+                .bind(operation.header.to_bytes().len().to_string())
                 .bind(operation.body.map(|body| body.to_bytes()))
                 .bind(
                     encode_cbor(&operation.header.extensions)
@@ -69,6 +73,7 @@ where
                 .map_err(SqliteError::Sqlite)
             })
             .await?;
+
         Ok(result.rows_affected() > 0)
     }
 
@@ -119,6 +124,7 @@ where
                 .map_err(SqliteError::Sqlite)
             })
             .await?;
+
         Ok(result.is_some())
     }
 
@@ -139,15 +145,34 @@ where
                 .map_err(SqliteError::Sqlite)
             })
             .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn delete_operation_payload(&self, id: &Hash) -> Result<bool, Self::Error> {
+        let result = query(
+            "
+            UPDATE
+                operations_v1
+            SET
+                body = NULL
+            WHERE
+                operations_v1.hash = ?
+            ",
+        )
+        .bind(id.to_hex())
+        .execute(&self.pool)
+        .await?;
+
         Ok(result.rows_affected() > 0)
     }
 }
 
 /// Single operation row as it is inserted in the SQLite database.
-#[derive(Debug, FromRow)]
-struct OperationRow {
+#[derive(Clone, Debug, FromRow)]
+pub(crate) struct OperationRow {
     hash: String,
-    header: Vec<u8>,
+    pub(crate) header: Vec<u8>,
     body: Option<Vec<u8>>,
 }
 

--- a/p2panda-store-next/src/operations/traits.rs
+++ b/p2panda-store-next/src/operations/traits.rs
@@ -33,4 +33,10 @@ pub trait OperationStore<T, ID, C> {
     /// Returns `true` when the removal occurred and `false` when the operation was not found in
     /// the store.
     fn delete_operation(&self, id: &ID) -> impl Future<Output = Result<bool, Self::Error>>;
+
+    /// Delete an operation payload.
+    ///
+    /// Returns `true` when the removal occurred and `false` when the operation was not found in
+    /// the store.
+    fn delete_operation_payload(&self, id: &ID) -> impl Future<Output = Result<bool, Self::Error>>;
 }

--- a/p2panda-store-next/src/sqlite.rs
+++ b/p2panda-store-next/src/sqlite.rs
@@ -177,7 +177,7 @@ pub type Transaction<'a> = sqlx::Transaction<'a, Sqlite>;
 #[derive(Clone, Debug)]
 pub struct SqliteStore<'a> {
     tx: Arc<Mutex<Option<Transaction<'a>>>>,
-    pool: sqlx::SqlitePool,
+    pub(crate) pool: sqlx::SqlitePool,
     semaphore: Arc<Semaphore>,
 }
 


### PR DESCRIPTION
Introduces `LogStore` trait in `p2panda-store` and implements an opinionated SQLite version for use in p2panda `Node`, along with tests.
    
We also add the `delete_operation_payload()` trait to the `OperationStore` and supply implementations for the memory and SQLite stores.

https://github.com/p2panda/p2panda/issues/1003

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header