### PR TITLE
Use MockInstant for Timestamp when running tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Highlights are marked with a pancake 🥞
 - Node API improvements [#1061](https://github.com/p2panda/p2panda/pull/1061)
 - Minor store improvements [#1068](https://github.com/p2panda/p2panda/pull/1068)
 - Use Borrow to express required args in ingest [#1078](https://github.com/p2panda/p2panda/pull/1078)
+- Use MockInstant for Timestamp when running tests [#1081](https://github.com/p2panda/p2panda/pull/1081)
 
 ### Fixed
 

--- a/p2panda-core/Cargo.toml
+++ b/p2panda-core/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 [features]
 default = ["prune"]
 prune = []
-test_utils = []
+test_utils = ["dep:mock_instant"]
 
 [dependencies]
 arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
@@ -30,11 +30,12 @@ blake3 = "1.8.1"
 ciborium = "0.2.2"
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 hex = { version = "0.4.3", features = ["serde"] }
+mock_instant = { version = "0.6.0", optional = true }
 rand = "0.8.5"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_bytes = { version = "0.11.17" }
 thiserror = "2.0.12"
 
 [dev-dependencies]
-mock_instant = "0.6.0"
+p2panda-core = { path = ".", features = ["test_utils"] }
 serde_json = "1.0.140"

--- a/p2panda-core/src/timestamp.rs
+++ b/p2panda-core/src/timestamp.rs
@@ -6,12 +6,12 @@ use std::hash::Hash as StdHash;
 use std::num::ParseIntError;
 use std::ops::Add;
 use std::str::FromStr;
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "test_utils")))]
 use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test_utils"))]
 use mock_instant::SystemTimeError;
-#[cfg(test)]
+#[cfg(any(test, feature = "test_utils"))]
 use mock_instant::thread_local::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -60,6 +60,7 @@ sync = [
 supervisor = []
 test_utils = [
   "dep:tracing-subscriber",
+  "p2panda-core/test_utils",
   "p2panda-store/test_utils",
   "p2panda-discovery/test_utils"
 ]

--- a/p2panda-net/src/discovery/actors/manager.rs
+++ b/p2panda-net/src/discovery/actors/manager.rs
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#[cfg(test)]
+use mock_instant::thread_local::Instant;
 use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::fmt::Debug;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(test))]
+use std::time::Instant;
 
 use iroh::endpoint::QuicTransportConfig;
 use iroh::protocol::ProtocolHandler;

--- a/p2panda-net/src/discovery/tests.rs
+++ b/p2panda-net/src/discovery/tests.rs
@@ -27,15 +27,11 @@ async fn smoke_test() {
     setup_logging();
 
     // Spawn nodes.
-    let alice = TestNode::spawn([7; 32]).await;
-    let mut bob = TestNode::spawn([8; 32]).await;
-
-    // Alice inserts Bob's info in their address book. Bob's address book is empty;
-    alice
-        .address_book
-        .insert_node_info(bob.node_info())
-        .await
-        .unwrap();
+    //
+    // Bob's address book is empty.
+    let mut bob = TestNode::spawn([8; 32], None).await;
+    // Alice manually inserts Bob's info into her address book.
+    let alice = TestNode::spawn([7; 32], Some(bob.node_info())).await;
 
     // Wait until both parties finished at least one discovery session.
     let alice_session_ended = session_ended_handle(&alice).await;
@@ -43,8 +39,8 @@ async fn smoke_test() {
     alice_session_ended.await.unwrap();
     bob_session_ended.await.unwrap();
 
-    // Alice didn't learn about new transport info of Bob as their manually added node info was
-    // already the "latest".
+    // Alice didn't learn about new transport info for Bob; the node info she
+    // added manually was already the "latest".
     let alice_metrics = alice.discovery.metrics().await.unwrap();
     assert_eq!(alice_metrics.newly_learned_transport_infos, 0);
 

--- a/p2panda-net/src/sync/log_sync/tests.rs
+++ b/p2panda-net/src/sync/log_sync/tests.rs
@@ -23,14 +23,8 @@ async fn e2e_log_sync() {
     let topic: Topic = [0; 32].into();
     let log_id = 0;
 
-    let mut alice = TestNode::spawn([10; 32]).await;
-    let mut bob = TestNode::spawn([11; 32]).await;
-
-    alice
-        .address_book
-        .insert_node_info(bob.node_info())
-        .await
-        .unwrap();
+    let mut bob = TestNode::spawn([11; 32], None).await;
+    let mut alice = TestNode::spawn([10; 32], Some(bob.node_info())).await;
 
     // Populate Alice's and Bob's store with some test data.
     alice
@@ -233,21 +227,9 @@ async fn e2e_three_party_sync() {
     let log_id = 0;
 
     // Spawn nodes.
-    let mut bob = TestNode::spawn([30; 32]).await;
-    let mut alice = TestNode::spawn([31; 32]).await;
-    let mut carol = TestNode::spawn([32; 32]).await;
-
-    alice
-        .address_book
-        .insert_node_info(bob.args.node_info())
-        .await
-        .unwrap();
-
-    carol
-        .address_book
-        .insert_node_info(alice.args.node_info())
-        .await
-        .unwrap();
+    let mut bob = TestNode::spawn([30; 32], None).await;
+    let mut alice = TestNode::spawn([31; 32], Some(bob.node_info())).await;
+    let mut carol = TestNode::spawn([32; 32], Some(alice.node_info())).await;
 
     // Populate stores with some test data.
     alice
@@ -483,7 +465,7 @@ async fn unsubscribe_from_gossip_after_drop() {
 
     let sync_topic: Topic = [0; 32].into();
 
-    let alice = TestNode::spawn([73; 32]).await;
+    let alice = TestNode::spawn([73; 32], None).await;
     let alice_handle = alice.log_sync.stream(sync_topic, true).await.unwrap();
 
     let mut watcher = alice

--- a/p2panda-net/src/test_utils.rs
+++ b/p2panda-net/src/test_utils.rs
@@ -167,11 +167,14 @@ pub struct TestNode {
 }
 
 impl TestNode {
-    pub async fn spawn(seed: [u8; 32]) -> Self {
-        Self::spawn_with_args(test_args_from_seed(seed)).await
+    pub async fn spawn(seed: [u8; 32], node_info: Option<NodeInfo>) -> Self {
+        Self::spawn_with_args(test_args_from_seed(seed), node_info).await
     }
 
-    pub async fn spawn_with_args(mut args: ApplicationArguments) -> Self {
+    pub async fn spawn_with_args(
+        mut args: ApplicationArguments,
+        node_info: Option<NodeInfo>,
+    ) -> Self {
         let client = TestClient::new(
             // The identity of the "author" or client has a different private key from the node.
             PrivateKey::from_bytes(&args.rng.random::<[u8; 32]>()),
@@ -179,6 +182,14 @@ impl TestNode {
         .await;
 
         let address_book = AddressBook::builder().spawn().await.unwrap();
+
+        // Insert provided node info into the address book.
+        //
+        // This is useful for informing the local node of a remote node manually, before the
+        // discovery services have been spawned.
+        if let Some(info) = node_info {
+            address_book.insert_node_info(info).await.unwrap();
+        }
 
         let endpoint = Endpoint::builder(address_book.clone())
             .config(args.iroh_config.clone())

--- a/p2panda-net/tests/e2e.rs
+++ b/p2panda-net/tests/e2e.rs
@@ -19,7 +19,7 @@ async fn gossip_and_sync_with_same_topic() {
     // =======
 
     // Start Panda's node.
-    let mut panda = TestNode::spawn([98; 32]).await;
+    let mut panda = TestNode::spawn([98; 32], None).await;
 
     // Subscribe to gossip overlay to receive (ephemeral) messages.
     let panda_gossip_handle = panda.gossip.stream(topic).await.unwrap();
@@ -51,7 +51,7 @@ async fn gossip_and_sync_with_same_topic() {
     // =======
 
     // Start Penguin's node.
-    let mut penguin = TestNode::spawn([99; 32]).await;
+    let mut penguin = TestNode::spawn([99; 32], None).await;
 
     // Penguin adds Panda as a "bootstrap" node in its address book.
     penguin

--- a/p2panda/Cargo.toml
+++ b/p2panda/Cargo.toml
@@ -42,6 +42,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"], optional = true }
 
 [dev-dependencies]
+mock_instant = "0.6.0"
 p2panda = { path = ".", features = ["test_utils"] }
 p2panda-core = { path = "../p2panda-core", version = "0.5.1", features = ["test_utils"] }
 p2panda-store = { path = "../p2panda-store", version = "0.5.1", features = ["test_utils"] }

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use futures_util::StreamExt;
+use mock_instant::thread_local::MockClock;
 use p2panda::operation::Operation;
 use p2panda::streams::{EphemeralMessage, Offset, ProcessedOperation, StreamEvent};
 use p2panda::test_utils::setup_logging;
@@ -49,6 +50,8 @@ async fn ephemeral_stream() {
 
         tokio::spawn(async move {
             let message = rx.next().await.unwrap();
+            // Advance the clock to ensure icebear's message is published later than panda's.
+            MockClock::advance_system_time(Duration::from_secs(1));
             tx.publish("Hi, Panda!".into()).await.unwrap();
             message
         })


### PR DESCRIPTION
p2panda-core was not previously configured to use MockInstant when running in test contexts. This meant that the discovery smoke test (in p2panda-net) became flaky when the Timestamp type was moved to p2panda-core. This PR ensures that MockInstant is now used by p2panda-core when tests are run.

The change brought about a failure in the p2panda API test when comparing the timestamp of messages received by panda and icebear. This has been fixed by manually advancing the time after the first message has been received.

Fixes: https://github.com/p2panda/p2panda/issues/1069

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] ~~New files contain a SPDX license header~~
