### PR TITLE
Define and implement `Forge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
+- Define and implement `Forge` [#1032](https://github.com/p2panda/p2panda/pull/1032)
 - Add `LogStore` trait and SQLite implementation [#1004](https://github.com/p2panda/p2panda/pull/1004)
 - Add `TopicStore` trait and SQLite implementation [#1011](https://github.com/p2panda/p2panda/pull/1011)
 

--- a/p2panda/Cargo.toml
+++ b/p2panda/Cargo.toml
@@ -40,4 +40,5 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"], optional =
 
 [dev-dependencies]
 p2panda = { path = ".", features = ["test_utils"] }
+p2panda-store = { path = "../p2panda-store", version = "0.5.1", features = ["test_utils"] }
 tokio = { version = "1.49.0", features = ["macros", "rt"] }

--- a/p2panda/src/builder.rs
+++ b/p2panda/src/builder.rs
@@ -5,13 +5,13 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use p2panda_core::PrivateKey;
 use p2panda_net::discovery::DiscoveryConfig;
 use p2panda_net::gossip::GossipConfig;
-use p2panda_net::iroh_endpoint::{IrohConfig, RelayUrl};
+use p2panda_net::iroh_endpoint::RelayUrl;
 use p2panda_net::iroh_mdns::MdnsDiscoveryMode;
 use p2panda_net::{NetworkId, NodeId};
 use p2panda_store::sqlite::SqliteStoreBuilder;
 
 use crate::Node;
-use crate::network::NetworkConfig;
+use crate::forge::OperationForge;
 use crate::node::{AckPolicy, Config, NodeError};
 
 #[derive(Default)]
@@ -105,7 +105,8 @@ impl NodeBuilder {
     pub async fn spawn(self) -> Result<Node, NodeError> {
         let private_key = self.private_key.unwrap_or_default();
         let store = self.store.build().await?;
+        let forge = OperationForge::from_private_key(private_key, store.clone());
 
-        Node::spawn_inner(self.config, private_key, store).await
+        Node::spawn_inner(self.config, store, forge).await
     }
 }

--- a/p2panda/src/forge.rs
+++ b/p2panda/src/forge.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::error::Error as StdError;
+use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
+
+use p2panda_core::{Body, Hash, PrivateKey, PublicKey, SeqNum, Topic};
+use p2panda_store::logs::LogStore;
+use p2panda_store::operations::OperationStore;
+use p2panda_store::topics::TopicStore;
+use p2panda_store::{SqliteError, SqliteStore, tx};
+use thiserror::Error;
+
+use crate::operation::{Extensions, Header, Operation};
+
+/// Interface for obtaining a keypair and creating signed operations.
+pub trait Forge<T, C, E> {
+    type Error: StdError;
+
+    fn private_key(&self) -> &PrivateKey;
+
+    fn public_key(&self) -> PublicKey;
+
+    fn create_operation(
+        &mut self,
+        topic: T,
+        collection_id: C,
+        body: Option<Vec<u8>>,
+        extensions: E,
+    ) -> impl Future<Output = Result<Option<p2panda_core::Operation<E>>, Self::Error>>;
+}
+
+#[derive(Clone, Debug)]
+pub struct OperationForge {
+    private_key: PrivateKey,
+    store: SqliteStore<'static>,
+}
+
+impl OperationForge {
+    /// Create a forge for inserting signed operations into the database and associating topics
+    /// with logs.
+    ///
+    /// The forge holds the private key used to sign operations. This method generates a new key
+    /// using CSPRNG from the system.
+    pub fn new(store: SqliteStore<'static>) -> Self {
+        Self {
+            private_key: PrivateKey::new(),
+            store,
+        }
+    }
+
+    /// Create a forge using an existing private key.
+    pub fn from_private_key(private_key: PrivateKey, store: SqliteStore<'static>) -> Self {
+        Self { private_key, store }
+    }
+}
+
+type LogId = [u8; 32];
+
+impl Forge<Topic, LogId, Extensions> for OperationForge {
+    type Error = ForgeError;
+
+    fn private_key(&self) -> &PrivateKey {
+        &self.private_key
+    }
+
+    fn public_key(&self) -> PublicKey {
+        self.private_key.public_key()
+    }
+
+    /// Create a signed operation and insert it into the store.
+    ///
+    /// This method performs several actions: it first queries the store to determine the latest
+    /// entry for the given author and log id. It then composes an operation and signs it. Finally,
+    /// the relevant log is associated with the topic and the signed operation is inserted into the
+    /// store. Both the log-topic association and operation insertion are executed as part of a
+    /// single transaction, thereby ensuring atomicity.
+    async fn create_operation(
+        &mut self,
+        topic: Topic,
+        log_id: LogId,
+        body: Option<Vec<u8>>,
+        extensions: Extensions,
+    ) -> Result<Option<Operation>, Self::Error> {
+        let (seq_num, backlink) = <SqliteStore<'static> as LogStore<
+            Operation,
+            PublicKey,
+            [u8; 32],
+            SeqNum,
+            Hash,
+        >>::get_latest_entry(
+            &self.store, &self.private_key.public_key(), &log_id
+        )
+        .await?
+        .map(|(hash, seq_num)| (seq_num + 1, Some(hash)))
+        .unwrap_or((0, None));
+
+        let body: Option<Body> = body.map(|bytes| bytes.into());
+
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+
+        let mut header = Header {
+            version: 1,
+            public_key: self.private_key.public_key(),
+            signature: None,
+            payload_size: body.as_ref().map(|body| body.size()).unwrap_or(0),
+            payload_hash: body.as_ref().map(|body| body.hash()),
+            timestamp,
+            seq_num,
+            backlink,
+            previous: vec![],
+            extensions,
+        };
+
+        header.sign(&self.private_key);
+        let hash = header.hash();
+
+        let operation = Operation {
+            hash,
+            header: header.clone(),
+            body,
+        };
+
+        // Acquire a store permit, associate the topic with the log, insert the
+        // operation and commit the transaction.
+        let inserted = tx!(self.store, {
+            <SqliteStore<'static> as TopicStore<Topic, PublicKey, [u8; 32]>>::associate(
+                &self.store,
+                &topic,
+                &self.private_key.public_key(),
+                &log_id,
+            )
+            .await?;
+
+            self.store
+                .insert_operation(&hash.clone(), operation.clone(), log_id)
+                .await?
+        });
+
+        Ok(inserted.then_some(operation))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ForgeError {
+    #[error(transparent)]
+    Sqlite(#[from] SqliteError),
+
+    #[error(transparent)]
+    SystemTime(#[from] SystemTimeError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use p2panda_core::{Body, Operation, Topic};
+    use p2panda_store::SqliteStore;
+    use p2panda_store::logs::LogStore;
+
+    use crate::Extensions;
+    use crate::forge::Forge;
+
+    use super::OperationForge;
+
+    #[tokio::test]
+    async fn operation_forge() {
+        let store = SqliteStore::temporary().await;
+        let mut forge = OperationForge::new(store.clone());
+
+        let topic = Topic::new();
+        let log_id: [u8; 32] = Topic::new().into();
+        let extensions = Extensions { version: 1 };
+
+        forge
+            .create_operation(
+                topic,
+                log_id,
+                Some("spring!".as_bytes().to_vec()),
+                extensions.clone(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        forge
+            .create_operation(
+                topic,
+                log_id,
+                Some("summer!".as_bytes().to_vec()),
+                extensions,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let public_key = forge.public_key();
+
+        let result = <SqliteStore<'_> as LogStore<Operation, _, _, _, _>>::get_log_heights(
+            &store,
+            &forge.public_key(),
+            &[log_id],
+        )
+        .await
+        .unwrap();
+
+        let expected_result = BTreeMap::from([(log_id, 1)]);
+
+        assert_eq!(result, Some(expected_result));
+    }
+}

--- a/p2panda/src/lib.rs
+++ b/p2panda/src/lib.rs
@@ -7,6 +7,7 @@
 // TODO: Check error type size.
 
 mod builder;
+mod forge;
 mod network;
 pub mod node;
 pub mod operation;

--- a/p2panda/src/network.rs
+++ b/p2panda/src/network.rs
@@ -40,7 +40,9 @@ impl Network {
         let address_book = AddressBook::builder().store(store.clone()).spawn().await?;
 
         for bootstrap in &config.bootstraps {
-            address_book.insert_node_info(NodeInfo::new(*bootstrap).bootstrap());
+            address_book
+                .insert_node_info(NodeInfo::new(*bootstrap).bootstrap())
+                .await?;
         }
 
         let mut endpoint = Endpoint::builder(address_book.clone())

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::marker::PhantomData;
-
-use p2panda_core::{Hash, PrivateKey, PublicKey, Topic};
+use p2panda_core::{Hash, Topic};
 use p2panda_net::NodeId;
 use p2panda_net::gossip::GossipError;
 use p2panda_net::sync::LogSyncError;
@@ -12,14 +10,14 @@ use thiserror::Error;
 
 use crate::Extensions;
 pub use crate::builder::NodeBuilder;
+use crate::forge::{Forge, OperationForge};
 use crate::network::{Network, NetworkConfig, NetworkError};
 use crate::streams::{EphemeralStreamHandle, EventStream, StreamHandle};
 
 // TODO: Can we expose network or will this explode the API surface for GObject unnecessarily?
 pub struct Node {
-    private_key: PrivateKey,
-    public_key: PublicKey,
     store: SqliteStore<'static>,
+    forge: OperationForge,
     network: Network,
 }
 
@@ -29,31 +27,30 @@ impl Node {
     }
 
     pub async fn spawn() -> Result<Self, NodeError> {
-        // Generates new private key using CSPRNG from system.
-        let private_key = PrivateKey::new();
-
         // Initialises an in-memory SQLite database.
         let store = SqliteStoreBuilder::default().build().await?;
+
+        // Create a forge with a new internally-generated private key.
+        let forge = OperationForge::new(store.clone());
 
         // Use default config, this will _not_ include a bootstrap and relay and reduces the
         // functionality of p2panda to only work on local-area networks.
         let config = Config::default();
 
-        Node::spawn_inner(config, private_key, store).await
+        Node::spawn_inner(config, store, forge).await
     }
 
     pub(crate) async fn spawn_inner(
         config: Config,
-        private_key: PrivateKey,
         store: SqliteStore<'static>,
+        forge: OperationForge,
     ) -> Result<Self, NodeError> {
-        let public_key = private_key.public_key();
-        let network = Network::spawn(config.network, private_key.clone(), store.clone()).await?;
+        let network =
+            Network::spawn(config.network, forge.private_key().clone(), store.clone()).await?;
 
         Ok(Node {
-            private_key,
-            public_key,
             store,
+            forge,
             network,
         })
     }
@@ -63,8 +60,9 @@ impl Node {
         M: Serialize + for<'a> Deserialize<'a>,
     {
         let handle = self.network.log_sync.stream(topic.into(), true).await?;
+        let forge = self.forge.clone();
 
-        Ok(StreamHandle::new(topic, handle))
+        Ok(StreamHandle::new(topic, handle, forge))
     }
 
     pub async fn ephemeral_stream<M>(
@@ -78,7 +76,7 @@ impl Node {
 
         Ok(EphemeralStreamHandle::new(
             topic,
-            self.private_key.clone(),
+            self.forge.private_key().clone(),
             handle,
         ))
     }
@@ -88,7 +86,7 @@ impl Node {
     }
 
     pub fn id(&self) -> NodeId {
-        self.public_key
+        self.forge.public_key()
     }
 
     pub fn ack(&self, _message_id: Hash) {

--- a/p2panda/src/operation.rs
+++ b/p2panda/src/operation.rs
@@ -6,8 +6,17 @@ pub type Header = p2panda_core::Header<Extensions>;
 
 pub type Operation = p2panda_core::Operation<Extensions>;
 
+/// Versioning for internal extensions format.
+pub(crate) const VERSION: u64 = 0;
+
 // TODO: Make sure encoding is canonical over map keys (sort it before serializing).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Extensions {
-    version: u64,
+    pub version: u64,
+}
+
+impl Default for Extensions {
+    fn default() -> Self {
+        Self { version: VERSION }
+    }
 }

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -5,12 +5,14 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures_util::Stream;
+use p2panda_core::cbor::{EncodeError, encode_cbor};
 use p2panda_core::{Hash, PublicKey, Topic};
 use p2panda_net::sync::SyncHandle;
 use p2panda_sync::protocols::TopicLogSyncEvent;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::forge::{Forge, ForgeError, OperationForge};
 use crate::{Extensions, Header, Operation};
 
 /// Handle onto an eventually-consistent stream, exposes API for publishing messages, subscribing
@@ -18,6 +20,7 @@ use crate::{Extensions, Header, Operation};
 pub struct StreamHandle<M> {
     topic: Topic,
     inner: SyncHandle<Operation, TopicLogSyncEvent<Extensions>>,
+    forge: OperationForge,
     _marker: PhantomData<M>,
 }
 
@@ -28,10 +31,12 @@ where
     pub(crate) fn new(
         topic: Topic,
         handle: SyncHandle<Operation, TopicLogSyncEvent<Extensions>>,
+        forge: OperationForge,
     ) -> Self {
         Self {
             topic,
             inner: handle,
+            forge,
             _marker: PhantomData,
         }
     }
@@ -41,8 +46,29 @@ where
     }
 
     /// Publish a message.
-    pub async fn publish(&self, _message: M) -> Result<Hash, StreamError> {
-        unimplemented!()
+    pub async fn publish(&mut self, message: M) -> Result<Hash, PublishError> {
+        let extensions = Extensions::default();
+
+        let encoded_message = encode_cbor(&message)?;
+
+        let operation = self
+            .forge
+            .create_operation(
+                self.topic(),
+                self.topic().into(),
+                Some(encoded_message),
+                extensions,
+            )
+            .await?
+            .ok_or(PublishError::DuplicateOperation)?;
+        let hash = operation.hash;
+
+        self.inner
+            .publish(operation)
+            .await
+            .map_err(|err| PublishError::SyncHandle(err.to_string()))?;
+
+        Ok(hash)
     }
 
     /// Subscribe to the message stream.
@@ -140,3 +166,18 @@ where
 
 #[derive(Debug, Error)]
 pub enum StreamError {}
+
+#[derive(Debug, Error)]
+pub enum PublishError {
+    #[error("an error occurred while serializing the message for publication: {0}")]
+    MessageEncoding(#[from] EncodeError),
+
+    #[error("an error occurred while creating an operation in the forge: {0}")]
+    Forge(#[from] ForgeError),
+
+    #[error("message already exists in the forge")]
+    DuplicateOperation,
+
+    #[error("an error occurred while publishing an operation to the log sync stream: {0}")]
+    SyncHandle(String),
+}


### PR DESCRIPTION
Introduces a `Forge` trait interface for creating signed operations and holding
the signing keypair.

We also introduce a concrete `OperationForge` which implements the `Forge` trait
and provides a convenient interface which internally composes operations, signs
them, inserts them into the store and associates the operation log id with the
topic.

The `OperationForge` has been incorporated into the `Node` and is used internally
by the `StreamHandle` when messages are published.

Closes: https://github.com/p2panda/p2panda/issues/1027

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
