### PR TITLE
Replay stream from start based on offset rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Highlights are marked with a pancake 🥞
 - `Ingest` processor to insert operations and associate them with topic in store [#1044](https://github.com/p2panda/p2panda/pull/1044)
 - `as_bytes` method for `Body` [#1044](https://github.com/p2panda/p2panda/pull/1044)
 - Event processing pipeline in Node stream [#1045](https://github.com/p2panda/p2panda/pull/1045)
+- Replay all operations for a topic based on offset [#1064](https://github.com/p2panda/p2panda/pull/1064)
 
 ### Changed
 

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::fmt::Debug;
+
 use p2panda_core::{Hash, Topic};
 use p2panda_net::NodeId;
 use p2panda_store::sqlite::{SqliteError, SqliteStore, SqliteStoreBuilder};
@@ -114,8 +116,9 @@ impl Node {
 
         let (tx, rx) = processed_stream(
             topic,
-            self.config.ack_policy.clone(),
+            self.config.ack_policy,
             sync_handle,
+            self.store.clone(),
             self.forge.clone(),
             self.pipeline.clone(),
             offset,
@@ -157,7 +160,7 @@ impl Node {
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub enum AckPolicy {
     /// Each individual message must be acknowledged.
     Explicit,

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -3,6 +3,7 @@
 mod ephemeral_stream;
 mod event_stream;
 mod offset;
+mod replay;
 mod stream;
 
 pub(crate) use ephemeral_stream::ephemeral_stream;

--- a/p2panda/src/streams/replay.rs
+++ b/p2panda/src/streams/replay.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::BTreeMap;
+
+use p2panda_core::{PublicKey, Topic};
+use p2panda_store::logs::LogStore;
+use p2panda_store::topics::TopicStore;
+use p2panda_store::{SqliteError, SqliteStore};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
+
+use crate::node::AckPolicy;
+use crate::operation::{Extensions, Operation};
+use crate::processor::Pipeline;
+use crate::streams::StreamEvent;
+use crate::streams::stream::process_operation;
+
+/// Retrieve from the store and re-process all operations for a given topic.
+pub(crate) async fn replay_from_start<M>(
+    topic: Topic,
+    store: SqliteStore,
+    app_tx: Sender<StreamEvent<M>>,
+    pipeline: Pipeline<Topic, Extensions, Topic>,
+    ack_policy: AckPolicy,
+) -> Result<(), ReplayError>
+where
+    M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
+{
+    let (replay_tx, mut replay_rx) = mpsc::unbounded_channel::<Operation>();
+
+    // Spawn task for retrieving operations from the store and sending them on a channel to be
+    // processed.
+    let replay_task: JoinHandle<Result<(), ReplayError>> = tokio::spawn(async move {
+        let author_logs: BTreeMap<PublicKey, Vec<Topic>> = store.resolve(&topic).await?;
+        for (author, logs) in author_logs {
+            for log_id in logs {
+                let Some(operations): Option<Vec<(Operation, _)>> =
+                    store.get_log_entries(&author, &log_id, None, None).await?
+                else {
+                    // If the log was concurrently deleted since calling TopicStore::resolve then
+                    // None is returned here. This is not considered an error, as no log integrity
+                    // is broken and deletes should be immediately respected.
+                    continue;
+                };
+
+                for (operation, _) in operations {
+                    replay_tx
+                        .send(operation)
+                        .map_err(|_| ReplayError::CriticalError)?;
+                }
+            }
+        }
+        Ok(())
+    });
+
+    // Pull operations from the replay channel and send them to the processing pipeline.
+    loop {
+        if let Some(operation) = replay_rx.recv().await {
+            match process_operation::<M>(operation, topic, &pipeline, ack_policy).await {
+                Some(event) => {
+                    app_tx
+                        .send(event)
+                        .await
+                        .map_err(|_| ReplayError::CriticalError)?;
+                }
+                None => continue,
+            }
+        };
+
+        if replay_task.is_finished() {
+            return replay_task
+                .await
+                .expect("panic in task")
+                .map_err(|_| ReplayError::CriticalError);
+        }
+    }
+}
+
+/// Error types which can occur during replay.
+#[derive(Debug, Error)]
+pub enum ReplayError {
+    #[error("an error occurred while querying the store: {0}")]
+    Store(#[from] SqliteError),
+
+    #[error("a critical error occurred in the replay task")]
+    CriticalError,
+}

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -11,6 +12,7 @@ use p2panda_core::traits::Digest;
 use p2panda_core::{Hash, PublicKey, Topic};
 use p2panda_net::NodeId;
 use p2panda_net::sync::{SyncHandle, SyncHandleError};
+use p2panda_store::SqliteStore;
 use p2panda_sync::protocols::TopicLogSyncEvent;
 use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
@@ -25,6 +27,7 @@ use crate::node::AckPolicy;
 use crate::operation::{Extensions, Operation};
 use crate::processor::{Event, Pipeline};
 use crate::streams::Offset;
+use crate::streams::replay::replay_from_start;
 
 /// Number of items which can stay in the buffer before the application-layer picks up the
 /// operations. If buffer runs full the processor will pause work and we'll apply backpressure to
@@ -37,9 +40,10 @@ pub(crate) async fn processed_stream<M>(
     topic: Topic,
     ack_policy: AckPolicy,
     sync_handle: SyncHandle<Operation, TopicLogSyncEvent<Extensions>>,
+    store: SqliteStore,
     forge: OperationForge,
     pipeline: Pipeline<Topic, Extensions, Topic>,
-    _offset: Offset,
+    offset: Offset,
 ) -> Result<
     (StreamPublisher<M>, StreamSubscription<M>),
     SyncHandleError<Operation, TopicLogSyncEvent<Extensions>>,
@@ -51,10 +55,32 @@ where
 
     let (app_tx, app_rx) = mpsc::channel::<StreamEvent<M>>(BUFFER_SIZE);
 
-    // TODO: Get offset from database and re-play events first before we move on to new events.
-    // This will be required by applications like Reflection.
-
     let sync_task = tokio::spawn(async move {
+        // In the case where a full replay of the topic stream is requested, then spawn a replay
+        // task and await it's completion. This will block processing of the sync stream until it
+        // is complete.
+        if offset == Offset::Start {
+            // Errors occurring in the replay task which be returned to the user
+            let result = replay_from_start(
+                topic,
+                store.clone(),
+                app_tx.clone(),
+                pipeline.clone(),
+                ack_policy,
+            )
+            .await;
+
+            if let Err(err) = result {
+                warn!("error occurred in replay task: {err:?}");
+                let _ = app_tx
+                    .send(StreamEvent::ReplayFailed {
+                        topic,
+                        error: err.to_string(),
+                    })
+                    .await;
+            }
+        }
+
         while let Some(result) = sync_stream.next().await {
             // Ignore internal broadcast channel error, this only indicates that the channel
             // dropped a message which we can't do much about on this layer anymore. In the future
@@ -67,61 +93,10 @@ where
 
             let event = match from_sync.event {
                 TopicLogSyncEvent::Operation(operation) => {
-                    // TODO: Extract log id from operation extensions instead.
-                    let log_id = topic;
-
-                    // Send operation to processor task and wait for result. This blocks the sync
-                    // stream and makes sure that all events are handled in same order.
-                    let event = pipeline
-                        .process(Event::new(*operation, log_id, topic))
-                        .await;
-
-                    // Do not forward operations which failed processing on system-level. We do
-                    // _not_ forward the error to application-level, only log an error.
-                    if event.is_failed() {
-                        warn!(
-                            id = %event.hash(),
-                            "processing operation failed: {}",
-                            event.failure_reason().expect("error")
-                        );
-
-                        continue;
+                    match process_operation::<M>(*operation, topic, &pipeline, ack_policy).await {
+                        Some(event) => event,
+                        None => continue,
                     }
-
-                    // Do not forward operations to the application-layer if there's no body.
-                    let Some(body) = event.body() else {
-                        continue;
-                    };
-
-                    // Attempt decoding application-layer message. This takes place _after_
-                    // system-level processing completed and the operation was ingested.
-                    //
-                    // In case decoding fails due to an application bug, users have the option to
-                    // re-play this persisted operation and attempt decoding again.
-                    //
-                    // If application data is malformed users can choose to remove the payload of
-                    // the operation or delete the whole log altogether.
-                    //
-                    // TODO: Is this mixing up concerns? We can only handle bytes on our end and
-                    // let the users do decoding on application layer?
-                    let event = match decode_cbor::<M, _>(body.as_bytes()) {
-                        Ok(message) => StreamEvent::Processed(ProcessedOperation {
-                            event,
-                            topic,
-                            message,
-                        }),
-                        Err(err) => StreamEvent::DecodingFailed {
-                            event,
-                            topic,
-                            error: err,
-                        },
-                    };
-
-                    if ack_policy == AckPolicy::Automatic {
-                        // TODO: Automatically acknowledge this message.
-                    }
-
-                    event
                 }
                 // TODO: Correctly handle log sync events.
                 TopicLogSyncEvent::SyncStatus(metrics) => StreamEvent::SyncStarted {
@@ -163,6 +138,68 @@ where
     };
 
     Ok((tx, rx))
+}
+
+pub(crate) async fn process_operation<M>(
+    operation: Operation,
+    topic: Topic,
+    pipeline: &Pipeline<Topic, Extensions, Topic>,
+    ack_policy: AckPolicy,
+) -> Option<StreamEvent<M>>
+where
+    M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
+{
+    // TODO: Extract log id from operation extensions instead.
+    let log_id = topic;
+
+    // Send operation to processor task and wait for result. This blocks the sync
+    // stream and makes sure that all events are handled in same order.
+    let event = pipeline.process(Event::new(operation, log_id, topic)).await;
+
+    // Do not forward operations which failed processing on system-level. We do
+    // _not_ forward the error to application-level, only log an error.
+    if event.is_failed() {
+        warn!(
+            id = %event.hash(),
+            "processing operation failed: {}",
+            event.failure_reason().expect("error")
+        );
+
+        return None;
+    }
+
+    // Do not forward operations to the application-layer if there's no body.
+    let body = event.body()?;
+
+    // Attempt decoding application-layer message. This takes place _after_
+    // system-level processing completed and the operation was ingested.
+    //
+    // In case decoding fails due to an application bug, users have the option to
+    // re-play this persisted operation and attempt decoding again.
+    //
+    // If application data is malformed users can choose to remove the payload of
+    // the operation or delete the whole log altogether.
+    //
+    // TODO: Is this mixing up concerns? We can only handle bytes on our end and
+    // let the users do decoding on application layer?
+    let event = match decode_cbor::<M, _>(body.as_bytes()) {
+        Ok(message) => StreamEvent::Processed(ProcessedOperation {
+            event,
+            topic,
+            message,
+        }),
+        Err(err) => StreamEvent::DecodingFailed {
+            event,
+            topic,
+            error: err,
+        },
+    };
+
+    if ack_policy == AckPolicy::Automatic {
+        // TODO: Automatically acknowledge this message.
+    }
+
+    Some(event)
 }
 
 #[derive(Clone)]
@@ -254,6 +291,10 @@ pub enum StreamEvent<M> {
         event: Event<Topic, Extensions, Topic>,
         topic: Topic,
         error: DecodeError,
+    },
+    ReplayFailed {
+        topic: Topic,
+        error: String,
     },
 }
 

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::time::Duration;
+
 use futures_util::StreamExt;
-use p2panda::streams::{EphemeralMessage, ProcessedOperation, StreamEvent};
+use p2panda::streams::{EphemeralMessage, Offset, ProcessedOperation, StreamEvent};
 use p2panda::test_utils::setup_logging;
 use p2panda_core::{PrivateKey, Topic};
 use tokio::task::JoinHandle;
@@ -93,4 +95,48 @@ async fn eventually_consistent_stream() {
     let received = received.expect("icebear should have received operation");
     assert_eq!(received.message(), &"Hello, Icebear!".to_string());
     assert_eq!(received.author(), panda.id());
+}
+
+#[tokio::test]
+async fn replay_stream() {
+    setup_logging();
+
+    let chat_id = Topic::new();
+
+    let panda = p2panda::builder().spawn().await.unwrap();
+    let icebear = p2panda::builder().spawn().await.unwrap();
+
+    // Panda subscribes to chat and publishes one message.
+    {
+        let (mut panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
+        panda_tx.publish("Hello, Icebear!".into()).await.unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Panda subscribes again, this time asking to replay all messages.
+    let (_panda_tx, mut panda_rx) = panda
+        .stream_from::<String>(chat_id, Offset::Start)
+        .await
+        .unwrap();
+
+    // Icebear joins the chat and publishes one message.
+    let (mut icebear_tx, _icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
+    icebear_tx.publish("Hello, Panda!".into()).await.unwrap();
+
+    // Panda should receive the first message they sent again, followed by Icebear's message which
+    // arrived via sync.
+    let mut received = vec![];
+
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Processed(processed) = event {
+            received.push(processed);
+            if received.len() == 2 {
+                break;
+            }
+        }
+    }
+
+    assert_eq!(received[0].message(), &"Hello, Icebear!".to_string());
+    assert_eq!(received[1].message(), &"Hello, Panda!".to_string());
 }


### PR DESCRIPTION
When a user calls stream_from with argument Offset::Start then before
processing operations arriving via sync all local operations for the
topic will be retrieved from the store and re-processed. This is done
inside a dedicated task where operations are retrieved in batches from
the store.

Closes: #1067 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
