### PR TITLE
`README.md` and more doc-strings for high-level Node API

### DIFF
--- a/p2panda/Cargo.toml
+++ b/p2panda/Cargo.toml
@@ -7,9 +7,11 @@ authors = [
   "sandreae <contact@samandreae.com>",
   "glyph <glyph@mycelial.technology>",
 ]
+description = "Out-of-the-box p2panda Node API for application developers"
 repository = "https://github.com/p2panda/p2panda"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+keywords = ["p2p", "local-first", "sync", "event-sourcing"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/p2panda/README.md
+++ b/p2panda/README.md
@@ -1,0 +1,115 @@
+<h1 align="center">p2panda</h1>
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/p2panda/.github/main/assets/panda-left.gif" width="auto" height="30px">
+  <strong>Out-of-the-box p2panda Node API for application developers</strong>
+  <img src="https://raw.githubusercontent.com/p2panda/.github/main/assets/panda-right.gif" width="auto" height="30px">
+</div>
+
+<div align="center">
+  <h3>
+    <a href="https://docs.rs/p2panda">
+      Documentation
+    </a>
+    <span> | </span>
+    <a href="https://github.com/p2panda/p2panda/releases">
+      Releases
+    </a>
+    <span> | </span>
+    <a href="https://p2panda.org">
+      Website
+    </a>
+  </h3>
+</div>
+
+p2panda's high-level Node API is an opiniated, out-of-the-box peer-to-peer stack which orchestrates
+all individual [p2panda] modules.
+
+```rust
+let topic = Topic::new();
+let node = p2panda::spawn().await?;
+let (tx, rx) = node.stream(topic).await?;
+```
+
+It provides peer-to-peer networking, discovery, bootstrap, local-first sync, event streaming, causal
+ordering, storage, and more in one easy-to-use API.
+
+> 🚧 This library is under active development and the APIs are not yet considered stable for
+> production use. Core data types and user-facing APIs may still undergo breaking changes. Stability
+> guarantees will improve with the release of v1.0.0.
+
+## Features
+
+- High-level p2panda Node API for building decentralised p2p and [local-first] applications with
+  minimal setup
+- Unified orchestration of p2p networking, node discovery, mDNS, bootstrap, [eventually consistent]
+  sync, event streaming, causal ordering, pruning, and persistence
+- Topic-based [Publish & Subscribe] model with partial replication - sync only the data relevant to
+  a topic
+- Transport-agnostic "event delivery" architecture supporting Internet p2p today (QUIC/iroh) and
+  future mesh/radio transports such as BLE and LoRa
+- Built on single-writer append-only, fork-resistant CRDT operation logs with pruning, multi-writer
+  causal ordering, and efficient sync
+- Persistent local SQLite storage for operations, sync state, address books, stream cursors, and
+  soon encryption/access-control state
+- Event-stream-inspired consumer model with acknowledgements, replay support, at-least-once delivery
+  semantics, and crash recovery
+- Atomic transactional processing pipeline for resilience against crashes and corrupted database
+  state
+- Observable system state, events, and metrics
+
+## Getting Started
+
+Install the Rust crate using `cargo add p2panda` and read our [documentation] and [examples] folder
+for an introduction and code examples of the Node API.
+
+## Other languages / FFI
+
+There's experimental support for bindings of p2panda's Node API into alternative programming
+languages and flavours:
+
+- [`p2panda-gobject`] Introspectable GLib/GObject API for various languages
+- [`p2panda-ffi`] Node.js, Python and Go support via UniFFI
+
+## Roadmap
+
+- Out-of-the-box [Tor support] to protect IP addresses
+- Filterable topic streams
+- Integration of Capabilities, like [Meadowcap] or [UCAN]
+- [Multi-device group management] with revocation
+- [Encryption for groups] with Forward Secrecy
+- [Support Nodes] to assure higher availability
+- Event delivery via [delay tolerant, replicated mesh-routing] for BLE and LoRa
+
+[Encryption for groups]: https://p2panda.org/2025/02/24/group-encryption.html
+[Meadowcap]: https://willowprotocol.org/specs/meadowcap/index.html
+[Multi-device group management]: https://p2panda.org/2025/07/28/access-control.html
+[Publish & Subscribe]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
+[Support Nodes]: https://fosdem.org/2026/schedule/event/MCVBNK-p2panda-modal-reflection/
+[Tor support]: https://www.torproject.org
+[UCAN]: https://ucan.xyz/
+[`p2panda-ffi`]: https://github.com/p2panda/p2panda-ffi
+[`p2panda-gobject`]: https://github.com/p2panda/p2panda-gobject
+[delay tolerant, replicated mesh-routing]: https://en.wikipedia.org/wiki/Delay-tolerant_networking
+[documentation]: https://docs.rs/p2panda
+[eventually consistent]: https://en.wikipedia.org/wiki/Eventual_consistency
+[examples]: https://github.com/p2panda/p2panda/tree/main/p2panda/examples
+[local-first]: https://www.inkandswitch.com/local-first-software/
+[p2panda]: https://p2panda.org
+
+## License
+
+Licensed under either of [Apache License, Version 2.0] or [MIT license] at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in
+p2panda by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
+additional terms or conditions.
+
+[Apache License, Version 2.0]: https://github.com/p2panda/p2panda/blob/main/LICENSES/Apache-2.0.txt
+[MIT license]: https://github.com/p2panda/p2panda/blob/main/LICENSES/MIT.txt
+
+---
+
+_This project has received funding from the European Union’s Horizon 2020 research and innovation
+programme within the framework of the NGI-POINTER Project funded under grant agreement No 871528,
+NGI-ASSURE No 957073, NGI0-ENTRUST No 101069594 and NGI0-COMMONS No 101135429._

--- a/p2panda/src/builder.rs
+++ b/p2panda/src/builder.rs
@@ -17,6 +17,9 @@ use crate::network::MdnsDiscoveryMode;
 use crate::node::{AckPolicy, Config, SpawnError};
 use crate::processor::{Pipeline, TaskTracker};
 
+/// Builder for `Node`.
+///
+/// To create the `Node` call `NodeBuilder::spawn()`.
 #[derive(Default)]
 pub struct NodeBuilder {
     signing_key: Option<SigningKey>,
@@ -25,6 +28,7 @@ pub struct NodeBuilder {
 }
 
 impl NodeBuilder {
+    /// Creates a new `NodeBuilder` using default configuration values.
     pub fn new() -> Self {
         NodeBuilder {
             signing_key: None,
@@ -33,36 +37,109 @@ impl NodeBuilder {
         }
     }
 
+    /// Sets the signing key.
+    ///
+    /// The public key derived from the given private key is used to identify the node in the
+    /// network. For example, this key can be used to directly connect to the node. The private key
+    /// serves as the means of authenticating the node during the connection handshake (using TLS
+    /// 1.3) and is also used to sign operations to ensure data integrity and authenticity.
+    ///
+    /// If left unset, a new key will be randomly generated.
     pub fn signing_key(mut self, signing_key: SigningKey) -> Self {
         self.signing_key = Some(signing_key);
         self
     }
 
+    /// Defines the database URL to be used by the store.
+    ///
+    /// The given URL must take the form of a SQLite database URI: <https://sqlite.org/uri.html>.
+    ///
+    /// Database migrations are run automatically. Users should use `NodeBuilder::database_pool()`
+    /// together with `sqlx` if manual migration management is required.
+    ///
+    /// If left unset, the node will default to using an ephemeral in-memory database.
     pub fn database_url(mut self, url: &str) -> Self {
         self.store_options = StoreBuilderOptions::Url(url.to_string());
         self
     }
 
+    /// Defines the connection pool to be used by the store.
+    ///
+    /// If left unset, a new connection pool will be created using the default maximum connections
+    /// value of 16 and the database URL (either the default in-memory URL or the URL set by
+    /// calling `NodeBuilder::database_url()`).
     pub fn database_pool(mut self, pool: SqlitePool) -> Self {
         self.store_options = StoreBuilderOptions::Pool(pool);
         self
     }
 
+    /// Defines the acknowledgement policy.
+    ///
+    /// If left unset, the policy defaults to `Automatic` and all messages emitted from topic
+    /// streams will be automatically acknowledged.
+    ///
+    /// See the `Node::stream(topic)` documentation for further information.
     pub fn ack_policy(mut self, value: AckPolicy) -> Self {
         self.config.ack_policy = value;
         self
     }
 
+    /// Sets the network identifier.
+    ///
+    /// The network identifier is used to achieve separation and prevent interoperability between
+    /// distinct networks. This is the most global identifier to group nodes into networks. Different
+    /// applications may choose to share the same underlying network infrastructure by using the same
+    /// network identifier.
+    ///
+    /// **WARNING:** The network identifier is _not_ confidentially exchanged with a remote node and
+    /// can not be treated as a secret value. See: <https://github.com/p2panda/p2panda/issues/965>
+    ///
+    /// If left unset, the network ID defaults to the byte representation of the BLAKE3 hash of the
+    /// string "p2panda".
     pub fn network_id(mut self, network_id: NetworkId) -> Self {
         self.config.network.network_id = network_id;
         self
     }
 
+    /// Sets a relay server URL to assist in establishing direct connections.
+    ///
+    /// Multipe relays can be added; a single "home relay" will be automatically selected based on
+    /// latency.
+    ///
+    /// Relays fullfil multiple functions:
+    ///
+    /// 1. The relay server helps establish connections by temporarily routing encrypted traffic
+    ///    until a direct, P2P connection is feasible. This allows nodes to immediately get
+    ///    started, without waiting for holepunching / STUN to complete first.
+    /// 2. Handle learning a node's public addresses (via QUIC address discovery), signalling and
+    ///    hole-punching to establish direct connections between two nodes. This set of methods is
+    ///    also understood as STUN. After this point the relay is not required anymore.
+    /// 3. Relayed and encrypted fallback using the server when establishing a direct connection
+    ///    failed (TURN).
+    ///
+    /// If no relay is given other nodes can only connect to us if a directly-reachable IP address
+    /// is available and known to them.
     pub fn relay_url(mut self, url: RelayUrl) -> Self {
         self.config.network.relay_urls.insert(url);
         self
     }
 
+    /// Inserts a bootstrap node into the local address book.
+    ///
+    /// Bootstrap nodes are used as a starting point for the random-walk discovery algorithm to
+    /// find other nodes in the network, without the need for any centralised registry. Any node
+    /// can serve as a bootstrap into the network. The URL of the relay used by the bootstrap node
+    /// is required to assist with connectivity (via relaying of traffic and negotiation of
+    /// hole-punching for direct connections).
+    ///
+    /// Multiple bootstrap nodes can be registered. Each iteration of the discovery algorithm
+    /// begins by picking a random node from the set of known bootstrap nodes. It's recommended to
+    /// register several bootstrap nodes, especially if they are not highly-available; this
+    /// offers redunancy in the case that any of the bootstrap nodes go offline or are otherwise
+    /// unavailable.
+    ///
+    /// Consult the documentation of the `p2panda-discovery` crate for further details concerning
+    /// the discovery protocol.
     pub fn bootstrap(mut self, node_id: NodeId, relay_url: RelayUrl) -> Self {
         let endpoint_addr =
             EndpointAddr::new(from_verifying_key(node_id)).with_relay_url(relay_url);
@@ -73,41 +150,70 @@ impl NodeBuilder {
         self
     }
 
+    /// Sets the mDNS discovery mode.
+    ///
+    /// mDNS may be set to active, passive or disabled mode.
+    ///
+    /// If left unset, the mode defaults to active and this node will actively advertise it's
+    /// endpoint address on the local area network.
     pub fn mdns_mode(mut self, mode: MdnsDiscoveryMode) -> Self {
         self.config.network.mdns_mode = mode;
         self
     }
 
+    /// Binds an IPv4 socket at the given address.
+    ///
+    /// If left unset, the address defaults to `0.0.0.0`.
     pub fn bind_ip_v4(mut self, ip: Ipv4Addr) -> Self {
         self.config.network.iroh.bind_ip_v4 = ip;
         self
     }
 
+    /// Sets the IPv4 address port.
+    ///
+    /// If left unset, the port defaults to `0` which results in a random free port being chosen.
+    /// If the given port is already in use, a random port will be chosen as a fallback.
     pub fn bind_port_v4(mut self, port: u16) -> Self {
         self.config.network.iroh.bind_port_v4 = port;
         self
     }
 
+    /// Binds an IPv6 socket at the given address.
+    ///
+    /// If left unset, the address defaults to `[::]`.
     pub fn bind_ip_v6(mut self, ip: Ipv6Addr) -> Self {
         self.config.network.iroh.bind_ip_v6 = ip;
         self
     }
 
+    /// Sets the IPv6 address port.
+    ///
+    /// If left unset, the port defaults to `0` which results in a random free port being chosen.
+    /// If the given port is already in use, a random port will be chosen as a fallback.
     pub fn bind_port_v6(mut self, port: u16) -> Self {
         self.config.network.iroh.bind_port_v6 = port;
         self
     }
 
+    /// Defines custom discovery configuration parameters.
+    ///
+    /// This allows fine-tuning of the random walk protocol, including the number of walkers and
+    /// their reset probability.
     pub fn discovery_config(mut self, config: DiscoveryConfig) -> Self {
         self.config.network.discovery = config;
         self
     }
 
+    /// Defines custom gossip configuration parameters.
+    ///
+    /// This allows fine-tuning of swarm membership and gossip broadcast parameters, as well as the
+    /// maximum message size for broadcast. The default maximum message size is 4096 bytes.
     pub fn gossip_config(mut self, config: GossipConfig) -> Self {
         self.config.network.gossip = config;
         self
     }
 
+    /// Spawns the `Node`.
     pub async fn spawn(self) -> Result<Node, SpawnError> {
         let signing_key = self.signing_key.unwrap_or_default();
         let store = match self.store_options {

--- a/p2panda/src/lib.rs
+++ b/p2panda/src/lib.rs
@@ -1,5 +1,254 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! p2panda's high-level Node API is an opinionated, out-of-the-box peer-to-peer stack which
+//! orchestrates all individual [p2panda] modules.
+//!
+//! ```rust
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let topic = p2panda::Topic::new();
+//! let node = p2panda::spawn().await?;
+//! let (tx, rx) = node.stream(topic).await?;
+//! # tx.publish(b"Hello!".to_vec()).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! It provides peer-to-peer networking, discovery, bootstrap, local-first sync, event streaming,
+//! causal ordering, storage, and more in one easy-to-use API.
+//!
+//! ## Features
+//!
+//! - High-level p2panda Node API for building decentralised p2p and [local-first] applications with
+//!   minimal setup
+//! - Unified orchestration of p2p networking, node discovery, mDNS, bootstrap, [eventually
+//!   consistent] sync, event streaming, causal ordering, pruning and persistence
+//! - Topic-based [Publish & Subscribe] model with partial replication - sync only the data relevant
+//!   to a topic
+//! - Transport-agnostic event delivery architecture supporting Internet p2p today (QUIC/iroh) and
+//!   future mesh/radio transports such as BLE and LoRa
+//! - Built on single-writer append-only, fork-resistant CRDT operation logs with pruning,
+//!   multi-writer causal ordering, and efficient sync
+//! - Persistent local SQLite storage for operations, sync state, address books, stream cursors, and
+//!   soon encryption/access-control state
+//! - Event-stream-inspired consumer model with acknowledgements, replay support, at-least-once
+//!   delivery semantics and crash recovery
+//! - Atomic transactional processing pipeline for resilience against crashes and corrupted database
+//!   state
+//! - Observable system state, events, and metrics
+//!
+//! ## Walkaway Stack
+//!
+//! The Node API is designed around a separation between the event delivery and event processing
+//! layers. Applications built with p2panda should not need to care abot _where_ messages originate
+//! from, but rather _how_ they are processed.
+//!
+//! The stack confidentially discovers nodes interested in the same topic, synchronises missed
+//! messages and delivers them to the processing layer.
+//!
+//! Today this is implemented over the Internet using [iroh] for direct peer-to-peer connections
+//! but the abstraction is designed to support additional transports such as LoRa or BLE, including
+//! delay-tolerant and store-and-forward mesh network topologies in the future.
+//!
+//! Application developers primarily interact with the API to monitor networking and sync activity,
+//! configure transports and manage access control, while the stack handles message delivery,
+//! synchronisation and persistence.
+//!
+//! This allows applications to remain portable across different network infrastructures - what we
+//! refer to as a ["Walkaway Stack"].
+//!
+//! ### Append-only log operations
+//!
+//! Application messages are transported using p2panda's `Operation` data type: a single-writer
+//! append-only log with pruning support and fork resistance. Multiple logs can coexist
+//! independently or form causally-ordered graphs when arranged in multi-writer streams over a
+//! topic.
+//!
+//! Append-only logs are also well-suited for radio-based meshes, where synchronisation needs to
+//! remain bandwidth-efficient. State vectors can be exchanged in constant size and work naturally
+//! in broadcast-oriented networks.
+//!
+//! Operations can be thought of as carriers for application data, similar to how IP datagrams
+//! transport arbitrary payloads over the Internet.
+//!
+//! ### Composable event processors
+//!
+//! Additional system-level functionality can be layered on top of Operations by extending their
+//! headers with metadata for pruning, tombstones, causal ordering, group encryption and other
+//! behaviours.
+//!
+//! The design also allows integration with external processors, CRDTs, key agreement solutions,
+//! databases, schemas or capability systems such as Willow's [Meadowcap] or [UCAN] for permission
+//! checks and delegated access control.
+//!
+//! ### Multicast by nature
+//!
+//! Applications generate a Topic (random bytes) and publish messages into it while subscribing to
+//! receive messages from other nodes. This follows a [Publish & Subscribe] (PubSub) model.
+//!
+//! Topics provide a way to group related data. A topic might represent a text document, a chess
+//! game session or a chat room for example.
+//!
+//! ### SQLite database
+//!
+//! The Node API persists synchronised Operations in a local SQLite database, together with
+//! additional state such as address books, causal ordering buffers, topic mappings and stream
+//! cursors.
+//!
+//! Future versions may also store encryption state, secret key material and access control
+//! metadata.
+//!
+//! ### Event streaming and state materialisation
+//!
+//! Once data is available locally, the stack processes and delivers it to the application layer
+//! using concepts inspired by event-streaming systems such as NATS JetStream or Kafka - adapted for
+//! decentralised and autonomous p2p networks.
+//!
+//! Subscribing to a topic creates a stateful stream consumer.
+//!
+//! Each operation first passes through an internal _system-level_ processing layer where the system
+//! validates log integrity, applies pruning rules, performs causal ordering and, in the future,
+//! handles decryption.
+//!
+//! The processed operation is then forwarded to the _application-level_ together with metadata and
+//! debugging information.
+//!
+//! Applications can then apply their own domain-specific processing logic, such as updating a
+//! document title, processing a chat message, applying a text CRDT operation or handling a chess
+//! move.
+//!
+//! ### Crash resilience & acknowledgements
+//!
+//! Operations can be acknowledged after successful processing. Once acknowledged, they are
+//! internally marked as processed and will not be delivered again when re-subscribing to the same
+//! stream.
+//!
+//! By default acknowledgements are handled automatically, though manual control is also possible
+//! for advanced use cases.
+//!
+//! This becomes important in scenarios where an application crashes or is terminated during
+//! processing - for example on mobile devices. Unacknowledged operations are replayed on the next
+//! startup, allowing applications to maintain at-least-once processing guarantees.
+//!
+//! Internally, processing and state updates are performed atomically using transactions to minimise
+//! the risk of corruption during unexpected shutdowns. Combined with acknowledgements and replay
+//! support, this provides a resilient foundation for long-running p2p applications.
+//!
+//! Replay functionality can also be used to rebuild application state after schema changes, logic
+//! updates or recovery scenarios.
+//!
+//! ### Local-first publishing
+//!
+//! Publishing a message appends a new operation to the right log for the given topic, signs it,
+//! persists it locally and forwards it to the networking layer.
+//!
+//! If nodes are currently connected, operations may be propagated eagerly in real time. Otherwise,
+//! missed operations are synchronised automatically the next time nodes are online again.
+//!
+//! ## Examples
+//!
+//! ### Topic stream
+//!
+//! ```rust,no_run
+//! # use futures_util::StreamExt;
+//! # use p2panda::Topic;
+//! # use p2panda::streams::StreamEvent;
+//! #
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Spawn default, in-memory node with mdns discovery.
+//! let node = p2panda::spawn().await?;
+//!
+//! // Generate random topic.
+//! let chat_id = Topic::new();
+//!
+//! // Publish and subscribe topic stream with sync.
+//! let (tx, mut rx) = node.stream(chat_id).await?;
+//! tx.publish("Hello, Panda!".to_string()).await?;
+//!
+//! while let Some(event) = rx.next().await {
+//!     // React to system events.
+//!     if let StreamEvent::SyncStarted {
+//!         remote_node_id,
+//!         incoming_bytes,
+//!         ..
+//!     } = event {
+//!         println!("syncing {} bytes from {}", incoming_bytes, remote_node_id);
+//!     }
+//!
+//!     // Handle application messages.
+//!     if let StreamEvent::Processed { operation, .. } = event {
+//!         println!(
+//!             "[{}]: received {} from {}",
+//!             operation.timestamp(),
+//!             operation.message(),
+//!             operation.author(),
+//!         );
+//!     }
+//! }
+//! #
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Node configuration
+//!
+//! ```rust,no_run
+//! # use p2panda::RelayUrl;
+//! #
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Public key of node helping to bootstrap the network for any topic.
+//! let bootstrap_id = "1021253b4ccdfba6cac196d2b9fa6ebb605b747bcd502d6bf1d46887f04ec913".parse()?;
+//!
+//! // URL of iroh relay to establish a direct connection over the Internet.
+//! let relay_url: RelayUrl = "https://my.relay.link".parse()?;
+//!
+//! // Persist SQLite database under given file path.
+//! let database_url = "db.sqlite";
+//!
+//! // Check the builder docs for more information on configuration options.
+//! let node = p2panda::builder()
+//!     .database_url(database_url)
+//!     .bootstrap(bootstrap_id, relay_url.clone())
+//!     .relay_url(relay_url)
+//!     .spawn()
+//!     .await?;
+//! #
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Application messages
+//!
+//! ```rust
+//! # use p2panda::Topic;
+//! # use serde::{Serialize, Deserialize};
+//! #
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // This will automatically serialise to CBOR.
+//! #[derive(Serialize, Deserialize)]
+//! enum CalendarMessage {
+//!     Update { title: String },
+//!     Delete,
+//! }
+//!
+//! let node = p2panda::spawn().await?;
+//! let topic = Topic::new();
+//! let (tx, rx) = node.stream::<CalendarMessage>(topic).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ["Walkaway Stack"]: https://fosdem.org/2026/schedule/event/J3FLC3-walkaway-stack/
+//! [Meadowcap]: https://willowprotocol.org/specs/meadowcap/index.html
+//! [Publish & Subscribe]: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
+//! [UCAN]: https://ucan.xyz/
+//! [eventually consistent]: https://en.wikipedia.org/wiki/Eventual_consistency
+//! [iroh]: https://www.iroh.computer/
+//! [local-first]: https://www.inkandswitch.com/local-first-software/
+//! [p2panda]: https://p2panda.org
 mod builder;
 mod forge;
 pub mod network;
@@ -22,10 +271,12 @@ pub use builder::NodeBuilder;
 #[doc(inline)]
 pub use node::Node;
 
+/// Spawns a `Node` using default configuration parameters.
 pub async fn spawn() -> Result<Node, node::SpawnError> {
     Node::spawn().await
 }
 
+/// Returns the builder for a `Node`.
 pub fn builder() -> builder::NodeBuilder {
     Node::builder()
 }
@@ -33,7 +284,7 @@ pub fn builder() -> builder::NodeBuilder {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_runtime_spawn() {
+    fn runtime_spawn() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
 
         runtime.spawn(async move {

--- a/p2panda/src/network.rs
+++ b/p2panda/src/network.rs
@@ -23,9 +23,9 @@ use thiserror::Error;
 use crate::operation::Extensions;
 
 #[derive(Clone, Debug)]
-#[allow(unused)]
 pub(crate) struct Network {
     pub address_book: AddressBook,
+    #[allow(unused)]
     pub mdns: Option<MdnsDiscovery>,
     pub endpoint: Endpoint,
     pub discovery: Discovery,
@@ -39,8 +39,6 @@ impl Network {
         signing_key: SigningKey,
         store: SqliteStore,
     ) -> Result<Self, NetworkError> {
-        // TODO: Supervision of actors.
-
         let address_book = AddressBook::builder().store(store.clone()).spawn().await?;
 
         for (node_id, transport_info) in config.bootstraps {
@@ -121,15 +119,22 @@ impl Network {
         }
         Ok(())
     }
-
-    // TODO: Do we need methods to get the transport info (with ip addresses etc.)?
 }
 
+/// mDNS discovery mode.
+///
+/// By default this is set to "active" meaning we are actively advertising our address and public
+/// key on local-area networks on local-area networks.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum MdnsDiscoveryMode {
+    /// mDNS discovery disabled.
     Disabled,
+
+    /// Advertise our own and listen for others' discovery announcements.
     #[default]
     Active,
+
+    /// Listen for others' discovery announcements but don't advertise our own.
     Passive,
 }
 
@@ -168,6 +173,7 @@ impl Default for NetworkConfig {
     }
 }
 
+/// Errors coming from the networking layer.
 #[derive(Debug, Error)]
 pub enum NetworkError {
     #[error(transparent)]

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -20,24 +20,29 @@ use crate::streams::{
     StreamSubscription, SystemEvent, ephemeral_stream, event_stream, processed_stream,
 };
 
+/// Node API with methods to establish ephemeral and eventually consistent topic streams.
 #[derive(Debug)]
 pub struct Node {
     config: Config,
-    #[allow(unused)]
     store: SqliteStore,
     forge: OperationForge,
-    // NOTE: One single pipeline is currently used to handle _all_ incoming operations,
-    // independent of number of streams. While this is sufficient for most applications for now we
-    // might want to make the number of processors configurable to avoid head-of-line blocking.
+    // NOTE: One single pipeline is currently used to handle _all_ incoming operations, independent
+    // of number of streams. While this is sufficient for most applications for now we might want to
+    // make the number of processors configurable to avoid head-of-line blocking.
     pipeline: Pipeline<LogId, Extensions, Topic>,
     network: Network,
 }
 
 impl Node {
+    /// Returns the builder for a `Node`.
     pub fn builder() -> NodeBuilder {
         NodeBuilder::new()
     }
 
+    /// Spawns a `Node` using default configuration parameters.
+    ///
+    /// A [`SpawnError`] is returned if spawning is unsuccessful due to a network or store-related
+    /// failure.
     pub async fn spawn() -> Result<Self, SpawnError> {
         // Initialises an in-memory SQLite database.
         let store = SqliteStoreBuilder::default().build().await?;
@@ -301,6 +306,14 @@ impl Node {
         Ok((tx, rx))
     }
 
+    /// Returns a publisher and subscriber pair for an ephemeral stream of messages over the given
+    /// topic.
+    ///
+    /// Messages sent or received on this stream will not be persisted in local storage. Only
+    /// currently online and reachable nodes will receive published messages.
+    ///
+    /// Message payloads are signed providing integrity and provenance guarantees, plus making sure
+    /// each message is unique with the help of a timestamp.
     pub async fn ephemeral_stream<M>(
         &self,
         topic: impl Into<Topic>,
@@ -319,10 +332,14 @@ impl Node {
         Ok(ephemeral_stream(topic, self.forge.clone(), handle))
     }
 
-    /// System event stream.
+    /// Returns a stream of system events.
     ///
     /// System events include all network-related events, such as discovery events, which are not
     /// associated with a specific topic.
+    ///
+    /// Any events generated before this method is called will _not_ be emitted. Therefore, it's
+    /// recommended to call `event_stream()` right after the `Node` is spawned if you wish to
+    /// observe network behaviour throughout the lifetime of the `Node`.
     pub async fn event_stream(
         &self,
     ) -> Result<impl Stream<Item = SystemEvent> + Send + Unpin + 'static, CreateStreamError> {
@@ -336,14 +353,32 @@ impl Node {
         Ok(event_stream(discovery_events))
     }
 
+    /// Returns the node identifier (public key).
     pub fn id(&self) -> NodeId {
         self.forge.verifying_key()
     }
 
+    /// Returns the network identifier being used by the node.
     pub fn network_id(&self) -> NetworkId {
         self.network.network_id()
     }
 
+    /// Inserts a bootstrap node into the local address book.
+    ///
+    /// Bootstrap nodes are used as a starting point for the random-walk discovery algorithm to
+    /// find other nodes in the network, without the need for any centralised registry. Any node
+    /// can serve as a bootstrap into the network. The URL of the relay used by the bootstrap node
+    /// is required to assist with connectivity (via relaying of traffic and negotiation of
+    /// hole-punching for direct connections).
+    ///
+    /// Multiple bootstrap nodes can be registered. Each iteration of the discovery algorithm
+    /// begins by picking a random node from the set of known bootstrap nodes. It's recommended to
+    /// register several bootstrap nodes, especially if they are not highly-available; this
+    /// offers redunancy in the case that any of the bootstrap nodes go offline or are otherwise
+    /// unavailable.
+    ///
+    /// Consult the documentation of the `p2panda-discovery` crate for further details concerning
+    /// the discovery protocol.
     pub async fn insert_bootstrap(
         &self,
         node_id: NodeId,
@@ -355,6 +390,7 @@ impl Node {
 
 #[cfg(any(test, feature = "test_utils"))]
 impl Node {
+    /// Returns a clone of the underlying store for this `Node`.
     // NOTE(adz): This feels like something we would like to have on the regular Node API as well,
     // I'll leave it here for now until we've made a decision.
     pub fn store(&self) -> SqliteStore {
@@ -362,6 +398,14 @@ impl Node {
     }
 }
 
+/// Message acknowledgement policy for eventually-consistent topic streams.
+///
+/// Every `StreamSubscription` instance is stateful and keeps track of already acknowledged
+/// operations by persisting them in the local SQLite database. Specifying a policy defines how and
+/// when events are acknowledged.
+///
+/// Operations which have not been acknowledged yet will be automatically re-played when this stream
+/// is created again.
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub enum AckPolicy {
     /// Each individual message must be acknowledged.
@@ -378,6 +422,7 @@ pub(crate) struct Config {
     pub network: NetworkConfig,
 }
 
+/// Error occurred when spawning network or store processes.
 #[derive(Debug, Error)]
 pub enum SpawnError {
     #[error(transparent)]

--- a/p2panda/src/operation.rs
+++ b/p2panda/src/operation.rs
@@ -6,14 +6,17 @@ use p2panda_core::hash::{HASH_LEN, Hash};
 use p2panda_core::{PruneFlag, Topic};
 use serde::{Deserialize, Serialize};
 
+/// Header type with our system-level extensions.
 pub type Header = p2panda_core::Header<Extensions>;
 
+/// Operation type with our system-level extensions.
 pub type Operation = p2panda_core::Operation<Extensions>;
 
 /// Versioning for internal extensions format.
 pub(crate) const VERSION: u64 = 1;
 
-// TODO: Make sure encoding is canonical over map keys (sort it before serializing).
+/// Header extensions used in the event processor pipeline to coordinate system-level concerns, for
+/// example pruning.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Extensions {
     #[serde(
@@ -40,6 +43,7 @@ impl Extensions {
     }
 }
 
+/// Append-only log identifier used by the Node API.
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, PartialEq, Eq, StdHash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct LogId(Hash);

--- a/p2panda/src/processor/event.rs
+++ b/p2panda/src/processor/event.rs
@@ -73,10 +73,12 @@ where
         }
     }
 
+    /// System-level data (append-only log, pruning coordination, etc.) of this operation.
     pub fn header(&self) -> &Header<E> {
         &self.operation.header
     }
 
+    /// Payload of this operation.
     pub fn body(&self) -> Option<&Body> {
         self.operation.body.as_ref()
     }
@@ -107,6 +109,10 @@ where
     }
 }
 
+/// Operation failed during event processing of the system-level pipeline.
+///
+/// This is likely to come from either processing invalid operations from a broken / malicious node
+/// or due to a bug in the Node API.
 #[derive(Clone, Debug, Error)]
 pub enum ProcessorError {
     #[error("ingest processor failed with: {0}")]

--- a/p2panda/src/streams/acked.rs
+++ b/p2panda/src/streams/acked.rs
@@ -177,6 +177,7 @@ async fn get_log_heights(
     Ok(result)
 }
 
+/// Acknowledgment of event failed due to critical error.
 #[derive(Debug, Error)]
 pub enum AckedError {
     #[error("an error occurred while querying the store: {0}")]

--- a/p2panda/src/streams/ephemeral_stream.rs
+++ b/p2panda/src/streams/ephemeral_stream.rs
@@ -160,6 +160,11 @@ enum WrappedMessageError {
     InvalidSignature,
 }
 
+/// Message coming from an ephemeral stream subscription.
+///
+/// Ephemeral messages are verified (for integrity and provenance) but not persisted on a system
+/// layer. They contain the application's message payloads as well as public key of the author and
+/// timestamp at which they were sent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EphemeralMessage<M> {
     topic: Topic,
@@ -170,14 +175,19 @@ impl<M> EphemeralMessage<M>
 where
     M: Serialize + for<'a> Deserialize<'a>,
 {
+    /// Associated topic.
     pub fn topic(&self) -> Topic {
         self.topic
     }
 
+    /// Verified author.
     pub fn author(&self) -> VerifyingKey {
         self.inner.verifying_key
     }
 
+    /// Timestamp when this operation was created.
+    ///
+    /// Microseconds since the UNIX epoch based on system time.
     pub fn timestamp(&self) -> u64 {
         // Only return the wall-clock time to the user as this is the interesting bit, the logical
         // lamport timestamp helps internally with keeping messages unique.
@@ -185,6 +195,7 @@ where
         timestamp.into()
     }
 
+    /// Application message payload.
     pub fn body(&self) -> &M {
         &self.inner.body
     }
@@ -215,6 +226,40 @@ pub(crate) fn ephemeral_stream<M>(
     (tx, rx)
 }
 
+/// Publish messages into an ephemeral topic stream.
+///
+/// Any message type `M` can be published as long as it can be encoded into bytes by implementing
+/// serde's [`Serialize`] and [`Deserialize`] traits.
+///
+/// Only currently reachable and subscribed peers will receive published messages.
+///
+/// ## Example
+///
+/// ```rust
+/// # use p2panda_core::Topic;
+/// # use serde::{Serialize, Deserialize};
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let node = p2panda::builder().spawn().await?;
+/// #
+/// let now_playing = Topic::new();
+///
+/// #[derive(Clone, Debug, Serialize, Deserialize)]
+/// struct PlaylistItem {
+///     artist: String,
+///     song_name: String,
+/// }
+///
+/// let (tx, _rx) = node.ephemeral_stream::<PlaylistItem>(now_playing).await?;
+///
+/// tx.publish(PlaylistItem {
+///     artist: "Richard Cheese".into(),
+///     song_name: "Panda".into(),
+/// }).await?;
+/// #
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug)]
 pub struct EphemeralStreamPublisher<M> {
     topic: Topic,
@@ -228,10 +273,14 @@ impl<M> EphemeralStreamPublisher<M>
 where
     M: Serialize + for<'a> Deserialize<'a>,
 {
+    /// Associated topic.
     pub fn topic(&self) -> Topic {
         self.topic
     }
 
+    /// Publish a message into an ephemeral topic stream.
+    ///
+    /// Only currently reachable and subscribed peers will receive published messages.
     pub async fn publish(&self, message: M) -> Result<(), EphemeralPublishError> {
         // The PlumTree implementation for the gossip overlay used by p2panda-net ignores duplicate
         // messages to avoid flooding the network. This can lead to surprises by the users as they
@@ -262,6 +311,7 @@ where
     }
 }
 
+/// Error occurred when publishing a message to ephemeral topic stream.
 #[derive(Debug, Error)]
 pub enum EphemeralPublishError {
     /// If this error occurs probably something is wrong with the system.
@@ -276,6 +326,27 @@ pub enum EphemeralPublishError {
     BrokenChannel,
 }
 
+/// Subscription to messages arriving from an ephemeral topic stream.
+///
+/// ## Example
+///
+/// ```no_run
+/// use futures_util::StreamExt;
+/// use p2panda_core::Topic;
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let node = p2panda::spawn().await?;
+/// let topic = Topic::new();
+///
+/// let (_tx, mut rx) = node.ephemeral_stream::<String>(topic).await?;
+///
+/// while let Some(stream_event) = rx.next().await {
+///     // .. react to received messages
+/// }
+/// #
+/// # Ok(())
+/// # }
+/// ```
 #[pin_project]
 pub struct EphemeralStreamSubscription<M> {
     topic: Topic,
@@ -288,6 +359,7 @@ impl<M> EphemeralStreamSubscription<M>
 where
     M: Serialize + for<'a> Deserialize<'a>,
 {
+    /// Associated topic.
     pub fn topic(&self) -> Topic {
         self.topic
     }

--- a/p2panda/src/streams/replay.rs
+++ b/p2panda/src/streams/replay.rs
@@ -92,7 +92,7 @@ where
     Ok(())
 }
 
-/// Error types which can occur during replay.
+/// Topic stream could not re-play events due to an internal error.
 #[derive(Debug, Error)]
 pub enum ReplayError {
     #[error("an error occurred while querying the store: {0}")]

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -498,6 +498,69 @@ pub(crate) async fn ack_published_operation<M>(
     })
 }
 
+/// Publish messages into a topic stream.
+///
+/// Any message type `M` can be published as long as it can be encoded into bytes by implementing
+/// serde's [`Serialize`] and [`Deserialize`] traits.
+///
+/// ## Example
+///
+/// ```rust
+/// # use p2panda_core::Topic;
+/// # use serde::{Serialize, Deserialize};
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let node = p2panda::builder().spawn().await?;
+/// #
+/// let our_trees = Topic::new();
+///
+/// #[derive(Clone, Debug, Serialize, Deserialize)]
+/// struct Tree {
+///     leafy: bool,
+///     latin_name: String,
+/// }
+///
+/// let (tx, _rx) = node.stream::<Tree>(our_trees).await?;
+///
+/// tx.publish(Tree {
+///     leafy: true,
+///     latin_name: "Acer pseudoplatanus".into(),
+/// }).await?;
+/// #
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Append-only log
+///
+/// The Node API internally maintains an append-only log data-type for published application
+/// messages in a topic stream.
+///
+/// Publishing a message creates and signs an [`Operation`] which gets automatically appended to
+/// the author's log for the given topic. The message itself is the payload of the created
+/// operation.
+///
+/// ```plain
+/// Author "Panda"
+/// Topic "Trees" Log: [ Header ] <-- [ Header ] <-- [ Header ] ...
+///                         |             |              |
+///                         v            ...            ...
+///                     [ Body ]
+///               "Acer pseudoplatanus"
+///
+/// Author "Icebear"
+/// Topic "Trees" Log: [ Header ] <-- [ Header ] ...
+///                         |             |
+///                         v            ...
+///                     [ Body ]
+///                 "Pinus halepensis"
+/// ```
+///
+/// ## External sources
+///
+/// Operations can be imported from external sources into the processing pipeline by calling
+/// [`StreamPublisher::import`]. This allows transporting data via sneakernets (USB stick, etc.) or
+/// other sync solutions.
 #[derive(Clone, Debug)]
 pub struct StreamPublisher<M> {
     topic: Topic,
@@ -520,16 +583,21 @@ impl<M> StreamPublisher<M>
 where
     M: Serialize,
 {
+    /// Associated topic.
     pub fn topic(&self) -> Topic {
         self.topic
     }
 
-    /// Publish a message.
+    /// Publish a message into a topic stream.
+    ///
+    /// Locally created operations are processed by the same pipeline as remotely received
+    /// operations. It is possible to await the processing result which can be useful for some
+    /// applications if they want to block UI components etc.
     pub async fn publish(&self, message: M) -> Result<PublishFuture, PublishError> {
         self.publish_inner(Some(message), false).await
     }
 
-    /// Deletes all our previously published messages in this stream.
+    /// Deletes all our previously published messages in this topic stream.
     ///
     /// This signals to all other nodes that they should remove them as well.
     ///
@@ -545,6 +613,10 @@ where
     }
 
     /// Import an external source of operations.
+    ///
+    /// Please note: Operations do not contain any information by themselves about to which topic
+    /// they belong. By importing operations into a topic stream, they will be assigned to this
+    /// topic. Make sure you accordingly routed operations into the correct topic before.
     pub async fn import(
         &self,
         stream: impl Stream<Item = Operation> + Send + 'static,
@@ -583,8 +655,8 @@ where
             .await?;
         let hash = operation.hash;
 
-        // Start processing operation in pipeline. Keep an oneshot receiver around to allow users
-        // to optionally await & get informed when processing has finished.
+        // Start processing operation in pipeline. Keep a oneshot receiver around to allow users to
+        // optionally await & get informed when processing has finished.
         let (processed_tx, processed_rx) = oneshot::channel();
         self.publish_tx
             .send((operation.clone(), message, processed_tx))
@@ -594,8 +666,8 @@ where
         // Try pushing operation to other nodes if we have an active and "live" sync session with
         // them. This allows disseminating new messages fastly in the network.
         //
-        // If no active live session exists, nodes will pick up the operation later when running
-        // the sync protocol.
+        // If no active live session exists, nodes will pick up the operation later when running the
+        // sync protocol.
         self.sync_handle
             .publish(operation)
             .await
@@ -605,7 +677,7 @@ where
     }
 }
 
-/// Future which can be awaited to find out when locally published operation has finished
+/// Future which can be awaited to find out when a locally published operation has finished
 /// processing.
 #[derive(Debug)]
 pub struct PublishFuture {
@@ -628,9 +700,34 @@ impl Future for PublishFuture {
     }
 }
 
-/// Subscription to events arriving from a stream.
+/// Subscription to events arriving from a topic stream.
+///
+/// A topic stream emits:
+///
+/// - Locally created or remotely synced [`ProcessedOperation`] with application messages inside
+/// - Topic-scoped system-events, for example if a sync session has begun and how much will be sent
+/// - Critical errors such as [`AckedError`] coming from the processing pipeline
+///
+/// ## Example
+///
+/// ```no_run
+/// use futures_util::StreamExt;
+/// use p2panda_core::Topic;
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let node = p2panda::spawn().await?;
+/// let topic = Topic::new();
+///
+/// let (_tx, mut rx) = node.stream::<String>(topic).await?;
+///
+/// while let Some(stream_event) = rx.next().await {
+///     // .. react to topic stream events
+/// }
+/// #
+/// # Ok(())
+/// # }
+/// ```
 pub struct StreamSubscription<M> {
-    #[allow(unused)]
     topic: Topic,
     store: SqliteStore,
     acked: Acked,
@@ -640,9 +737,18 @@ pub struct StreamSubscription<M> {
 }
 
 impl<M> StreamSubscription<M> {
+    /// Associated topic.
+    pub fn topic(&self) -> Topic {
+        self.topic
+    }
+
     /// Explicitly acknowledge operation.
     ///
     /// Fails silently if operation is not known (it might have been pruned, etc.).
+    ///
+    /// If the [`AckPolicy`] is set to "explicit", users want to call this method _after_
+    /// applicaton-level processing has successfully finished. See high-level description in
+    /// [`Node::stream`](crate::node::Node::stream) for more details.
     pub async fn ack(&self, id: Hash) -> Result<(), AckedError> {
         if let Some(operation) =
             OperationStore::<_, _, LogId>::get_operation(&self.store, &id).await?
@@ -669,9 +775,15 @@ where
     }
 }
 
+/// Operations with application messages, system events and errors coming from a topic stream
+/// subscription.
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum StreamEvent<M> {
+    /// Operation with application message coming from a topic stream.
+    ///
+    /// Operations can arrive from various sources. For example, from a sync session with a remote
+    /// node, a locally created message or import.
     Processed {
         /// Processed operation.
         operation: ProcessedOperation<M>,
@@ -679,6 +791,8 @@ pub enum StreamEvent<M> {
         /// The source of the operation.
         source: Source,
     },
+
+    /// Sync session started with a remote node.
     SyncStarted {
         /// Id of the remote sending node.
         remote_node_id: NodeId,
@@ -701,6 +815,8 @@ pub enum StreamEvent<M> {
         /// Total sessions currently running over the same topic.
         topic_sessions: u64,
     },
+
+    /// Sync session ended with a remote node.
     SyncEnded {
         /// Id of the remote sending node.
         remote_node_id: NodeId,
@@ -729,14 +845,23 @@ pub enum StreamEvent<M> {
         /// If the sync session ended with an error the reason is included here.
         error: Option<SyncError>,
     },
+
+    /// Import of operations from an external stream has started.
     ImportStarted {
         /// Id of the import session.
         session_id: SessionId,
     },
+
+    /// Import of operations from an external stream has ended.
     ImportEnded {
         /// Id of the import session.
         session_id: SessionId,
     },
+
+    /// Operation failed during event processing of the system-level pipeline.
+    ///
+    /// This is likely to come from either processing invalid operations from a broken / malicious
+    /// node or due to a bug in the Node API.
     ProcessingFailed {
         /// Event which failed during system-level processing.
         ///
@@ -749,19 +874,28 @@ pub enum StreamEvent<M> {
         /// The source of the operation.
         source: Source,
     },
+
+    /// Deserializing the application message into the specified type failed.
+    ///
+    /// This is an application-level error and indicates an invalid application payload.
+    // TODO(adz): Since this is an applicaton-level concern we should remove encoding / decoding
+    // from our APIs. See related issue: https://github.com/p2panda/p2panda/issues/1072
     DecodeFailed {
         event: Event<LogId, Extensions, Topic>,
         error: DecodeError,
     },
-    ReplayFailed {
-        error: Arc<ReplayError>,
-    },
+
+    /// Topic stream could not re-play events due to an internal error.
+    ReplayFailed { error: Arc<ReplayError> },
+
+    /// Topic stream could not acknowledge events due to an internal error.
     AckFailed {
         event: Event<LogId, Extensions, Topic>,
         error: Arc<AckedError>,
     },
 }
 
+/// Processed operation with application message coming from a topic stream.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ProcessedOperation<M> {
     event: Event<LogId, Extensions, Topic>,
@@ -771,30 +905,76 @@ pub struct ProcessedOperation<M> {
 }
 
 impl<M> ProcessedOperation<M> {
+    /// Associated topic.
     pub fn topic(&self) -> Topic {
         self.topic
     }
 
+    /// Unique identifier of this operation.
     pub fn id(&self) -> Hash {
         self.event.hash()
     }
 
+    /// Verified author.
     pub fn author(&self) -> VerifyingKey {
         self.event.header().verifying_key
     }
 
+    /// Timestamp when this operation was created.
+    ///
+    /// Microseconds since the UNIX epoch based on system time.
     pub fn timestamp(&self) -> u64 {
         self.event.header().timestamp.into()
     }
 
+    /// Application message.
     pub fn message(&self) -> &M {
         &self.message
     }
 
+    /// Meta-data for inspecting and debugging the processed event (failure / success status) and
+    /// underlying [`Operation`] of the append-only log.
     pub fn processed(&self) -> &Event<LogId, Extensions, Topic> {
         &self.event
     }
 
+    /// Acknowledge this event.
+    ///
+    /// If the [`AckPolicy`] is set to "explicit", users want to call this method _after_
+    /// applicaton-level processing has successfully finished. See high-level description in
+    /// [`Node::stream`](crate::node::Node::stream) for more details.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// # use futures_util::StreamExt;
+    /// # use p2panda::node::AckPolicy;
+    /// # use p2panda::streams::StreamEvent;
+    /// # use p2panda_core::Topic;
+    /// # use serde::{Serialize, Deserialize};
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let node = p2panda::builder()
+    ///     .ack_policy(AckPolicy::Explicit)
+    ///     .spawn()
+    ///     .await?;
+    ///
+    /// let topic = Topic::new();
+    ///
+    /// let (_tx, mut rx) = node.stream::<Vec<u8>>(topic).await?;
+    ///
+    /// while let Some(StreamEvent::Processed { operation, .. }) = rx.next().await {
+    ///     // Do things with the message, event sourcing, apply to CRDT, materialise state,
+    ///     // write to database, ..
+    ///     let crdt = operation.message();
+    ///
+    ///     // Finally, acknowledge it.
+    ///     operation.ack().await?;
+    /// }
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn ack(&self) -> Result<(), AckedError> {
         self.acked.ack(self).await?;
         Ok(())
@@ -807,11 +987,11 @@ impl<M> Borrow<Header> for &ProcessedOperation<M> {
     }
 }
 
-/// The source of a processed operation.
+/// Source of a processed operation.
 #[derive(Clone, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum Source {
-    /// Source when an operation arrived via a sync session.
+    /// Source when an operation arrived via a sync session with a remote node.
     SyncSession {
         /// Id of the remote sending node.
         remote_node_id: NodeId,
@@ -852,6 +1032,7 @@ pub enum Source {
     LocalStore,
 }
 
+/// Error occurred when creating operation and publishing it to topic stream.
 #[derive(Debug, Error)]
 pub enum PublishError {
     #[error("an error occurred while serializing the message for publication: {0}")]

--- a/p2panda/src/streams/sync_metrics.rs
+++ b/p2panda/src/streams/sync_metrics.rs
@@ -240,6 +240,7 @@ impl<E, M> From<SyncEvent<E>> for StreamEvent<M> {
     }
 }
 
+/// Error occurred during a sync session.
 #[derive(Clone, Debug, Error)]
 #[error("an error occurred during sync: {0}")]
 pub struct SyncError(String);


### PR DESCRIPTION
- [x] `README.md` (adz)
- [x] crate-level doc-string (adz)
- [x] `builder()` (glyph)
- [x] `spawn()` (glyph)
- [x] `Node`
    - [x] `insert_bootstrap` / `id` / `network_id` (glyph)
    - [x] `event_stream` (glyph)
    - [x] `ephemeral_stream` (sam)
        - [x] `EphemeralMessage`
        - [x] `EphemeralStreamPublisher`
        - [x] `EphemeralStreamSubscription`
    - [x] `stream` / `stream_from` (adz)
        - [x] `ProcessedOperation`
        - [x] `StreamPublisher`
        - [x] `StreamSubscription`
        - [x] `StreamEvent`
- [x] `NodeBuilder` (glyph)