### PR TITLE
Add insert_bootstrap to the node API as a thin wrapper around the net…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Highlights are marked with a pancake 🥞
 - Use Borrow to express required args in ingest [#1078](https://github.com/p2panda/p2panda/pull/1078)
 - Use MockInstant for Timestamp when running tests [#1081](https://github.com/p2panda/p2panda/pull/1081)
 - Derive log id from topic [#1082](https://github.com/p2panda/p2panda/pull/1082)
+- Expose insert_bootstrap on the node API [#1125](https://github.com/p2panda/p2panda/pull/1125)
 
 ### Fixed
 

--- a/p2panda/src/network.rs
+++ b/p2panda/src/network.rs
@@ -8,7 +8,9 @@ use p2panda_net::address_book::AddressBookError;
 use p2panda_net::addrs::{NodeInfo, TrustedTransportInfo};
 use p2panda_net::discovery::{DiscoveryConfig, DiscoveryError};
 use p2panda_net::gossip::{GossipConfig, GossipError};
-use p2panda_net::iroh_endpoint::{EndpointError, IrohConfig, RelayUrl};
+use p2panda_net::iroh_endpoint::{
+    EndpointAddr, EndpointError, IrohConfig, RelayUrl, from_public_key,
+};
 use p2panda_net::iroh_mdns::{MdnsDiscoveryError, MdnsDiscoveryMode};
 use p2panda_net::sync::LogSyncError;
 use p2panda_net::{
@@ -102,9 +104,12 @@ impl Network {
     pub async fn insert_bootstrap(
         &self,
         node_id: NodeId,
-        transport_info: TrustedTransportInfo,
+        relay_url: RelayUrl,
     ) -> Result<(), NetworkError> {
         let mut node_info = NodeInfo::new(node_id).bootstrap();
+        let endpoint_addr = EndpointAddr::new(from_public_key(node_id)).with_relay_url(relay_url);
+        let transport_info = TrustedTransportInfo::from(endpoint_addr);
+
         if node_info.update_transports(transport_info.into()).is_ok() {
             self.address_book.insert_node_info(node_info).await?;
         }

--- a/p2panda/src/network.rs
+++ b/p2panda/src/network.rs
@@ -99,9 +99,15 @@ impl Network {
     }
 
     #[allow(unused)]
-    pub async fn insert_bootstrap(&self, node_id: NodeId) -> Result<(), NetworkError> {
-        let node_info = NodeInfo::new(node_id).bootstrap();
-        self.address_book.insert_node_info(node_info).await?;
+    pub async fn insert_bootstrap(
+        &self,
+        node_id: NodeId,
+        transport_info: TrustedTransportInfo,
+    ) -> Result<(), NetworkError> {
+        let mut node_info = NodeInfo::new(node_id).bootstrap();
+        if node_info.update_transports(transport_info.into()).is_ok() {
+            self.address_book.insert_node_info(node_info).await?;
+        }
         Ok(())
     }
 

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use futures_util::Stream;
 pub use p2panda_core::identity::{PrivateKey, PublicKey};
 pub use p2panda_core::{Hash, Topic};
+use p2panda_net::addrs::TrustedTransportInfo;
 pub use p2panda_net::iroh_endpoint::{EndpointAddr, RelayUrl};
 pub use p2panda_net::iroh_mdns::MdnsDiscoveryMode;
 pub use p2panda_net::{NetworkId, NodeId};
@@ -176,8 +177,12 @@ impl Node {
         self.forge.public_key()
     }
 
-    pub async fn insert_bootstrap(&self, node_id: NodeId) -> Result<(), NetworkError> {
-        self.network.insert_bootstrap(node_id).await
+    pub async fn insert_bootstrap(
+        &self,
+        node_id: NodeId,
+        transport_info: TrustedTransportInfo,
+    ) -> Result<(), NetworkError> {
+        self.network.insert_bootstrap(node_id, transport_info).await
     }
 
     pub fn ack(&self, _message_id: Hash) {

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -176,6 +176,10 @@ impl Node {
         self.forge.public_key()
     }
 
+    pub async fn insert_bootstrap(&self, node_id: NodeId) -> Result<(), NetworkError> {
+        self.network.insert_bootstrap(node_id).await
+    }
+
     pub fn ack(&self, _message_id: Hash) {
         unimplemented!()
     }

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -5,7 +5,6 @@ use std::fmt::Debug;
 use futures_util::Stream;
 pub use p2panda_core::identity::{PrivateKey, PublicKey};
 pub use p2panda_core::{Hash, Topic};
-use p2panda_net::addrs::TrustedTransportInfo;
 pub use p2panda_net::iroh_endpoint::{EndpointAddr, RelayUrl};
 pub use p2panda_net::iroh_mdns::MdnsDiscoveryMode;
 pub use p2panda_net::{NetworkId, NodeId};
@@ -180,9 +179,9 @@ impl Node {
     pub async fn insert_bootstrap(
         &self,
         node_id: NodeId,
-        transport_info: TrustedTransportInfo,
+        relay_url: RelayUrl,
     ) -> Result<(), NetworkError> {
-        self.network.insert_bootstrap(node_id, transport_info).await
+        self.network.insert_bootstrap(node_id, relay_url).await
     }
 
     pub fn ack(&self, _message_id: Hash) {


### PR DESCRIPTION
I suggest the addition of the insert_bootstrap function from network to the node API.

I imagine you're going to have to carefully consider additions to the node API. When I migrated to the node, this one felt pretty immediate. I am allowing users to add bootstrap nodes at runtime, so I don't know how else I'd achieve this. Unlike some other parts of the network config, this is designed to be added on the fly fairly easily. 

There are no tests for this PR. It's such a thin wrapper that doesn't seem worth it to me, but I'm happy to add them. Mostly this is a prompt for discussion.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
