### PR TITLE
Ensure iroh Gossip is shut down gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Highlights are marked with a pancake 🥞
 - Race where replay_from misses processing ops [#1104](https://github.com/p2panda/p2panda/pull/1104)
 - Race where replay state was determined late [#1104](https://github.com/p2panda/p2panda/pull/1104)
 - React to node address changes in mDNS test [#1141](https://github.com/p2panda/p2panda/pull/1141)
+- Ensure iroh Gossip is shut down gracefully [#1139](https://github.com/p2panda/p2panda/pull/1139)
 
 ## [0.5.2] - 09/03/2026
 

--- a/p2panda-net/src/gossip/actors/manager.rs
+++ b/p2panda-net/src/gossip/actors/manager.rs
@@ -75,6 +75,9 @@ pub enum ToGossipManager {
 
     /// Subscribe to system events.
     Events(RpcReplyPort<broadcast::Receiver<GossipEvent>>),
+
+    /// Gracefully shut down the gossip actor, cleaning up connection state.
+    Shutdown,
 }
 
 /// Mapping of topic to the associated sender channels for getting messages into and out of the
@@ -158,26 +161,6 @@ impl ThreadLocalActor for GossipManager {
             neighbours,
             events_tx,
         })
-    }
-
-    async fn post_stop(
-        &self,
-        _myself: ActorRef<Self::Msg>,
-        state: &mut Self::State,
-    ) -> Result<(), ActorProcessingErr> {
-        // Leave all subscribed topics, send `Disconnect` messages to nodes and drop all state and
-        // connections.
-        if let Some(gossip) = state.gossip.take() {
-            // Make sure the endpoint has all the time it needs to gracefully shut down while other
-            // processes might already drop the whole actor.
-            tokio::task::spawn(async move {
-                if let Err(err) = gossip.shutdown().await {
-                    warn!("gossip failed during shutdown: {err:?}");
-                }
-            });
-        }
-
-        Ok(())
     }
 
     async fn handle(
@@ -379,6 +362,13 @@ impl ThreadLocalActor for GossipManager {
             }
             ToGossipManager::Events(reply) => {
                 let _ = reply.send(state.events_tx.subscribe());
+            }
+            ToGossipManager::Shutdown => {
+                if let Some(gossip) = state.gossip.take()
+                    && let Err(err) = gossip.shutdown().await
+                {
+                    warn!("failed to gracefully shut down iroh gossip: {err:?}");
+                }
             }
         }
 

--- a/p2panda-net/src/gossip/api.rs
+++ b/p2panda-net/src/gossip/api.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc::error::SendError;
 use tokio::sync::{RwLock, broadcast, mpsc};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
-use tracing::trace;
+use tracing::{trace, warn};
 
 use crate::NodeId;
 use crate::address_book::{AddressBook, AddressBookError};
@@ -236,8 +236,21 @@ impl Drop for Inner {
             "drop gossip actor reference"
         );
 
-        // Stop actor after all references (Gossip, GossipHandle, GossipSubscription) have dropped.
-        self.actor_ref.stop(None);
+        // Stop the gossip manager actor once all references to Gossip have been dropped.
+        //
+        // Process all messages which are already in the inboxes of the gossip actors which are the
+        // children of the gossip manager.
+        self.actor_ref.drain_children();
+
+        // Tell the gossip manager to shutdown.
+        if let Err(err) = self.actor_ref.send_message(ToGossipManager::Shutdown) {
+            warn!("failed to send shutdown event to gossip manager: {}", err)
+        }
+
+        // Proccess all messages in the inbox of the gossip manager before stopping it.
+        if let Err(err) = self.actor_ref.drain() {
+            warn!("failed to drain gossip manager: {}", err)
+        }
     }
 }
 

--- a/p2panda-net/src/gossip/tests.rs
+++ b/p2panda-net/src/gossip/tests.rs
@@ -585,6 +585,9 @@ async fn leave_overlay_on_drop() {
     // See issue: https://github.com/p2panda/p2panda/issues/967
     setup_logging();
 
+    // Configure two nodes, ant and bat, which know about one another.
+    // Then get a handle to the same gossip topic stream for both.
+
     let mut ant_args = test_args();
     let mut bat_args = test_args();
     let topic: Topic = [1; 32].into();


### PR DESCRIPTION
We previously observed flakiness in the `leave_overlay_on_drop` gossip test, whose purpose is to ensure cleanup of state when gossip stream handles - or the entire gossip system - are dropped. The test would simply hang without completion.

I tracked the behaviour down to a failure to join the gossip overlay after the p2panda `Gossip` object had been dropped and recreated from scratch for one of the two nodes in the test. This suggested that the node which remained running may have held some incorrect connection state relating to the downed node; the assumption being that this prevented the latest overlay connection attempt to fail.

On further inspection, I realised that the call to gracefully shut down iroh gossip (from within the `post_stop` method of the gossip manager actor) was not being executed. Calling `gossip.shutdown()` directly in `post_stop`, without spawning it in a tokio task, resulted in the shut down but caused a panic of unknown origin. My suspicion is that one of the other gossip actors was causing the panic.

The implemented solution is three-fold (all in the `Drop` impl for p2panda):

1) Drain all children of the gossip manager actor
2) Send the newly-added Shutdown message to the gossip manager actor
3) Drain the gossip manager actor

The test now passes reliably without any panics.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`