### PR TITLE
Update iroh dependencies to v0.98.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Highlights are marked with a pancake 🥞
 - Expose insert_bootstrap on the node API [#1125](https://github.com/p2panda/p2panda/pull/1125)
 - Update iroh to v0.98.1 [#1131](https://github.com/p2panda/p2panda/pull/1131)
 - Forge result is never `None` or duplicate [#1132](https://github.com/p2panda/p2panda/pull/1132)
+- Update iroh to v0.98.2 [#1137](https://github.com/p2panda/p2panda/pull/1137)
 
 ### Fixed
 

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -70,7 +70,7 @@ ciborium = "0.2.2"
 futures-channel = "0.3.31"
 futures-util = "0.3.31"
 hex = "0.4.3"
-iroh = { version = "0.98.1", default-features = false, features = ["tls-ring"], optional = true }
+iroh = { version = "0.98.2", default-features = false, features = ["tls-ring"], optional = true }
 iroh-base = { version = "0.98.0", optional = true }
 iroh-gossip = { version = "0.98.0", optional = true }
 p2panda-core = { path = "../p2panda-core", version = "0.5.2" }


### PR DESCRIPTION
iroh have provided a patch release to fix the broken compilation resulting from an incorrectly pinned dependency.

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`