### PR TITLE
React to node address changes in mDNS test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Highlights are marked with a pancake 🥞
 - Fix automatic roll-back of unused, dropped permits [#1075](https://github.com/p2panda/p2panda/pull/1075)
 - Race where replay_from misses processing ops [#1104](https://github.com/p2panda/p2panda/pull/1104)
 - Race where replay state was determined late [#1104](https://github.com/p2panda/p2panda/pull/1104)
+- React to node address changes in mDNS test [#1141](https://github.com/p2panda/p2panda/pull/1141)
 
 ## [0.5.2] - 09/03/2026
 

--- a/p2panda-net/src/iroh_mdns/tests.rs
+++ b/p2panda-net/src/iroh_mdns/tests.rs
@@ -1,9 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::time::Duration;
-
-use tokio::time::sleep;
-
 use crate::address_book::AddressBook;
 use crate::iroh_endpoint::Endpoint;
 use crate::iroh_mdns::{MdnsDiscovery, MdnsDiscoveryMode};
@@ -34,6 +30,31 @@ async fn mdns_discovery() {
         .await
         .unwrap();
 
+    // Alice and Bob do not yet know about one another.
+    let result = bob_address_book
+        .node_info(alice_args.public_key)
+        .await
+        .unwrap();
+    assert!(result.is_none());
+
+    let result = alice_address_book
+        .node_info(bob_args.public_key)
+        .await
+        .unwrap();
+    assert!(result.is_none());
+
+    // Listen for changes to Bob's node info in Alice's address book.
+    let mut alice_address_book_bob = alice_address_book
+        .watch_node_info(bob_endpoint.node_id(), true)
+        .await
+        .unwrap();
+
+    // Listen for changes to Alice's node info in Bob's address book.
+    let mut bob_address_book_alice = bob_address_book
+        .watch_node_info(alice_endpoint.node_id(), true)
+        .await
+        .unwrap();
+
     // Enable active discovery mode, otherwise they'll not find each other.
     let _alice_mdns = MdnsDiscovery::builder(alice_address_book.clone(), alice_endpoint.clone())
         .mode(MdnsDiscoveryMode::Active)
@@ -47,7 +68,8 @@ async fn mdns_discovery() {
         .unwrap();
 
     // Wait until they find each other and exchange transport infos.
-    sleep(Duration::from_millis(1000)).await;
+    alice_address_book_bob.recv().await;
+    bob_address_book_alice.recv().await;
 
     // Alice should be in Bob's address book and vice-versa.
     let result = bob_address_book


### PR DESCRIPTION
The mDNS discovery test, which relied on assertions that Alice and Bob had learned one another's node info, was sometimes failing. We were relying on a 1 second sleep after spawning the mDNS processes to allow enough time for discovery. I believe this duration is not always sufficient for both peers to discover one another and update their address books, thus resulting in inconsistent test outcomes.

The test now uses address book watchers; we wait for Bob's node info to be updated in Alice's address book (and vice versa) before running the assertions. This ensures that the mutual discovery process has enough time to complete.

Closes https://github.com/p2panda/p2panda/issues/1140

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
