### PR TITLE
Update iroh dependencies to v0.98.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Highlights are marked with a pancake 🥞
 - Use MockInstant for Timestamp when running tests [#1081](https://github.com/p2panda/p2panda/pull/1081)
 - Derive log id from topic [#1082](https://github.com/p2panda/p2panda/pull/1082)
 - Expose insert_bootstrap on the node API [#1125](https://github.com/p2panda/p2panda/pull/1125)
+- Update iroh to v0.98.1 [#1131](https://github.com/p2panda/p2panda/pull/1131)
 
 ### Fixed
 

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -70,9 +70,9 @@ ciborium = "0.2.2"
 futures-channel = "0.3.31"
 futures-util = "0.3.31"
 hex = "0.4.3"
-iroh = { version = "0.96.1", default-features = false, optional = true }
-iroh-base = { version = "0.96.1", optional = true }
-iroh-gossip = { version = "0.96.0", optional = true }
+iroh = { version = "0.98.1", default-features = false, features = ["tls-ring"], optional = true }
+iroh-base = { version = "0.98.0", optional = true }
+iroh-gossip = { version = "0.98.0", optional = true }
 p2panda-core = { path = "../p2panda-core", version = "0.5.2" }
 p2panda-discovery = { path = "../p2panda-discovery", version = "0.5.2", optional = true }
 p2panda-store = { path= "../p2panda-store", version = "0.5.2", optional= true }
@@ -98,5 +98,5 @@ p2panda-discovery = { path = "../p2panda-discovery", version = "0.5.2", features
 p2panda-net = { path = ".", features = ["test_utils"] }
 p2panda-store = { path = "../p2panda-store", version = "0.5.2", features = ["test_utils"] }
 p2panda-sync = { path = "../p2panda-sync", features = ["test_utils"] }
-tokio = { version = "1.47.1", features = ["rt", "sync", "time"] }
+tokio = { version = "1.47.1", features = ["rt", "sync", "time", "signal"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }

--- a/p2panda-net/src/iroh_endpoint/actors/endpoint.rs
+++ b/p2panda-net/src/iroh_endpoint/actors/endpoint.rs
@@ -7,7 +7,7 @@ use std::net::{SocketAddrV4, SocketAddrV6};
 use std::sync::Arc;
 use std::time::Duration;
 
-use iroh::endpoint::QuicTransportConfig;
+use iroh::endpoint::{QuicTransportConfig, presets};
 use iroh::protocol::DynProtocolHandler;
 use p2panda_core::PrivateKey;
 use ractor::thread_local::{ThreadLocalActor, ThreadLocalActorSpawner};
@@ -194,7 +194,8 @@ impl ThreadLocalActor for IrohEndpoint {
                 );
 
                 // Create and bind the endpoint to the socket.
-                let endpoint = iroh::Endpoint::empty_builder(relay_mode)
+                let endpoint = iroh::Endpoint::builder(presets::Minimal)
+                    .relay_mode(relay_mode)
                     .address_lookup(address_book_discovery)
                     .secret_key(from_private_key(state.private_key.clone()))
                     .transport_config(quic_transport_config)

--- a/p2panda-net/src/iroh_mdns/actor.rs
+++ b/p2panda-net/src/iroh_mdns/actor.rs
@@ -150,6 +150,11 @@ impl ThreadLocalActor for MdnsActor {
                                             // Additionally we don't know if that node might actually still
                                             // be reachable (just not inside the same local area network).
                                         }
+                                        Some(_) => {
+                                            // `DiscoveryEvent` is marked as non-exhaustive so we
+                                            // need this wildcard check to satisfy the compiler; do
+                                            // nothing.
+                                        }
                                         None => {
                                             // The stream has seized, close actor.
                                             myself.stop(Some("mdns stream stopped".into()));
@@ -262,9 +267,7 @@ impl ThreadLocalActor for MdnsActor {
                         .service
                         .as_ref()
                         .expect("exists at this point")
-                        .publish(
-                            &EndpointData::from(endpoint_addr).with_user_data(Some(user_data)),
-                        );
+                        .publish(&EndpointData::from(endpoint_addr).with_user_data(user_data));
                 }
             }
         }

--- a/p2panda-net/src/sync/log_sync/tests.rs
+++ b/p2panda-net/src/sync/log_sync/tests.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use assert_matches::assert_matches;
 use iroh::Endpoint;
-use iroh::endpoint::Connection;
+use iroh::endpoint::{Connection, presets};
 use iroh::protocol::{AcceptError, ProtocolHandler, Router};
 use p2panda_core::{Operation, Topic};
 use p2panda_net::cbor::{into_cbor_sink, into_cbor_stream};
@@ -414,13 +414,13 @@ async fn panic_on_sink_closure_after_error_regression() {
 
     let (session, _events_rx, _live_tx) = peer.topic_sync_protocol(topic.clone(), true);
 
-    let acceptor = Endpoint::bind().await.unwrap();
+    let acceptor = Endpoint::bind(presets::Minimal).await.unwrap();
     let acceptor_router = Router::builder(acceptor)
         .accept(ALPN, TestProtocol::default())
         .spawn();
     let addr = acceptor_router.endpoint().addr();
 
-    let initiator = Endpoint::bind().await.unwrap();
+    let initiator = Endpoint::bind(presets::Minimal).await.unwrap();
     let connection = initiator.connect(addr, ALPN).await.unwrap();
     let (tx, rx) = connection.open_bi().await.unwrap();
     let mut tx = into_cbor_sink::<TestTopicSyncMessage, _>(tx);


### PR DESCRIPTION
Only a couple of small changes were required to comply with the updated API, the main one being the need to configure the crypto provider via the `Minimal` endpoint preset and the associated feature flag. We are using `tls-ring` which was the previous default.

Closes https://github.com/p2panda/p2panda/issues/1090

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes