### PR TITLE
Forge result is never None or duplicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Highlights are marked with a pancake 🥞
 - Derive log id from topic [#1082](https://github.com/p2panda/p2panda/pull/1082)
 - Expose insert_bootstrap on the node API [#1125](https://github.com/p2panda/p2panda/pull/1125)
 - Update iroh to v0.98.1 [#1131](https://github.com/p2panda/p2panda/pull/1131)
+- Forge result is never `None` or duplicate [#1132](https://github.com/p2panda/p2panda/pull/1132)
 
 ### Fixed
 

--- a/p2panda/src/forge.rs
+++ b/p2panda/src/forge.rs
@@ -26,7 +26,7 @@ pub trait Forge<TP, C, E> {
         collection_id: C,
         body: Option<Vec<u8>>,
         extensions: E,
-    ) -> impl Future<Output = Result<Option<p2panda_core::Operation<E>>, Self::Error>>;
+    ) -> impl Future<Output = Result<p2panda_core::Operation<E>, Self::Error>>;
 }
 
 #[derive(Clone, Debug)]
@@ -78,7 +78,7 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
         log_id: LogId,
         body: Option<Vec<u8>>,
         extensions: Extensions,
-    ) -> Result<Option<Operation>, Self::Error> {
+    ) -> Result<Operation, Self::Error> {
         // Perform prerequisite computations outside of the locked transaction.
         let payload_size = body.as_ref().map(|bytes| bytes.len()).unwrap_or(0) as u64;
         let body: Option<Body> = body.map(|bytes| bytes.into());
@@ -136,8 +136,9 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
 
             self.store
                 .insert_operation(&hash, &operation, &log_id)
-                .await?
-                .then_some(operation)
+                .await?;
+
+            operation
         });
 
         Ok(operation)
@@ -180,7 +181,6 @@ mod tests {
                 extensions.clone(),
             )
             .await
-            .unwrap()
             .unwrap();
 
         forge
@@ -191,7 +191,6 @@ mod tests {
                 extensions,
             )
             .await
-            .unwrap()
             .unwrap();
 
         let result = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_log_heights(

--- a/p2panda/src/streams/acked.rs
+++ b/p2panda/src/streams/acked.rs
@@ -224,7 +224,6 @@ mod tests {
                 Extensions::from_topic(topic),
             )
             .await
-            .unwrap()
             .unwrap();
 
         // This first operation was not acked yet.
@@ -271,7 +270,6 @@ mod tests {
                 Extensions::from_topic(topic),
             )
             .await
-            .unwrap()
             .unwrap();
 
         // The first cursor acks it.
@@ -316,7 +314,6 @@ mod tests {
                 Extensions::from_topic(topic),
             )
             .await
-            .unwrap()
             .unwrap();
 
         acked.ack(operation_0).await.unwrap();

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -506,8 +506,7 @@ where
         let operation = self
             .forge
             .create_operation(self.topic(), extensions.log_id, body_bytes, extensions)
-            .await?
-            .ok_or(PublishError::DuplicateOperation)?;
+            .await?;
         let hash = operation.hash;
 
         // Start processing operation in pipeline. Keep an oneshot receiver around to allow users
@@ -771,9 +770,6 @@ pub enum PublishError {
 
     #[error("an error occurred while creating an operation in the forge: {0}")]
     Forge(#[from] ForgeError),
-
-    #[error("message already exists in the forge")]
-    DuplicateOperation,
 
     #[error("an error occurred while publishing an operation to the log sync stream: {0}")]
     SyncHandle(String),


### PR DESCRIPTION
This patch removes the `Option` from the return type of `Forge::create_operation`.

It was used to indicate if _no_ operation was created, which was supposed to happen if this operation already exists. Since we're applying strict atomicity rules this is a condition which can't occur (every operation creation is strictly serialized).

Closes: https://github.com/p2panda/p2panda/issues/1128

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
