### PR TITLE
Ensure log transactions are atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
+- Ensure log transactions as atomic [#1060](https://github.com/p2panda/p2panda/pull/1060)
 - Define and implement `Forge` [#1032](https://github.com/p2panda/p2panda/pull/1032)
 - Add `LogStore` trait and SQLite implementation [#1004](https://github.com/p2panda/p2panda/pull/1004)
 - Add `TopicStore` trait and SQLite implementation [#1011](https://github.com/p2panda/p2panda/pull/1011)

--- a/p2panda-net/src/test_utils.rs
+++ b/p2panda-net/src/test_utils.rs
@@ -295,21 +295,23 @@ impl TestClient {
         body: &[u8],
         log_id: u64,
     ) -> (Header<()>, Vec<u8>, Body) {
-        let (seq_num, backlink) =
-            <SqliteStore as LogStore<
+        let (header, header_bytes, body) = tx_unwrap!(&self.store, {
+            let (seq_num, backlink) = <SqliteStore as LogStore<
                 Operation<TestExtensions>,
                 PublicKey,
                 u64,
                 u64,
                 p2panda_core::Hash,
-            >>::get_latest_entry(&self.store, &self.private_key.public_key(), &log_id)
+            >>::get_latest_entry_tx(
+                &self.store, &self.private_key.public_key(), &log_id
+            )
             .await
             .unwrap()
             .map(|(hash, seq_num)| (seq_num + 1, Some(hash)))
             .unwrap_or((0, None));
 
-        let (header, header_bytes, body) =
-            create_operation(&self.private_key, body, seq_num, seq_num, backlink);
+            create_operation(&self.private_key, body, seq_num, seq_num, backlink)
+        });
 
         (header, header_bytes, body)
     }

--- a/p2panda-store/src/logs/sqlite/mod.rs
+++ b/p2panda-store/src/logs/sqlite/mod.rs
@@ -15,6 +15,19 @@ use crate::logs::sqlite::models::{LatestEntryRow, LogHeightRow, LogMetaRow};
 use crate::operations::OperationRow;
 use crate::sqlite::{SqliteError, SqliteStore};
 
+const GET_LATEST_ENTRY: &str = "
+    SELECT
+        hash,
+        seq_num
+    FROM
+        operations_v1
+    WHERE
+        public_key = ?
+        AND log_id = ?
+    ORDER BY
+        CAST(seq_num AS NUMERIC) DESC LIMIT 1
+";
+
 impl<'a, L, E> LogStore<Operation<E>, PublicKey, L, SeqNum, Hash> for SqliteStore<'a>
 where
     E: Extensions,
@@ -28,25 +41,51 @@ where
         author: &PublicKey,
         log_id: &L,
     ) -> Result<Option<(Hash, SeqNum)>, Self::Error> {
-        if let Some(latest_entry) = query_as::<_, LatestEntryRow>(
-            "
-            SELECT
-                hash,
-                seq_num
-            FROM
-                operations_v1
-            WHERE
-                public_key = ?
-                AND log_id = ?
-            ORDER BY
-                CAST(seq_num AS NUMERIC) DESC LIMIT 1
-            ",
-        )
-        .bind(author.to_string())
-        .bind(encode_cbor(&log_id).map_err(|err| SqliteError::Encode("log id".to_string(), err))?)
-        .fetch_optional(&self.pool)
-        .await?
+        if let Some(latest_entry) = query_as::<_, LatestEntryRow>(GET_LATEST_ENTRY)
+            .bind(author.to_string())
+            .bind(
+                encode_cbor(&log_id)
+                    .map_err(|err| SqliteError::Encode("log id".to_string(), err))?,
+            )
+            .fetch_optional(&self.pool)
+            .await?
         {
+            let hash_seq_num = latest_entry.try_into()?;
+
+            Ok(Some(hash_seq_num))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Retrieve the hash and sequence number of the latest entry in an author's log.
+    ///
+    /// This variant of the method is intended to be used in situations where atomicity of database
+    /// operations is needed. It requires a transaction context with an acquired permit.
+    // TODO: In the future we may be able to remove this `_tx` variant of the query by instead
+    // requiring that API users exlicitly handle transactions themselves.
+    //
+    // See: https://github.com/p2panda/p2panda/issues/1065
+    async fn get_latest_entry_tx(
+        &self,
+        author: &PublicKey,
+        log_id: &L,
+    ) -> Result<Option<(Hash, SeqNum)>, Self::Error> {
+        let result = self
+            .tx(async |tx| {
+                query_as::<_, LatestEntryRow>(GET_LATEST_ENTRY)
+                    .bind(author.to_string())
+                    .bind(
+                        encode_cbor(&log_id)
+                            .map_err(|err| SqliteError::Encode("log id".to_string(), err))?,
+                    )
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        if let Some(latest_entry) = result {
             let hash_seq_num = latest_entry.try_into()?;
 
             Ok(Some(hash_seq_num))

--- a/p2panda-store/src/logs/sqlite/tests.rs
+++ b/p2panda-store/src/logs/sqlite/tests.rs
@@ -40,15 +40,15 @@ async fn get_latest_entry() {
             .unwrap()
     );
 
-    store.commit(permit).await.unwrap();
-
-    let result = <SqliteStore<'_> as LogStore<Operation, _, _, _, _>>::get_latest_entry(
+    let result = <SqliteStore<'_> as LogStore<Operation, _, _, _, _>>::get_latest_entry_tx(
         &store,
         &log.author(),
         &log.id(),
     )
     .await
     .unwrap();
+
+    store.commit(permit).await.unwrap();
 
     assert_eq!(result, Some((operation_2.hash, operation_2.header.seq_num)));
 }

--- a/p2panda-store/src/logs/traits.rs
+++ b/p2panda-store/src/logs/traits.rs
@@ -20,6 +20,19 @@ pub trait LogStore<T, A, L, S, ID> {
         log_id: &L,
     ) -> impl Future<Output = Result<Option<(ID, S)>, Self::Error>>;
 
+    /// Get the ID and sequence number of the latest entry in a log.
+    ///
+    /// This method must be called within the context of a transaction. Failure to do so will
+    /// result in an error. See the documentation for the `Transaction` trait and the
+    /// corresponding implementation for `SqliteStore` to learn more.
+    ///
+    /// Returns None when the author or a log with the requested id was not found.
+    fn get_latest_entry_tx(
+        &self,
+        author: &A,
+        log_id: &L,
+    ) -> impl Future<Output = Result<Option<(ID, S)>, Self::Error>>;
+
     /// Get current heights for a set of logs.
     ///
     /// Returns the sequence number for the latest entry in every requested log.

--- a/p2panda-store/src/operations/sqlite.rs
+++ b/p2panda-store/src/operations/sqlite.rs
@@ -8,6 +8,26 @@ use sqlx::{FromRow, query, query_as};
 use crate::operations::OperationStore;
 use crate::sqlite::{SqliteError, SqliteStore};
 
+const GET_OPERATION: &str = "
+    SELECT
+        hash,
+        header,
+        body
+    FROM
+        operations_v1
+    WHERE
+        hash = ?
+";
+
+const HAS_OPERATION: &str = "
+    SELECT
+        1
+    FROM
+        operations_v1
+    WHERE
+        hash = ?
+";
+
 impl<'a, E, L> OperationStore<Operation<E>, Hash, L> for SqliteStore<'a>
 where
     E: Extensions,
@@ -80,22 +100,32 @@ where
     async fn get_operation(&self, id: &Hash) -> Result<Option<Operation<E>>, Self::Error> {
         let result = self
             .execute(async |pool| {
-                query_as::<_, OperationRow>(
-                    "
-                    SELECT
-                        hash,
-                        header,
-                        body
-                    FROM
-                        operations_v1
-                    WHERE
-                        hash = ?
-                    ",
-                )
-                .bind(id.to_hex())
-                .fetch_optional(pool)
-                .await
-                .map_err(SqliteError::Sqlite)
+                query_as::<_, OperationRow>(GET_OPERATION)
+                    .bind(id.to_hex())
+                    .fetch_optional(pool)
+                    .await
+                    .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        match result {
+            Some(row) => Ok(Some(row.try_into()?)),
+            None => Ok(None),
+        }
+    }
+
+    // TODO: In the future we may be able to remove this `_tx` variant of the query by instead
+    // requiring that API users exlicitly handle transactions themselves.
+    //
+    // See: https://github.com/p2panda/p2panda/issues/1065
+    async fn get_operation_tx(&self, id: &Hash) -> Result<Option<Operation<E>>, Self::Error> {
+        let result = self
+            .tx(async |tx| {
+                query_as::<_, OperationRow>(GET_OPERATION)
+                    .bind(id.to_hex())
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(SqliteError::Sqlite)
             })
             .await?;
 
@@ -108,20 +138,25 @@ where
     async fn has_operation(&self, id: &Hash) -> Result<bool, Self::Error> {
         let result = self
             .execute(async |pool| {
-                query(
-                    "
-                    SELECT
-                        1
-                    FROM
-                        operations_v1
-                    WHERE
-                        hash = ?
-                    ",
-                )
-                .bind(id.to_hex())
-                .fetch_optional(pool)
-                .await
-                .map_err(SqliteError::Sqlite)
+                query(HAS_OPERATION)
+                    .bind(id.to_hex())
+                    .fetch_optional(pool)
+                    .await
+                    .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        Ok(result.is_some())
+    }
+
+    async fn has_operation_tx(&self, id: &Hash) -> Result<bool, Self::Error> {
+        let result = self
+            .tx(async |tx| {
+                query(HAS_OPERATION)
+                    .bind(id.to_hex())
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(SqliteError::Sqlite)
             })
             .await?;
 

--- a/p2panda-store/src/operations/traits.rs
+++ b/p2panda-store/src/operations/traits.rs
@@ -23,10 +23,26 @@ pub trait OperationStore<T, ID, C> {
     /// Get an operation by id.
     fn get_operation(&self, id: &ID) -> impl Future<Output = Result<Option<T>, Self::Error>>;
 
+    /// Get an operation by id.
+    ///
+    /// This method must be called within the context of a transaction. Failure to do so will
+    /// result in an error. See the documentation for the `Transaction` trait and the
+    /// corresponding implementation for `SqliteStore` to learn more.
+    fn get_operation_tx(&self, id: &ID) -> impl Future<Output = Result<Option<T>, Self::Error>>;
+
     /// Query the existence of an operation.
     ///
     /// Returns `true` if the operation was found in the store and `false` if not.
     fn has_operation(&self, id: &ID) -> impl Future<Output = Result<bool, Self::Error>>;
+
+    /// Query the existence of an operation.
+    ///
+    /// This method must be called within the context of a transaction. Failure to do so will
+    /// result in an error. See the documentation for the `Transaction` trait and the
+    /// corresponding implementation for `SqliteStore` to learn more.
+    ///
+    /// Returns `true` if the operation was found in the store and `false` if not.
+    fn has_operation_tx(&self, id: &ID) -> impl Future<Output = Result<bool, Self::Error>>;
 
     /// Delete an operation.
     ///

--- a/p2panda-stream/src/ingest/operation.rs
+++ b/p2panda-stream/src/ingest/operation.rs
@@ -39,9 +39,14 @@ where
     // Validate operation format.
     validate_operation(operation)?;
 
+    let permit = store
+        .begin()
+        .await
+        .map_err(|err| IngestError::StoreError(err.to_string()))?;
+
     // Ignore insertion if operation already exists.
     let already_exists = store
-        .has_operation(&operation.hash)
+        .has_operation_tx(&operation.hash)
         .await
         .map_err(|err| IngestError::StoreError(err.to_string()))?;
     if already_exists {
@@ -53,13 +58,13 @@ where
         // TODO: This is not returning the "latest entry". See related issue:
         // https://github.com/p2panda/p2panda/issues/1039
         let latest = store
-            .get_latest_entry(&operation.header.public_key, &log_id)
+            .get_latest_entry_tx(&operation.header.public_key, &log_id)
             .await
             .map_err(|err| IngestError::StoreError(err.to_string()))?;
 
         let latest_operation = match latest {
             Some(latest) => store
-                .get_operation(&latest.0)
+                .get_operation_tx(&latest.0)
                 .await
                 .map_err(|err| IngestError::StoreError(err.to_string()))?,
             None => None,
@@ -75,11 +80,6 @@ where
     // Insert operation into store and associate its log with the given topic.
     let id = operation.hash;
     let public_key = operation.header.public_key;
-
-    let permit = store
-        .begin()
-        .await
-        .map_err(|err| IngestError::StoreError(err.to_string()))?;
 
     store
         .insert_operation(&id, operation.to_owned(), log_id.clone())

--- a/p2panda/src/forge.rs
+++ b/p2panda/src/forge.rs
@@ -81,45 +81,53 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
         body: Option<Vec<u8>>,
         extensions: Extensions,
     ) -> Result<Option<Operation>, Self::Error> {
-        let (seq_num, backlink) = <SqliteStore<'static> as LogStore<
-            Operation,
-            PublicKey,
-            LogId,
-            SeqNum,
-            Hash,
-        >>::get_latest_entry(
-            &self.store, &self.private_key.public_key(), &log_id
-        )
-        .await?
-        .map(|(hash, seq_num)| (seq_num + 1, Some(hash)))
-        .unwrap_or((0, None));
-
+        // Perform prerequisite computations outside of the locked transaction.
+        let payload_size = body.as_ref().map(|bytes| bytes.len()).unwrap_or(0) as u64;
         let body: Option<Body> = body.map(|bytes| bytes.into());
+        let payload_hash = body.as_ref().map(|body| body.hash());
 
-        let mut header = Header {
-            version: 1,
-            public_key: self.private_key.public_key(),
-            signature: None,
-            payload_size: body.as_ref().map(|body| body.size()).unwrap_or(0),
-            payload_hash: body.as_ref().map(|body| body.hash()),
-            timestamp: Timestamp::now(),
-            seq_num,
-            backlink,
-            extensions,
-        };
+        // Acquire a lock on the store for the duration of the read to write cycle.
+        //
+        // This is to ensure that the data returned from the `get_latest_entry()` query does not
+        // become stale before the call to `insert_operation()`.
+        //
+        // Here we acquire a store permit, query the latest log entry, associate the topic with
+        // the log, insert the operation and commit the transaction before dropping the permit.
+        let operation = tx!(self.store, {
+            let (seq_num, backlink) = <SqliteStore<'static> as LogStore<
+                Operation,
+                PublicKey,
+                LogId,
+                SeqNum,
+                Hash,
+            >>::get_latest_entry_tx(
+                &self.store, &self.private_key.public_key(), &log_id
+            )
+            .await?
+            .map(|(hash, seq_num)| (seq_num + 1, Some(hash)))
+            .unwrap_or((0, None));
 
-        header.sign(&self.private_key);
-        let hash = header.hash();
+            let mut header = Header {
+                version: 1,
+                public_key: self.private_key.public_key(),
+                signature: None,
+                payload_size,
+                payload_hash,
+                timestamp: Timestamp::now(),
+                seq_num,
+                backlink,
+                extensions,
+            };
 
-        let operation = Operation {
-            hash,
-            header: header.clone(),
-            body,
-        };
+            header.sign(&self.private_key);
+            let hash = header.hash();
 
-        // Acquire a store permit, associate the topic with the log, insert the operation and
-        // commit the transaction.
-        let inserted = tx!(self.store, {
+            let operation = Operation {
+                hash,
+                header: header.clone(),
+                body,
+            };
+
             <SqliteStore<'static> as TopicStore<Topic, PublicKey, LogId>>::associate(
                 &self.store,
                 &topic,
@@ -131,9 +139,10 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
             self.store
                 .insert_operation(&hash.clone(), operation.clone(), log_id)
                 .await?
+                .then_some(operation)
         });
 
-        Ok(inserted.then_some(operation))
+        Ok(operation)
     }
 }
 


### PR DESCRIPTION
This PR introduces two new trait methods and implementations: one to the
`OperationStore` and one to the `LogStore`. Both are versions of existing
methods which are designed to be used within the context of a
transaction. These include `get_latest_entry_tx` and `get_operation_tx`.

The updated methods are utilised within the `create_operation` (forge) and
`ingest_operation` (stream) methods.

Closes: https://github.com/p2panda/p2panda/issues/798

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] ~~New files contain a SPDX license header~~
