### PR TITLE
System event stream API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Highlights are marked with a pancake 🥞
 - Log-prefix pruning processor [#1073](https://github.com/p2panda/p2panda/pull/1073)
 - Process local operations [#1080](https://github.com/p2panda/p2panda/pull/1080)
 - Process and aggregate metrics for sync events [#1085](https://github.com/p2panda/p2panda/pull/1085)
+- Introduce system event API for Node [#1087](https://github.com/p2panda/p2panda/pull/1087)
 
 ### Changed
 

--- a/p2panda/src/forge.rs
+++ b/p2panda/src/forge.rs
@@ -166,7 +166,7 @@ mod tests {
     #[tokio::test]
     async fn operation_forge() {
         let store = SqliteStore::temporary().await;
-        let mut forge = OperationForge::new(store.clone());
+        let forge = OperationForge::new(store.clone());
 
         let topic = Topic::new();
         let log_id = LogId::from_topic(topic);

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -2,7 +2,8 @@
 
 use std::fmt::Debug;
 
-pub use p2panda_core::{Hash, PrivateKey, PublicKey, Topic};
+use futures_util::Stream;
+use p2panda_core::{Hash, Topic};
 use p2panda_store::sqlite::{SqliteError, SqliteStore, SqliteStoreBuilder};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -18,7 +19,7 @@ use crate::operation::{Extensions, LogId};
 use crate::processor::{Pipeline, TaskTracker};
 use crate::streams::{
     EphemeralStreamPublisher, EphemeralStreamSubscription, Offset, StreamPublisher,
-    StreamSubscription, SystemEventStream, ephemeral_stream, processed_stream,
+    StreamSubscription, SystemEvent, ephemeral_stream, event_stream, processed_stream,
 };
 
 #[derive(Debug)]
@@ -82,6 +83,10 @@ impl Node {
     }
 
     /// Eventually consistent publish and subscribe stream of messages.
+    ///
+    /// Items emitted from the stream include operations, sync events and system events (ie.
+    /// network-related events, such as discovery events, which are not directly associated with a
+    /// specific topic).
     pub async fn stream<M>(
         &self,
         topic: impl Into<Topic>,
@@ -150,8 +155,21 @@ impl Node {
         Ok(ephemeral_stream(topic, self.forge.clone(), handle))
     }
 
-    pub async fn events(&self) -> Result<SystemEventStream, CreateStreamError> {
-        unimplemented!()
+    /// System event stream.
+    ///
+    /// System events include all network-related events, such as discovery events, which are not
+    /// associated with a specific topic.
+    pub async fn event_stream(
+        &self,
+    ) -> Result<impl Stream<Item = SystemEvent> + Send + Unpin + 'static, CreateStreamError> {
+        let discovery_events = self
+            .network
+            .discovery
+            .events()
+            .await
+            .map_err(|err| CreateStreamError(err.to_string()))?;
+
+        Ok(event_stream(discovery_events))
     }
 
     pub fn id(&self) -> NodeId {

--- a/p2panda/src/streams/event_stream.rs
+++ b/p2panda/src/streams/event_stream.rs
@@ -1,18 +1,33 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
 use futures_util::Stream;
+use futures_util::stream::{SelectAll, StreamExt};
+use p2panda_net::discovery::DiscoveryEvent;
+use tokio::sync::broadcast::Receiver as BroadcastReceiver;
+use tokio_stream::wrappers::BroadcastStream;
 
-pub struct SystemEventStream;
-
-impl Stream for SystemEventStream {
-    type Item = SystemEvent;
-
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        todo!()
-    }
+/// System event.
+///
+/// System events encompass all network-related events which are not directly associated with a
+/// topic.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SystemEvent {
+    Discovery(DiscoveryEvent),
 }
 
-pub enum SystemEvent {}
+/// Merge the provided event streams into a single, unified system event stream.
+pub(crate) fn event_stream(
+    discovery_events: BroadcastReceiver<DiscoveryEvent>,
+) -> impl Stream<Item = SystemEvent> + Send + Unpin + 'static {
+    let discovery_broadcast_stream = BroadcastStream::new(discovery_events);
+
+    let discovery_stream = Box::pin(
+        discovery_broadcast_stream
+            .filter_map(|event| async { event.ok().map(SystemEvent::Discovery) }),
+    );
+
+    let mut stream_set = SelectAll::new();
+    stream_set.push(discovery_stream);
+
+    Box::pin(stream_set)
+}

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -11,7 +11,8 @@ pub(crate) use ephemeral_stream::ephemeral_stream;
 pub use ephemeral_stream::{
     EphemeralMessage, EphemeralStreamPublisher, EphemeralStreamSubscription, PublishError,
 };
-pub use event_stream::{SystemEvent, SystemEventStream};
+pub use event_stream::SystemEvent;
+pub(crate) use event_stream::event_stream;
 pub use offset::Offset;
 pub(crate) use stream::processed_stream;
 pub use stream::{

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -81,6 +81,7 @@ const PUBLISH_BUFFER_SIZE: usize = 128;
 ///               │ Application Stream  │
 ///               └─────────────────────┘
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn processed_stream<M>(
     topic: Topic,
     ack_policy: AckPolicy,
@@ -142,7 +143,7 @@ where
             let mut aggregator = Aggregator::new();
             loop {
                 let event = tokio::select! {
-                    // Received incoming operation from remote source.
+                   // Received incoming operation from remote source.
                     item = sync_stream.next() => {
                         let Some(result) = item else {
                             // Log sync stream seized, we stop the task as well.

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -5,9 +5,10 @@ use std::time::Duration;
 use futures_util::StreamExt;
 use mock_instant::thread_local::MockClock;
 use p2panda::operation::{LogId, Operation};
-use p2panda::streams::{EphemeralMessage, Offset, ProcessedOperation, StreamEvent};
+use p2panda::streams::{EphemeralMessage, Offset, ProcessedOperation, StreamEvent, SystemEvent};
 use p2panda::test_utils::setup_logging;
 use p2panda_core::{PrivateKey, Topic};
+use p2panda_net::discovery::DiscoveryEvent;
 use p2panda_store::logs::LogStore;
 use tokio::task::JoinHandle;
 
@@ -82,7 +83,7 @@ async fn eventually_consistent_stream() {
     let icebear = p2panda::builder().spawn().await.unwrap();
 
     // Panda joins the chat and sends a message to icebear.
-    let (mut panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
+    let (panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
     panda_tx.publish("Hello, Icebear!".into()).await.unwrap();
 
     // Icebear joins the chat and waits for a message of panda.
@@ -113,7 +114,7 @@ async fn replay_stream() {
 
     // Panda subscribes to chat and publishes one message.
     {
-        let (mut panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
+        let (panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
         panda_tx.publish("Hello, Icebear!".into()).await.unwrap();
     }
 
@@ -126,7 +127,7 @@ async fn replay_stream() {
         .unwrap();
 
     // Icebear joins the chat and publishes one message.
-    let (mut icebear_tx, _icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
+    let (icebear_tx, _icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
     icebear_tx.publish("Hello, Panda!".into()).await.unwrap();
 
     // Panda should receive the first message they sent again, followed by Icebear's message which
@@ -147,6 +148,38 @@ async fn replay_stream() {
 }
 
 #[tokio::test]
+async fn event_stream() {
+    setup_logging();
+
+    let chat_id = Topic::new();
+
+    let panda = p2panda::builder().spawn().await.unwrap();
+    let icebear = p2panda::builder().spawn().await.unwrap();
+
+    // Panda joins the chat and sends a message to icebear.
+    let (panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
+    panda_tx.publish("Hello, Icebear!".into()).await.unwrap();
+
+    // Icebear joins the chat.
+    let (_icebear_tx, _icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
+
+    // Create a system event stream for panda.
+    let mut events = panda.event_stream().await.unwrap();
+
+    let mut received_event = false;
+
+    // Wait for the first discovery session started event.
+    while let Some(event) = events.next().await {
+        if let SystemEvent::Discovery(DiscoveryEvent::SessionStarted { .. }) = event {
+            received_event = true;
+            break;
+        }
+    }
+
+    assert!(received_event);
+}
+
+#[tokio::test]
 async fn log_prefix_pruning() {
     setup_logging();
 
@@ -155,7 +188,7 @@ async fn log_prefix_pruning() {
     let panda = p2panda::builder().spawn().await.unwrap();
     let icebear = p2panda::builder().spawn().await.unwrap();
 
-    let (mut panda_tx, _) = panda.stream::<usize>(topic).await.unwrap();
+    let (panda_tx, _) = panda.stream::<usize>(topic).await.unwrap();
 
     // 1. Panda publishes 3 operations into their append-only log.
     panda_tx.publish(1).await.unwrap();


### PR DESCRIPTION
Here we introduce an `event_stream` method on the `Node` API which
serves as an aggregator for several network-related system event
streams. The event stream currently emits discovery events, with further
events still to be added.

The implementation uses `SelectAll` to allow merging several streams
into one.

Related to: https://github.com/p2panda/p2panda/issues/1083

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
