### PR TITLE
Introduce `LogId` to `OperationStore`

### DIFF
--- a/p2panda-core/src/test_utils.rs
+++ b/p2panda-core/src/test_utils.rs
@@ -4,13 +4,14 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::{Body, Extensions, Hash, Header, Operation, PrivateKey};
+use crate::{Body, Extensions, Hash, Header, Operation, PrivateKey, Topic};
 
 #[derive(Clone, Default)]
 pub struct TestLog {
     private_key: PrivateKey,
     backlink: Rc<RefCell<Option<Hash>>>,
     seq_num: Rc<RefCell<u64>>,
+    log_id: Topic,
 }
 
 impl TestLog {
@@ -19,7 +20,12 @@ impl TestLog {
             private_key: PrivateKey::new(),
             backlink: Rc::default(),
             seq_num: Rc::default(),
+            log_id: Topic::new(),
         }
+    }
+
+    pub fn id(&self) -> Topic {
+        self.log_id
     }
 
     pub fn operation<E: Extensions>(&self, body: &[u8], extensions: E) -> Operation<E> {

--- a/p2panda-store-next/migrations/20250928132835_create_operations.sql
+++ b/p2panda-store-next/migrations/20250928132835_create_operations.sql
@@ -4,6 +4,7 @@
 -- defined in the p2panda specification as TEXT.
 CREATE TABLE IF NOT EXISTS operations_v1 (
     hash                    TEXT            NOT NULL    PRIMARY KEY,
+    log_id                  TEXT            NOT NULL,
     version                 TEXT            NOT NULL,
     public_key              TEXT            NOT NULL,
     signature               TEXT            NOT NULL,

--- a/p2panda-store-next/src/operations/memory.rs
+++ b/p2panda-store-next/src/operations/memory.rs
@@ -7,6 +7,8 @@ use std::fmt::Debug;
 use std::hash::Hash as StdHash;
 use std::rc::Rc;
 
+use p2panda_core::LogId;
+
 use crate::memory::MemoryStore;
 use crate::operations::OperationStore;
 
@@ -30,14 +32,20 @@ impl<T, ID> Default for OperationMemoryStore<T, ID> {
     }
 }
 
-impl<T, ID> OperationStore<T, ID> for MemoryStore<T, ID>
+impl<T, ID, L> OperationStore<T, ID, L> for MemoryStore<T, ID>
 where
     T: Clone + Debug,
     ID: Clone + Eq + Debug + StdHash,
+    L: LogId,
 {
     type Error = Infallible;
 
-    async fn insert_operation(&self, id: &ID, operation: T) -> Result<bool, Self::Error> {
+    async fn insert_operation(
+        &self,
+        id: &ID,
+        operation: T,
+        _log_id: L,
+    ) -> Result<bool, Self::Error> {
         let mut operations = self.operations.operations.borrow_mut();
         Ok(operations.insert(id.clone(), operation).is_none())
     }

--- a/p2panda-store-next/src/operations/tests.rs
+++ b/p2panda-store-next/src/operations/tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use p2panda_core::test_utils::TestLog;
-use p2panda_core::{Hash, Operation};
+use p2panda_core::{Hash, Operation, Topic};
 
 use crate::memory::MemoryStore;
 use crate::operations::OperationStore;
@@ -23,26 +23,26 @@ async fn insert_get_delete_operations_memory() {
 
     assert!(
         store
-            .insert_operation(&operation_1.hash.clone(), operation_1.clone())
+            .insert_operation(&operation_1.hash.clone(), operation_1.clone(), log.id())
             .await
             .unwrap()
     );
     // Re-inserting the same operation returns false.
     assert!(
         !store
-            .insert_operation(&operation_1.hash.clone(), operation_1.clone())
+            .insert_operation(&operation_1.hash.clone(), operation_1.clone(), log.id())
             .await
             .unwrap()
     );
     assert!(
         store
-            .insert_operation(&operation_3.hash.clone(), operation_3.clone())
+            .insert_operation(&operation_3.hash.clone(), operation_3.clone(), log.id())
             .await
             .unwrap()
     );
     assert!(
         store
-            .insert_operation(&operation_4.hash.clone(), operation_4.clone())
+            .insert_operation(&operation_4.hash.clone(), operation_4.clone(), log.id())
             .await
             .unwrap()
     );
@@ -51,13 +51,13 @@ async fn insert_get_delete_operations_memory() {
     // ~~~
 
     assert!(
-        OperationStore::<Operation<()>, Hash>::has_operation(&store, &operation_1.hash)
+        OperationStore::<Operation<()>, Hash, Topic>::has_operation(&store, &operation_1.hash)
             .await
             .unwrap()
     );
     // Operation 2 was not inserted.
     assert!(
-        !OperationStore::<Operation<()>, Hash>::has_operation(&store, &operation_2.hash)
+        !OperationStore::<Operation<()>, Hash, Topic>::has_operation(&store, &operation_2.hash)
             .await
             .unwrap()
     );
@@ -66,11 +66,13 @@ async fn insert_get_delete_operations_memory() {
     // ~~~
 
     assert_eq!(
-        store.get_operation(&operation_4.hash).await.unwrap(),
+        OperationStore::<Operation<()>, Hash, Topic>::get_operation(&store, &operation_4.hash)
+            .await
+            .unwrap(),
         Some(operation_4.clone())
     );
     assert_eq!(
-        OperationStore::<Operation<()>, Hash>::get_operation(&store, &operation_2.hash)
+        OperationStore::<Operation<()>, Hash, Topic>::get_operation(&store, &operation_2.hash)
             .await
             .unwrap(),
         None
@@ -80,13 +82,13 @@ async fn insert_get_delete_operations_memory() {
     // ~~~~~~
 
     assert!(
-        OperationStore::<Operation<()>, Hash>::delete_operation(&store, &operation_4.hash)
+        OperationStore::<Operation<()>, Hash, Topic>::delete_operation(&store, &operation_4.hash)
             .await
             .unwrap(),
     );
     // Deleting the same item again returns false.
     assert!(
-        !OperationStore::<Operation<()>, Hash>::delete_operation(&store, &operation_4.hash)
+        !OperationStore::<Operation<()>, Hash, Topic>::delete_operation(&store, &operation_4.hash)
             .await
             .unwrap(),
     );
@@ -115,26 +117,26 @@ async fn insert_get_delete_operations_sqlite() {
 
     assert!(
         store
-            .insert_operation(&operation_1.hash.clone(), operation_1.clone())
+            .insert_operation(&operation_1.hash.clone(), operation_1.clone(), log.id())
             .await
             .unwrap()
     );
     // Re-inserting the same operation returns false.
     assert!(
         !store
-            .insert_operation(&operation_1.hash.clone(), operation_1.clone())
+            .insert_operation(&operation_1.hash.clone(), operation_1.clone(), log.id())
             .await
             .unwrap()
     );
     assert!(
         store
-            .insert_operation(&operation_3.hash.clone(), operation_3.clone())
+            .insert_operation(&operation_3.hash.clone(), operation_3.clone(), log.id())
             .await
             .unwrap()
     );
     assert!(
         store
-            .insert_operation(&operation_4.hash.clone(), operation_4.clone())
+            .insert_operation(&operation_4.hash.clone(), operation_4.clone(), log.id())
             .await
             .unwrap()
     );
@@ -145,13 +147,13 @@ async fn insert_get_delete_operations_sqlite() {
     // ~~~
 
     assert!(
-        OperationStore::<Operation<()>, Hash>::has_operation(&store, &operation_1.hash)
+        OperationStore::<Operation<()>, Hash, Topic>::has_operation(&store, &operation_1.hash)
             .await
             .unwrap()
     );
     // Operation 2 was not inserted.
     assert!(
-        !OperationStore::<Operation<()>, Hash>::has_operation(&store, &operation_2.hash)
+        !OperationStore::<Operation<()>, Hash, Topic>::has_operation(&store, &operation_2.hash)
             .await
             .unwrap()
     );
@@ -160,11 +162,13 @@ async fn insert_get_delete_operations_sqlite() {
     // ~~~
 
     assert_eq!(
-        store.get_operation(&operation_4.hash).await.unwrap(),
+        OperationStore::<Operation<()>, Hash, Topic>::get_operation(&store, &operation_4.hash)
+            .await
+            .unwrap(),
         Some(operation_4.clone())
     );
     assert_eq!(
-        OperationStore::<Operation<()>, Hash>::get_operation(&store, &operation_2.hash)
+        OperationStore::<Operation<()>, Hash, Topic>::get_operation(&store, &operation_2.hash)
             .await
             .unwrap(),
         None
@@ -176,13 +180,13 @@ async fn insert_get_delete_operations_sqlite() {
     let permit = store.begin().await.unwrap();
 
     assert!(
-        OperationStore::<Operation<()>, Hash>::delete_operation(&store, &operation_4.hash)
+        OperationStore::<Operation<()>, Hash, Topic>::delete_operation(&store, &operation_4.hash)
             .await
             .unwrap(),
     );
     // Deleting the same item again returns false.
     assert!(
-        !OperationStore::<Operation<()>, Hash>::delete_operation(&store, &operation_4.hash)
+        !OperationStore::<Operation<()>, Hash, Topic>::delete_operation(&store, &operation_4.hash)
             .await
             .unwrap(),
     );

--- a/p2panda-store-next/src/operations/traits.rs
+++ b/p2panda-store-next/src/operations/traits.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 ///
 /// The concrete type of an "operation" is generic and implementors can use the same interface for
 /// different approaches: sets, append-only logs, hash-graphs (DAG) etc.
-pub trait OperationStore<T, ID> {
+pub trait OperationStore<T, ID, C> {
     type Error: Error;
 
     /// Insert an operation.
@@ -17,6 +17,7 @@ pub trait OperationStore<T, ID> {
         &self,
         id: &ID,
         operation: T,
+        collection_id: C,
     ) -> impl Future<Output = Result<bool, Self::Error>>;
 
     /// Get an operation by id.


### PR DESCRIPTION
Here we add an additional generic type parameter `C` as a requirement on the `OperationStore` trait. The generic specifies a collection id which has been added as a parameter to the `insert_operation()` method. This is useful for the SQLite operation store so that we can easily query by log id when making log-related queries.

https://github.com/p2panda/p2panda/issues/1013

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] ~~Add this PR to the _Unreleased_ section in `CHANGELOG.md`~~
- [x] Link this PR to any issues it closes
- [x] ~~New files contain a SPDX license header~~
