### PR TITLE
Functionality for importing external operation streams in node API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Highlights are marked with a pancake 🥞
 - Re-play events from any cursor, track acked state [#1104](https://github.com/p2panda/p2panda/pull/1104)
 - Processor for groups operations [#1112](https://github.com/p2panda/p2panda/pull/1112)
 - `GroupsStore` with `SqliteStore` implementation [#1112](https://github.com/p2panda/p2panda/pull/1112)
+- Node API for importing external operation streams [#1135](https://github.com/p2panda/p2panda/pull/1135)
 
 ### Changed
 

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -17,10 +17,15 @@ use tokio::pin;
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 use tokio::task::LocalSet;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::processor::tasks::TaskTracker;
 use crate::processor::{Event, ProcessorStatus};
+
+/// Number of items which can stay in the pipeline buffer before backpressure is applied. If the
+/// buffer runs full, then sending of new operations into the processor will wait one is received
+/// by the processor.
+const PUBLISH_BUFFER_SIZE: usize = 128;
 
 /// Event processor pipeline which consists of multiple processors.
 ///
@@ -51,7 +56,7 @@ use crate::processor::{Event, ProcessorStatus};
 /// ```
 #[derive(Clone, Debug)]
 pub struct Pipeline<L, E, TP> {
-    pipeline_tx: mpsc::UnboundedSender<Event<L, E, TP>>,
+    pipeline_tx: mpsc::Sender<Event<L, E, TP>>,
     tasks: TaskTracker<Event<L, E, TP>, Hash>,
 }
 
@@ -85,7 +90,7 @@ where
             + Send
             + 'static,
     {
-        let (pipeline_tx, pipeline_rx) = mpsc::unbounded_channel();
+        let (pipeline_tx, pipeline_rx) = mpsc::channel(PUBLISH_BUFFER_SIZE);
 
         {
             let tasks = tasks.clone();
@@ -104,7 +109,7 @@ where
                     let log_prune = LogPrune::<S, Event<L, E, TP>, L, E>::new(store);
 
                     // Receive incoming events through mpsc channel.
-                    let pipeline = UnboundedReceiverStream::new(pipeline_rx)
+                    let pipeline = ReceiverStream::new(pipeline_rx)
                         .layer(ingest)
                         .map(|result| match result {
                             Ok((mut event, result)) => {
@@ -160,7 +165,7 @@ where
 
         // Send operation to processing pipeline, it will handle this operation eventually in a
         // concurrent "background" task.
-        let _ = self.pipeline_tx.send(input);
+        let _ = self.pipeline_tx.send(input).await;
 
         // Block and await here until the mananger received the signal that the task has finished.
         // This assures that operations are handled in-order.

--- a/p2panda/src/streams/external_stream.rs
+++ b/p2panda/src/streams/external_stream.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::stream::SelectAll;
+use futures_util::stream::{BoxStream, once};
+use futures_util::{FutureExt, Stream, StreamExt};
+use tokio::sync::oneshot;
+
+use crate::operation::Operation;
+
+pub type SessionId = u64;
+
+/// Set of currently active external streams.
+#[derive(Default)]
+pub(crate) struct ExternalStream {
+    streams: SelectAll<BoxStream<'static, ExternalStreamEvent>>,
+    next_session_id: SessionId,
+}
+
+impl ExternalStream {
+    /// Insert a new stream into the set, it is assigned the next available session id, and a
+    /// future is returned which will complete when the stream has ended and all operations are
+    /// processed.
+    pub fn insert(&mut self, stream: BoxStream<'static, Operation>) -> ExternalStreamFuture {
+        let session_id = self.next_session_id();
+        let (complete_tx, complete_rx) = oneshot::channel::<()>();
+        let future = ExternalStreamFuture {
+            session_id,
+            complete_rx,
+        };
+
+        let event_stream = once(async move { ExternalStreamEvent::Start { session_id } })
+            .chain(stream.map(move |operation| ExternalStreamEvent::Operation {
+                session_id,
+                operation: Box::new(operation),
+            }))
+            .chain(once(async move {
+                let _ = complete_tx.send(());
+                ExternalStreamEvent::End { session_id }
+            }));
+
+        self.streams.push(Box::pin(event_stream));
+
+        future
+    }
+
+    fn next_session_id(&mut self) -> SessionId {
+        let next = self.next_session_id;
+        self.next_session_id += 1;
+        next
+    }
+}
+
+impl Stream for ExternalStream {
+    type Item = ExternalStreamEvent;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.streams.poll_next_unpin(cx)
+    }
+}
+
+pub(crate) enum ExternalStreamEvent {
+    Start {
+        session_id: SessionId,
+    },
+    Operation {
+        session_id: SessionId,
+        operation: Box<Operation>,
+    },
+    End {
+        session_id: SessionId,
+    },
+}
+
+/// Future which can be awaited to find out when external stream has completed processing.
+#[derive(Debug)]
+pub struct ExternalStreamFuture {
+    session_id: SessionId,
+    complete_rx: oneshot::Receiver<()>,
+}
+
+impl ExternalStreamFuture {
+    pub fn session_id(&self) -> SessionId {
+        self.session_id
+    }
+}
+
+impl Future for ExternalStreamFuture {
+    type Output = Result<(), oneshot::error::RecvError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.complete_rx.poll_unpin(cx)
+    }
+}

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -3,6 +3,7 @@
 mod acked;
 mod ephemeral_stream;
 mod event_stream;
+mod external_stream;
 mod replay;
 mod stream;
 mod sync_metrics;

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use futures_util::stream::BoxStream;
 use futures_util::{FutureExt, Stream, StreamExt};
 use p2panda_core::cbor::{DecodeError, EncodeError, decode_cbor, encode_cbor};
 use p2panda_core::traits::Digest;
@@ -28,6 +29,9 @@ use crate::node::{AckPolicy, CreateStreamError};
 use crate::operation::{Extensions, Header, LogId, Operation};
 use crate::processor::{Event, Pipeline, ProcessorError};
 use crate::streams::acked::{Acked, AckedError};
+use crate::streams::external_stream::{
+    ExternalStream, ExternalStreamEvent, ExternalStreamFuture, SessionId,
+};
 use crate::streams::replay::{ReplayError, StreamFrom, replay_log_ranges};
 use crate::streams::sync_metrics::{self, Aggregator, SessionPhase, SyncError};
 
@@ -39,6 +43,10 @@ const BUFFER_SIZE: usize = 16;
 /// Number of items which can stay in the buffer before processing kicks in for locally published
 /// items. If buffer runs full, creating new operations will apply backpressure.
 const PUBLISH_BUFFER_SIZE: usize = 128;
+
+/// Number of streams which can stay in the import buffer. If the buffer runs full importing of
+/// new streams will have backpressure applied.
+const IMPORT_BUFFER_SIZE: usize = 16;
 
 /// Returns publish and subscribe halfs of an eventually consistent messaging stream for a given
 /// topic.
@@ -113,6 +121,15 @@ where
         Option<M>,
         oneshot::Sender<Event<LogId, Extensions, Topic>>,
     )>(PUBLISH_BUFFER_SIZE);
+
+    // Channel for importing external operation streams.
+    let (import_tx, mut import_rx) = mpsc::channel::<(
+        BoxStream<'static, Operation>,
+        oneshot::Sender<ExternalStreamFuture>,
+    )>(IMPORT_BUFFER_SIZE);
+
+    // Set of currently active external streams.
+    let mut external_stream = ExternalStream::default();
 
     // Determine from which point on we re-play locally stored operations.
     let nacked_log_ranges = acked
@@ -240,6 +257,38 @@ where
 
                         event
                     }
+
+                    // Receive imported external source of operations.
+                    Some((stream, ready_tx)) = import_rx.recv() => {
+                        let external_stream_future = external_stream.insert(stream);
+                        let session_id = external_stream_future.session_id();
+                        if ready_tx.send(external_stream_future).is_err() {
+                            warn!(session_id = session_id, "failed sending on import ready channel")
+                        };
+                        continue;
+                    }
+
+                    // Receive the next ready event from any imported external source.
+                    Some(event) = external_stream.next() => {
+                        match event {
+                            ExternalStreamEvent::Start { session_id } => StreamEvent::ImportStarted { session_id },
+                            ExternalStreamEvent::Operation { session_id, operation } => {
+                                let Some(event) = process_operation::<M>(
+                                    *operation,
+                                    topic,
+                                    &pipeline,
+                                    ack_policy,
+                                    &acked,
+                                    Source::ExternalStream { session_id },
+                                ).await else {
+                                    continue;
+                                };
+
+                                event
+                            },
+                            ExternalStreamEvent::End { session_id } => StreamEvent::ImportEnded { session_id },
+                        }
+                    }
                 };
 
                 // Send processing result to application layer.
@@ -260,6 +309,7 @@ where
         sync_handle: sync_handle.clone(),
         forge,
         publish_tx,
+        import_tx,
         _marker: PhantomData,
     };
 
@@ -459,6 +509,10 @@ pub struct StreamPublisher<M> {
         Option<M>,
         oneshot::Sender<Event<LogId, Extensions, Topic>>,
     )>,
+    import_tx: mpsc::Sender<(
+        BoxStream<'static, Operation>,
+        oneshot::Sender<ExternalStreamFuture>,
+    )>,
     _marker: PhantomData<M>,
 }
 
@@ -488,6 +542,26 @@ where
     /// "older" / before the point where the prune flag was set.
     pub async fn prune(&self, message: Option<M>) -> Result<PublishFuture, PublishError> {
         self.publish_inner(message, true).await
+    }
+
+    /// Import an external source of operations.
+    pub async fn import(
+        &self,
+        stream: impl Stream<Item = Operation> + Send + 'static,
+    ) -> Result<ExternalStreamFuture, ImportError> {
+        // Send stream to processor.
+        let stream = Box::pin(stream);
+        let (ready_tx, ready_rx) = oneshot::channel::<ExternalStreamFuture>();
+        self.import_tx
+            .send((stream, ready_tx))
+            .await
+            .map_err(|err| ImportError::SendToProcessor(err.to_string()))?;
+
+        // Await receiving the session id and future which will complete when the external stream
+        // closes and all operations have been processed.
+        ready_rx
+            .await
+            .map_err(|err| ImportError::ReceiveFromProcessor(err.to_string()))
     }
 
     async fn publish_inner(
@@ -655,6 +729,14 @@ pub enum StreamEvent<M> {
         /// If the sync session ended with an error the reason is included here.
         error: Option<SyncError>,
     },
+    ImportStarted {
+        /// Id of the import session.
+        session_id: SessionId,
+    },
+    ImportEnded {
+        /// Id of the import session.
+        session_id: SessionId,
+    },
     ProcessingFailed {
         /// Event which failed during system-level processing.
         ///
@@ -759,6 +841,13 @@ pub enum Source {
         phase: SessionPhase,
     },
 
+    /// Source when an operation arrived by an external stream (eg. reading from the filesystem or
+    /// a remote service).
+    ExternalStream {
+        /// Id of the import session.
+        session_id: u64,
+    },
+
     /// Source when an operation was published locally or replayed.
     LocalStore,
 }
@@ -774,6 +863,15 @@ pub enum PublishError {
     #[error("an error occurred while publishing an operation to the log sync stream: {0}")]
     SyncHandle(String),
 
-    #[error("could not send operation to processor pipeline: {0}")]
+    #[error("could not send to processor pipeline: {0}")]
     SendToProcessor(String),
+}
+
+#[derive(Debug, Error)]
+pub enum ImportError {
+    #[error("could not send to processor pipeline: {0}")]
+    SendToProcessor(String),
+
+    #[error("an error occurred awaiting message from processor: {0}")]
+    ReceiveFromProcessor(String),
 }

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -5,12 +5,14 @@ use std::time::Duration;
 use futures_util::StreamExt;
 use mock_instant::thread_local::MockClock;
 use p2panda::node::AckPolicy;
-use p2panda::operation::{LogId, Operation};
+use p2panda::operation::{Extensions, LogId, Operation};
 use p2panda::streams::{
     EphemeralMessage, ProcessedOperation, StreamEvent, StreamFrom, SystemEvent,
 };
 use p2panda::test_utils::setup_logging;
+use p2panda_core::cbor::encode_cbor;
 use p2panda_core::logs::LogHeights;
+use p2panda_core::test_utils::TestLog;
 use p2panda_core::{Cursor, Hash, PrivateKey, Topic};
 use p2panda_net::discovery::DiscoveryEvent;
 use p2panda_store::logs::LogStore;
@@ -383,4 +385,99 @@ async fn replay_stream_from_cursor() {
     // We expect to only receive the second and third message.
     assert_message_id(&rx.next().await.unwrap(), message_id_2);
     assert_message_id(&rx.next().await.unwrap(), message_id_3);
+}
+
+#[tokio::test]
+async fn import_external_stream() {
+    setup_logging();
+
+    let chat_id = Topic::new();
+
+    // Panda opens their app and publishes some messages into a chat.
+    let panda_log = TestLog::new();
+    let extensions = Extensions {
+        prune_flag: false.into(),
+        log_id: LogId::from_topic(chat_id),
+        version: Default::default(),
+    };
+    let operation_1 = panda_log.operation(
+        &encode_cbor(&"Hello, Icebear!").unwrap(),
+        extensions.clone(),
+    );
+    let operation_2 = panda_log.operation(
+        &encode_cbor(&"I'm in a remote place with no internet, it's really nice :-p").unwrap(),
+        extensions.clone(),
+    );
+    let operation_3 = panda_log.operation(
+        &encode_cbor(&"Gunna post these messages to you on an SD card yo!").unwrap(),
+        extensions,
+    );
+
+    // Panda exports messages to an SD card.
+    let exported = vec![
+        operation_1.clone(),
+        operation_2.clone(),
+        operation_3.clone(),
+    ];
+
+    // Panda goes offline and walks to the post office to send the SD card to Icebear.
+
+    // Icebear receives the SD card, opens their app and initiates import.
+    let import_stream = futures_util::stream::iter(exported);
+    let icebear = p2panda::builder().spawn().await.unwrap();
+    let (icebear_tx, mut icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
+    let import = icebear_tx.import(import_stream).await.unwrap();
+
+    assert_eq!(import.session_id(), 0);
+    assert!(import.await.is_ok());
+
+    // Icebear receives the new messages after they've been processed.
+    let mut imported = Vec::new();
+    let mut start_received = false;
+    let mut end_received = false;
+    while let Some(event) = icebear_rx.next().await {
+        if let StreamEvent::ImportStarted { session_id } = &event {
+            assert!(!start_received);
+            assert_eq!(session_id, &0);
+            start_received = true;
+            continue;
+        };
+
+        if let StreamEvent::Processed { operation, .. } = &event {
+            assert!(start_received);
+            assert!(!end_received);
+            imported.push(operation.clone());
+            if imported.len() == 3 {
+                continue;
+            }
+        }
+
+        if let StreamEvent::ImportEnded { session_id } = event {
+            assert!(start_received);
+            assert!(!end_received);
+            assert_eq!(session_id, 0);
+            end_received = true;
+            break;
+        };
+    }
+
+    assert!(start_received);
+    assert!(end_received);
+    assert_eq!(imported.len(), 3);
+    assert!(
+        imported
+            .iter()
+            .any(|event| event.id() == operation_1.header().hash())
+    );
+    assert!(
+        imported
+            .iter()
+            .any(|event| event.id() == operation_2.header().hash())
+    );
+    assert!(
+        imported
+            .iter()
+            .any(|event| event.id() == operation_3.header().hash())
+    );
+    assert!(end_received);
 }


### PR DESCRIPTION
## Context

Being able to import already forged operations from an arbitrary source is an important feature for several use cases, these include importing from a USB stick or the filesystem, or syncing with a remote service, like a "support node". The current node API does not currently support this use case, it is only possible to forge operations locally or receive them over the built-in sync protocol which runs in the background. 

## Decision

Introduce an API for importing operations from an arbitrary source. Imported operations should be processed in the existing node pipeline and users should be notified when processing is complete via the event stream. The API should be idiomatic for the target use cases (reading from file, streaming from a remote service).

## Action

Add an `import` method to the `StreamPublisher` which a user receives when calling `node.stream(topic)`. The import method takes an `impl Stream<Item = Operation>` which is polled internally until completion, produced operations are processed in the node pipeline and events emitted via the event stream.

- [x] add import method to `StreamPublisher` which takes a `impl Stream<Item = Operation>`
- [x] associate each stream with a "session id" 
- [x] received operations are processed in the pipeline
- [x] issue lifetime events for each "batch" of operations (start, operation, end)
- [ ] attach basic metrics to events
    - optional but nice 
- [x] return `SessionId` on calls to `import()` 
- [x] support back-pressure for import operation streams
- [x] test

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
