### PR TITLE
Derive log id from topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Highlights are marked with a pancake 🥞
 - Minor store improvements [#1068](https://github.com/p2panda/p2panda/pull/1068)
 - Use Borrow to express required args in ingest [#1078](https://github.com/p2panda/p2panda/pull/1078)
 - Use MockInstant for Timestamp when running tests [#1081](https://github.com/p2panda/p2panda/pull/1081)
+- Derive log id from topic [#1082](https://github.com/p2panda/p2panda/pull/1082)
 
 ### Fixed
 

--- a/p2panda/src/forge.rs
+++ b/p2panda/src/forge.rs
@@ -10,10 +10,10 @@ use p2panda_store::topics::TopicStore;
 use p2panda_store::{SqliteError, SqliteStore, tx};
 use thiserror::Error;
 
-use crate::operation::{Extensions, Header, Operation};
+use crate::operation::{Extensions, Header, LogId, Operation};
 
 /// Interface for obtaining a keypair and creating signed operations.
-pub trait Forge<T, C, E> {
+pub trait Forge<TP, C, E> {
     type Error: StdError;
 
     fn private_key(&self) -> &PrivateKey;
@@ -22,7 +22,7 @@ pub trait Forge<T, C, E> {
 
     fn create_operation(
         &mut self,
-        topic: T,
+        topic: TP,
         collection_id: C,
         body: Option<Vec<u8>>,
         extensions: E,
@@ -53,8 +53,6 @@ impl OperationForge {
         }
     }
 }
-
-pub type LogId = Topic;
 
 impl Forge<Topic, LogId, Extensions> for OperationForge {
     type Error = ForgeError;
@@ -161,7 +159,7 @@ mod tests {
     use p2panda_store::logs::LogStore;
 
     use crate::forge::Forge;
-    use crate::operation::Extensions;
+    use crate::operation::{Extensions, LogId};
 
     use super::OperationForge;
 
@@ -171,8 +169,8 @@ mod tests {
         let mut forge = OperationForge::new(store.clone());
 
         let topic = Topic::new();
-        let log_id = Topic::new();
-        let extensions = Extensions::default();
+        let log_id = LogId::from_topic(topic);
+        let extensions = Extensions::from_topic(topic);
 
         forge
             .create_operation(

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::builder::NodeBuilder;
 use crate::forge::{Forge, OperationForge};
 use crate::network::{Network, NetworkConfig, NetworkError};
-use crate::operation::Extensions;
+use crate::operation::{Extensions, LogId};
 use crate::processor::{Pipeline, TaskTracker};
 use crate::streams::{
     EphemeralStreamPublisher, EphemeralStreamSubscription, Offset, StreamPublisher,
@@ -26,7 +26,7 @@ pub struct Node {
     // NOTE: One single pipeline is currently used to handle _all_ incoming operations,
     // independent of number of streams. While this is sufficient for most applications for now we
     // might want to make the number of processors configurable to avoid head-of-line blocking.
-    pipeline: Pipeline<Topic, Extensions, Topic>,
+    pipeline: Pipeline<LogId, Extensions, Topic>,
     network: Network,
 }
 
@@ -59,7 +59,7 @@ impl Node {
         config: Config,
         store: SqliteStore,
         forge: OperationForge,
-        pipeline: Pipeline<Topic, Extensions, Topic>,
+        pipeline: Pipeline<LogId, Extensions, Topic>,
     ) -> Result<Self, NetworkError> {
         let network = Network::spawn(
             config.network.clone(),

--- a/p2panda/src/operation.rs
+++ b/p2panda/src/operation.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use p2panda_core::PruneFlag;
+use std::hash::Hash as StdHash;
+
+use p2panda_core::hash::{HASH_LEN, Hash};
+use p2panda_core::{PruneFlag, Topic};
 use serde::{Deserialize, Serialize};
 
 pub type Header = p2panda_core::Header<Extensions>;
@@ -18,14 +21,55 @@ pub struct Extensions {
         default = "PruneFlag::default"
     )]
     pub prune_flag: PruneFlag,
+    pub log_id: LogId,
     pub version: u64,
 }
 
-impl Default for Extensions {
-    fn default() -> Self {
+impl Extensions {
+    pub(crate) fn from_topic(topic: Topic) -> Self {
         Self {
+            log_id: LogId::from_topic(topic),
             prune_flag: PruneFlag::default(),
             version: VERSION,
         }
+    }
+
+    pub(crate) fn prune_flag(mut self, prune_flag: bool) -> Self {
+        self.prune_flag = prune_flag.into();
+        self
+    }
+}
+
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, PartialEq, Eq, StdHash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LogId(Hash);
+
+impl LogId {
+    /// Derive log id from a topic.
+    ///
+    /// Since topics are randomly generated we get the guarantee that every log and thus operation
+    /// will be uniquely identifiable.
+    ///
+    /// To keep topic itself private we derive it with a BLAKE3 digest.
+    pub fn from_topic(topic: Topic) -> Self {
+        LogId(Hash::new(topic.as_bytes()))
+    }
+
+    pub fn as_bytes(&self) -> &[u8; HASH_LEN] {
+        self.0.as_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p2panda_core::Topic;
+
+    use super::LogId;
+
+    #[test]
+    fn derive_from_topic() {
+        let topic = Topic::new();
+        let log_id = LogId::from_topic(topic);
+        assert_ne!(topic.as_bytes(), log_id.as_bytes());
     }
 }

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -177,6 +177,7 @@ mod tests {
     use p2panda_core::{PrivateKey, PruneFlag, Topic};
     use p2panda_store::SqliteStore;
 
+    use crate::operation::LogId;
     use crate::processor::TaskTracker;
 
     use super::{Event, Pipeline};
@@ -185,7 +186,7 @@ mod tests {
     async fn processing_operations() {
         let store = SqliteStore::temporary().await;
         let tasks = TaskTracker::new();
-        let processor = Pipeline::<Topic, (), Topic>::new(store, tasks);
+        let processor = Pipeline::<LogId, (), Topic>::new(store, tasks);
 
         let log = TestLog::new();
         let topic = Topic::new();
@@ -196,7 +197,7 @@ mod tests {
         let result = processor
             .process(Event::new(
                 operation.clone(),
-                topic,
+                LogId::from_topic(topic),
                 topic,
                 PruneFlag::default(),
             ))
@@ -212,7 +213,7 @@ mod tests {
         let result = processor
             .process(Event::new(
                 operation.clone(),
-                topic,
+                LogId::from_topic(topic),
                 topic,
                 PruneFlag::default(),
             ))

--- a/p2panda/src/streams/replay.rs
+++ b/p2panda/src/streams/replay.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 
 use crate::node::AckPolicy;
-use crate::operation::{Extensions, Operation};
+use crate::operation::{Extensions, LogId, Operation};
 use crate::processor::Pipeline;
 use crate::streams::StreamEvent;
 use crate::streams::stream::process_operation;
@@ -23,7 +23,7 @@ pub(crate) async fn replay_from_start<M>(
     topic: Topic,
     store: SqliteStore,
     app_tx: Sender<StreamEvent<M>>,
-    pipeline: Pipeline<Topic, Extensions, Topic>,
+    pipeline: Pipeline<LogId, Extensions, Topic>,
     ack_policy: AckPolicy,
 ) -> Result<(), ReplayError>
 where

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -23,7 +23,7 @@ use tracing::warn;
 
 use crate::forge::{Forge, ForgeError, OperationForge};
 use crate::node::AckPolicy;
-use crate::operation::{Extensions, Operation};
+use crate::operation::{Extensions, LogId, Operation};
 use crate::processor::{Event, Pipeline};
 use crate::streams::Offset;
 use crate::streams::replay::replay_from_start;
@@ -86,7 +86,7 @@ pub(crate) async fn processed_stream<M>(
     sync_handle: SyncHandle<Operation, TopicLogSyncEvent<Extensions>>,
     store: SqliteStore,
     forge: OperationForge,
-    pipeline: Pipeline<Topic, Extensions, Topic>,
+    pipeline: Pipeline<LogId, Extensions, Topic>,
     offset: Offset,
 ) -> Result<
     (StreamPublisher<M>, StreamSubscription<M>),
@@ -105,7 +105,7 @@ where
     let (publish_tx, mut publish_rx) = mpsc::channel::<(
         Operation,
         Option<M>,
-        oneshot::Sender<Event<Topic, Extensions, Topic>>,
+        oneshot::Sender<Event<LogId, Extensions, Topic>>,
     )>(PUBLISH_BUFFER_SIZE);
 
     {
@@ -256,14 +256,13 @@ where
 pub(crate) async fn process_operation<M>(
     operation: Operation,
     topic: Topic,
-    pipeline: &Pipeline<Topic, Extensions, Topic>,
+    pipeline: &Pipeline<LogId, Extensions, Topic>,
     ack_policy: AckPolicy,
 ) -> Option<StreamEvent<M>>
 where
     M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
 {
-    // TODO: Extract log id from operation extensions instead.
-    let log_id = topic;
+    let log_id = LogId::from_topic(topic);
     let prune_flag = operation.header.extensions.prune_flag;
 
     // Send operation to processor task and wait for result. This blocks any parent stream and
@@ -329,10 +328,9 @@ where
 pub(crate) async fn process_published_operation(
     operation: Operation,
     topic: Topic,
-    pipeline: &Pipeline<Topic, Extensions, Topic>,
-) -> Event<Topic, Extensions, Topic> {
-    // TODO: Extract log id from operation extensions instead.
-    let log_id = topic;
+    pipeline: &Pipeline<LogId, Extensions, Topic>,
+) -> Event<LogId, Extensions, Topic> {
+    let log_id = LogId::from_topic(topic);
     let prune_flag = operation.header.extensions.prune_flag;
 
     // Send operation to processor task and wait for result. This blocks any parent stream and
@@ -363,7 +361,7 @@ pub struct StreamPublisher<M> {
     publish_tx: mpsc::Sender<(
         Operation,
         Option<M>,
-        oneshot::Sender<Event<Topic, Extensions, Topic>>,
+        oneshot::Sender<Event<LogId, Extensions, Topic>>,
     )>,
     _marker: PhantomData<M>,
 }
@@ -402,21 +400,16 @@ where
         prune_flag: bool,
     ) -> Result<PublishFuture, PublishError> {
         // Create, sign and persist operation with given payload.
-        let extensions = Extensions {
-            prune_flag: prune_flag.into(),
-            ..Default::default()
-        };
+        let extensions = Extensions::from_topic(self.topic()).prune_flag(prune_flag);
 
         let body_bytes = match message {
             Some(ref message) => Some(encode_cbor(&message)?),
             None => None,
         };
 
-        let log_id = self.topic();
-
         let operation = self
             .forge
-            .create_operation(self.topic(), log_id, body_bytes, extensions)
+            .create_operation(self.topic(), extensions.log_id, body_bytes, extensions)
             .await?
             .ok_or(PublishError::DuplicateOperation)?;
         let hash = operation.hash;
@@ -448,7 +441,7 @@ where
 #[derive(Debug)]
 pub struct PublishFuture {
     hash: Hash,
-    processed_rx: oneshot::Receiver<Event<Topic, Extensions, Topic>>,
+    processed_rx: oneshot::Receiver<Event<LogId, Extensions, Topic>>,
 }
 
 impl PublishFuture {
@@ -459,7 +452,7 @@ impl PublishFuture {
 }
 
 impl Future for PublishFuture {
-    type Output = Result<Event<Topic, Extensions, Topic>, oneshot::error::RecvError>;
+    type Output = Result<Event<LogId, Extensions, Topic>, oneshot::error::RecvError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.processed_rx.poll_unpin(cx)
@@ -511,7 +504,7 @@ pub enum StreamEvent<M> {
         session_id: u64,
     },
     DecodingFailed {
-        event: Event<Topic, Extensions, Topic>,
+        event: Event<LogId, Extensions, Topic>,
         topic: Topic,
         error: DecodeError,
     },
@@ -523,7 +516,7 @@ pub enum StreamEvent<M> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ProcessedOperation<M> {
-    event: Event<Topic, Extensions, Topic>,
+    event: Event<LogId, Extensions, Topic>,
     topic: Topic,
     message: M,
 }
@@ -549,7 +542,7 @@ impl<M> ProcessedOperation<M> {
         &self.message
     }
 
-    pub fn processed(&self) -> &Event<Topic, Extensions, Topic> {
+    pub fn processed(&self) -> &Event<LogId, Extensions, Topic> {
         &self.event
     }
 

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use futures_util::StreamExt;
 use mock_instant::thread_local::MockClock;
-use p2panda::operation::Operation;
+use p2panda::operation::{LogId, Operation};
 use p2panda::streams::{EphemeralMessage, Offset, ProcessedOperation, StreamEvent};
 use p2panda::test_utils::setup_logging;
 use p2panda_core::{PrivateKey, Topic};
@@ -193,9 +193,10 @@ async fn log_prefix_pruning() {
     }
 
     // There should only be 1 message in Panda's and Icebear's database as the log was pruned.
+    let log_id = LogId::from_topic(topic);
     let panda_result: Vec<(Operation, Vec<u8>)> = panda
         .store()
-        .get_log_entries(&panda.id(), &topic, None, None)
+        .get_log_entries(&panda.id(), &log_id, None, None)
         .await
         .expect("no store failure")
         .expect("result to be Some");
@@ -203,7 +204,7 @@ async fn log_prefix_pruning() {
 
     let icebear_result: Vec<(Operation, Vec<u8>)> = icebear
         .store()
-        .get_log_entries(&panda.id(), &topic, None, None)
+        .get_log_entries(&panda.id(), &log_id, None, None)
         .await
         .expect("no store failure")
         .expect("result to be Some");


### PR DESCRIPTION
Since topics are randomly generated we get the guarantee that every log and thus operation will be uniquely identifiable.

To keep topic itself private we derive it with a BLAKE3 digest.

Closes: #1052 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
