### PR TITLE
Introduce processor module for ordering and consuming groups control messages

### DIFF
--- a/p2panda-auth/Cargo.toml
+++ b/p2panda-auth/Cargo.toml
@@ -20,18 +20,34 @@ all-features = true
 workspace = true
 
 [features]
-default = []
-test_utils = ["dep:rand", "serde"]
+default = ["processor"]
+processor = ["dep:tokio", "serde", "dep:p2panda-core", "dep:p2panda-stream"]
+test_utils = ["dep:rand", "serde", "dep:p2panda-core"]
 serde = ["dep:serde"]
+test = ["test_utils"]
 
 [dependencies]
 p2panda-core = { path = "../p2panda-core", version = "0.5.1", optional = true }
+p2panda-stream = { path = "../p2panda-stream", version = "0.5.1", optional = true }
 petgraph = { version = "0.8.1", features = ["serde-1"] }
 rand = { version = "0.9.0", features = ["alloc"], optional = true }
 serde = { version = "1.0.219", features = ["derive"], optional = true }
+tokio = { version = "1.49.0", features = ["sync"], optional = true }
 thiserror = "2.0.12"
 
 [dev-dependencies]
+p2panda-core = { path = "../p2panda-core", version = "0.5.1" }
+p2panda-net = { path = "../p2panda-net", version = "0.5.1" }
+p2panda-sync = { path = "../p2panda-sync", version = "0.5.1" }
+p2panda-store = { path = "../p2panda-store", version = "0.5.1" }
 rand = { version = "0.9.1", features = ["alloc"] }
 serde = { version = "1.0.219", features = ["derive"] }
 ciborium = "0.2.2"
+tokio = "1.49.0"
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+anyhow = "1.0.102"
+clap = { version = "4.5.54", features = ["derive"] }
+futures-util = "0.3.32"
+rand_chacha = "0.9.0"
+tracing = "0.1.44"
+hex = "0.4.3"

--- a/p2panda-auth/examples/groups.rs
+++ b/p2panda-auth/examples/groups.rs
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Example CLI app for group management.
+//!
+//! ## Usage
+//!
+//! Run the example on the first node:
+//!
+//! `cargo run --example groups`
+//!
+//! Run the example on a second node, using the topic ID and public key of the first node:
+//!
+//! `cargo run --example groups -- -t <TOPIC_ID> -b <FIRST_NODE_PUBLIC_KEY>`
+//!
+//! ### Commands
+//!
+//! The public key of the running node is used as the `<MEMBER_PUBLIC_KEY>` for the local actor
+//! and is added to any newly created group as a manager member. Valid values for `<ACCESS_LEVEL>`
+//! are "pull" | "read" | "write" | "manage".
+//!
+//! ```
+//! # create a group with the local author as manage member
+//! create
+//!
+//! # add a member to an existing group
+//! add <MEMBER_PUBLIC_KEY> <GROUP_ID> <ACCESS_LEVEL>
+//!
+//! # add a member to an existing group
+//! remove <MEMBER_PUBLIC_KEY> <GROUP_ID>
+//! ```
+use std::collections::{HashMap, VecDeque};
+use std::convert::Infallible;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use clap::Parser;
+use futures_util::StreamExt;
+use p2panda_auth::group::{GroupAction, GroupMember};
+use p2panda_auth::processor::{
+    AuthState, GroupsArgs, GroupsOperation, GroupsProcessor, Store as GroupsStore,
+};
+use p2panda_auth::traits::Operation as GroupsOperationTrait;
+use p2panda_auth::{Access, AccessError};
+use p2panda_core::{Extension, Hash, Header, IdentityError, Operation, PrivateKey, PublicKey};
+use p2panda_net::addrs::NodeInfo;
+use p2panda_net::iroh_endpoint::{EndpointAddr, from_public_key};
+use p2panda_net::iroh_mdns::MdnsDiscoveryMode;
+use p2panda_net::utils::ShortFormat;
+use p2panda_net::{
+    AddressBook, Discovery, Endpoint, Gossip, LogSync, MdnsDiscovery, NodeId, TopicId,
+};
+use p2panda_store::{MemoryStore, OperationStore};
+use p2panda_sync::protocols::{Logs, TopicLogSyncEvent as SyncEvent};
+use p2panda_sync::traits::TopicMap;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha12Rng;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::{RwLock, mpsc};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::prelude::*;
+
+type LogId = u64;
+
+/// This application maintains only one log per author, this is why we can hard-code it.
+const LOG_ID: LogId = 1;
+
+const RELAY_URL: &str = "https://euc1-1.relay.n0.iroh-canary.iroh.link.";
+
+pub fn setup_logging() {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .with(EnvFilter::from_default_env())
+        .try_init()
+        .ok();
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AppExtensions {
+    auth: Option<GroupsArgs>,
+}
+
+impl Extension<GroupsArgs> for AppExtensions {
+    fn extract(header: &Header<Self>) -> Option<GroupsArgs> {
+        header.extensions.auth.clone()
+    }
+}
+
+#[derive(Parser)]
+struct Args {
+    /// Bootstrap node identifier.
+    #[arg(short = 'b', long, value_name = "BOOTSTRAP_ID")]
+    bootstrap_id: Option<NodeId>,
+
+    /// Topic identifier.
+    #[arg(short = 't', long, value_name = "TOPIC_ID")]
+    topic_id: Option<String>,
+
+    /// Enable mDNS discovery
+    #[arg(short = 'm', long, action)]
+    mdns: bool,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct GroupsTopicMap(Arc<RwLock<HashMap<TopicId, Logs<LogId>>>>);
+
+impl GroupsTopicMap {
+    async fn insert(&self, topic_id: TopicId, node_id: NodeId, log_id: LogId) {
+        let mut map = self.0.write().await;
+        map.entry(topic_id)
+            .and_modify(|logs| {
+                logs.insert(node_id, vec![log_id]);
+            })
+            .or_insert({
+                let mut value = HashMap::new();
+                value.insert(node_id, vec![log_id]);
+                value
+            });
+    }
+}
+
+impl TopicMap<TopicId, Logs<LogId>> for GroupsTopicMap {
+    type Error = Infallible;
+
+    async fn get(&self, topic_query: &TopicId) -> Result<Logs<LogId>, Self::Error> {
+        let map = self.0.read().await;
+        Ok(map.get(topic_query).cloned().unwrap_or_default())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    setup_logging();
+
+    let args = Args::parse();
+
+    let private_key = PrivateKey::new();
+    let public_key = private_key.public_key();
+
+    // Retrieve the chat topic ID from the provided arguments, otherwise generate a new, random,
+    // cryptographically-secure identifier.
+    let topic_id: TopicId = if let Some(topic) = args.topic_id {
+        let topic_id = hex::decode(topic)?;
+        topic_id.try_into().expect("topic id should be 32 bytes")
+    } else {
+        let mut rng = ChaCha12Rng::from_os_rng();
+        rng.random()
+    };
+
+    // Set up sync for p2panda operations.
+    let mut store = MemoryStore::<LogId, AppExtensions>::new();
+
+    let topic_map = GroupsTopicMap::default();
+    topic_map.insert(topic_id, public_key, LOG_ID).await;
+
+    // Prepare address book.
+    let address_book = AddressBook::builder().spawn().await?;
+
+    // Add a bootstrap node to our address book if one was supplied by the user.
+    if let Some(id) = args.bootstrap_id {
+        let endpoint_addr = EndpointAddr::new(from_public_key(id));
+        let endpoint_addr = endpoint_addr.with_relay_url(RELAY_URL.parse()?);
+        address_book
+            .insert_node_info(NodeInfo::from(endpoint_addr).bootstrap())
+            .await?;
+    }
+
+    let endpoint = Endpoint::builder(address_book.clone())
+        .private_key(private_key.clone())
+        .relay_url(RELAY_URL.parse().unwrap())
+        .spawn()
+        .await?;
+
+    println!("network id: {}", endpoint.network_id().fmt_short());
+    println!("topic id: {}", hex::encode(topic_id));
+    println!("public key: {}", public_key.to_hex());
+    println!("relay url: {}", RELAY_URL);
+
+    let _discovery = Discovery::builder(address_book.clone(), endpoint.clone())
+        .spawn()
+        .await?;
+
+    let mdns_discovery_mode = if args.mdns {
+        MdnsDiscoveryMode::Active
+    } else {
+        MdnsDiscoveryMode::Passive
+    };
+    let _mdns = MdnsDiscovery::builder(address_book.clone(), endpoint.clone())
+        .mode(mdns_discovery_mode)
+        .spawn()
+        .await?;
+
+    let gossip = Gossip::builder(address_book.clone(), endpoint.clone())
+        .spawn()
+        .await?;
+
+    let sync = LogSync::builder(store.clone(), topic_map.clone(), endpoint, gossip)
+        .spawn()
+        .await?;
+
+    let sync_tx = sync.stream(topic_id, true).await?;
+    let mut sync_rx = sync_tx.subscribe().await?;
+
+    let groups_store = GroupsStore::<GroupsOperation>::default();
+
+    // Receive messages from the sync stream.
+    {
+        let mut store = store.clone();
+        let groups_store = groups_store.clone();
+        tokio::task::spawn(async move {
+            while let Some(Ok(from_sync)) = sync_rx.next().await {
+                match from_sync.event {
+                    SyncEvent::SyncFinished(metrics) => {
+                        info!(
+                            "finished sync session with {}, bytes received = {}, bytes sent = {}",
+                            from_sync.remote.fmt_short(),
+                            metrics.total_bytes_remote.unwrap_or_default(),
+                            metrics.total_bytes_local.unwrap_or_default()
+                        );
+                    }
+                    SyncEvent::Operation(operation) => {
+                        if store.has_operation(operation.hash).await.unwrap() {
+                            continue;
+                        }
+
+                        let control_message: GroupsOperation = operation
+                            .deref()
+                            .clone()
+                            .try_into()
+                            .expect("all operations have groups args");
+
+                        if let Err(err) =
+                            GroupsProcessor::process(&groups_store, &control_message).await
+                        {
+                            println!();
+                            println!("error: {err:?}");
+                            println!();
+                            continue;
+                        };
+
+                        store
+                            .insert_operation(
+                                operation.hash,
+                                &operation.header,
+                                operation.body.as_ref(),
+                                &operation.header.to_bytes(),
+                                &LOG_ID,
+                            )
+                            .await
+                            .unwrap();
+
+                        topic_map
+                            .insert(topic_id, operation.header.public_key, LOG_ID)
+                            .await;
+
+                        print_group(&groups_store, &control_message).await;
+                    }
+                    _ => (),
+                }
+            }
+        });
+    }
+
+    // Listen for text input via the terminal.
+    let (line_tx, mut line_rx) = mpsc::channel(1);
+    std::thread::spawn(move || input_loop(line_tx));
+
+    let mut seq_num = 0;
+    let mut backlink = None;
+
+    // Sign and encode each line of text input and broadcast it on the chat topic.
+    tokio::task::spawn(async move {
+        while let Some(text) = line_rx.recv().await {
+            let (group_id, action) = match text_2_action(&groups_store, public_key, text).await {
+                Ok(action) => action,
+                Err(err) => {
+                    println!();
+                    println!("error: {err:?}");
+                    println!();
+                    continue;
+                }
+            };
+
+            let groups_args = GroupsArgs { group_id, action };
+            let previous: Vec<Hash> = groups_store.get_state().await.crdt.heads();
+
+            let (hash, header, header_bytes, operation) =
+                create_operation(&private_key, seq_num, backlink, &previous, groups_args);
+
+            let control_message: GroupsOperation = operation
+                .clone()
+                .try_into()
+                .expect("all operations have groups args");
+
+            if let Err(err) = GroupsProcessor::process(&groups_store, &control_message).await {
+                println!();
+                println!("error: {err:?}");
+                println!();
+                continue;
+            };
+
+            store
+                .insert_operation(hash, &header, None, &header_bytes, &LOG_ID)
+                .await
+                .unwrap();
+
+            print_group(&groups_store, &control_message).await;
+
+            sync_tx.publish(operation).await.unwrap();
+
+            seq_num += 1;
+            backlink = Some(hash);
+        }
+    });
+
+    // Listen for `Ctrl+c` and shutdown the node.
+    tokio::signal::ctrl_c().await?;
+
+    Ok(())
+}
+
+fn input_loop(line_tx: mpsc::Sender<String>) -> Result<()> {
+    let mut buffer = String::new();
+    let stdin = std::io::stdin();
+    loop {
+        stdin.read_line(&mut buffer)?;
+        line_tx.blocking_send(buffer.clone())?;
+        buffer.clear();
+    }
+}
+
+fn create_operation(
+    private_key: &PrivateKey,
+    seq_num: u64,
+    backlink: Option<Hash>,
+    previous: &[Hash],
+    groups_args: GroupsArgs,
+) -> (
+    Hash,
+    Header<AppExtensions>,
+    Vec<u8>,
+    Operation<AppExtensions>,
+) {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let mut header = Header {
+        version: 1,
+        public_key: private_key.public_key(),
+        signature: None,
+        payload_size: 0,
+        payload_hash: None,
+        timestamp,
+        seq_num,
+        backlink,
+        previous: previous.to_vec(),
+        extensions: AppExtensions {
+            auth: Some(groups_args),
+        },
+    };
+
+    header.sign(private_key);
+    let header_bytes = header.to_bytes();
+    let hash = header.hash();
+
+    let operation = Operation {
+        hash,
+        header: header.clone(),
+        body: None,
+    };
+
+    (hash, header, header_bytes, operation)
+}
+
+#[derive(Debug, Error)]
+enum Text2ActionError {
+    #[error("invalid arguments: {0}")]
+    InvalidArgs(String),
+
+    #[error("unknown command: {0}")]
+    UnknownCommand(String),
+
+    #[error(transparent)]
+    Identity(#[from] IdentityError),
+
+    #[error(transparent)]
+    Access(#[from] AccessError),
+}
+
+async fn text_2_action(
+    store: &GroupsStore<GroupsOperation>,
+    me: PublicKey,
+    text: String,
+) -> Result<(PublicKey, GroupAction<PublicKey>), Text2ActionError> {
+    let y = store.get_state().await;
+    let args = if let Some(_text) = text.strip_prefix("create") {
+        let group_id = PrivateKey::new().public_key();
+        (
+            group_id,
+            GroupAction::Create {
+                initial_members: vec![(GroupMember::Individual(me), Access::manage())],
+            },
+        )
+    } else if let Some(text) = text.strip_prefix("add") {
+        let text = text.trim();
+        let mut args: VecDeque<&str> = text.split(" ").filter(|s| !s.is_empty()).collect();
+        let Some(member_id) = args.pop_front() else {
+            return Err(Text2ActionError::InvalidArgs(
+                "member_id required when adding member to a group".to_string(),
+            ));
+        };
+        let member = parse_member(&y, member_id)?;
+
+        let Some(group_id) = args.pop_front() else {
+            return Err(Text2ActionError::InvalidArgs(
+                "group_id required when adding member to a group".to_string(),
+            ));
+        };
+
+        let group_id: PublicKey = group_id.trim().parse()?;
+
+        let Some(access) = args.pop_front() else {
+            return Err(Text2ActionError::InvalidArgs(
+                "access level required for new group member".to_string(),
+            ));
+        };
+        let access: Access = access.parse()?;
+        let action = GroupAction::Add { member, access };
+        (group_id, action)
+    } else if let Some(text) = text.strip_prefix("remove") {
+        let text = text.trim();
+        let mut args: VecDeque<&str> = text.split(" ").filter(|s| !s.is_empty()).collect();
+        let Some(member_id) = args.pop_front() else {
+            return Err(Text2ActionError::InvalidArgs(
+                "member_id required when removing member from a group".to_string(),
+            ));
+        };
+        let member = parse_member(&y, member_id)?;
+
+        let Some(group_id) = args.pop_front() else {
+            return Err(Text2ActionError::InvalidArgs(
+                "group_id required when removing member from a group".to_string(),
+            ));
+        };
+
+        let group_id: PublicKey = group_id.trim().parse()?;
+        let action = GroupAction::Remove { member };
+        (group_id, action)
+    } else {
+        return Err(Text2ActionError::UnknownCommand(text));
+    };
+
+    Ok(args)
+}
+
+fn parse_member(
+    y: &AuthState<GroupsOperation>,
+    member_id: &str,
+) -> Result<GroupMember<PublicKey>, Text2ActionError> {
+    let member_id: PublicKey = member_id.trim().parse()?;
+
+    // Check if this member is a group or individual.
+    let member = if y.crdt.has_group(member_id) {
+        GroupMember::Group(member_id)
+    } else {
+        GroupMember::Individual(member_id)
+    };
+
+    Ok(member)
+}
+
+async fn print_group(store: &GroupsStore<GroupsOperation>, operation: &GroupsOperation) {
+    let y = store.get_state().await;
+    let members = y
+        .crdt
+        .members(operation.group_id())
+        .into_iter()
+        .map(|(member, access)| format!("{}:{}", member.fmt_short(), access))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let action = match operation.action() {
+        GroupAction::Create { initial_members } => {
+            let members = initial_members
+                .into_iter()
+                .map(|(member, access)| format!("{}:{}", member.id().fmt_short(), access))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            format!(
+                "author={}, action=create, initial members=[{}]",
+                operation.author().fmt_short(),
+                members
+            )
+        }
+        GroupAction::Add { member, access } => {
+            format!(
+                "author={}, action=add, member={}:{}",
+                operation.author().fmt_short(),
+                member.id().fmt_short(),
+                access
+            )
+        }
+        GroupAction::Remove { member } => {
+            format!(
+                "author={}, action=remove, member={}",
+                operation.author().fmt_short(),
+                member.id().fmt_short()
+            )
+        }
+        _ => unimplemented!(),
+    };
+
+    println!();
+    println!("group id : {}", operation.group_id());
+    println!("action   : {action}");
+    println!("members  : [{members}]");
+    println!();
+}

--- a/p2panda-auth/src/access.rs
+++ b/p2panda-auth/src/access.rs
@@ -2,9 +2,11 @@
 
 use std::cmp::Ordering;
 use std::fmt::Display;
+use std::str::FromStr;
 
 #[cfg(any(test, feature = "serde"))]
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::traits::Conditions;
 
@@ -149,6 +151,28 @@ impl<C: PartialOrd + Eq> Ord for Access<C> {
 }
 
 impl Conditions for () {}
+
+#[derive(Debug, Error)]
+pub enum AccessError {
+    #[error("unknown access string: {0}")]
+    Unknown(String),
+}
+
+impl FromStr for Access {
+    type Err = AccessError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let access = match s {
+            "pull" => Access::pull(),
+            "read" => Access::read(),
+            "write" => Access::write(),
+            "manage" => Access::manage(),
+            _ => return Err(AccessError::Unknown(s.to_string())),
+        };
+
+        Ok(access)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -62,7 +62,10 @@ pub(crate) type GroupStates<ID, C> = HashMap<ID, GroupMembersState<GroupMember<I
 /// Inner state object for `GroupCrdt` which contains the actual groups state,
 /// including operation graph and membership snapshots.
 #[derive(Debug)]
-#[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
+#[cfg_attr(
+    any(test, feature = "test_utils", feature = "processor"),
+    derive(Clone)
+)]
 #[cfg_attr(any(test, feature = "serde"), derive(Deserialize, Serialize))]
 pub struct GroupCrdtInnerState<ID, OP, M, C>
 where
@@ -276,7 +279,10 @@ where
 /// State object for `GroupCrdt` containing an orderer state and the inner
 /// state.
 #[derive(Debug)]
-#[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
+#[cfg_attr(
+    any(test, feature = "test_utils", feature = "processor"),
+    derive(Clone)
+)]
 #[cfg_attr(
     any(test, feature = "serde"),
     derive(Deserialize, Serialize),
@@ -352,6 +358,11 @@ where
     /// Returns `true` if the passed group exists in the current state.
     pub fn has_group(&self, group_id: ID) -> bool {
         self.inner.current_state().contains_key(&group_id)
+    }
+
+    /// Current tips for the groups operation graph.
+    pub fn heads(&self) -> Vec<OP> {
+        self.inner.heads().into_iter().collect()
     }
 }
 

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -52,8 +52,8 @@ pub struct StrongRemove<ID, OP, M, C> {
 
 impl<ID, OP, M, C> Resolver<ID, OP, M, C> for StrongRemove<ID, OP, M, C>
 where
-    ID: IdentityHandle + Ord,
-    OP: OperationId + Ord,
+    ID: IdentityHandle,
+    OP: OperationId,
     M: Clone + Operation<ID, OP, C>,
     C: Conditions,
 {
@@ -103,8 +103,8 @@ where
 
 impl<ID, OP, M, C> StrongRemove<ID, OP, M, C>
 where
-    ID: IdentityHandle + Ord,
-    OP: OperationId + Ord,
+    ID: IdentityHandle,
+    OP: OperationId,
     M: Clone + Operation<ID, OP, C>,
     C: Conditions,
 {
@@ -311,8 +311,8 @@ where
 /// manager access.
 fn removed_or_demoted_manager<ID, OP, M, C>(operation: &M) -> Option<ID>
 where
-    ID: IdentityHandle + Ord,
-    OP: OperationId + Ord,
+    ID: IdentityHandle,
+    OP: OperationId,
     M: Clone + Operation<ID, OP, C>,
     C: Conditions,
 {
@@ -337,8 +337,8 @@ where
 /// manager access.
 fn added_or_promoted_manager<ID, OP, M, C>(operation: &M) -> Option<ID>
 where
-    ID: IdentityHandle + Ord,
-    OP: OperationId + Ord,
+    ID: IdentityHandle,
+    OP: OperationId,
     M: Clone + Operation<ID, OP, C>,
     C: Conditions,
 {

--- a/p2panda-auth/src/lib.rs
+++ b/p2panda-auth/src/lib.rs
@@ -75,8 +75,10 @@
 mod access;
 pub mod graph;
 pub mod group;
+#[cfg(feature = "processor")]
+pub mod processor;
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_utils;
 pub mod traits;
 
-pub use access::{Access, AccessLevel};
+pub use access::{Access, AccessError, AccessLevel};

--- a/p2panda-auth/src/processor/args.rs
+++ b/p2panda-auth/src/processor/args.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Arguments required for constructing groups `GroupsOperation` and conversion trait from p2panda
+//! operations which contain an `E` extension which implements `Extension<GroupsArgs>`.
+use p2panda_core::{Extension, Extensions, Hash, Operation, PublicKey};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::group::GroupAction;
+use crate::processor::operation::GroupsOperation;
+use crate::traits::Conditions;
+
+/// Additional operation arguments required for constructing a groups GroupsOperation.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GroupsArgs<C = ()> {
+    pub group_id: PublicKey,
+    pub action: GroupAction<PublicKey, C>,
+}
+
+impl<E, C> TryInto<GroupsOperation<PublicKey, Hash, C>> for Operation<E>
+where
+    E: Extensions + Extension<GroupsArgs<C>>,
+    C: Conditions,
+{
+    type Error = GroupsArgsError;
+
+    fn try_into(self) -> Result<GroupsOperation<PublicKey, Hash, C>, Self::Error> {
+        let args = self.header.extension().ok_or(GroupsArgsError {})?;
+        Ok(GroupsOperation {
+            id: self.hash,
+            author: self.header.public_key,
+            dependencies: self.header.previous,
+            group_id: args.group_id,
+            action: args.action,
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("groups args missing from operation extensions")]
+pub struct GroupsArgsError;

--- a/p2panda-auth/src/processor/mod.rs
+++ b/p2panda-auth/src/processor/mod.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Types and methods for ordering and processing groups control messages.
+mod args;
+mod operation;
+#[allow(clippy::module_inception)]
+mod processor;
+mod store;
+
+pub use args::GroupsArgs;
+pub use operation::GroupsOperation;
+pub use processor::{GroupsProcessor, GroupsProcessorError};
+pub use store::{AuthState, Store};

--- a/p2panda-auth/src/processor/operation.rs
+++ b/p2panda-auth/src/processor/operation.rs
@@ -1,0 +1,42 @@
+use p2panda_core::{Hash, PublicKey};
+
+use crate::group::GroupAction;
+use crate::traits::{Conditions, IdentityHandle, Operation, OperationId};
+
+/// Concrete groups control message type.
+#[derive(Clone, Debug)]
+pub struct GroupsOperation<A = PublicKey, ID = Hash, C = ()> {
+    pub(crate) id: ID,
+    pub(crate) author: A,
+    pub(crate) dependencies: Vec<ID>,
+    pub(crate) group_id: A,
+    pub(crate) action: GroupAction<A, C>,
+}
+
+/// Implementation of groups Operation trait.
+impl<A, ID, C> Operation<A, ID, C> for GroupsOperation<A, ID, C>
+where
+    A: IdentityHandle,
+    ID: OperationId,
+    C: Conditions,
+{
+    fn id(&self) -> ID {
+        self.id
+    }
+
+    fn author(&self) -> A {
+        self.author
+    }
+
+    fn dependencies(&self) -> Vec<ID> {
+        self.dependencies.clone()
+    }
+
+    fn group_id(&self) -> A {
+        self.group_id
+    }
+
+    fn action(&self) -> GroupAction<A, C> {
+        self.action.clone()
+    }
+}

--- a/p2panda-auth/src/processor/processor.rs
+++ b/p2panda-auth/src/processor/processor.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt::{Debug, Display};
+use std::marker::PhantomData;
+
+use p2panda_core::{Hash, PublicKey};
+use p2panda_stream::partial::{PartialOrder, PartialOrderError};
+use thiserror::Error;
+
+use crate::group::resolver::StrongRemove;
+use crate::group::{GroupCrdt, GroupCrdtError};
+use crate::processor::Store;
+use crate::traits::{Conditions, IdentityHandle, Operation as GroupsOperation, OperationId};
+
+impl IdentityHandle for PublicKey {}
+impl OperationId for Hash {}
+
+/// Processor for groups operations.
+#[derive(Clone)]
+pub struct GroupsProcessor<M, A = PublicKey, ID = Hash, C = ()>
+where
+    M: GroupsOperation<A, ID, C>,
+    A: IdentityHandle,
+    ID: OperationId + Display,
+    C: Conditions,
+{
+    _marker: PhantomData<(M, A, ID, C)>,
+}
+
+impl<M, A, ID, C> GroupsProcessor<M, A, ID, C>
+where
+    M: GroupsOperation<A, ID, C> + Clone + Debug,
+    A: IdentityHandle,
+    ID: OperationId + Display,
+    C: Conditions,
+{
+    /// Process a groups operation.
+    ///
+    /// Processed operations are first partially ordered, and only processed on the auth groups state
+    /// if all their dependencies have been met. If other operations become "ready" by this one, then
+    /// they will be all processed in order.
+    pub async fn process(
+        store: &Store<M, A, ID, C>,
+        operation: &M,
+    ) -> Result<(), GroupsProcessorError<M, A, ID, C>> {
+        // Retrieve the current groups state from the store.
+        //
+        // @TODO: we will use the new store API here once upstream changes in `development` are
+        // merged to main. This includes a transactional API which protects against potential race
+        // conditions when multiple processes try to mutate the store concurrently. For now we use
+        // an in-memory store with a Mutex to coordinate shared access.
+        let _lock = store.begin_transaction().await;
+        let mut y = store.take_state().await;
+
+        // Add operation to the internal buffer.
+        let operation_id = operation.id();
+        let dependencies = operation.dependencies();
+        y.operation_buffer.insert(operation_id, operation.clone());
+
+        // Process the operation in the orderer.
+        let mut orderer = PartialOrder::new(y.orderer.clone());
+        orderer.process(operation_id, &dependencies).await?;
+
+        // For all operations that are now "ready" (their dependencies have all been processed)
+        // apply them to the groups state.
+        while let Some(hash) = orderer.next().await? {
+            let operation = match y.operation_buffer.remove(&hash) {
+                Some(operation) => operation,
+                None => {
+                    return Err(GroupsProcessorError::MissingOperation(hash));
+                }
+            };
+
+            y.crdt =
+                GroupCrdt::<_, _, _, C, StrongRemove<A, ID, M, C>>::process(y.crdt, &operation)?;
+        }
+
+        // Set the groups state after processing is finished.
+        y.orderer = orderer.store();
+        store.set_state(y).await;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Error)]
+pub enum GroupsProcessorError<M, A, ID, C>
+where
+    A: IdentityHandle,
+    ID: OperationId,
+    M: GroupsOperation<A, ID, C> + Clone + Debug,
+    C: Conditions,
+{
+    #[error(transparent)]
+    Orderer(#[from] PartialOrderError),
+
+    #[error(transparent)]
+    Groups(#[from] GroupCrdtError<A, ID, M, C, StrongRemove<A, ID, M, C>>),
+
+    #[error("missing operation: {0}")]
+    MissingOperation(ID),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Access;
+    use crate::group::GroupMember;
+    use crate::processor::{GroupsProcessor, Store};
+    use crate::test_utils::{add_member, create_group};
+    use crate::traits::Operation;
+
+    #[tokio::test]
+    async fn ooo_operations() {
+        let group_id = 'G';
+
+        let alice = 'A';
+        let bobby = 'B';
+        let cathy = 'C';
+
+        let op_00 = create_group(
+            alice,
+            0,
+            group_id,
+            vec![(GroupMember::Individual(alice), Access::manage())],
+            vec![],
+        );
+
+        let op_01 = add_member(
+            alice,
+            1,
+            group_id,
+            GroupMember::Individual(bobby),
+            Access::manage(),
+            vec![op_00.id()],
+        );
+
+        let op_02 = add_member(
+            alice,
+            2,
+            group_id,
+            GroupMember::Individual(cathy),
+            Access::read(),
+            vec![op_01.id()],
+        );
+
+        let groups_store = Store::default();
+        GroupsProcessor::process(&groups_store, &op_02)
+            .await
+            .unwrap();
+        GroupsProcessor::process(&groups_store, &op_01)
+            .await
+            .unwrap();
+        GroupsProcessor::process(&groups_store, &op_00)
+            .await
+            .unwrap();
+    }
+}

--- a/p2panda-auth/src/processor/store.rs
+++ b/p2panda-auth/src/processor/store.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::traits::{IdentityHandle, OperationId};
+use crate::{
+    group::GroupCrdtState,
+    traits::{Conditions, Operation},
+};
+
+use p2panda_core::{Hash, PublicKey};
+use p2panda_stream::partial::MemoryStore;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{Mutex, MutexGuard};
+
+/// All state material required for ordering and processing group messages.
+#[derive(Clone)]
+pub struct AuthState<M, A = PublicKey, ID = Hash, C = ()>
+where
+    A: IdentityHandle,
+    ID: OperationId,
+    M: Operation<A, ID, C>,
+    C: Conditions,
+{
+    pub crdt: GroupCrdtState<A, ID, M, C>,
+    pub orderer: MemoryStore<ID>,
+    pub operation_buffer: HashMap<ID, M>,
+}
+
+impl<M, A, ID, C> Default for AuthState<M, A, ID, C>
+where
+    A: IdentityHandle,
+    ID: OperationId,
+    M: Operation<A, ID, C>,
+    C: Conditions,
+{
+    fn default() -> Self {
+        Self {
+            crdt: GroupCrdtState::default(),
+            orderer: MemoryStore::default(),
+            operation_buffer: HashMap::default(),
+        }
+    }
+}
+
+/// Memory store for retrieving and mutating auth state.
+///
+/// NOTE: this in-memory implementation will be replaced with SQLite stores in the near future.
+#[derive(Clone)]
+pub struct Store<M, A = PublicKey, ID = Hash, C = ()>
+where
+    A: IdentityHandle,
+    ID: OperationId,
+    M: Operation<A, ID, C>,
+    C: Conditions,
+{
+    transaction_lock: Arc<Mutex<()>>,
+
+    #[allow(clippy::type_complexity)]
+    state: Arc<Mutex<Option<AuthState<M, A, ID, C>>>>,
+}
+
+impl<M, A, ID, C> Store<M, A, ID, C>
+where
+    A: IdentityHandle,
+    ID: OperationId,
+    M: Operation<A, ID, C> + Clone,
+    C: Conditions,
+{
+    pub async fn begin_transaction(&self) -> MutexGuard<'_, ()> {
+        self.transaction_lock.lock().await
+    }
+
+    pub async fn take_state(&self) -> AuthState<M, A, ID, C> {
+        self.state.lock().await.take().unwrap_or_default()
+    }
+
+    pub async fn set_state(&self, state: AuthState<M, A, ID, C>) {
+        *self.state.lock().await = Some(state);
+    }
+
+    pub async fn get_state(&self) -> AuthState<M, A, ID, C> {
+        self.state
+            .lock()
+            .await
+            .as_ref()
+            .cloned()
+            .unwrap_or_default()
+    }
+}
+
+impl<M, A, ID, C> Default for Store<M, A, ID, C>
+where
+    A: IdentityHandle,
+    ID: OperationId,
+    M: Operation<A, ID, C>,
+    C: Conditions,
+{
+    fn default() -> Self {
+        Self {
+            transaction_lock: Arc::new(Mutex::new(())),
+            state: Arc::new(Mutex::new(Some(AuthState::default()))),
+        }
+    }
+}

--- a/p2panda-auth/src/traits/mod.rs
+++ b/p2panda-auth/src/traits/mod.rs
@@ -16,14 +16,14 @@ pub use resolver::Resolver;
 ///
 /// Note that this needs to be unique within a group, can be a username, number or preferably a
 /// long byte string.
-pub trait IdentityHandle: Copy + Debug + PartialEq + Eq + StdHash {}
+pub trait IdentityHandle: Copy + Debug + PartialEq + Eq + Ord + StdHash {}
 
 /// Identifier for each group membership operation.
 ///
 /// Operations trigger changes of the group state and are usually sent in form of messages over the
 /// network. Each operation needs to be uniquely identifiable, preferably by a collision-resistant
 /// hash.
-pub trait OperationId: Copy + Debug + PartialEq + Eq + StdHash {}
+pub trait OperationId: Copy + Debug + PartialEq + Eq + Ord + StdHash {}
 
 /// Conditions associated with an actors access level.
 pub trait Conditions: Clone + Debug + PartialEq + PartialOrd {}

--- a/p2panda-stream/src/ordering/partial/mod.rs
+++ b/p2panda-stream/src/ordering/partial/mod.rs
@@ -119,6 +119,11 @@ where
         Ok(())
     }
 
+    /// Take the store from the orderer.
+    pub fn store(self) -> S {
+        self.store
+    }
+
     /// Recursively check if any pending items now have their dependencies met.
     async fn process_pending(&mut self, key: K) -> Result<(), PartialOrderError> {
         // Get all items which depend on the passed key.


### PR DESCRIPTION
## Context

`p2panda-auth` contains a generic group crdt with messaging protocol, messages must be partially ordered before they are processed in the provided APIs. With all the generics it's flexible enough to be integrated into systems with different core types and approaches to message ordering. However this makes it a little hard to "just use", even with core p2panda types and provided ordering approaches, some scaffolding is required.

## Decision 

We want to introduce a more opinionated API and types which allow a user to satisfy basic ordering requirements with built in support for core p2panda data types. It should still not be opinionated regarding application layer logic around how groups are created and managed (who are the initial members etc..) and it should be designed in a way where messages are forged outside of the API itself and simply passed in for processing. Message persistence and sync should also handled elsewhere.

## Changes

Introduce `processor` module containing types and methods  which can be used for ordering and processing auth groups control messages. 

- `AuthState` state object containing an operation buffer, orderer state and the groups crdt state itself
- `Store` providing a simple in-memory get/set API for the auth state object
- `Processor` struct with one `process(store, operation)` method which processes all group control messages
- `args` and `operation` modules which contain additional arguments expected on operations containing groups control messages and conversion trait for `Operation<E>` into concrete `GroupsOperation` 
- `groups` example demonstrating use with `p2panda-net` and `p2panda-sync` 

## Next steps
- extend store API to allow handing multiple auth states
- changes required to use new SQLite stores being worked on in `development`

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
