### PR TITLE
Process sync events and aggregate per-topic metrics in stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Highlights are marked with a pancake 🥞
 - Replay all operations for a topic based on offset [#1064](https://github.com/p2panda/p2panda/pull/1064)
 - Log-prefix pruning processor [#1073](https://github.com/p2panda/p2panda/pull/1073)
 - Process local operations [#1080](https://github.com/p2panda/p2panda/pull/1080)
+- Process and aggregate metrics for sync events [#1085](https://github.com/p2panda/p2panda/pull/1085)
 
 ### Changed
 

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -242,15 +242,15 @@ async fn main() -> Result<()> {
         tokio::task::spawn(async move {
             while let Some(Ok(from_sync)) = sync_rx.next().await {
                 match from_sync.event {
-                    SyncEvent::SyncFinished(metrics) => {
+                    SyncEvent::SessionFinished { metrics } => {
                         info!(
                             "finished sync session with {}, bytes received = {}, bytes sent = {}",
                             from_sync.remote.fmt_short(),
-                            metrics.total_bytes_remote.unwrap_or_default(),
-                            metrics.total_bytes_local.unwrap_or_default()
+                            metrics.received_bytes(),
+                            metrics.sent_bytes()
                         );
                     }
-                    SyncEvent::Operation(operation) => {
+                    SyncEvent::OperationReceived { operation, .. } => {
                         if <SqliteStore as OperationStore<Operation, Hash, LogId>>::has_operation(
                             &store,
                             &operation.hash,

--- a/p2panda-net/src/sync/log_sync/tests.rs
+++ b/p2panda-net/src/sync/log_sync/tests.rs
@@ -26,7 +26,6 @@ async fn e2e_log_sync() {
     let mut bob = TestNode::spawn([11; 32], None).await;
     let mut alice = TestNode::spawn([10; 32], Some(bob.node_info())).await;
 
-    // Populate Alice's and Bob's store with some test data.
     alice
         .client
         .create_operation(b"Hello from Alice", log_id)
@@ -41,14 +40,12 @@ async fn e2e_log_sync() {
         .associate(&topic, &HashMap::from([(bob.client_id(), vec![log_id])]))
         .await;
 
-    // Alice and Bob create stream for the same topic.
     let alice_handle = alice.log_sync.stream(topic, true).await.unwrap();
     let mut alice_subscription = alice_handle.subscribe().await.unwrap();
 
     let bob_handle = bob.log_sync.stream(topic, true).await.unwrap();
     let mut bob_subscription = bob_handle.subscribe().await.unwrap();
 
-    // Alice manually initiates a sync session with Bob.
     alice_handle.initiate_session(bob.node_id());
 
     // Assert Alice receives the expected events.
@@ -59,14 +56,14 @@ async fn e2e_log_sync() {
         Ok(FromSync {
             session_id: 0,
             remote,
-            event: Event::SyncStarted(_),
+            event: Event::SyncStarted { .. },
         }) if remote == bob_id
     );
     let event = alice_subscription.next().await.unwrap();
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::SyncStatus(_),
+            event: Event::OperationReceived { .. },
             ..
         })
     );
@@ -74,23 +71,7 @@ async fn e2e_log_sync() {
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::SyncStatus(_),
-            ..
-        })
-    );
-    let event = alice_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::Operation(_),
-            ..
-        })
-    );
-    let event = alice_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::SyncFinished(_),
+            event: Event::SyncFinished { .. },
             ..
         })
     );
@@ -111,15 +92,14 @@ async fn e2e_log_sync() {
         Ok(FromSync {
             session_id: 0,
             remote,
-            event: Event::SyncStarted(_),
+            event: Event::SyncStarted { .. },
         }) if remote == alice_id
     );
-
     let event = bob_subscription.next().await.unwrap();
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::SyncStatus(_),
+            event: Event::OperationReceived { .. },
             ..
         })
     );
@@ -127,23 +107,7 @@ async fn e2e_log_sync() {
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::SyncStatus(_),
-            ..
-        })
-    );
-    let event = bob_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::Operation(_),
-            ..
-        })
-    );
-    let event = bob_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::SyncFinished(_),
+            event: Event::SyncFinished { .. },
             ..
         })
     );
@@ -156,7 +120,7 @@ async fn e2e_log_sync() {
         })
     );
 
-    // Alice publishes "live" message.
+    // Alice publishes a live message.
     let (header, _, body) = alice
         .client
         .create_operation(b"live message from Alice", log_id)
@@ -170,12 +134,12 @@ async fn e2e_log_sync() {
         .await
         .unwrap();
 
-    // Bob receives Alice's message.
+    // Bob receives Alice's live message.
     let event = bob_subscription.next().await.unwrap();
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::Operation(_),
+            event: Event::OperationReceived { .. },
             ..
         })
     );
@@ -183,29 +147,12 @@ async fn e2e_log_sync() {
     // Drop Alice's stream to enforce closing live session with Bob.
     drop(alice_handle);
 
+    // Both peers observe a clean session close.
     let event = bob_subscription.next().await.unwrap();
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::LiveModeFinished(_),
-            ..
-        })
-    );
-    let event = bob_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::Success,
-            ..
-        })
-    );
-
-    // Assert Alice's final events.
-    let event = alice_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::LiveModeFinished(_),
+            event: Event::SessionFinished { .. },
             ..
         })
     );
@@ -213,7 +160,7 @@ async fn e2e_log_sync() {
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::Success,
+            event: Event::SessionFinished { .. },
             ..
         })
     );
@@ -226,12 +173,10 @@ async fn e2e_three_party_sync() {
     let topic: Topic = [0; 32].into();
     let log_id = 0;
 
-    // Spawn nodes.
     let mut bob = TestNode::spawn([30; 32], None).await;
     let mut alice = TestNode::spawn([31; 32], Some(bob.node_info())).await;
     let mut carol = TestNode::spawn([32; 32], Some(alice.node_info())).await;
 
-    // Populate stores with some test data.
     alice
         .client
         .create_operation(b"Hello from Alice", log_id)
@@ -255,14 +200,12 @@ async fn e2e_three_party_sync() {
         .associate(&topic, &HashMap::from([(carol.client_id(), vec![log_id])]))
         .await;
 
-    // Alice and Bob create stream for the same topic. Carol is inactive here.
     let alice_handle = alice.log_sync.stream(topic, true).await.unwrap();
     let mut alice_subscription = alice_handle.subscribe().await.unwrap();
 
     let bob_handle = bob.log_sync.stream(topic, true).await.unwrap();
     let mut bob_subscription = bob_handle.subscribe().await.unwrap();
 
-    // Alice initiates sync.
     alice_handle.initiate_session(bob.node_id());
 
     // Assert Alice receives the expected events.
@@ -273,14 +216,14 @@ async fn e2e_three_party_sync() {
         Ok(FromSync {
             session_id: 0,
             remote,
-            event: Event::SyncStarted(_),
+            event: Event::SyncStarted { .. },
         }) if remote == bob_id
     );
     let event = alice_subscription.next().await.unwrap();
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::SyncStatus(_),
+            event: Event::OperationReceived { .. },
             ..
         })
     );
@@ -288,23 +231,7 @@ async fn e2e_three_party_sync() {
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::SyncStatus(_),
-            ..
-        })
-    );
-    let event = alice_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::Operation(_),
-            ..
-        })
-    );
-    let event = alice_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::SyncFinished(_),
+            event: Event::SyncFinished { .. },
             ..
         })
     );
@@ -325,14 +252,14 @@ async fn e2e_three_party_sync() {
         Ok(FromSync {
             session_id: 0,
             remote,
-            event: Event::SyncStarted(_),
+            event: Event::SyncStarted { .. },
         }) if remote == alice_id
     );
     let event = bob_subscription.next().await.unwrap();
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::SyncStatus(_),
+            event: Event::OperationReceived { .. },
             ..
         })
     );
@@ -340,23 +267,7 @@ async fn e2e_three_party_sync() {
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::SyncStatus(_),
-            ..
-        })
-    );
-    let event = bob_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::Operation(_),
-            ..
-        })
-    );
-    let event = bob_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::SyncFinished(_),
+            event: Event::SyncFinished { .. },
             ..
         })
     );
@@ -383,21 +294,20 @@ async fn e2e_three_party_sync() {
         .await
         .unwrap();
 
-    // Bob receives Alice's message.
+    // Bob receives Alice's live message.
     let event = bob_subscription.next().await.unwrap();
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::Operation(_),
+            event: Event::OperationReceived { .. },
             ..
         })
     );
 
-    // Create Carol's stream.
+    // Carol creates her stream and initiates sync with Alice.
     let carol_handle = carol.log_sync.stream(topic, true).await.unwrap();
     let mut carol_subscription = carol_handle.subscribe().await.unwrap();
 
-    // Carol initiates sync with Alice.
     carol_handle.initiate_session(alice.node_id());
 
     let event = carol_subscription.next().await.unwrap();
@@ -405,7 +315,7 @@ async fn e2e_three_party_sync() {
         event,
         Ok(FromSync {
             session_id: 0,
-            event: Event::SyncStarted(_),
+            event: Event::SyncStarted { .. },
             ..
         })
     );
@@ -413,7 +323,7 @@ async fn e2e_three_party_sync() {
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::SyncStatus(_),
+            event: Event::OperationReceived { .. },
             ..
         })
     );
@@ -421,7 +331,7 @@ async fn e2e_three_party_sync() {
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::SyncStatus(_),
+            event: Event::OperationReceived { .. },
             ..
         })
     );
@@ -429,23 +339,7 @@ async fn e2e_three_party_sync() {
     assert_matches!(
         event,
         Ok(FromSync {
-            event: Event::Operation(_),
-            ..
-        })
-    );
-    let event = carol_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::Operation(_),
-            ..
-        })
-    );
-    let event = carol_subscription.next().await.unwrap();
-    assert_matches!(
-        event,
-        Ok(FromSync {
-            event: Event::SyncFinished(_),
+            event: Event::SyncFinished { .. },
             ..
         })
     );
@@ -474,15 +368,12 @@ async fn unsubscribe_from_gossip_after_drop() {
         .await
         .unwrap();
 
-    // Alice should be subscribed to the topic.
     while let Some(event) = watcher.recv().await {
-        // Assert that the original sync topic is _not_ used but the derived gossip topic instead.
         if !event.value.contains(&sync_topic) && event.value.len() == 1 {
             break;
         }
     }
 
-    // Alice should be unsubscribed from the topic after dropping the sync handle.
     drop(alice_handle);
 
     while let Some(event) = watcher.recv().await {
@@ -545,7 +436,6 @@ async fn panic_on_sink_closure_after_error_regression() {
     // already in a closed state causes an error. The fix is to introduce a custom Sink wrapper
     // instead of chaining adaptors.
     connection.close(0u32.into(), b"testing");
-
     let result = handle.await.unwrap();
     assert!(result.is_err());
 }

--- a/p2panda-net/tests/e2e.rs
+++ b/p2panda-net/tests/e2e.rs
@@ -40,7 +40,7 @@ async fn gossip_and_sync_with_same_topic() {
     // Panda waits for Penguin to send something here as well.
     let panda_sync_task = tokio::spawn(async move {
         while let Some(Ok(item)) = panda_sync_rx.next().await {
-            if let TopicLogSyncEvent::Operation(operation) = item.event {
+            if let TopicLogSyncEvent::OperationReceived { operation, .. } = item.event {
                 return Some(operation);
             }
         }

--- a/p2panda-sync/src/manager/event_stream.rs
+++ b/p2panda-sync/src/manager/event_stream.rs
@@ -99,7 +99,7 @@ where
                     let event = from_sync.event();
 
                     let operation = match event {
-                        TopicLogSyncEvent::Operation(operation) => Some(*operation.clone()),
+                        TopicLogSyncEvent::OperationReceived{operation, ..} => Some(*operation.clone()),
                         _ => return (state, Some(from_sync)),
                     };
 

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -226,7 +226,6 @@ pub enum TopicSyncManagerError {
     #[error(transparent)]
     Send(#[from] mpsc::SendError),
 }
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -240,7 +239,7 @@ mod tests {
 
     use crate::protocols::TopicLogSyncEvent;
     use crate::test_utils::{
-        Peer, TestTopicSyncEvent, TestTopicSyncManager, drain_stream, run_protocol, setup_logging,
+        Peer, TestTopicSyncManager, drain_stream, run_protocol, setup_logging,
     };
     use crate::traits::{Manager, Protocol};
     use crate::{FromSync, SessionConfig, ToSync};
@@ -276,7 +275,6 @@ mod tests {
         peer_b.associate(&topic, &logs).await;
         let mut peer_b_manager = TestTopicSyncManager::new(peer_b.store.clone());
 
-        // Instantiate sync session for Peer A.
         let config = SessionConfig {
             topic,
             remote: peer_b.id(),
@@ -287,10 +285,8 @@ mod tests {
         let mut event_stream_a = peer_a_manager.subscribe();
         let mut event_stream_b = peer_b_manager.subscribe();
 
-        // Instantiate sync session for Peer A.
+        // Instantiate sync sessions.
         let peer_a_session = peer_a_manager.session(SESSION_ID, &config).await;
-
-        // Instantiate sync session for Peer B.
         let peer_b_session = peer_b_manager.session(SESSION_ID, &config).await;
 
         // Get a handle to Peer A sync session.
@@ -312,56 +308,42 @@ mod tests {
         run_protocol(peer_a_session, peer_b_session).await.unwrap();
 
         // Assert Peer A's events.
-        for index in 0..=7 {
+        for index in 0..=4 {
             let event = event_stream_a.next().await.unwrap();
             assert_eq!(event.session_id(), 0);
             match index {
                 0 => assert_matches!(
                     event,
                     FromSync {
-                        event: TopicLogSyncEvent::SyncStarted(_),
+                        event: TopicLogSyncEvent::SyncStarted { .. },
                         ..
                     }
                 ),
-                1 | 2 => assert_matches!(
+                1 => assert_matches!(
                     event,
                     FromSync {
-                        event: TopicLogSyncEvent::SyncStatus(_),
+                        event: TopicLogSyncEvent::OperationReceived { .. },
+                        ..
+                    }
+                ),
+                2 => assert_matches!(
+                    event,
+                    FromSync {
+                        event: TopicLogSyncEvent::SyncFinished { .. },
                         ..
                     }
                 ),
                 3 => assert_matches!(
                     event,
                     FromSync {
-                        event: TopicLogSyncEvent::Operation(_),
+                        event: TopicLogSyncEvent::LiveModeStarted,
                         ..
                     }
                 ),
                 4 => assert_matches!(
                     event,
                     FromSync {
-                        event: TopicLogSyncEvent::SyncFinished(_),
-                        ..
-                    }
-                ),
-                5 => assert_matches!(
-                    event,
-                    FromSync {
-                        event: TopicLogSyncEvent::LiveModeStarted,
-                        ..
-                    }
-                ),
-                6 => assert_matches!(
-                    event,
-                    FromSync {
-                        event: TopicLogSyncEvent::LiveModeFinished(_),
-                        ..
-                    }
-                ),
-                7 => assert_matches!(
-                    event,
-                    FromSync {
-                        event: TopicLogSyncEvent::Success,
+                        event: TopicLogSyncEvent::SessionFinished { .. },
                         ..
                     }
                 ),
@@ -370,30 +352,37 @@ mod tests {
         }
 
         // Assert Peer B's events.
-        for index in 0..=8 {
+        for index in 0..=5 {
             let event = event_stream_b.next().await.unwrap();
             match index {
                 0 => assert_matches!(
                     event,
                     FromSync {
                         session_id: 0,
-                        event: TopicLogSyncEvent::SyncStarted(_),
+                        event: TopicLogSyncEvent::SyncStarted { .. },
                         ..
                     }
                 ),
-                1 | 2 => assert_matches!(
+                1 => assert_matches!(
                     event,
                     FromSync {
                         session_id: 0,
-                        event: TopicLogSyncEvent::SyncStatus(_),
+                        event: TopicLogSyncEvent::OperationReceived { .. },
+                        ..
+                    }
+                ),
+                2 => assert_matches!(
+                    event,
+                    FromSync {
+                        session_id: 0,
+                        event: TopicLogSyncEvent::SyncFinished { .. },
                         ..
                     }
                 ),
                 3 => assert_matches!(
                     event,
                     FromSync {
-                        session_id: 0,
-                        event: TopicLogSyncEvent::Operation(_),
+                        event: TopicLogSyncEvent::LiveModeStarted,
                         ..
                     }
                 ),
@@ -401,36 +390,14 @@ mod tests {
                     event,
                     FromSync {
                         session_id: 0,
-                        event: TopicLogSyncEvent::SyncFinished(_),
+                        event: TopicLogSyncEvent::OperationReceived { .. },
                         ..
                     }
                 ),
                 5 => assert_matches!(
                     event,
                     FromSync {
-                        event: TopicLogSyncEvent::LiveModeStarted,
-                        ..
-                    }
-                ),
-                6 => assert_matches!(
-                    event,
-                    FromSync {
-                        session_id: 0,
-                        event: TopicLogSyncEvent::Operation(_),
-                        ..
-                    }
-                ),
-                7 => assert_matches!(
-                    event,
-                    FromSync {
-                        event: TopicLogSyncEvent::LiveModeFinished(_),
-                        ..
-                    }
-                ),
-                8 => assert_matches!(
-                    event,
-                    FromSync {
-                        event: TopicLogSyncEvent::Success,
+                        event: TopicLogSyncEvent::SessionFinished { .. },
                         ..
                     }
                 ),
@@ -449,7 +416,6 @@ mod tests {
         const SESSION_BA: u64 = 2;
         const SESSION_CA: u64 = 3;
 
-        // Shared topic
         let topic = Topic::new();
 
         // Peer A
@@ -476,7 +442,7 @@ mod tests {
         peer_c.associate(&topic, &logs).await;
         let mut manager_c = TestTopicSyncManager::new(peer_c.store.clone());
 
-        // Session A -> B (A initiates)
+        // Session A -> B
         let mut config = SessionConfig {
             topic: topic.clone(),
             remote: peer_b.id(),
@@ -486,7 +452,7 @@ mod tests {
         config.remote = peer_a.id();
         let session_b = manager_b.session(SESSION_BA, &config).await;
 
-        // Session A -> C (A initiates)
+        // Session A -> C
         let mut config = SessionConfig {
             topic: topic.clone(),
             remote: peer_c.id(),
@@ -500,7 +466,7 @@ mod tests {
         let mut event_stream_b = manager_b.subscribe();
         let mut event_stream_c = manager_c.subscribe();
 
-        // Run both protocols concurrently
+        // Run both protocols concurrently.
         {
             let (mut local_message_tx, local_message_rx) = mpsc::channel(128);
             let (mut remote_message_tx, remote_message_rx) = mpsc::channel(128);
@@ -539,7 +505,7 @@ mod tests {
             });
         }
 
-        // Send live-mode messages from all peers
+        // Send live-mode messages from all peers.
         let mut handle_ab = manager_a.session_handle(SESSION_AB).await.unwrap();
         let mut handle_ac = manager_a.session_handle(SESSION_AC).await.unwrap();
         let mut handle_ba = manager_b.session_handle(SESSION_BA).await.unwrap();
@@ -584,17 +550,17 @@ mod tests {
             loop {
                 tokio::select! {
                     Some(event) = event_stream_a.next() => {
-                        if let TestTopicSyncEvent::Operation(operation) = event.event() {
+                        if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
                             operations_a.push(*operation.clone());
                         }
                     }
                     Some(event) = event_stream_b.next() => {
-                        if let TestTopicSyncEvent::Operation(operation) = event.event() {
+                        if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
                             operations_b.push(*operation.clone());
                         }
                     }
                     Some(event) = event_stream_c.next() => {
-                        if let TestTopicSyncEvent::Operation(operation) = event.event() {
+                        if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
                             operations_c.push(*operation.clone());
                         }
                     }
@@ -604,8 +570,8 @@ mod tests {
         })
         .await;
 
-        // All peers received 4 messages, B & C received each other messages via A, and nobody
-        // received their own messages.
+        // All peers received 4 messages; B & C received each other's messages via A,
+        // and nobody received their own messages.
         assert_eq!(operations_a.len(), 4);
         assert_eq!(operations_b.len(), 4);
         assert_eq!(operations_c.len(), 4);
@@ -663,7 +629,6 @@ mod tests {
         peer_b.associate(&topic, &logs).await;
         let mut peer_b_manager = TestTopicSyncManager::new(peer_b.store.clone());
 
-        // Instantiate sync session for Peer A.
         let config = SessionConfig {
             topic,
             remote: peer_b.id(),
@@ -672,7 +637,6 @@ mod tests {
 
         let peer_a_session = peer_a_manager.session(SESSION_ID, &config).await;
 
-        // Instantiate sync session for Peer B.
         let event_stream = peer_b_manager.subscribe();
         let peer_b_session = peer_b_manager.session(SESSION_ID, &config).await;
 
@@ -696,30 +660,37 @@ mod tests {
 
         // Assert Peer B's events.
         let events = drain_stream(event_stream).await;
-        assert_eq!(events.len(), 9);
+        assert_eq!(events.len(), 6);
         for (index, event) in events.into_iter().enumerate() {
             match index {
                 0 => assert_matches!(
                     event,
                     FromSync {
                         session_id: 0,
-                        event: TopicLogSyncEvent::SyncStarted(_),
+                        event: TopicLogSyncEvent::SyncStarted { .. },
                         ..
                     }
                 ),
-                1 | 2 => assert_matches!(
+                1 => assert_matches!(
                     event,
                     FromSync {
                         session_id: 0,
-                        event: TopicLogSyncEvent::SyncStatus(_),
+                        event: TopicLogSyncEvent::OperationReceived { .. },
+                        ..
+                    }
+                ),
+                2 => assert_matches!(
+                    event,
+                    FromSync {
+                        session_id: 0,
+                        event: TopicLogSyncEvent::SyncFinished { .. },
                         ..
                     }
                 ),
                 3 => assert_matches!(
                     event,
                     FromSync {
-                        session_id: 0,
-                        event: TopicLogSyncEvent::Operation(_),
+                        event: TopicLogSyncEvent::LiveModeStarted,
                         ..
                     }
                 ),
@@ -727,36 +698,14 @@ mod tests {
                     event,
                     FromSync {
                         session_id: 0,
-                        event: TopicLogSyncEvent::SyncFinished(_),
+                        event: TopicLogSyncEvent::OperationReceived { .. },
                         ..
                     }
                 ),
                 5 => assert_matches!(
                     event,
                     FromSync {
-                        event: TopicLogSyncEvent::LiveModeStarted,
-                        ..
-                    }
-                ),
-                6 => assert_matches!(
-                    event,
-                    FromSync {
-                        session_id: 0,
-                        event: TopicLogSyncEvent::Operation(_),
-                        ..
-                    }
-                ),
-                7 => assert_matches!(
-                    event,
-                    FromSync {
-                        event: TopicLogSyncEvent::LiveModeFinished(_),
-                        ..
-                    }
-                ),
-                8 => assert_matches!(
-                    event,
-                    FromSync {
-                        event: TopicLogSyncEvent::Success,
+                        event: TopicLogSyncEvent::SessionFinished { .. },
                         ..
                     }
                 ),

--- a/p2panda-sync/src/protocols/log_sync.rs
+++ b/p2panda-sync/src/protocols/log_sync.rs
@@ -30,24 +30,21 @@ enum State<L> {
     Start,
 
     /// Calculate local log heights and send Have message to remote.
-    SendHave { metrics: LogSyncMetrics },
+    SendHave,
 
     /// Receive have message from remote and calculate operation diff.
-    ReceiveHave {
-        local: LogHeights<PublicKey, L>,
-        metrics: LogSyncMetrics,
-    },
+    ReceiveHave { local: LogHeights<PublicKey, L> },
 
     /// Send PreSync message to remote or Done if we have nothing to send.
     SendPreSync {
         remote_needs: LogRanges<PublicKey, L>,
-        metrics: LogSyncMetrics,
     },
 
     /// Receive PreSync message from remote or Done if they have nothing to send.
     ReceivePreSyncOrDone {
         remote_needs: LogRanges<PublicKey, L>,
-        metrics: LogSyncMetrics,
+        outbound_operations: u64,
+        outbound_bytes: u64,
     },
 
     /// Enter sync loop where we exchange operations with the remote, moves onto next state when
@@ -116,26 +113,16 @@ where
 
         let metrics = loop {
             match self.state {
-                State::Start => {
-                    let metrics = LogSyncMetrics::default();
-                    self.event_tx
-                        .send(
-                            LogSyncEvent::Status(LogSyncStatus::Started {
-                                metrics: metrics.clone(),
-                            })
-                            .into(),
-                        )
-                        .map_err(|_| LogSyncError::BroadcastSend)?;
-                    self.state = State::SendHave { metrics };
-                }
-                State::SendHave { metrics } => {
+                State::Start => self.state = State::SendHave,
+                State::SendHave => {
                     let local = get_log_heights(&self.store, &self.logs).await?;
                     sink.send(LogSyncMessage::<L>::Have(local.clone()))
                         .await
                         .map_err(|err| LogSyncError::MessageSink(format!("{err:?}")))?;
-                    self.state = State::ReceiveHave { local, metrics };
+
+                    self.state = State::ReceiveHave { local };
                 }
-                State::ReceiveHave { local, mut metrics } => {
+                State::ReceiveHave { local } => {
                     let Some(message) = stream.next().await else {
                         return Err(LogSyncError::UnexpectedStreamClosure);
                     };
@@ -147,41 +134,29 @@ where
 
                     let remote_needs = compare(&local, &remote);
 
-                    let mut operation_count = 0;
-                    let mut byte_count = 0;
+                    self.state = State::SendPreSync { remote_needs };
+                }
+                State::SendPreSync { remote_needs } => {
+                    let mut outbound_operations = 0;
+                    let mut outbound_bytes = 0;
                     for (public_key, log_range) in remote_needs.iter() {
                         for (log_id, (after, until)) in log_range.iter() {
-                            if let Some((inner_operation_count, inner_byte_count)) = self
+                            if let Some((inner_outbound_operations, inner_outbound_bytes)) = self
                                 .store
                                 .get_log_size(public_key, log_id, *after, *until)
                                 .await
                                 .map_err(|err| LogSyncError::OperationStore(format!("{err}")))?
                             {
-                                operation_count += inner_operation_count;
-                                byte_count += inner_byte_count;
+                                outbound_operations += inner_outbound_operations;
+                                outbound_bytes += inner_outbound_bytes;
                             };
                         }
                     }
 
-                    metrics.total_operations_local = Some(operation_count);
-                    metrics.total_bytes_local = Some(byte_count);
-
-                    self.state = State::SendPreSync {
-                        remote_needs,
-                        metrics,
-                    };
-                }
-                State::SendPreSync {
-                    remote_needs,
-                    metrics,
-                } => {
-                    let total_operations = metrics.total_operations_local.unwrap();
-                    let total_bytes = metrics.total_bytes_local.unwrap();
-
-                    if total_operations > 0 {
+                    if outbound_bytes > 0 {
                         sink.send(LogSyncMessage::PreSync {
-                            total_bytes,
-                            total_operations,
+                            total_operations: outbound_operations,
+                            total_bytes: outbound_bytes,
                         })
                         .await
                         .map_err(|err| LogSyncError::MessageSink(format!("{err:?}")))?;
@@ -192,23 +167,16 @@ where
                         sync_done_sent = true;
                     }
 
-                    self.event_tx
-                        .send(
-                            LogSyncEvent::Status(LogSyncStatus::Progress {
-                                metrics: metrics.clone(),
-                            })
-                            .into(),
-                        )
-                        .map_err(|_| LogSyncError::BroadcastSend)?;
-
                     self.state = State::ReceivePreSyncOrDone {
                         remote_needs,
-                        metrics,
+                        outbound_operations,
+                        outbound_bytes,
                     };
                 }
                 State::ReceivePreSyncOrDone {
                     remote_needs,
-                    mut metrics,
+                    outbound_operations,
+                    outbound_bytes,
                 } => {
                     let Some(message) = stream.next().await else {
                         return Err(LogSyncError::UnexpectedStreamClosure);
@@ -216,36 +184,44 @@ where
                     let message =
                         message.map_err(|err| LogSyncError::MessageStream(format!("{err:?}")))?;
 
-                    metrics.total_bytes_remote = Some(0);
-                    metrics.total_operations_remote = Some(0);
-
-                    match message {
+                    let (inbound_operations, inbound_bytes) = match message {
                         LogSyncMessage::PreSync {
                             total_operations,
                             total_bytes,
-                        } => {
-                            metrics.total_bytes_remote = Some(total_bytes);
-                            metrics.total_operations_remote = Some(total_operations);
+                        } => (total_operations, total_bytes),
+                        LogSyncMessage::Done => {
+                            sync_done_received = true;
+                            (0, 0)
                         }
-                        LogSyncMessage::Done => sync_done_received = true,
                         message => {
                             return Err(LogSyncError::UnexpectedMessage(message.to_string()));
                         }
-                    }
+                    };
 
                     debug!(
-                        local_ops = metrics.total_operations_local.unwrap_or_default(),
-                        remote_ops = metrics.total_operations_remote.unwrap_or_default(),
-                        local_bytes = metrics.total_bytes_local.unwrap_or_default(),
-                        remote_bytes = metrics.total_bytes_remote.unwrap_or_default(),
-                        "sync metrics received",
+                        local_ops = outbound_operations,
+                        remote_ops = inbound_operations,
+                        local_bytes = outbound_bytes,
+                        remote_bytes = inbound_bytes,
+                        "sync metrics exchanged",
                     );
+
+                    let metrics = LogSyncMetrics {
+                        outbound_operations,
+                        outbound_bytes,
+                        inbound_operations,
+                        inbound_bytes,
+                        sent_operations: 0,
+                        sent_bytes: 0,
+                        received_operations: 0,
+                        received_bytes: 0,
+                    };
 
                     self.event_tx
                         .send(
-                            LogSyncEvent::Status(LogSyncStatus::Progress {
+                            LogSyncEvent::MetricsExchanged {
                                 metrics: metrics.clone(),
-                            })
+                            }
                             .into(),
                         )
                         .map_err(|_| LogSyncError::BroadcastSend)?;
@@ -272,11 +248,11 @@ where
 
                                 match message {
                                     LogSyncMessage::Operation(header, body) => {
-                                        metrics.total_bytes_received += {
+                                        metrics.received_bytes += {
                                             header.len()
                                                 + body.as_ref().map(|bytes| bytes.len()).unwrap_or_default()
                                         } as u64;
-                                        metrics.total_operations_received += 1;
+                                        metrics.received_operations += 1;
 
                                         let header: Header<E> = decode_cbor(&header[..])?;
                                         let body = body.map(|ref bytes| Body::new(bytes));
@@ -287,19 +263,15 @@ where
                                         trace!(
                                             phase = "sync",
                                             id = ?header.hash().fmt_short(),
-                                            received_ops = metrics.total_operations_received,
-                                            received_bytes = metrics.total_bytes_received,
+                                            received_ops = metrics.received_operations,
+                                            received_bytes = metrics.received_bytes,
                                             "received operation"
                                         );
 
                                         // Forward data received from the remote to the app layer.
                                         self.event_tx
                                             .send(
-                                                LogSyncEvent::Data(Box::new(Operation {
-                                                    hash: header.hash(),
-                                                    header,
-                                                    body,
-                                                }))
+                                                LogSyncEvent::OperationReceived{operation:Box::new(Operation{hash:header.hash(),header,body,}), metrics: metrics.clone() }
                                                 .into(),
                                             )
                                             .map_err(|_| LogSyncError::BroadcastSend)?;
@@ -340,10 +312,10 @@ where
                                         let body = operation.body;
                                         let hash = operation.hash;
 
-                                        metrics.total_bytes_sent += { header_bytes.len() +
+                                        metrics.sent_bytes += { header_bytes.len() +
                                             body.as_ref().map(|body|
                                         body.to_bytes().len()).unwrap_or_default() } as u64;
-                                        metrics.total_operations_sent += 1;
+                                        metrics.sent_operations += 1;
 
                                         trace!(
                                             phase = "sync",
@@ -351,8 +323,8 @@ where
                                             log_id = ?log_id,
                                             seq_num = header.seq_num,
                                             id = %hash.fmt_short(),
-                                            sent_ops = metrics.total_operations_sent,
-                                            sent_bytes = metrics.total_bytes_sent,
+                                            sent_ops = metrics.sent_operations,
+                                            sent_bytes = metrics.sent_bytes,
                                             "send operation",
                                         );
 
@@ -393,14 +365,6 @@ where
                     self.state = State::End { metrics };
                 }
                 State::End { metrics } => {
-                    self.event_tx
-                        .send(
-                            LogSyncEvent::Status(LogSyncStatus::Completed {
-                                metrics: metrics.clone(),
-                            })
-                            .into(),
-                        )
-                        .map_err(|_| LogSyncError::BroadcastSend)?;
                     break metrics;
                 }
             }
@@ -470,29 +434,30 @@ where
 /// Events emitted from log sync sessions.
 #[derive(Clone, Debug, PartialEq)]
 pub enum LogSyncEvent<E> {
-    Status(LogSyncStatus),
-    Data(Box<Operation<E>>),
+    /// We have calculated and sent the estimated bytes and operations to be sent during this sync
+    /// session and received the remotes' estimates.
+    ///
+    /// This is the first event to occur and will only be sent once.
+    MetricsExchanged { metrics: LogSyncMetrics },
+
+    /// An operation has been received from the remote.
+    OperationReceived {
+        operation: Box<Operation<E>>,
+        metrics: LogSyncMetrics,
+    },
 }
 
 /// Sync metrics emitted in event messages.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct LogSyncMetrics {
-    pub total_operations_local: Option<u64>,
-    pub total_operations_remote: Option<u64>,
-    pub total_operations_received: u64,
-    pub total_operations_sent: u64,
-    pub total_bytes_local: Option<u64>,
-    pub total_bytes_remote: Option<u64>,
-    pub total_bytes_received: u64,
-    pub total_bytes_sent: u64,
-}
-
-/// Sync status variants sent on log sync events.
-#[derive(Clone, Debug, PartialEq)]
-pub enum LogSyncStatus {
-    Started { metrics: LogSyncMetrics },
-    Progress { metrics: LogSyncMetrics },
-    Completed { metrics: LogSyncMetrics },
+    pub outbound_operations: u64,
+    pub outbound_bytes: u64,
+    pub inbound_operations: u64,
+    pub inbound_bytes: u64,
+    pub sent_operations: u64,
+    pub sent_bytes: u64,
+    pub received_operations: u64,
+    pub received_bytes: u64,
 }
 
 /// Protocol error types.
@@ -552,9 +517,7 @@ mod tests {
     use p2panda_store::operations::OperationStore;
     use p2panda_store::{SqliteStore, tx_unwrap};
 
-    use crate::protocols::log_sync::{
-        LogSyncError, LogSyncEvent, LogSyncMetrics, LogSyncStatus, Logs, Operation,
-    };
+    use crate::protocols::log_sync::{LogSyncError, LogSyncEvent, Logs, Operation};
     use crate::test_utils::{
         Peer, TestLogSyncMessage, run_protocol, run_protocol_uni, setup_logging,
     };
@@ -565,7 +528,7 @@ mod tests {
         let mut peer: Peer = Peer::new(0).await;
 
         let (session, mut event_rx) = peer.log_sync_protocol(&Logs::default());
-        let remote_message_rx = run_protocol_uni(
+        let ((_, metrics), mut remote_message_rx) = run_protocol_uni(
             session,
             &[
                 TestLogSyncMessage::Have(BTreeMap::default()),
@@ -575,61 +538,27 @@ mod tests {
         .await
         .unwrap();
 
-        for index in 0..=3 {
-            let event = event_rx.recv().await.unwrap();
-            match index {
-                0 => {
-                    let (total_operations, total_bytes) = assert_matches!(
-                        event,
-                        LogSyncEvent::Status(LogSyncStatus::Started { metrics: LogSyncMetrics { total_operations_remote, total_bytes_remote, .. } })
-                         => (total_operations_remote, total_bytes_remote)
-                    );
-                    assert_eq!(total_operations, None);
-                    assert_eq!(total_bytes, None);
-                }
-                1 => {
-                    let (total_operations, total_bytes) = assert_matches!(
-                        event,
-                        LogSyncEvent::Status(LogSyncStatus::Progress { metrics: LogSyncMetrics { total_operations_local, total_bytes_local, .. } })
-                         => (total_operations_local, total_bytes_local)
-                    );
-                    assert_eq!(total_operations, Some(0));
-                    assert_eq!(total_bytes, Some(0));
-                }
-                2 => {
-                    let (total_operations, total_bytes) = assert_matches!(
-                        event,
-                        LogSyncEvent::Status(LogSyncStatus::Progress { metrics: LogSyncMetrics { total_operations_remote, total_bytes_remote, .. } })
-                         => (total_operations_remote, total_bytes_remote)
-                    );
-                    assert_eq!(total_operations, Some(0));
-                    assert_eq!(total_bytes, Some(0));
-                }
-                3 => {
-                    let (total_operations, total_bytes) = assert_matches!(
-                        event,
-                        LogSyncEvent::Status(LogSyncStatus::Completed { metrics: LogSyncMetrics { total_operations_remote, total_bytes_remote, .. } })
-                         => (total_operations_remote, total_bytes_remote)
-                    );
-                    assert_eq!(total_operations, Some(0));
-                    assert_eq!(total_bytes, Some(0));
-                }
-                _ => panic!(),
-            };
-        }
+        let event_metrics = assert_matches!(
+            event_rx.recv().await.unwrap(),
+            LogSyncEvent::MetricsExchanged { metrics } => metrics
+        );
 
-        let messages = remote_message_rx.collect::<Vec<_>>().await;
-        assert_eq!(messages.len(), 2);
-        for (index, message) in messages.into_iter().enumerate() {
-            match index {
-                0 => assert_eq!(message, TestLogSyncMessage::Have(BTreeMap::default())),
-                1 => {
-                    assert_eq!(message, TestLogSyncMessage::Done);
-                    break;
-                }
-                _ => panic!(),
-            };
-        }
+        assert_eq!(metrics.outbound_operations, 0);
+        assert_eq!(metrics.outbound_bytes, 0);
+        assert_eq!(metrics.inbound_operations, 0);
+        assert_eq!(metrics.inbound_bytes, 0);
+
+        assert_eq!(event_metrics, metrics);
+
+        assert_eq!(
+            remote_message_rx.recv().await.unwrap(),
+            TestLogSyncMessage::Have(BTreeMap::default())
+        );
+
+        assert_eq!(
+            remote_message_rx.recv().await.unwrap(),
+            TestLogSyncMessage::Done
+        );
     }
 
     #[tokio::test]
@@ -646,7 +575,7 @@ mod tests {
         logs.insert(peer.id(), vec![log_id]);
 
         let (session, mut event_rx) = peer.log_sync_protocol(&logs);
-        let remote_message_rx = run_protocol_uni(
+        let ((_, final_metrics), remote_message_rx) = run_protocol_uni(
             session,
             &[
                 TestLogSyncMessage::Have(BTreeMap::default()),
@@ -663,95 +592,60 @@ mod tests {
             + header_2.payload_size
             + header_bytes_2.len() as u64;
 
-        for index in 0..=3 {
-            let event = event_rx.recv().await.unwrap();
-            match index {
-                0 => {
-                    assert_matches!(event, LogSyncEvent::Status(LogSyncStatus::Started { .. }));
-                }
-                1 => {
-                    let (total_operations, total_bytes) = assert_matches!(
-                        event,
-                        LogSyncEvent::Status(LogSyncStatus::Progress {
-                            metrics: LogSyncMetrics { total_operations_local, total_bytes_local, .. }
-                        }) => (total_operations_local, total_bytes_local)
-                    );
-                    assert_eq!(total_operations, Some(3));
+        let metrics = assert_matches!(
+            event_rx.recv().await.unwrap(),
+            LogSyncEvent::MetricsExchanged { metrics } => metrics
+        );
 
-                    assert_eq!(total_bytes, Some(expected_bytes));
-                }
-                2 => {
-                    let (total_operations, total_bytes) = assert_matches!(
-                        event,
-                        LogSyncEvent::Status(LogSyncStatus::Progress {
-                            metrics: LogSyncMetrics { total_operations_remote, total_bytes_remote, .. }
-                        }) => (total_operations_remote, total_bytes_remote)
-                    );
-                    assert_eq!(total_operations, Some(0));
-                    assert_eq!(total_bytes, Some(0));
-                }
-                3 => {
-                    let (total_operations, total_bytes) = assert_matches!(
-                        event,
-                        LogSyncEvent::Status(LogSyncStatus::Completed {
-                            metrics: LogSyncMetrics { total_operations_remote, total_bytes_remote, .. }
-                        }) => (total_operations_remote, total_bytes_remote)
-                    );
-                    assert_eq!(total_operations, Some(0));
-                    assert_eq!(total_bytes, Some(0));
-                }
-                _ => panic!(),
-            };
-        }
+        assert_eq!(metrics.outbound_operations, 3);
+        assert_eq!(metrics.outbound_bytes, expected_bytes);
+        assert_eq!(metrics.inbound_operations, 0);
+        assert_eq!(metrics.inbound_bytes, 0);
+
+        assert_eq!(final_metrics.sent_operations, 3);
+        assert_eq!(final_metrics.sent_bytes, expected_bytes);
+        assert_eq!(final_metrics.received_operations, 0);
+        assert_eq!(final_metrics.received_bytes, 0);
 
         let messages = remote_message_rx.collect::<Vec<_>>().await;
+
         assert_eq!(messages.len(), 6);
-        for (index, message) in messages.into_iter().enumerate() {
-            match index {
-                0 => assert_eq!(
-                    message,
-                    TestLogSyncMessage::Have(BTreeMap::from([(
-                        peer.id(),
-                        BTreeMap::from([(0, 2)])
-                    )]))
-                ),
-                1 => assert_eq!(
-                    message,
-                    TestLogSyncMessage::PreSync {
-                        total_operations: 3,
-                        total_bytes: expected_bytes
-                    }
-                ),
-                2 => {
-                    let (header, body_inner) = assert_matches!(message, TestLogSyncMessage::Operation(
-                        header,
-                        Some(body),
-                    ) => (header, body));
-                    assert_eq!(header, header_bytes_0);
-                    assert_eq!(Body::new(&body_inner), body)
-                }
-                3 => {
-                    let (header, body_inner) = assert_matches!(message, TestLogSyncMessage::Operation(
-                        header,
-                        Some(body),
-                    ) => (header, body));
-                    assert_eq!(header, header_bytes_1);
-                    assert_eq!(Body::new(&body_inner), body)
-                }
-                4 => {
-                    let (header, body_inner) = assert_matches!(message, TestLogSyncMessage::Operation(
-                        header,
-                        Some(body),
-                    ) => (header, body));
-                    assert_eq!(header, header_bytes_2);
-                    assert_eq!(Body::new(&body_inner), body)
-                }
-                5 => {
-                    assert_eq!(message, TestLogSyncMessage::Done);
-                }
-                _ => panic!(),
-            };
-        }
+
+        assert_eq!(
+            messages[0],
+            TestLogSyncMessage::Have(BTreeMap::from([(peer.id(), BTreeMap::from([(0, 2)]))]))
+        );
+
+        assert_eq!(
+            messages[1],
+            TestLogSyncMessage::PreSync {
+                total_operations: 3,
+                total_bytes: expected_bytes
+            }
+        );
+
+        let (header, body_inner) = assert_matches!(
+            &messages[2],
+            TestLogSyncMessage::Operation(header, Some(body)) => (header.clone(), body.clone())
+        );
+        assert_eq!(header, header_bytes_0);
+        assert_eq!(Body::new(&body_inner), body);
+
+        let (header, body_inner) = assert_matches!(
+            &messages[3],
+            TestLogSyncMessage::Operation(header, Some(body)) => (header.clone(), body.clone())
+        );
+        assert_eq!(header, header_bytes_1);
+        assert_eq!(Body::new(&body_inner), body);
+
+        let (header, body_inner) = assert_matches!(
+            &messages[4],
+            TestLogSyncMessage::Operation(header, Some(body)) => (header.clone(), body.clone())
+        );
+        assert_eq!(header, header_bytes_2);
+        assert_eq!(Body::new(&body_inner), body);
+
+        assert_eq!(messages[5], TestLogSyncMessage::Done);
     }
 
     #[tokio::test]
@@ -779,81 +673,74 @@ mod tests {
         let (a_session, mut peer_a_event_rx) = peer_a.log_sync_protocol(&logs);
         let (b_session, mut peer_b_event_rx) = peer_b.log_sync_protocol(&logs);
 
-        run_protocol(a_session, b_session).await.unwrap();
+        let ((_, local_metrics), (_, remote_metrics)) =
+            run_protocol(a_session, b_session).await.unwrap();
 
-        for index in 0..=5 {
-            let event = peer_a_event_rx.recv().await.unwrap();
-            match index {
-                0 => assert_matches!(event, LogSyncEvent::Status(LogSyncStatus::Started { .. })),
-                1 => assert_matches!(event, LogSyncEvent::Status(LogSyncStatus::Progress { .. })),
-                2 => assert_matches!(event, LogSyncEvent::Status(LogSyncStatus::Progress { .. })),
-                3 => {
-                    let (header, body_inner) = assert_matches!(
-                        event,
-                        LogSyncEvent::Data(operation) => {let Operation {header, body, ..} = *operation; (header, body)}
-                    );
-                    assert_eq!(header, header_b0);
-                    assert_eq!(body_inner.unwrap(), body_b);
-                }
-                4 => {
-                    let (header, body_inner) = assert_matches!(
-                        event,
-                        LogSyncEvent::Data(operation) => {let Operation {header, body, ..} = *operation; (header, body)}
-                    );
-                    assert_eq!(header, header_b1);
-                    assert_eq!(body_inner.unwrap(), body_b);
-                }
-                5 => {
-                    assert_matches!(event, LogSyncEvent::Status(LogSyncStatus::Completed { .. }));
-                    break;
-                }
-                _ => panic!(),
+        assert_matches!(
+            peer_a_event_rx.recv().await.unwrap(),
+            LogSyncEvent::MetricsExchanged { .. }
+        );
+
+        let (header, body_inner) = assert_matches!(
+            peer_a_event_rx.recv().await.unwrap(),
+            LogSyncEvent::OperationReceived { operation, .. } => {
+                let Operation { header, body, .. } = *operation;
+                (header, body)
             }
-        }
+        );
+        assert_eq!(header, header_b0);
+        assert_eq!(body_inner.unwrap(), body_b);
 
-        for index in 0..=5 {
-            let event = peer_b_event_rx.recv().await.unwrap();
-            match index {
-                0 => assert_matches!(event, LogSyncEvent::Status(LogSyncStatus::Started { .. })),
-                1 => assert_matches!(event, LogSyncEvent::Status(LogSyncStatus::Progress { .. })),
-                2 => assert_matches!(event, LogSyncEvent::Status(LogSyncStatus::Progress { .. })),
-                3 => {
-                    let (header, body_inner) = assert_matches!(
-                        event,
-                        LogSyncEvent::Data(operation) => {let Operation {header, body, ..} = *operation; (header, body)}
-                    );
-                    assert_eq!(header, header_a0);
-                    assert_eq!(body_inner.unwrap(), body_a);
-                }
-                4 => {
-                    let (header, body_inner) = assert_matches!(
-                        event,
-                        LogSyncEvent::Data(operation) => {let Operation {header, body, ..} = *operation; (header, body)}
-                    );
-                    assert_eq!(header, header_a1);
-                    assert_eq!(body_inner.unwrap(), body_a);
-                }
-                5 => {
-                    let metrics = assert_matches!(event, LogSyncEvent::Status(LogSyncStatus::Completed { metrics }) => metrics);
-                    let LogSyncMetrics {
-                        total_operations_local,
-                        total_operations_remote,
-                        total_operations_received,
-                        total_operations_sent,
-                        total_bytes_local,
-                        total_bytes_remote,
-                        total_bytes_received,
-                        total_bytes_sent,
-                    } = metrics;
-
-                    assert_eq!(total_operations_remote.unwrap(), total_operations_received);
-                    assert_eq!(total_bytes_remote.unwrap(), total_bytes_received);
-                    assert_eq!(total_operations_local.unwrap(), total_operations_sent);
-                    assert_eq!(total_bytes_local.unwrap(), total_bytes_sent);
-                }
-                _ => panic!(),
+        let (header, body_inner) = assert_matches!(
+            peer_a_event_rx.recv().await.unwrap(),
+            LogSyncEvent::OperationReceived { operation, .. } => {
+                let Operation { header, body, .. } = *operation;
+                (header, body)
             }
-        }
+        );
+        assert_eq!(header, header_b1);
+        assert_eq!(body_inner.unwrap(), body_b);
+
+        assert_matches!(
+            peer_b_event_rx.recv().await.unwrap(),
+            LogSyncEvent::MetricsExchanged { .. }
+        );
+
+        let (header, body_inner) = assert_matches!(
+            peer_b_event_rx.recv().await.unwrap(),
+            LogSyncEvent::OperationReceived { operation, .. } => {
+                let Operation { header, body, .. } = *operation;
+                (header, body)
+            }
+        );
+        assert_eq!(header, header_a0);
+        assert_eq!(body_inner.unwrap(), body_a);
+
+        let (header, body_inner) = assert_matches!(
+            peer_b_event_rx.recv().await.unwrap(),
+            LogSyncEvent::OperationReceived { operation, .. } => {
+                let Operation { header, body, .. } = *operation;
+                (header, body)
+            }
+        );
+        assert_eq!(header, header_a1);
+        assert_eq!(body_inner.unwrap(), body_a);
+
+        assert_eq!(
+            local_metrics.inbound_operations,
+            local_metrics.received_operations
+        );
+        assert_eq!(local_metrics.inbound_bytes, local_metrics.received_bytes);
+        assert_eq!(
+            local_metrics.outbound_operations,
+            local_metrics.sent_operations
+        );
+        assert_eq!(local_metrics.outbound_bytes, local_metrics.sent_bytes);
+        assert_eq!(local_metrics.outbound_bytes, remote_metrics.inbound_bytes);
+        assert_eq!(
+            local_metrics.outbound_operations,
+            remote_metrics.inbound_operations
+        );
     }
 
     #[tokio::test]
@@ -869,7 +756,6 @@ mod tests {
 
         let (session, _event_rx) = peer.log_sync_protocol(&logs);
 
-        // Remote sends Operation without PreSync first.
         let messages = vec![
             TestLogSyncMessage::Have(BTreeMap::from([(peer.id(), BTreeMap::from([(LOG_ID, 0)]))])),
             TestLogSyncMessage::Operation(header_bytes.clone(), Some(body.to_bytes())),
@@ -881,6 +767,7 @@ mod tests {
         ];
 
         let result = run_protocol_uni(session, &messages).await;
+
         assert!(matches!(result, Err(LogSyncError::UnexpectedMessage(_))));
     }
 
@@ -894,6 +781,7 @@ mod tests {
 
         let mut logs = Logs::default();
         logs.insert(peer.id(), vec![LOG_ID]);
+
         let (session, _event_rx) = peer.log_sync_protocol(&logs);
 
         let messages = vec![
@@ -910,6 +798,7 @@ mod tests {
         ];
 
         let result = run_protocol_uni(session, &messages).await;
+
         assert!(matches!(result, Err(LogSyncError::UnexpectedMessage(_))));
     }
 
@@ -923,22 +812,20 @@ mod tests {
         let messages = vec![TestLogSyncMessage::Done];
         let result = run_protocol_uni(session, &messages).await;
 
-        assert!(
-            matches!(result, Err(LogSyncError::UnexpectedMessage(_))),
-            "{:?}",
-            result
-        );
+        assert!(matches!(result, Err(LogSyncError::UnexpectedMessage(_))));
     }
 
     #[tokio::test]
     async fn log_sync_unexpected_have_after_presend() {
         let mut peer = Peer::new(0).await;
         const LOG_ID: u64 = 1;
+
         let body = Body::new(b"bad have order");
         peer.create_operation(&body, LOG_ID).await;
 
         let mut logs = Logs::default();
         logs.insert(peer.id(), vec![LOG_ID]);
+
         let (session, _event_rx) = peer.log_sync_protocol(&logs);
 
         let messages = vec![
@@ -950,11 +837,12 @@ mod tests {
             TestLogSyncMessage::Have(BTreeMap::from([(
                 peer.id(),
                 BTreeMap::from([(LOG_ID, 99)]),
-            )])), // invalid here
+            )])),
             TestLogSyncMessage::Done,
         ];
 
         let result = run_protocol_uni(session, &messages).await;
+
         assert!(matches!(result, Err(LogSyncError::UnexpectedMessage(_))));
     }
 
@@ -968,22 +856,26 @@ mod tests {
 
         let body = Body::new(&[0; 1000]);
 
-        // Load up the peer with three logs.
         for _ in 0..100 {
             let _ = peer_a.create_operation(&body, 0).await;
         }
+
         for _ in 0..100 {
             let _ = peer_a.create_operation(&body, 1).await;
         }
+
         let mut to_be_pruned_log = vec![];
+
         for _ in 0..50 {
             let (header, _) = peer_c.create_operation(&body, 0).await;
             let id = header.hash();
+
             let operation = Operation {
                 hash: header.hash(),
                 header,
                 body: Some(body.clone()),
             };
+
             tx_unwrap!(
                 &peer_a.store,
                 peer_a
@@ -992,6 +884,7 @@ mod tests {
                     .await
                     .unwrap()
             );
+
             to_be_pruned_log.push(id);
         }
 
@@ -1005,7 +898,7 @@ mod tests {
         let _peer_b_event_tx_clone = b_session.event_tx.clone();
 
         // Spawn a task to run the sync session.
-        {
+        let session_b_handle = {
             let (mut local_message_tx, local_message_rx) = mpsc::channel(512);
             let (mut remote_message_tx, remote_message_rx) = mpsc::channel(512);
             let mut local_message_rx = local_message_rx.map(Ok::<_, ()>);
@@ -1020,14 +913,14 @@ mod tests {
                 b_session
                     .run(&mut remote_message_tx, &mut local_message_rx)
                     .await
-                    .unwrap();
-            });
-        }
+                    .unwrap()
+            })
+        };
 
         loop {
             let event = peer_b_event_rx.recv().await.unwrap();
-            if let LogSyncEvent::Data(_) = event {
-                // Concurrently delete the first operation from the last log.
+
+            if let LogSyncEvent::OperationReceived { .. } = event {
                 tx_unwrap!(&peer_a.store, {
                     <SqliteStore as OperationStore<Operation<()>, Hash, ()>>::delete_operation(
                         &peer_a.store,
@@ -1041,24 +934,8 @@ mod tests {
             }
         }
 
-        loop {
-            let event = peer_b_event_rx.recv().await.unwrap();
-            if let LogSyncEvent::Status(LogSyncStatus::Completed { metrics }) = event {
-                let LogSyncMetrics {
-                    total_operations_remote,
-                    total_operations_received,
-                    ..
-                } = metrics;
-
-                // We expect all operations to be included in the total remote operations as these
-                // were calculated before pruning occurred.
-                assert_eq!(total_operations_remote.unwrap(), 250);
-
-                // One operation was not sent because it got deleted after the sync session
-                // started.
-                assert_eq!(total_operations_received, 249);
-                break;
-            }
-        }
+        let (_, metrics) = session_b_handle.await.unwrap();
+        assert_eq!(metrics.inbound_operations, 250);
+        assert_eq!(metrics.received_operations, 249);
     }
 }

--- a/p2panda-sync/src/protocols/topic_log_sync.rs
+++ b/p2panda-sync/src/protocols/topic_log_sync.rs
@@ -23,7 +23,7 @@ use crate::ToSync;
 use crate::dedup::DEFAULT_BUFFER_CAPACITY;
 use crate::protocols::ShortFormat;
 use crate::protocols::log_sync::{
-    LogSync, LogSyncError, LogSyncEvent, LogSyncMessage, LogSyncMetrics, LogSyncStatus,
+    LogSync, LogSyncError, LogSyncEvent, LogSyncMessage, LogSyncMetrics,
 };
 use crate::traits::Protocol;
 
@@ -157,7 +157,15 @@ where
             // If the log sync session ended with an error, then send a "failed" event and return
             // here with the error itself.
             match result {
-                Ok(output) => output,
+                Ok((dedup, metrics)) => {
+                    self.event_tx
+                        .send(TopicLogSyncEvent::SyncFinished {
+                            metrics: metrics.clone().into(),
+                        })
+                        .map_err(|_| TopicLogSyncChannelError::EventSend)?;
+
+                    (dedup, metrics)
+                }
                 Err(err) => {
                     self.event_tx
                         .send(TopicLogSyncEvent::Failed {
@@ -175,7 +183,8 @@ where
             }
         };
 
-        let mut metrics: TopicLogSyncLiveMetrics = sync_metrics.into();
+        let mut metrics: Metrics = sync_metrics.into();
+
         let result = match self.live_mode_rx {
             None => Ok(()),
             Some(mut live_mode_rx) => {
@@ -190,7 +199,7 @@ where
                     .send(TopicLogSyncEvent::LiveModeStarted)
                     .map_err(|_| TopicLogSyncChannelError::EventSend)?;
 
-                let result = loop {
+                loop {
                     tokio::select! {
                         biased;
                         Some(message) = live_mode_rx.next() => {
@@ -201,15 +210,15 @@ where
                                         continue;
                                     }
 
-                                    metrics.bytes_sent +=
+                                    metrics.sent_live_bytes +=
                                         operation.header.to_bytes().len() as u64 + operation.header.payload_size;
-                                    metrics.operations_sent += 1;
+                                    metrics.sent_live_operations += 1;
 
                                     trace!(
                                         phase = "live",
                                         id = ?operation.hash.fmt_short(),
-                                        sent_ops = ?metrics.operations_sent,
-                                        sent_bytes = ?metrics.bytes_sent,
+                                        sent_ops = ?metrics.sent_live_operations,
+                                        sent_bytes = ?metrics.sent_live_bytes,
                                         "sent operation"
                                     );
 
@@ -275,23 +284,23 @@ where
                                         continue;
                                     }
 
-                                    metrics.bytes_received += header.to_bytes().len() as u64 + header.payload_size;
-                                    metrics.operations_received += 1;
+                                    metrics.received_live_bytes += header.to_bytes().len() as u64 + header.payload_size;
+                                    metrics.received_live_operations += 1;
 
                                     trace!(
                                         phase = "live",
                                         operation_id = ?header.hash().fmt_short(),
-                                        received_ops = %metrics.operations_received,
-                                        received_bytes = %metrics.bytes_received,
+                                        received_ops = %metrics.received_live_operations,
+                                        received_bytes = %metrics.received_live_bytes,
                                         "received operation"
                                     );
 
                                     self.event_tx
-                                        .send(TopicLogSyncEvent::Operation(Box::new(Operation {
+                                        .send(TopicLogSyncEvent::OperationReceived{operation: Box::new(Operation {
                                             hash: header.hash(),
                                             header,
                                             body,
-                                        })))
+                                        }), metrics: metrics.clone()})
                                         .map_err(|_| TopicLogSyncChannelError::EventSend)?;
                                 }
                                 Err(err) => {
@@ -303,13 +312,7 @@ where
                             }
                         }
                     }
-                };
-
-                self.event_tx
-                    .send(TopicLogSyncEvent::LiveModeFinished(metrics.clone()))
-                    .map_err(|_| TopicLogSyncChannelError::EventSend)?;
-
-                result
+                }
             }
         };
 
@@ -320,13 +323,13 @@ where
         let final_event = match result.as_ref() {
             Ok(_) => {
                 debug!(
-                    sent_ops = ?metrics.operations_sent,
-                    sent_bytes = ?metrics.bytes_sent,
-                    received_ops = %metrics.operations_received,
-                    received_bytes = %metrics.bytes_received,
+                    sent_ops = ?metrics.sent_operations(),
+                    sent_bytes = ?metrics.sent_bytes(),
+                    received_ops = %metrics.received_operations(),
+                    received_bytes = %metrics.received_bytes(),
                     "sync session closed"
                 );
-                TopicLogSyncEvent::Success
+                TopicLogSyncEvent::SessionFinished { metrics }
             }
             Err(err) => {
                 warn!(error = ?err, "sync session closed with error");
@@ -405,48 +408,111 @@ pub enum TopicLogSyncError {
     DecodeMessage(String),
 }
 
-/// Sync metrics emitted in event messages.
-#[derive(Clone, Debug, PartialEq, Default)]
-pub struct TopicLogSyncLiveMetrics {
-    pub operations_received: u64,
-    pub operations_sent: u64,
-    pub bytes_received: u64,
-    pub bytes_sent: u64,
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Metrics {
+    pub outbound_sync_bytes: u64,
+    pub outbound_sync_operations: u64,
+    pub inbound_sync_bytes: u64,
+    pub inbound_sync_operations: u64,
+    pub sent_sync_bytes: u64,
+    pub sent_sync_operations: u64,
+    pub received_sync_bytes: u64,
+    pub received_sync_operations: u64,
+    pub sent_live_bytes: u64,
+    pub sent_live_operations: u64,
+    pub received_live_bytes: u64,
+    pub received_live_operations: u64,
 }
 
-impl From<LogSyncMetrics> for TopicLogSyncLiveMetrics {
-    fn from(value: LogSyncMetrics) -> TopicLogSyncLiveMetrics {
-        TopicLogSyncLiveMetrics {
-            operations_received: value.total_operations_received,
-            operations_sent: value.total_operations_sent,
-            bytes_received: value.total_bytes_received,
-            bytes_sent: value.total_bytes_sent,
+impl Metrics {
+    pub fn sent_bytes(&self) -> u64 {
+        self.sent_sync_bytes + self.sent_live_bytes
+    }
+
+    pub fn received_bytes(&self) -> u64 {
+        self.received_sync_bytes + self.received_live_bytes
+    }
+
+    pub fn sent_operations(&self) -> u64 {
+        self.sent_sync_operations + self.sent_live_operations
+    }
+
+    pub fn received_operations(&self) -> u64 {
+        self.received_sync_operations + self.received_live_operations
+    }
+}
+
+impl From<LogSyncMetrics> for Metrics {
+    fn from(value: LogSyncMetrics) -> Metrics {
+        Metrics {
+            inbound_sync_bytes: value.inbound_bytes,
+            outbound_sync_bytes: value.outbound_bytes,
+            sent_sync_bytes: value.sent_bytes,
+            received_sync_bytes: value.received_bytes,
+            inbound_sync_operations: value.inbound_operations,
+            outbound_sync_operations: value.outbound_operations,
+            sent_sync_operations: value.sent_operations,
+            received_sync_operations: value.received_operations,
+            ..Default::default()
         }
     }
 }
 
 /// Events emitted from topic log sync sessions.
 #[derive(Debug, Clone, PartialEq)]
-pub enum TopicLogSyncEvent<E> {
-    SyncStarted(LogSyncMetrics),
-    SyncStatus(LogSyncMetrics),
-    SyncFinished(LogSyncMetrics),
+pub enum TopicLogSyncEvent<E = ()> {
+    /// A session has been initiated locally.
+    ///
+    /// This event is always sent and will be followed by `SyncStarted` or `Failed` events.
+    SessionStarted,
+
+    /// We have exchanged initial session metrics with the remote and the sync phase of this
+    /// session has started.
+    ///
+    /// This event will be followed by any number of `OperationReceived` events, or a `SyncFinished` or `Failed`.
+    SyncStarted { metrics: Metrics },
+
+    /// All past state has been replicated and we will now enter live mode `LiveModeStarted` (if configured) or the
+    /// session will end `SessionFinished`.
+    ///
+    /// This event will be followed by a `LiveModeStarted` event or a `SyncFinished` or `Failed` event.
+    SyncFinished { metrics: Metrics },
+
+    /// The session has entered live mode, we will send and receive operations in realtime.
+    ///
+    /// This event will be followed by any number of `OperationReceived` events or a `SyncFinished` or `Failed` event.
     LiveModeStarted,
-    LiveModeFinished(TopicLogSyncLiveMetrics),
-    Operation(Box<Operation<E>>),
-    Success,
+
+    /// An operation has been received, this can be in the "sync" or "live mode" phase of a session.
+    OperationReceived {
+        operation: Box<Operation<E>>,
+        metrics: Metrics,
+    },
+
+    /// The session has finished.
+    ///
+    /// When no error occurs this event will always be sent at the end of a session.
+    SessionFinished { metrics: Metrics },
+
+    /// The session failed.
+    ///
+    /// This event will always be the final event sent when an error occurred in any phase of the
+    /// session.
     Failed { error: String },
 }
 
 impl<E> From<LogSyncEvent<E>> for TopicLogSyncEvent<E> {
     fn from(event: LogSyncEvent<E>) -> Self {
         match event {
-            LogSyncEvent::Status(status_event) => match status_event {
-                LogSyncStatus::Started { metrics } => TopicLogSyncEvent::SyncStarted(metrics),
-                LogSyncStatus::Progress { metrics } => TopicLogSyncEvent::SyncStatus(metrics),
-                LogSyncStatus::Completed { metrics } => TopicLogSyncEvent::SyncFinished(metrics),
+            LogSyncEvent::MetricsExchanged { metrics } => TopicLogSyncEvent::SyncStarted {
+                metrics: metrics.into(),
             },
-            LogSyncEvent::Data(operation) => TopicLogSyncEvent::Operation(operation),
+            LogSyncEvent::OperationReceived { operation, metrics } => {
+                TopicLogSyncEvent::OperationReceived {
+                    operation,
+                    metrics: metrics.into(),
+                }
+            }
         }
     }
 }
@@ -537,7 +603,6 @@ where
             .map_err(|err| TopicLogSyncChannelError::MessageSink(format!("{err:?}")))
     }
 }
-
 #[cfg(test)]
 pub mod tests {
     use std::collections::BTreeMap;
@@ -550,12 +615,11 @@ pub mod tests {
     use crate::ToSync;
     use crate::protocols::{LogSyncError, LogSyncMessage};
     use crate::test_utils::{
-        Peer, TestTopicSyncEvent, TestTopicSyncMessage, run_protocol, run_protocol_uni,
-        setup_logging,
+        Peer, TestTopicSyncMessage, run_protocol, run_protocol_uni, setup_logging,
     };
     use crate::traits::Protocol;
 
-    use super::{TopicLogSyncError, TopicLogSyncEvent, TopicLogSyncLiveMetrics};
+    use super::{TopicLogSyncError, TopicLogSyncEvent};
 
     #[tokio::test]
     async fn sync_session_no_operations() {
@@ -565,7 +629,7 @@ pub mod tests {
 
         let (session, mut events_rx, _) = peer.topic_sync_protocol(topic.clone(), false);
 
-        let remote_rx = run_protocol_uni(
+        let (_, remote_rx) = run_protocol_uni(
             session,
             &[
                 TestTopicSyncMessage::Sync(LogSyncMessage::Have(BTreeMap::default())),
@@ -577,21 +641,16 @@ pub mod tests {
 
         assert_matches!(
             events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStarted(_)
+            TopicLogSyncEvent::SyncStarted { .. }
         );
         assert_matches!(
             events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStatus(_)
+            TopicLogSyncEvent::SyncFinished { .. }
         );
         assert_matches!(
             events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStatus(_)
+            TopicLogSyncEvent::SessionFinished { .. }
         );
-        assert_matches!(
-            events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncFinished(_)
-        );
-        assert_matches!(events_rx.recv().await.unwrap(), TestTopicSyncEvent::Success);
 
         let messages = remote_rx.collect::<Vec<_>>().await;
         assert_eq!(messages.len(), 2);
@@ -628,7 +687,7 @@ pub mod tests {
 
         let (session, mut events_rx, _) = peer.topic_sync_protocol(topic.clone(), false);
 
-        let remote_rx = run_protocol_uni(
+        let (_, remote_rx) = run_protocol_uni(
             session,
             &[
                 TestTopicSyncMessage::Sync(LogSyncMessage::Have(BTreeMap::default())),
@@ -640,21 +699,16 @@ pub mod tests {
 
         assert_matches!(
             events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStarted(_)
+            TopicLogSyncEvent::SyncStarted { .. }
         );
         assert_matches!(
             events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStatus(_)
+            TopicLogSyncEvent::SyncFinished { .. }
         );
         assert_matches!(
             events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStatus(_)
+            TopicLogSyncEvent::SessionFinished { .. }
         );
-        assert_matches!(
-            events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncFinished(_)
-        );
-        assert_matches!(events_rx.recv().await.unwrap(), TestTopicSyncEvent::Success);
 
         let messages = remote_rx.collect::<Vec<_>>().await;
         assert_eq!(messages.len(), 6);
@@ -685,25 +739,25 @@ pub mod tests {
                 }
                 2 => {
                     let (header, body_inner) = assert_matches!(message, TestTopicSyncMessage::Sync(LogSyncMessage::Operation(
-                    header,
-                    Some(body),
-                )) => (header, body));
+                        header,
+                        Some(body),
+                    )) => (header, body));
                     assert_eq!(header, header_bytes_0);
                     assert_eq!(Body::new(&body_inner), body)
                 }
                 3 => {
                     let (header, body_inner) = assert_matches!(message, TestTopicSyncMessage::Sync(LogSyncMessage::Operation(
-                    header,
-                    Some(body),
-                )) => (header, body));
+                        header,
+                        Some(body),
+                    )) => (header, body));
                     assert_eq!(header, header_bytes_1);
                     assert_eq!(Body::new(&body_inner), body)
                 }
                 4 => {
                     let (header, body_inner) = assert_matches!(message, TestTopicSyncMessage::Sync(LogSyncMessage::Operation(
-                    header,
-                    Some(body),
-                )) => (header, body));
+                        header,
+                        Some(body),
+                    )) => (header, body));
                     assert_eq!(header, header_bytes_2);
                     assert_eq!(Body::new(&body_inner), body)
                 }
@@ -744,63 +798,56 @@ pub mod tests {
         // Assert peer a events.
         assert_matches!(
             peer_a_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStarted(_)
+            TopicLogSyncEvent::SyncStarted { .. }
         );
         assert_matches!(
             peer_a_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStatus(_)
+            TopicLogSyncEvent::SyncFinished { .. }
         );
         assert_matches!(
             peer_a_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStatus(_)
-        );
-        assert_matches!(
-            peer_a_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncFinished(_)
-        );
-        assert_matches!(
-            peer_a_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::Success
+            TopicLogSyncEvent::SessionFinished { .. }
         );
 
         // Assert peer b events.
         assert_matches!(
             peer_b_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStarted(_)
-        );
-        assert_matches!(
-            peer_b_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStatus(_)
-        );
-        assert_matches!(
-            peer_b_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncStatus(_)
+            TopicLogSyncEvent::SyncStarted { .. }
         );
         let (header, body_inner) = assert_matches!(
             peer_b_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::Operation (operation) => {let Operation {header, body, ..} = *operation; (header, body)}
+            TopicLogSyncEvent::OperationReceived { operation, .. } => {
+                let Operation { header, body, .. } = *operation;
+                (header, body)
+            }
         );
         assert_eq!(header, header_0);
         assert_eq!(body_inner.unwrap(), body);
         let (header, body_inner) = assert_matches!(
             peer_b_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::Operation (operation) => {let Operation {header, body, ..} = *operation; (header, body)}
+            TopicLogSyncEvent::OperationReceived { operation, .. } => {
+                let Operation { header, body, .. } = *operation;
+                (header, body)
+            }
         );
         assert_eq!(header, header_1);
         assert_eq!(body_inner.unwrap(), body);
         let (header, body_inner) = assert_matches!(
             peer_b_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::Operation (operation) => {let Operation {header, body, ..} = *operation; (header, body)}
+            TopicLogSyncEvent::OperationReceived { operation, .. } => {
+                let Operation { header, body, .. } = *operation;
+                (header, body)
+            }
         );
         assert_eq!(header, header_2);
         assert_eq!(body_inner.unwrap(), body);
         assert_matches!(
             peer_b_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::SyncFinished(_)
+            TopicLogSyncEvent::SyncFinished { .. }
         );
         assert_matches!(
             peer_b_events_rx.recv().await.unwrap(),
-            TestTopicSyncEvent::Success
+            TopicLogSyncEvent::SessionFinished { .. }
         );
     }
 
@@ -842,7 +889,7 @@ pub mod tests {
         live_mode_tx.send(ToSync::Close).await.unwrap();
 
         let total_bytes = header_bytes_0.len() + body.to_bytes().len();
-        let remote_rx = run_protocol_uni(
+        let (_, remote_rx) = run_protocol_uni(
             protocol,
             &[
                 TestTopicSyncMessage::Sync(LogSyncMessage::Have(BTreeMap::default())),
@@ -862,49 +909,34 @@ pub mod tests {
         .await
         .unwrap();
 
-        for index in 0..=8 {
-            let event = events_rx.recv().await.unwrap();
-            match index {
-                0 => {
-                    assert_matches!(event, TestTopicSyncEvent::SyncStarted(_));
-                }
-                1 => {
-                    assert_matches!(event, TestTopicSyncEvent::SyncStatus(_));
-                }
-                2 => {
-                    assert_matches!(event, TestTopicSyncEvent::SyncStatus(_));
-                }
-                3 => {
-                    assert_matches!(event, TestTopicSyncEvent::Operation(_));
-                }
-                4 => {
-                    assert_matches!(event, TestTopicSyncEvent::SyncFinished(_));
-                }
-                5 => {
-                    assert_matches!(event, TestTopicSyncEvent::LiveModeStarted);
-                }
-                6 => {
-                    assert_matches!(event, TestTopicSyncEvent::Operation(_));
-                }
-                7 => {
-                    let metrics = assert_matches!(event, TestTopicSyncEvent::LiveModeFinished(metrics) => metrics);
-                    let TopicLogSyncLiveMetrics {
-                        operations_received,
-                        operations_sent,
-                        bytes_received,
-                        bytes_sent,
-                    } = metrics;
-                    assert_eq!(operations_received, 2);
-                    assert_eq!(operations_sent, 1);
-                    assert_eq!(bytes_received, expected_bytes_received);
-                    assert_eq!(bytes_sent, expected_bytes_sent);
-                }
-                8 => {
-                    assert_matches!(event, TestTopicSyncEvent::Success)
-                }
-                _ => panic!(),
-            };
-        }
+        assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::SyncStarted { .. }
+        );
+        assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::OperationReceived { .. }
+        );
+        assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::SyncFinished { .. }
+        );
+        assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::LiveModeStarted
+        );
+        let metrics = assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::OperationReceived { metrics, .. } => metrics
+        );
+        assert_eq!(metrics.received_operations(), 2);
+        assert_eq!(metrics.sent_operations(), 1);
+        assert_eq!(metrics.received_bytes(), expected_bytes_received);
+        assert_eq!(metrics.sent_bytes(), expected_bytes_sent);
+        assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::SessionFinished { .. }
+        );
 
         let messages = remote_rx.collect::<Vec<_>>().await;
         assert_eq!(messages.len(), 4);
@@ -916,9 +948,9 @@ pub mod tests {
                 }
                 2 => {
                     let (header, body_inner) = assert_matches!(message, TestTopicSyncMessage::Live(
-                    header,
-                    Some(body)
-                ) => (header, body));
+                        header,
+                        Some(body)
+                    ) => (header, body));
                     assert_eq!(header, header_2);
                     assert_eq!(body_inner, body);
                 }
@@ -979,7 +1011,7 @@ pub mod tests {
         live_mode_tx.send(ToSync::Close).await.unwrap();
 
         let total_bytes = header_bytes_0.len() + body.to_bytes().len();
-        let remote_rx = run_protocol_uni(
+        let (_, remote_rx) = run_protocol_uni(
             protocol,
             &[
                 TestTopicSyncMessage::Sync(LogSyncMessage::Have(BTreeMap::default())),
@@ -1003,49 +1035,34 @@ pub mod tests {
         .await
         .unwrap();
 
-        for index in 0..=8 {
-            let event = events_rx.recv().await.unwrap();
-            match index {
-                0 => {
-                    assert_matches!(event, TestTopicSyncEvent::SyncStarted(_));
-                }
-                1 => {
-                    assert_matches!(event, TestTopicSyncEvent::SyncStatus(_));
-                }
-                2 => {
-                    assert_matches!(event, TestTopicSyncEvent::SyncStatus(_));
-                }
-                3 => {
-                    assert_matches!(event, TestTopicSyncEvent::Operation(_));
-                }
-                4 => {
-                    assert_matches!(event, TestTopicSyncEvent::SyncFinished(_));
-                }
-                5 => {
-                    assert_matches!(event, TestTopicSyncEvent::LiveModeStarted);
-                }
-                6 => {
-                    assert_matches!(event, TestTopicSyncEvent::Operation(_));
-                }
-                7 => {
-                    let metrics = assert_matches!(event, TestTopicSyncEvent::LiveModeFinished(metrics) => metrics);
-                    let TopicLogSyncLiveMetrics {
-                        operations_received,
-                        operations_sent,
-                        bytes_received,
-                        bytes_sent,
-                    } = metrics;
-                    assert_eq!(operations_received, 2);
-                    assert_eq!(operations_sent, 1);
-                    assert_eq!(bytes_received, expected_bytes_received);
-                    assert_eq!(bytes_sent, expected_bytes_sent);
-                }
-                8 => {
-                    assert_matches!(event, TestTopicSyncEvent::Success)
-                }
-                _ => panic!(),
-            };
-        }
+        assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::SyncStarted { .. }
+        );
+        assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::OperationReceived { .. }
+        );
+        assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::SyncFinished { .. }
+        );
+        assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::LiveModeStarted
+        );
+        let metrics = assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::OperationReceived { metrics, .. } => metrics
+        );
+        assert_eq!(metrics.received_operations(), 2);
+        assert_eq!(metrics.sent_operations(), 1);
+        assert_eq!(metrics.received_bytes(), expected_bytes_received);
+        assert_eq!(metrics.sent_bytes(), expected_bytes_sent);
+        assert_matches!(
+            events_rx.recv().await.unwrap(),
+            TopicLogSyncEvent::SessionFinished { .. }
+        );
 
         let messages = remote_rx.collect::<Vec<_>>().await;
         assert_eq!(messages.len(), 4);

--- a/p2panda-sync/src/test_utils.rs
+++ b/p2panda-sync/src/test_utils.rs
@@ -154,7 +154,10 @@ pub fn setup_logging() {
 }
 
 /// Run a pair of topic sync sessions.
-pub async fn run_protocol<P>(session_local: P, session_remote: P) -> Result<(), P::Error>
+pub async fn run_protocol<P>(
+    session_local: P,
+    session_remote: P,
+) -> Result<(P::Output, P::Output), P::Error>
 where
     P: Protocol + Send + 'static,
 {
@@ -168,16 +171,16 @@ where
         session_remote.run(&mut remote_message_tx, &mut local_message_rx)
     );
 
-    local_result?;
-    remote_result?;
-    Ok(())
+    let local_output = local_result?;
+    let remote_output = remote_result?;
+    Ok((local_output, remote_output))
 }
 
 /// Consume a vector of messages in a single topic sync session.
 pub async fn run_protocol_uni<P>(
     protocol: P,
     messages: &[P::Message],
-) -> Result<mpsc::Receiver<P::Message>, P::Error>
+) -> Result<(P::Output, mpsc::Receiver<P::Message>), P::Error>
 where
     P: Protocol,
     P::Message: Clone,
@@ -190,11 +193,11 @@ where
         remote_message_tx.send(message.to_owned()).await.unwrap();
     }
 
-    protocol
+    let result = protocol
         .run(&mut local_message_tx, &mut local_message_rx)
         .await?;
 
-    Ok(remote_message_rx)
+    Ok((result, remote_message_rx))
 }
 
 pub async fn drain_stream<S>(mut stream: S) -> Vec<S::Item>

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -5,6 +5,7 @@ mod event_stream;
 mod offset;
 mod replay;
 mod stream;
+mod sync_metrics;
 
 pub(crate) use ephemeral_stream::ephemeral_stream;
 pub use ephemeral_stream::{
@@ -14,5 +15,6 @@ pub use event_stream::{SystemEvent, SystemEventStream};
 pub use offset::Offset;
 pub(crate) use stream::processed_stream;
 pub use stream::{
-    ProcessedOperation, PublishFuture, StreamEvent, StreamPublisher, StreamSubscription,
+    ProcessedOperation, PublishFuture, Source, StreamEvent, StreamPublisher, StreamSubscription,
 };
+pub use sync_metrics::{SessionPhase, SyncError};

--- a/p2panda/src/streams/replay.rs
+++ b/p2panda/src/streams/replay.rs
@@ -16,7 +16,7 @@ use crate::node::AckPolicy;
 use crate::operation::{Extensions, LogId, Operation};
 use crate::processor::Pipeline;
 use crate::streams::StreamEvent;
-use crate::streams::stream::process_operation;
+use crate::streams::stream::{Source, process_operation};
 
 /// Retrieve from the store and re-process all operations for a given topic.
 pub(crate) async fn replay_from_start<M>(
@@ -59,7 +59,15 @@ where
     // Pull operations from the replay channel and send them to the processing pipeline.
     loop {
         if let Some(operation) = replay_rx.recv().await {
-            match process_operation::<M>(operation, topic, &pipeline, ack_policy).await {
+            match process_operation::<M>(
+                operation,
+                topic,
+                &pipeline,
+                ack_policy,
+                Source::LocalStore,
+            )
+            .await
+            {
                 Some(event) => {
                     app_tx
                         .send(event)

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -25,8 +25,9 @@ use crate::forge::{Forge, ForgeError, OperationForge};
 use crate::node::AckPolicy;
 use crate::operation::{Extensions, LogId, Operation};
 use crate::processor::{Event, Pipeline};
-use crate::streams::Offset;
 use crate::streams::replay::replay_from_start;
+use crate::streams::sync_metrics::{Aggregator, SessionPhase, SyncError};
+use crate::streams::{Offset, sync_metrics};
 
 /// Number of items which can stay in the buffer before the application-layer picks up the
 /// operations. If buffer runs full the processor will pause work and we'll apply backpressure to
@@ -138,6 +139,7 @@ where
                 }
             }
 
+            let mut aggregator = Aggregator::new();
             loop {
                 let event = tokio::select! {
                     // Received incoming operation from remote source.
@@ -156,41 +158,26 @@ where
                             continue;
                         };
 
-                        match from_sync.event {
-                            TopicLogSyncEvent::Operation(operation) => {
+                        let Some(event) = aggregator.process(from_sync) else {
+                            continue;
+                        };
+
+                        match event {
+                            sync_metrics::SyncEvent::SyncStarted { .. } => event.into(),
+                            sync_metrics::SyncEvent::SyncEnded { .. } => event.into(),
+                            sync_metrics::SyncEvent::OperationReceived { operation, source } => {
                                 let Some(event) = process_operation::<M>(
                                     *operation.clone(),
                                     topic,
                                     &pipeline,
-                                    ack_policy
+                                    ack_policy,
+                                    source
                                 ).await else {
                                     continue;
                                 };
 
                                 event
-                            }
-                            // TODO: Correctly handle log sync events.
-                            TopicLogSyncEvent::SyncStatus(metrics) => StreamEvent::SyncStarted {
-                                remote_node_id: from_sync.remote,
-                                session_id: from_sync.session_id,
-                                incoming_operations: metrics.total_operations_remote
-                                    .unwrap_or_default(),
-                                outgoing_operations: metrics.total_operations_local
-                                    .unwrap_or_default(),
-                                incoming_bytes: metrics.total_bytes_remote
-                                    .unwrap_or_default(),
-                                outgoing_bytes: metrics.total_bytes_local
-                                    .unwrap_or_default(),
                             },
-                            TopicLogSyncEvent::Success => StreamEvent::SyncEnded {
-                                remote_node_id: from_sync.remote,
-                                session_id: from_sync.session_id,
-                            },
-                            TopicLogSyncEvent::Failed { .. } => StreamEvent::SyncEnded {
-                                remote_node_id: from_sync.remote,
-                                session_id: from_sync.session_id,
-                            },
-                            _ => continue,
                         }
                     }
 
@@ -211,11 +198,14 @@ where
                         let _ = processed_tx.send(event.clone());
 
                         if let Some(message) = message {
-                            StreamEvent::Processed(ProcessedOperation {
-                                event,
-                                topic,
-                                message,
-                            })
+                            StreamEvent::Processed{
+                                operation: ProcessedOperation {
+                                    event,
+                                    topic,
+                                    message,
+                                },
+                                source: Source::LocalStore
+                            }
                         } else {
                             continue;
                         }
@@ -258,6 +248,7 @@ pub(crate) async fn process_operation<M>(
     topic: Topic,
     pipeline: &Pipeline<LogId, Extensions, Topic>,
     ack_policy: AckPolicy,
+    source: Source,
 ) -> Option<StreamEvent<M>>
 where
     M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
@@ -298,11 +289,14 @@ where
     // TODO: Is this mixing up concerns? We can only handle bytes on our end and let the users do
     // decoding on application layer?
     let event = match decode_cbor::<M, _>(body.as_bytes()) {
-        Ok(message) => StreamEvent::Processed(ProcessedOperation {
-            event,
-            topic,
-            message,
-        }),
+        Ok(message) => StreamEvent::Processed {
+            operation: ProcessedOperation {
+                event,
+                topic,
+                message,
+            },
+            source,
+        },
         Err(err) => StreamEvent::DecodingFailed {
             event,
             topic,
@@ -489,19 +483,64 @@ where
 }
 
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum StreamEvent<M> {
-    Processed(ProcessedOperation<M>),
+    Processed {
+        /// Processed operation.
+        operation: ProcessedOperation<M>,
+
+        /// The source of the operation.
+        source: Source,
+    },
     SyncStarted {
+        /// Id of the remote sending node.
         remote_node_id: NodeId,
+
+        /// Id of the sync session.
         session_id: u64,
+
+        /// Total operations which will be received during this session.
         incoming_operations: u64,
+
+        /// Total operations which will be sent during this session.
         outgoing_operations: u64,
+
+        /// Total bytes which will be received during this session.
         incoming_bytes: u64,
+
+        /// Total bytes which will be sent during this session.
         outgoing_bytes: u64,
+
+        /// Total sessions currently running over the same topic.
+        topic_sessions: u64,
     },
     SyncEnded {
+        /// Id of the remote sending node.
         remote_node_id: NodeId,
+
+        /// Id of the sync session.
         session_id: u64,
+
+        /// Operation sent during this session.
+        sent_operations: u64,
+
+        /// Operations received during this session.
+        received_operations: u64,
+
+        /// Bytes sent during this session.
+        sent_bytes: u64,
+
+        /// Bytes received during this session.
+        received_bytes: u64,
+
+        /// Total bytes sent for this topic across all sessions.
+        sent_bytes_topic_total: u64,
+
+        /// Total bytes received for this topic across all sessions.
+        received_bytes_topic_total: u64,
+
+        /// If the sync session ended with an error the reason is included here.
+        error: Option<SyncError>,
     },
     DecodingFailed {
         event: Event<LogId, Extensions, Topic>,
@@ -549,6 +588,44 @@ impl<M> ProcessedOperation<M> {
     pub async fn ack(&self) {
         unimplemented!()
     }
+}
+
+/// The source of a processed operation.
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum Source {
+    /// Source when an operation arrived via a sync session.
+    SyncSession {
+        /// Id of the remote sending node.
+        remote_node_id: NodeId,
+
+        /// Id of the sync session.
+        session_id: u64,
+
+        /// Operation sent during this session.
+        sent_operations: u64,
+
+        /// Operations received during this session.
+        received_operations: u64,
+
+        /// Bytes sent during this session.
+        sent_bytes: u64,
+
+        /// Bytes received during this session.
+        received_bytes: u64,
+
+        /// Total bytes sent for this topic across all sessions.
+        sent_bytes_topic_total: u64,
+
+        /// Total bytes received for this topic across all sessions.
+        received_bytes_topic_total: u64,
+
+        /// The session phase during which an operation arrived.
+        phase: SessionPhase,
+    },
+
+    /// Source when an operation was published locally or replayed.
+    LocalStore,
 }
 
 #[derive(Debug, Error)]

--- a/p2panda/src/streams/sync_metrics.rs
+++ b/p2panda/src/streams/sync_metrics.rs
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+
+use p2panda_core::{Extensions, Operation};
+use p2panda_net::NodeId;
+use p2panda_sync::FromSync;
+use p2panda_sync::protocols::{Metrics, TopicLogSyncEvent};
+use thiserror::Error;
+
+use crate::streams::StreamEvent;
+use crate::streams::stream::Source;
+
+type SessionId = u64;
+
+/// Track state of all running sync sessions for a topic and calculate useful aggregate data.
+#[derive(Clone, Debug, Default)]
+pub struct Aggregator {
+    /// Total number of running sync sessions for a topic.
+    running_sessions: u64,
+
+    /// Total number of bytes sent across all topic sessions.
+    total_bytes_sent: u64,
+
+    /// Total number of received bytes across all topic sessions.
+    total_bytes_received: u64,
+
+    /// Latest metrics for all sessions.
+    session_metrics: HashMap<SessionId, Metrics>,
+
+    /// Set of running sessions which have entered live mode.
+    live_mode: HashSet<SessionId>,
+}
+
+impl Aggregator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Process a `TopicLogSyncEvent`, collect metrics and calculate aggregates and return
+    /// enriched aggregate event types.
+    pub fn process<E: Extensions>(
+        &mut self,
+        from_sync: FromSync<TopicLogSyncEvent<E>>,
+    ) -> Option<SyncEvent<E>> {
+        let FromSync {
+            session_id,
+            remote,
+            event,
+            ..
+        } = from_sync;
+
+        match event {
+            TopicLogSyncEvent::SessionStarted => {
+                self.running_sessions += 1;
+                // Insert default metrics into the session metrics map for now, these will be
+                // removed or over-written on the next event.
+                self.session_metrics.insert(session_id, Metrics::default());
+                None
+            }
+            TopicLogSyncEvent::SyncStarted { metrics } => {
+                self.session_metrics.insert(session_id, metrics.clone());
+                Some(SyncEvent::SyncStarted {
+                    remote,
+                    session_id,
+                    incoming_operations: metrics.inbound_sync_operations,
+                    outgoing_operations: metrics.outbound_sync_operations,
+                    incoming_bytes: metrics.inbound_sync_bytes,
+                    outgoing_bytes: metrics.outbound_sync_bytes,
+                    topic_sessions: self.running_sessions(),
+                })
+            }
+            TopicLogSyncEvent::OperationReceived { operation, metrics } => {
+                self.session_metrics.insert(session_id, metrics.clone());
+                Some(SyncEvent::OperationReceived {
+                    operation,
+                    source: Source::SyncSession {
+                        remote_node_id: remote,
+                        session_id,
+                        sent_bytes: metrics.sent_bytes(),
+                        received_bytes: metrics.received_bytes(),
+                        sent_operations: metrics.sent_operations(),
+                        received_operations: metrics.received_operations(),
+                        sent_bytes_topic_total: self.total_bytes_sent(),
+                        received_bytes_topic_total: self.total_bytes_received(),
+                        phase: if self.live_mode.contains(&session_id) {
+                            SessionPhase::Live
+                        } else {
+                            SessionPhase::Sync
+                        },
+                    },
+                })
+            }
+            TopicLogSyncEvent::SyncFinished { metrics } => {
+                self.session_metrics.insert(session_id, metrics.clone());
+                self.total_bytes_sent += metrics.sent_bytes();
+                self.total_bytes_received += metrics.received_bytes();
+                None
+            }
+            TopicLogSyncEvent::SessionFinished { metrics } => {
+                self.handle_session_end(session_id);
+                self.total_bytes_sent += metrics.sent_bytes();
+                self.total_bytes_received += metrics.received_bytes();
+                Some(SyncEvent::SyncEnded {
+                    remote,
+                    session_id,
+                    sent_bytes: metrics.sent_bytes(),
+                    received_bytes: metrics.received_bytes(),
+                    sent_operations: metrics.sent_operations(),
+                    received_operations: metrics.received_operations(),
+                    sent_bytes_topic_total: self.total_bytes_sent(),
+                    received_bytes_topic_total: self.total_bytes_received(),
+                    error: None,
+                })
+            }
+            TopicLogSyncEvent::Failed { error } => {
+                let metrics = self.handle_session_end(session_id);
+                Some(SyncEvent::SyncEnded {
+                    remote,
+                    session_id,
+                    sent_bytes: metrics.sent_bytes(),
+                    received_bytes: metrics.received_bytes(),
+                    sent_operations: metrics.sent_operations(),
+                    received_operations: metrics.received_operations(),
+                    sent_bytes_topic_total: self.total_bytes_sent(),
+                    received_bytes_topic_total: self.total_bytes_received(),
+                    error: Some(SyncError(error)),
+                })
+            }
+            TopicLogSyncEvent::LiveModeStarted => {
+                self.live_mode.insert(session_id);
+                None
+            }
+        }
+    }
+
+    fn handle_session_end(&mut self, session_id: SessionId) -> Metrics {
+        self.running_sessions = self.running_sessions.saturating_sub(1);
+        self.live_mode.remove(&session_id);
+        self.session_metrics.remove(&session_id).unwrap_or_default()
+    }
+
+    /// Total running sessions for a topic.
+    pub fn running_sessions(&self) -> u64 {
+        self.running_sessions
+    }
+
+    /// Total bytes sent on a topic.
+    pub fn total_bytes_sent(&self) -> u64 {
+        self.total_bytes_sent
+    }
+
+    /// Total bytes received on a topic.
+    pub fn total_bytes_received(&self) -> u64 {
+        self.total_bytes_received
+    }
+}
+
+/// Which phase of a sync session an operation arrived in.
+#[derive(Clone, Debug)]
+pub enum SessionPhase {
+    Sync,
+    Live,
+}
+
+/// Intermediate sync event type enriched with aggregate data.
+#[derive(Debug)]
+pub(crate) enum SyncEvent<E> {
+    SyncStarted {
+        remote: NodeId,
+        session_id: u64,
+        incoming_operations: u64,
+        outgoing_operations: u64,
+        incoming_bytes: u64,
+        outgoing_bytes: u64,
+        topic_sessions: u64,
+    },
+    SyncEnded {
+        remote: NodeId,
+        session_id: u64,
+        sent_operations: u64,
+        received_operations: u64,
+        sent_bytes: u64,
+        received_bytes: u64,
+        sent_bytes_topic_total: u64,
+        received_bytes_topic_total: u64,
+        error: Option<SyncError>,
+    },
+    OperationReceived {
+        operation: Box<Operation<E>>,
+        source: Source,
+    },
+}
+
+impl<E, M> From<SyncEvent<E>> for StreamEvent<M> {
+    fn from(value: SyncEvent<E>) -> Self {
+        match value {
+            SyncEvent::SyncStarted {
+                remote,
+                session_id,
+                incoming_operations,
+                outgoing_operations,
+                incoming_bytes,
+                outgoing_bytes,
+                topic_sessions,
+            } => StreamEvent::SyncStarted {
+                remote_node_id: remote,
+                session_id,
+                incoming_operations,
+                outgoing_operations,
+                incoming_bytes,
+                outgoing_bytes,
+                topic_sessions,
+            },
+            SyncEvent::SyncEnded {
+                remote,
+                session_id,
+                sent_operations,
+                received_operations,
+                sent_bytes,
+                received_bytes,
+                sent_bytes_topic_total,
+                received_bytes_topic_total,
+                error,
+            } => StreamEvent::SyncEnded {
+                remote_node_id: remote,
+                session_id,
+                sent_operations,
+                received_operations,
+                sent_bytes,
+                received_bytes,
+                sent_bytes_topic_total,
+                received_bytes_topic_total,
+                error,
+            },
+            // We can't convert operation events simply like this as they need to be processed and
+            // decoded first so this branch is never called.
+            SyncEvent::OperationReceived { .. } => unreachable!(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Error)]
+#[error("an error occurred during sync: {0}")]
+pub struct SyncError(String);
+
+#[cfg(test)]
+mod tests {
+    use p2panda_net::NodeId;
+    use p2panda_sync::FromSync;
+    use p2panda_sync::protocols::{Metrics, TopicLogSyncEvent};
+
+    use crate::streams::sync_metrics::{Aggregator, SyncEvent};
+
+    fn from_sync(session_id: u64, event: TopicLogSyncEvent<()>) -> FromSync<TopicLogSyncEvent<()>> {
+        FromSync {
+            session_id,
+            remote: NodeId::default(),
+            event,
+        }
+    }
+
+    #[test]
+    fn running_sessions() {
+        let mut aggregator = Aggregator::new();
+
+        aggregator.process(from_sync(1, TopicLogSyncEvent::SessionStarted));
+        aggregator.process(from_sync(2, TopicLogSyncEvent::SessionStarted));
+        assert_eq!(aggregator.running_sessions(), 2);
+
+        aggregator.process(from_sync(
+            1,
+            TopicLogSyncEvent::SessionFinished {
+                metrics: Metrics::default(),
+            },
+        ));
+        assert_eq!(aggregator.running_sessions(), 1);
+    }
+
+    #[test]
+    fn failed_session() {
+        let mut aggregator = Aggregator::new();
+
+        aggregator.process(from_sync(1, TopicLogSyncEvent::SessionStarted));
+        assert_eq!(aggregator.running_sessions(), 1);
+
+        let result = aggregator.process(from_sync(
+            1,
+            TopicLogSyncEvent::Failed {
+                error: "connection dropped".to_string(),
+            },
+        ));
+        assert_eq!(aggregator.running_sessions(), 0);
+
+        match result {
+            Some(SyncEvent::SyncEnded { error, .. }) => {
+                assert!(error.is_some(), "expected an error on failed session");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn aggregate_bytes() {
+        let mut aggregator = Aggregator::new();
+
+        let metrics_start_a = Metrics {
+            inbound_sync_bytes: 100,
+            outbound_sync_bytes: 50,
+            ..Default::default()
+        };
+
+        let metrics_start_b = Metrics {
+            inbound_sync_bytes: 100,
+            outbound_sync_bytes: 80,
+            ..Default::default()
+        };
+
+        let metrics_end_a = Metrics {
+            inbound_sync_bytes: 100,
+            outbound_sync_bytes: 50,
+            received_sync_bytes: 100,
+            sent_sync_bytes: 50,
+            ..Default::default()
+        };
+
+        let metrics_end_b = Metrics {
+            inbound_sync_bytes: 100,
+            outbound_sync_bytes: 50,
+            received_sync_bytes: 100,
+            sent_sync_bytes: 80,
+            ..Default::default()
+        };
+
+        aggregator.process(from_sync(1, TopicLogSyncEvent::SessionStarted));
+        aggregator.process(from_sync(
+            1,
+            TopicLogSyncEvent::SyncStarted {
+                metrics: metrics_start_a,
+            },
+        ));
+        aggregator.process(from_sync(
+            1,
+            TopicLogSyncEvent::SyncFinished {
+                metrics: metrics_end_a,
+            },
+        ));
+        aggregator.process(from_sync(2, TopicLogSyncEvent::SessionStarted));
+        aggregator.process(from_sync(
+            2,
+            TopicLogSyncEvent::SyncStarted {
+                metrics: metrics_start_b,
+            },
+        ));
+        aggregator.process(from_sync(
+            2,
+            TopicLogSyncEvent::SyncFinished {
+                metrics: metrics_end_b,
+            },
+        ));
+
+        assert_eq!(aggregator.total_bytes_received(), 200);
+        assert_eq!(aggregator.total_bytes_sent(), 130);
+    }
+}

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -91,8 +91,8 @@ async fn eventually_consistent_stream() {
     let mut received: Option<ProcessedOperation<String>> = None;
 
     while let Some(event) = icebear_rx.next().await {
-        if let StreamEvent::Processed(processed) = event {
-            received = Some(processed);
+        if let StreamEvent::Processed { operation, .. } = event {
+            received = Some(operation);
             break;
         }
     }
@@ -134,8 +134,8 @@ async fn replay_stream() {
     let mut received = vec![];
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Processed(processed) = event {
-            received.push(processed);
+        if let StreamEvent::Processed { operation, .. } = event {
+            received.push(operation);
             if received.len() == 2 {
                 break;
             }
@@ -182,7 +182,7 @@ async fn log_prefix_pruning() {
     // 5. We wait until icebear processed the (from their perspective remotely incoming) pruning
     //    operation as well.
     while let Some(event) = icebear_rx.next().await {
-        if let StreamEvent::Processed(operation) = event {
+        if let StreamEvent::Processed { operation, .. } = event {
             assert!(operation.processed().is_completed());
             assert!(!operation.processed().is_failed());
 


### PR DESCRIPTION
Many sync sessions for a topic run concurrently and the events they emit are more fine-grained than what we want to forward to users of p2panda Node. We also want to offer insight into sync metrics for an entire topic (rather than per-session) and so should calculate aggregates and forward these in stream events.

This change makes some improvements to the lower level sync events and then introduces an aggregator which processes these events in the stream and emits intermediate events containing additional metrics and aggregate fields.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
