### PR TITLE
Mention stability status in READMEs

### DIFF
--- a/p2panda-auth/README.md
+++ b/p2panda-auth/README.md
@@ -39,6 +39,10 @@ levels to determine who to sync with and over which subsets of data. Access cond
 used to define application-layer specific access rules, for example when modelling moderation
 rules or additional write checks.
 
+🚧 This library is under active development and the APIs are not yet considered stable for
+production use. Core data types and user-facing APIs may still undergo breaking changes.
+Stability guarantees will improve with the release of v1.0.0.
+
 ## Features
 
 ### Eventually Consistent Group State

--- a/p2panda-blobs/README.md
+++ b/p2panda-blobs/README.md
@@ -26,6 +26,10 @@ This crate provides a networked blob store for streaming content-addressed blobs
 It can be used to import, export and download blobs. Both in-memory and filesystem-based
 persistence options are provided.
 
+🚧 This library is under active development and the APIs are not yet considered stable for
+production use. Core data types and user-facing APIs may still undergo breaking changes.
+Stability guarantees will improve with the release of v1.0.0.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0] or [MIT license] at your option.

--- a/p2panda-core/README.md
+++ b/p2panda-core/README.md
@@ -29,6 +29,10 @@ The primary data structure is an append-only implementation which supports histo
 multi-writer ordering, fork-tolerance, efficient partial sync, compatibility with any CRDT and is
 extensible depending on your application requirements.
 
+🚧 This library is under active development and the APIs are not yet considered stable for
+production use. Core data types and user-facing APIs may still undergo breaking changes.
+Stability guarantees will improve with the release of v1.0.0.
+
 ## Features
 
 - Cryptographic signatures for authorship verification and tamper-proof messages

--- a/p2panda-discovery/README.md
+++ b/p2panda-discovery/README.md
@@ -38,6 +38,10 @@ acknowledgement is achieved using a secure multiparty cryptographic technique
 known as Private Equality Testing (PET) or Private Set Intersection (PSI) which
 prevents unrelated topics being leaked to other parties.
 
+🚧 This library is under active development and the APIs are not yet considered stable for
+production use. Core data types and user-facing APIs may still undergo breaking changes.
+Stability guarantees will improve with the release of v1.0.0.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0] or [MIT license] at your option.

--- a/p2panda-encryption/README.md
+++ b/p2panda-encryption/README.md
@@ -28,6 +28,10 @@ The crate implements two different group key-agreement and encryption schemes fo
 
 More detail about the particular implementation and design choices of `p2panda-encryption` can be found in our [in-depth blog post](https://p2panda.org/2025/02/24/group-encryption.html).
 
+🚧 This library is under active development and the APIs are not yet considered stable for
+production use. Core data types and user-facing APIs may still undergo breaking changes.
+Stability guarantees will improve with the release of v1.0.0.
+
 ## Features
 
 ### Strong Security Guarantees

--- a/p2panda-net/README.md
+++ b/p2panda-net/README.md
@@ -29,6 +29,10 @@ these modules solve the problem of event delivery.
 Applications subscribe to any topic they are interested in and `p2panda-net`
 will automatically discover similar peers and exchange messages between them.
 
+🚧 This library is under active development and the APIs are not yet considered stable for
+production use. Core data types and user-facing APIs may still undergo breaking changes.
+Stability guarantees will improve with the release of v1.0.0.
+
 ## Features
 
 - [Publish & Subscribe] for ephemeral messages (gossip protocol)

--- a/p2panda-spaces/README.md
+++ b/p2panda-spaces/README.md
@@ -29,6 +29,10 @@ scheme is used for key agreement and group management is achieved through an int
 [p2panda-auth groups](https://docs.rs/p2panda-auth/latest/p2panda_auth/). The main entry point for
 users is the `Manager` struct from which groups and spaces can be created.
 
+🚧 This library is under active development and the APIs are not yet considered stable for
+production use. Core data types and user-facing APIs may still undergo breaking changes.
+Stability guarantees will improve with the release of v1.0.0.
+
 ## Features
 
 * Decentralised group key agreement with forward secrecy and encrypted messaging with

--- a/p2panda-sync/README.md
+++ b/p2panda-sync/README.md
@@ -36,6 +36,10 @@ For most high-level users `p2panda-net` will be the entry point into local-first
 p2panda. Interfaces in this crate are intended for cases where users want to integrate their own
 base convergent data-type and sync protocols as a module in the `p2panda-net` stack.
 
+🚧 This library is under active development and the APIs are not yet considered stable for
+production use. Core data types and user-facing APIs may still undergo breaking changes.
+Stability guarantees will improve with the release of v1.0.0.
+
 ## License
 
 Licensed under either of [Apache License, Version 2.0] or [MIT license] at your option.


### PR DESCRIPTION
Here we add a short warning to each library README to communicate that core data types and APIs are not yet considered stable for production use.

We'll need to remember to add this to `p2panda`, `p2panda-store` and `p2panda-stream` when we write those READMEs.