### PR TITLE
`TopicStore` trait and SQLite implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Highlights are marked with a pancake 🥞
 
 - Fix missing gossip events in sync manager [#988](https://github.com/p2panda/p2panda/pull/988)
 
+### Added
+
+- Add `TopicStore` trait and SQLite implementation [#1011](https://github.com/p2panda/p2panda/pull/1011)
+
 ## [0.5.1] - 09/02/2026
 
 ### Changed

--- a/p2panda-store-next/migrations/20260217222329_create_topics.sql
+++ b/p2panda-store-next/migrations/20260217222329_create_topics.sql
@@ -1,0 +1,9 @@
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+CREATE TABLE IF NOT EXISTS topics_v1 (
+    topic                   TEXT            NOT NULL,
+    author                  VARCHAR(64)     NOT NULL,
+    data_id                 BLOB            NOT NULL,
+
+    UNIQUE (topic, author, data_id)
+);

--- a/p2panda-store-next/src/lib.rs
+++ b/p2panda-store-next/src/lib.rs
@@ -8,3 +8,4 @@ pub mod orderer;
 pub mod sqlite;
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_utils;
+pub mod topics;

--- a/p2panda-store-next/src/topics/mod.rs
+++ b/p2panda-store-next/src/topics/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `TopicStore` trait for managing mappings of application data to topics as well as a concrete
+//! `SqliteStore` implementation.
+mod sqlite;
+#[cfg(test)]
+mod tests;
+mod traits;
+
+pub use traits::TopicStore;

--- a/p2panda-store-next/src/topics/sqlite.rs
+++ b/p2panda-store-next/src/topics/sqlite.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashMap;
+
+use p2panda_core::cbor::{decode_cbor, encode_cbor};
+use p2panda_core::{LogId, PublicKey, Topic};
+use sqlx::{query, query_as};
+
+use crate::sqlite::{SqliteError, SqliteStore};
+use crate::topics::TopicStore;
+
+/// SQLite `TopicStore` implementation that can be used to map a topic to a set of (generic)
+/// per-author data identifiers.
+impl<'a, S> TopicStore<Topic, PublicKey, S> for SqliteStore<'a>
+where
+    S: LogId,
+{
+    type Error = SqliteError;
+
+    async fn associate(
+        &self,
+        topic: &Topic,
+        author: &PublicKey,
+        data_id: &S,
+    ) -> Result<bool, SqliteError> {
+        let result = self
+            .tx(async |tx| {
+                query(
+                    "
+                    INSERT OR IGNORE
+                    INTO
+                        topics_v1 (
+                            topic,
+                            author,
+                            data_id
+                        )
+                    VALUES
+                        (?, ?, ?)
+                    ",
+                )
+                .bind(topic.to_string())
+                .bind(author.to_string())
+                .bind(
+                    encode_cbor(&data_id)
+                        .map_err(|err| SqliteError::Encode("data_id".to_string(), err))?,
+                )
+                .execute(&mut **tx)
+                .await
+                .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn remove(
+        &self,
+        topic: &Topic,
+        author: &PublicKey,
+        data_id: &S,
+    ) -> Result<bool, SqliteError> {
+        let result = self
+            .tx(async |tx| {
+                query(
+                    "
+                    DELETE FROM
+                        topics_v1
+                    WHERE
+                        topic = ?
+                        AND author = ?
+                        AND data_id = ?
+                    ",
+                )
+                .bind(topic.to_string())
+                .bind(author.to_string())
+                .bind(
+                    encode_cbor(&data_id)
+                        .map_err(|err| SqliteError::Encode("data_id".to_string(), err))?,
+                )
+                .execute(&mut **tx)
+                .await
+                .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn resolve(&self, topic: &Topic) -> Result<HashMap<PublicKey, Vec<S>>, Self::Error> {
+        let data_ids = self
+            .execute(async |pool| {
+                query_as::<_, (String, Vec<u8>)>(
+                    "
+            SELECT
+                author,
+                data_id
+            FROM
+                topics_v1
+            WHERE
+                topic = ?
+            ",
+                )
+                .bind(topic.to_string())
+                .fetch_all(pool)
+                .await
+                .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        let mut result: HashMap<PublicKey, Vec<S>> = HashMap::new();
+
+        for (author, data_id) in data_ids {
+            let author: PublicKey = author.parse().map_err(|_| {
+                SqliteError::Decode("author".into(), crate::sqlite::DecodeError::FromStr)
+            })?;
+
+            let data_id = decode_cbor(&data_id[..])
+                .map_err(|err| SqliteError::Decode("header".into(), err.into()))?;
+
+            // All items in the returned data set will be unique due to the SQL UNIQUE constraint.
+            result.entry(author).or_default().push(data_id);
+        }
+
+        Ok(result)
+    }
+}

--- a/p2panda-store-next/src/topics/tests.rs
+++ b/p2panda-store-next/src/topics/tests.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashMap;
+
+use p2panda_core::{PrivateKey, Topic};
+
+use crate::sqlite::SqliteStoreBuilder;
+use crate::topics::TopicStore;
+
+#[tokio::test]
+async fn update_and_resolve_topic_mapping() {
+    let store = SqliteStoreBuilder::new()
+        .random_memory_url()
+        .max_connections(1)
+        .build()
+        .await
+        .unwrap();
+
+    let topic = Topic::new();
+    // The log id is the same as the topic, in a use case like this there will be one log
+    // per-author in each topic.
+    let log_id = topic;
+
+    let alice = PrivateKey::from_bytes(&[1u8; 32]).public_key();
+    let bob = PrivateKey::from_bytes(&[2u8; 32]).public_key();
+
+    let permit = store.begin().await.unwrap();
+
+    let result = store.associate(&topic, &alice, &log_id).await.unwrap();
+    assert!(result);
+
+    let result = store.associate(&topic, &bob, &log_id).await.unwrap();
+    assert!(result);
+
+    store.commit(permit).await.unwrap();
+
+    // Inserting bob again results in a false result.
+    let permit = store.begin().await.unwrap();
+
+    let result = store.associate(&topic, &bob, &log_id).await.unwrap();
+    assert!(!result);
+
+    store.commit(permit).await.unwrap();
+
+    let expected_logs = HashMap::from([(alice, vec![topic]), (bob, vec![topic])]);
+
+    let logs = store.resolve(&topic).await.unwrap();
+    assert_eq!(logs, expected_logs);
+}
+
+#[tokio::test]
+async fn path_based_log_ids() {
+    let store = SqliteStoreBuilder::new()
+        .random_memory_url()
+        .max_connections(1)
+        .build()
+        .await
+        .unwrap();
+
+    let topic = Topic::new();
+
+    // Here we demonstrate use cases where there are multiple logs per-author in each topic.
+    let log_id_kittens = "kittens".to_string();
+    let log_id_kittens_sleepy = "kittens.sleepy".to_string();
+    let log_id_puppies = "puppies".to_string();
+
+    let alice = PrivateKey::from_bytes(&[1u8; 32]).public_key();
+    let bob = PrivateKey::from_bytes(&[2u8; 32]).public_key();
+
+    let permit = store.begin().await.unwrap();
+
+    let result = store
+        .associate(&topic, &alice, &log_id_kittens)
+        .await
+        .unwrap();
+    assert!(result);
+
+    let result = store
+        .associate(&topic, &alice, &log_id_kittens_sleepy)
+        .await
+        .unwrap();
+    assert!(result);
+
+    let result = store
+        .associate(&topic, &bob, &log_id_puppies)
+        .await
+        .unwrap();
+    assert!(result);
+
+    store.commit(permit).await.unwrap();
+
+    let expected_logs = HashMap::from([
+        (alice, vec![log_id_kittens, log_id_kittens_sleepy]),
+        (bob, vec![log_id_puppies]),
+    ]);
+
+    let logs = store.resolve(&topic).await.unwrap();
+    assert_eq!(logs, expected_logs);
+}
+
+#[tokio::test]
+async fn remove_association() {
+    let store = SqliteStoreBuilder::new()
+        .random_memory_url()
+        .max_connections(1)
+        .build()
+        .await
+        .unwrap();
+
+    let topic = Topic::new();
+
+    // Here we demonstrate use cases where there are multiple logs per-author in each topic.
+    let log_id_kittens = "kittens".to_string();
+    let log_id_kittens_sleepy = "kittens.sleepy".to_string();
+
+    let alice = PrivateKey::from_bytes(&[1u8; 32]).public_key();
+
+    let permit = store.begin().await.unwrap();
+
+    let result = store
+        .associate(&topic, &alice, &log_id_kittens)
+        .await
+        .unwrap();
+    assert!(result);
+
+    let result = store
+        .associate(&topic, &alice, &log_id_kittens_sleepy)
+        .await
+        .unwrap();
+    assert!(result);
+
+    store.commit(permit).await.unwrap();
+
+    let expected_logs = HashMap::from([(
+        alice,
+        vec![log_id_kittens.clone(), log_id_kittens_sleepy.clone()],
+    )]);
+
+    let logs = store.resolve(&topic).await.unwrap();
+    assert_eq!(logs, expected_logs);
+
+    let permit = store.begin().await.unwrap();
+
+    let result = store
+        .remove(&topic, &alice, &log_id_kittens_sleepy)
+        .await
+        .unwrap();
+
+    store.commit(permit).await.unwrap();
+
+    assert!(result);
+
+    let expected_logs = HashMap::from([(alice, vec![log_id_kittens])]);
+
+    let logs = store.resolve(&topic).await.unwrap();
+    assert_eq!(logs, expected_logs);
+}

--- a/p2panda-store-next/src/topics/traits.rs
+++ b/p2panda-store-next/src/topics/traits.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashMap;
+use std::error::Error;
+
+/// Maps a topic to a user defined data type being sent over the wire during sync.
+///
+/// It defines the type of data it is expecting to sync and how the scope for a particular session
+/// should be identified; users provide an implementation of the `TopicStore` trait in order to
+/// define how this mapping occurs.
+///
+/// Since `TopicStore` is generic we can use the same mapping across different sync
+/// implementations for the same data type when necessary.
+///
+/// For example a `TopicStore` map implementation could map a generic `T` to a set of logs.
+///
+/// ## Designing `TopicStore` for applications
+///
+/// Considering an example chat application which is based on append-only log data types, we
+/// probably want to organise messages from an author for a certain chat group into one log each.
+/// Like this, a chat group can be expressed as a collection of one to potentially many logs (one
+/// per member of the group):
+///
+/// ```text
+/// All authors: A, B and C
+/// All chat groups: 1 and 2
+///
+/// "Chat group 1 with members A and B"
+/// - Log A1
+/// - Log B1
+///
+/// "Chat group 2 with members A, B and C"
+/// - Log A2
+/// - Log B2
+/// - Log C2
+/// ```
+///
+/// If we implement `T` to express that we're interested in syncing over a specific chat group,
+/// for example "Chat Group 2" we would implement `TopicStore` to give us all append-only logs of
+/// all members inside this group, that is the entries inside logs `A2`, `B2` and `C2`.
+pub trait TopicStore<T, A, ID> {
+    type Error: Error;
+
+    /// Associate an author and data id pair with a topic.
+    fn associate(
+        &self,
+        topic: &T,
+        author: &A,
+        data_id: &ID,
+    ) -> impl Future<Output = Result<bool, Self::Error>>;
+
+    /// Remove an association with a topic.
+    fn remove(
+        &self,
+        topic: &T,
+        author: &A,
+        data_id: &ID,
+    ) -> impl Future<Output = Result<bool, Self::Error>>;
+
+    /// Get identifiers for all associated
+    fn resolve(&self, topic: &T) -> impl Future<Output = Result<HashMap<A, Vec<ID>>, Self::Error>>;
+}


### PR DESCRIPTION
Introduce `TopicStore` trait in `p2panda-store` (previously `TopicMap` in `p2panda-sync`) and implement an opinionated SQLite version for use in p2panda `Node`. 

closes #1009 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
