### PR TITLE
Publicly export `SeqNum`

### DIFF
--- a/p2panda-core/src/lib.rs
+++ b/p2panda-core/src/lib.rs
@@ -94,7 +94,7 @@ pub mod traits;
 pub use extensions::{Extension, Extensions};
 pub use hash::{Hash, HashError};
 pub use identity::{IdentityError, PrivateKey, PublicKey, Signature};
-pub use logs::LogId;
+pub use logs::{LogId, SeqNum};
 pub use operation::{
     Body, Header, Operation, OperationError, RawOperation, validate_backlink, validate_header,
     validate_operation,

--- a/p2panda-core/src/logs.rs
+++ b/p2panda-core/src/logs.rs
@@ -33,7 +33,8 @@ pub trait LogId: Clone + Eq + Ord + StdHash + Serialize + for<'de> Deserialize<'
 
 impl<T> LogId for T where T: Clone + Eq + Ord + StdHash + Serialize + for<'de> Deserialize<'de> {}
 
-type SeqNum = u64;
+/// Sequence number of an entry in an append-only log.
+pub type SeqNum = u64;
 
 /// Map of log heights grouped by author.
 pub type LogHeights<A, L> = BTreeMap<A, BTreeMap<L, SeqNum>>;

--- a/p2panda-store/src/logs/sqlite/mod.rs
+++ b/p2panda-store/src/logs/sqlite/mod.rs
@@ -7,15 +7,13 @@ mod tests;
 use std::collections::BTreeMap;
 
 use p2panda_core::cbor::encode_cbor;
-use p2panda_core::{Extensions, Hash, LogId, Operation, PublicKey};
+use p2panda_core::{Extensions, Hash, LogId, Operation, PublicKey, SeqNum};
 use sqlx::{query, query_as};
 
 use crate::logs::LogStore;
 use crate::logs::sqlite::models::{LatestEntryRow, LogHeightRow, LogMetaRow};
 use crate::operations::OperationRow;
 use crate::sqlite::{SqliteError, SqliteStore};
-
-pub type SeqNum = u64;
 
 impl<'a, L, E> LogStore<Operation<E>, PublicKey, L, SeqNum, Hash> for SqliteStore<'a>
 where

--- a/p2panda-store/src/logs/sqlite/models.rs
+++ b/p2panda-store/src/logs/sqlite/models.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use p2panda_core::cbor::decode_cbor;
-use p2panda_core::{Hash, HashError, LogId};
+use p2panda_core::{Hash, HashError, LogId, SeqNum};
 use sqlx::FromRow;
 
-use crate::logs::sqlite::SeqNum;
 use crate::sqlite::{DecodeError, SqliteError};
 
 /// Database representation of the sum of all header and body byte size.


### PR DESCRIPTION
We rely on `SeqNum` (`u64`) in `-core`, `-store` and `p2panda` so I suggest we expose it to reduce repeated definitions. 
