### PR TITLE
Add method for getting graph heads filtered by group ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Highlights are marked with a pancake 🥞
 - Get current network id from `Node` [#1143](https://github.com/p2panda/p2panda/pull/1143)
 - Deduplicate received operations in sync manager event stream [#1147](https://github.com/p2panda/p2panda/pull/1147)
 - Todo list example with LWW-CRDT for Node API [#1148](https://github.com/p2panda/p2panda/pull/1148)
+- Method for getting filtered groups CRDT heads [#1102](https://github.com/p2panda/p2panda/pull/1102)
 
 ### Changed
 

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use petgraph::prelude::DiGraphMap;
-use petgraph::visit::{DfsPostOrder, IntoNodeIdentifiers, NodeIndexable, Reversed};
+use petgraph::visit::{Bfs, DfsPostOrder, IntoNodeIdentifiers, NodeIndexable, Reversed};
 #[cfg(any(test, feature = "serde"))]
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -126,6 +126,29 @@ where
             .externals(petgraph::Direction::Outgoing)
             .map(|idx| self.graph.from_index(idx.index()))
             .collect::<HashSet<_>>()
+    }
+
+    /// Get graph tips filtered to only those which included "create" operation for passed group
+    /// ids in their causal history.
+    pub fn heads_filtered(&self, groups: &[ID]) -> HashSet<OP> {
+        let global_heads = self.heads();
+        global_heads
+            .into_iter()
+            .filter(|id| {
+                let reversed = Reversed(&self.graph);
+                let mut bfs = Bfs::new(&reversed, *id);
+                while let Some(inner_id) = bfs.next(&reversed) {
+                    let operation = self
+                        .operations
+                        .get(&inner_id)
+                        .expect("operation is present in map");
+                    if operation.action().is_create() && groups.contains(&operation.group_id()) {
+                        return true;
+                    }
+                }
+                false
+            })
+            .collect()
     }
 
     /// Current group states.
@@ -363,6 +386,12 @@ where
     /// Current tips for the groups operation graph.
     pub fn heads(&self) -> Vec<OP> {
         self.inner.heads().into_iter().collect()
+    }
+
+    /// Get graph tips filtered to only those which included "create" operation for passed group
+    /// ids in their causal history.
+    pub fn heads_filtered(&self, groups: &[ID]) -> Vec<OP> {
+        self.inner.heads_filtered(groups).into_iter().collect()
     }
 }
 

--- a/p2panda-auth/src/processor/processor.rs
+++ b/p2panda-auth/src/processor/processor.rs
@@ -309,4 +309,185 @@ mod tests {
         assert!(members.contains(&(bobby, Access::manage())));
         assert!(members.contains(&(cathy, Access::manage())));
     }
+
+    #[tokio::test]
+    async fn device_groups_single_context() {
+        let topic = Topic::new();
+
+        // All operations are processed on the same groups state context.
+        let state_id = 'S';
+
+        let alice_store = SqliteStore::temporary().await;
+        let bobby_store = SqliteStore::temporary().await;
+        let cathy_store = SqliteStore::temporary().await;
+
+        let alice_log = TestLog::new();
+        let alice = alice_log.author();
+        let bobby_log = TestLog::new();
+        let bobby = bobby_log.author();
+        let cathy_log = TestLog::new();
+        let cathy = cathy_log.author();
+
+        let alice_device_group = PrivateKey::new().public_key();
+        let bobby_device_group = PrivateKey::new().public_key();
+        let cathy_device_group = PrivateKey::new().public_key();
+        let ab_chat = PrivateKey::new().public_key();
+        let bc_chat = PrivateKey::new().public_key();
+
+        let alice_groups = GroupsProcessor::new(alice_store.clone());
+        let bobby_groups = GroupsProcessor::new(bobby_store.clone());
+        let cathy_groups = GroupsProcessor::new(cathy_store.clone());
+
+        // All members create their own device groups and process them on their own stores.
+
+        let args = GroupsArgs {
+            group_id: alice_device_group,
+            action: GroupAction::Create {
+                initial_members: vec![(GroupMember::Individual(alice), Access::manage())],
+            },
+            dependencies: vec![],
+        };
+        let create_alice_device_00: Operation<TestExtensions> =
+            alice_log.operation(&[], TestExtensions::from(args));
+
+        alice_groups
+            .process(&state_id, &topic, &create_alice_device_00)
+            .await
+            .unwrap();
+
+        let args = GroupsArgs {
+            group_id: bobby_device_group,
+            action: GroupAction::Create {
+                initial_members: vec![(GroupMember::Individual(bobby), Access::manage())],
+            },
+            dependencies: vec![],
+        };
+        let create_bobby_device_01: Operation<TestExtensions> =
+            bobby_log.operation(&[], TestExtensions::from(args));
+
+        bobby_groups
+            .process(&state_id, &topic, &create_bobby_device_01)
+            .await
+            .unwrap();
+
+        let args = GroupsArgs {
+            group_id: cathy_device_group,
+            action: GroupAction::Create {
+                initial_members: vec![(GroupMember::Individual(cathy), Access::manage())],
+            },
+            dependencies: vec![],
+        };
+        let create_cathy_device_02: Operation<TestExtensions> =
+            cathy_log.operation(&[], TestExtensions::from(args));
+
+        cathy_groups
+            .process(&state_id, &topic, &create_cathy_device_02)
+            .await
+            .unwrap();
+
+        // Alice creates chat with Bobby.
+        //
+        // First they process "create device group" operation from Bobby.
+        alice_groups
+            .process(&state_id, &topic, &create_bobby_device_01)
+            .await
+            .unwrap();
+
+        // Then they create the chat group.
+        let permit = alice_store.begin().await.unwrap();
+        let y: GroupsState = alice_store
+            .get_groups_state(&state_id)
+            .await
+            .unwrap()
+            .unwrap();
+        alice_store.commit(permit).await.unwrap();
+
+        let args = GroupsArgs {
+            group_id: ab_chat,
+            action: GroupAction::Create {
+                initial_members: vec![
+                    (GroupMember::Group(alice_device_group), Access::write()),
+                    (GroupMember::Group(bobby_device_group), Access::write()),
+                ],
+            },
+            dependencies: y.heads_filtered(&[alice_device_group, bobby_device_group]),
+        };
+        let create_alice_bobby_chat_03: Operation<TestExtensions> =
+            alice_log.operation(&[], TestExtensions::from(args));
+
+        alice_groups
+            .process(&state_id, &topic, &create_alice_bobby_chat_03)
+            .await
+            .unwrap();
+
+        // Bobby processes alice's "create device group" and "create ab chat".
+        for op in [create_alice_device_00.clone(), create_alice_bobby_chat_03] {
+            bobby_groups.process(&state_id, &topic, &op).await.unwrap();
+        }
+
+        // Both Alice and Bobby have the correct groups state.
+        for store in [alice_store.clone(), bobby_store.clone()] {
+            let permit = store.begin().await.unwrap();
+            let y: GroupsState = store.get_groups_state(&state_id).await.unwrap().unwrap();
+            store.commit(permit).await.unwrap();
+            let mut members = y.members(ab_chat);
+            members.sort();
+
+            assert_eq!(members.len(), 2);
+            assert!(members.contains(&(alice, Access::write())));
+            assert!(members.contains(&(bobby, Access::write())));
+        }
+
+        // Cathy now creates a chat with Bobby.
+        //
+        // First they process "create device group" for bobby.
+        cathy_groups
+            .process(&state_id, &topic, &create_bobby_device_01)
+            .await
+            .unwrap();
+
+        // Then they create the chat group.
+        let permit = cathy_store.begin().await.unwrap();
+        let y: GroupsState = cathy_store
+            .get_groups_state(&state_id)
+            .await
+            .unwrap()
+            .unwrap();
+        cathy_store.commit(permit).await.unwrap();
+        let args = GroupsArgs {
+            group_id: bc_chat,
+            action: GroupAction::Create {
+                initial_members: vec![
+                    (GroupMember::Group(bobby_device_group), Access::write()),
+                    (GroupMember::Group(cathy_device_group), Access::write()),
+                ],
+            },
+            dependencies: y.heads_filtered(&[bobby_device_group, cathy_device_group]),
+        };
+        let create_bobby_cathy_chat_04: Operation<TestExtensions> =
+            cathy_log.operation(&[], TestExtensions::from(args));
+
+        cathy_groups
+            .process(&state_id, &topic, &create_bobby_cathy_chat_04)
+            .await
+            .unwrap();
+
+        // Bobby processes cathy's "create device group" and "create bc chat".
+        for op in [create_cathy_device_02.clone(), create_bobby_cathy_chat_04] {
+            bobby_groups.process(&state_id, &topic, &op).await.unwrap();
+        }
+
+        // Both Cathy and Bobby have the correct groups state.
+        for store in [cathy_store, bobby_store] {
+            let permit = store.begin().await.unwrap();
+            let y: GroupsState = store.get_groups_state(&state_id).await.unwrap().unwrap();
+            store.commit(permit).await.unwrap();
+            let mut members = y.members(bc_chat);
+            members.sort();
+
+            assert_eq!(members.len(), 2);
+            assert!(members.contains(&(bobby, Access::write())));
+            assert!(members.contains(&(cathy, Access::write())));
+        }
+    }
 }


### PR DESCRIPTION
## Context

Operations in a single groups "context" (which contains operations for multiple groups) form a graph, and the current groups API only allows the user to get the ids of the current graph tips regardless of which groups the user may actually want to include (needed for computing operation dependencies). This results in the groups API forcing all groups in one context to be dependent on each other, which is not always the desired behaviour. If a context includes operations for groups A & B, but neither of these groups a children/parent of the other, then the user should be able to get dependencies (graph tips) selectively based on the group(s) they want to include.

## Decision

Allow the user of the groups API to specify which groups should be included when calculating dependencies via the graph tips.   

## Result

Introduce a `heads_filtered(&self, groups: &[ID]) -> HashSet<OP>` method where the user can specify the groups it wants to target when calculating graph tips. Sub-sections of the groups graph which do not contain operations for the passed groups will not be included in the calculation.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
