### PR TITLE
Return error when gossip message exceeds maximum size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Highlights are marked with a pancake 🥞
 - Process local operations [#1080](https://github.com/p2panda/p2panda/pull/1080)
 - Process and aggregate metrics for sync events [#1085](https://github.com/p2panda/p2panda/pull/1085)
 - Introduce system event API for Node [#1087](https://github.com/p2panda/p2panda/pull/1087)
+- Return error when gossip message exceeds maximum size [#1096](https://github.com/p2panda/p2panda/pull/1096)
 
 ### Changed
 

--- a/p2panda-net/src/gossip/api.rs
+++ b/p2panda-net/src/gossip/api.rs
@@ -9,6 +9,7 @@ use p2panda_core::Topic;
 use p2panda_store::address_book::NodeInfo as _;
 use ractor::{ActorRef, call};
 use thiserror::Error;
+use tokio::sync::mpsc::error::SendError;
 use tokio::sync::{RwLock, broadcast, mpsc};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
@@ -16,6 +17,7 @@ use tracing::trace;
 
 use crate::NodeId;
 use crate::address_book::{AddressBook, AddressBookError};
+use crate::gossip::GossipConfig;
 use crate::gossip::actors::ToGossipManager;
 use crate::gossip::builder::Builder;
 use crate::gossip::events::GossipEvent;
@@ -113,6 +115,7 @@ pub struct Gossip {
     address_book: AddressBook,
     inner: Arc<RwLock<Inner>>,
     senders: Arc<RwLock<GossipSenders>>,
+    config: GossipConfig,
 }
 
 #[derive(Debug)]
@@ -125,12 +128,14 @@ impl Gossip {
         actor_ref: ActorRef<ToGossipManager>,
         my_node_id: NodeId,
         address_book: AddressBook,
+        config: GossipConfig,
     ) -> Self {
         Self {
             my_node_id,
             address_book,
             inner: Arc::new(RwLock::new(Inner { actor_ref })),
             senders: Arc::new(RwLock::new(HashMap::new())),
+            config,
         }
     }
 
@@ -141,6 +146,8 @@ impl Gossip {
     /// Join gossip overlay for this topic and return a handle to publish messages to it or receive
     /// messages from the network.
     pub async fn stream(&self, topic: Topic) -> Result<GossipHandle, GossipError> {
+        let max_message_size = self.config.max_message_size;
+
         // Check if there's already a handle for this topic and clone it.
         //
         // If this handle exists but the topic counter is zero we know that all previous handles
@@ -152,6 +159,7 @@ impl Gossip {
         {
             return Ok(GossipHandle::new(
                 topic,
+                max_message_size,
                 to_gossip_tx.clone(),
                 from_gossip_tx.clone(),
                 guard.clone(),
@@ -203,6 +211,7 @@ impl Gossip {
 
         Ok(GossipHandle::new(
             topic,
+            max_message_size,
             to_gossip_tx,
             from_gossip_tx,
             guard,
@@ -246,11 +255,21 @@ pub enum GossipError {
     AddressBook(#[from] AddressBookError),
 }
 
+#[derive(Debug, Error, PartialEq)]
+pub enum GossipPublishError {
+    #[error("message size exceeds maximum limit ({} vs {})", .0.0, .0.1)]
+    MessageTooLarge((usize, usize)),
+
+    #[error(transparent)]
+    SendError(SendError<Vec<u8>>),
+}
+
 /// Handle for publishing ephemeral messages into the gossip overlay and receiving from the
 /// network for a specific topic.
 #[derive(Clone, Debug)]
 pub struct GossipHandle {
     topic: Topic,
+    max_message_size: usize,
     to_topic_tx: mpsc::Sender<Vec<u8>>,
     from_gossip_tx: broadcast::Sender<Vec<u8>>,
     _guard: TopicDropGuard,
@@ -259,12 +278,14 @@ pub struct GossipHandle {
 impl GossipHandle {
     fn new(
         topic: Topic,
+        max_message_size: usize,
         to_topic_tx: mpsc::Sender<Vec<u8>>,
         from_gossip_tx: broadcast::Sender<Vec<u8>>,
         _guard: TopicDropGuard,
     ) -> Self {
         Self {
             topic,
+            max_message_size,
             to_topic_tx,
             from_gossip_tx,
             _guard,
@@ -272,11 +293,27 @@ impl GossipHandle {
     }
 
     /// Publishes a message to the stream.
-    pub async fn publish(
-        &self,
-        bytes: impl Into<Vec<u8>>,
-    ) -> Result<(), mpsc::error::SendError<Vec<u8>>> {
-        self.to_topic_tx.send(bytes.into()).await
+    ///
+    /// An error will be returned if the size of the bytes exceeds the configured maximum message
+    /// size.
+    pub async fn publish(&self, bytes: impl Into<Vec<u8>>) -> Result<(), GossipPublishError> {
+        let bytes: Vec<u8> = bytes.into();
+        let message_size = bytes.len();
+
+        // NOTE(glyph): iroh-gossip currently fails silently when the message size exceeds the
+        // configured maximum; not even a warning is logged. We check the size here and return an
+        // error to guard against unexplained behaviour.
+        if message_size > self.max_message_size {
+            return Err(GossipPublishError::MessageTooLarge((
+                message_size,
+                self.max_message_size,
+            )));
+        }
+
+        self.to_topic_tx
+            .send(bytes)
+            .await
+            .map_err(GossipPublishError::SendError)
     }
 
     /// Subscribes to the stream.

--- a/p2panda-net/src/gossip/builder.rs
+++ b/p2panda-net/src/gossip/builder.rs
@@ -30,16 +30,21 @@ impl Builder {
 
     pub async fn spawn(self) -> Result<Gossip, GossipError> {
         let my_node_id = self.endpoint.node_id();
+        let config = self.config.unwrap_or_default();
 
         let (actor_ref, _) = {
             let thread_pool = ThreadLocalActorSpawner::new();
 
-            let config = self.config.unwrap_or_default();
-            let args = (config, self.address_book.clone(), self.endpoint);
+            let args = (config.clone(), self.address_book.clone(), self.endpoint);
 
             GossipManager::spawn(None, args, thread_pool).await?
         };
 
-        Ok(Gossip::new(actor_ref, my_node_id, self.address_book))
+        Ok(Gossip::new(
+            actor_ref,
+            my_node_id,
+            self.address_book,
+            config,
+        ))
     }
 }

--- a/p2panda-net/src/gossip/mod.rs
+++ b/p2panda-net/src/gossip/mod.rs
@@ -10,7 +10,7 @@ mod events;
 #[cfg(test)]
 mod tests;
 
-pub use api::{Gossip, GossipError, GossipHandle, GossipSubscription};
+pub use api::{Gossip, GossipError, GossipHandle, GossipPublishError, GossipSubscription};
 pub use builder::Builder;
 pub use config::{DEFAULT_MAX_MESSAGE_SIZE, GossipConfig, HyParViewConfig, PlumTreeConfig};
 pub use events::GossipEvent;

--- a/p2panda-net/src/gossip/tests.rs
+++ b/p2panda-net/src/gossip/tests.rs
@@ -10,7 +10,8 @@ use tokio::time::sleep;
 use tokio_stream::StreamExt;
 
 use crate::address_book::AddressBook;
-use crate::gossip::{Gossip, GossipEvent};
+use crate::gossip::api::GossipPublishError;
+use crate::gossip::{DEFAULT_MAX_MESSAGE_SIZE, Gossip, GossipEvent};
 use crate::iroh_endpoint::Endpoint;
 use crate::test_utils::{setup_logging, test_args};
 
@@ -720,4 +721,47 @@ async fn leave_overlay_on_drop() {
     let handle = ant_gossip.stream(topic).await.unwrap();
     assert!(handle.publish(b"test 3").await.is_ok());
     assert_eq!(bat_rx.next().await.unwrap().unwrap(), b"test 3".to_vec());
+}
+
+#[tokio::test]
+async fn large_message_error() {
+    setup_logging();
+
+    let args = test_args();
+
+    let topic = Topic::new();
+
+    // Create address book.
+    let address_book = AddressBook::builder().spawn().await.unwrap();
+
+    // Create endpoint.
+    let endpoint = Endpoint::builder(address_book.clone())
+        .config(args.iroh_config.clone())
+        .private_key(args.private_key.clone())
+        .spawn()
+        .await
+        .unwrap();
+
+    // Spawn gossip.
+    let gossip = Gossip::builder(address_book.clone(), endpoint.clone())
+        .spawn()
+        .await
+        .unwrap();
+
+    // Subscribe to gossip topic.
+    let handle = gossip.stream(topic).await.unwrap();
+
+    // The byte length of the hex-encoded published message will be 5000.
+    let large_str = hex::encode([255; 2500]);
+    let large_str_len = large_str.len();
+
+    let result = handle.publish(large_str).await;
+
+    assert_eq!(
+        result,
+        Err(GossipPublishError::MessageTooLarge((
+            large_str_len,
+            DEFAULT_MAX_MESSAGE_SIZE // 4096
+        )))
+    );
 }


### PR DESCRIPTION
Here we introduce a check on the size of a message before publishing it to a gossip stream. An error is returned to the caller if the size exceeds the configured maximum.

Addresses: https://github.com/p2panda/p2panda/issues/628

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
