### PR TITLE
Deduplicate received operations in sync manager event stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Highlights are marked with a pancake 🥞
 - Node API for importing external operation streams [#1135](https://github.com/p2panda/p2panda/pull/1135)
 - Option to disable mDNS discovery [#1143](https://github.com/p2panda/p2panda/pull/1143)
 - Get current network id from `Node` [#1143](https://github.com/p2panda/p2panda/pull/1143)
+- Deduplicate received operations in sync manager event stream [#1147](https://github.com/p2panda/p2panda/pull/1147)
 
 ### Changed
 

--- a/p2panda-sync/src/dedup.rs
+++ b/p2panda-sync/src/dedup.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::hash::Hash;
 
-pub static DEFAULT_BUFFER_CAPACITY: usize = 10000;
+pub static DEFAULT_BUFFER_CAPACITY: usize = 1024;
 
 /// Maintain a ring buffer of generic items and efficiently identify if an item is currently in
 /// the buffer.

--- a/p2panda-sync/src/manager/event_stream.rs
+++ b/p2panda-sync/src/manager/event_stream.rs
@@ -8,11 +8,13 @@ use std::task::{Context, Poll};
 use futures::channel::mpsc;
 use futures::stream::SelectAll;
 use futures::{SinkExt, Stream, StreamExt};
-use p2panda_core::Extensions;
+use p2panda_core::traits::Digest;
+use p2panda_core::{Extensions, Hash};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tracing::{debug, trace};
 
+use crate::dedup::Dedup;
 use crate::manager::{SessionStream, SessionTopicMap, ToTopicSync};
 use crate::protocols::TopicLogSyncEvent;
 use crate::{FromSync, ToSync};
@@ -31,6 +33,7 @@ where
     pub(crate) session_rx_set:
         SelectAll<Pin<Box<dyn StreamDebug<Option<FromSync<TopicLogSyncEvent<E>>>>>>>,
     pub(crate) session_topic_map: SessionTopicMap<T, mpsc::Sender<ToTopicSync<E>>>,
+    pub(crate) dedup: Dedup<Hash>,
 }
 
 type FutureOutput<T, E> = (
@@ -133,6 +136,13 @@ where
                         for id in dropped {
                             debug!(session_id = id, "drop session: channel unexpectedly closed");
                             state.session_topic_map.drop(id);
+                        }
+
+                        // If this operation was already present in the deduplication buffer then
+                        // it means we have received it before on this event stream and should not
+                        // return it again to any consumers.
+                        if !state.dedup.insert(operation.hash()) {
+                            return (state, None)
                         }
                     }
 

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -30,6 +30,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tracing::debug;
 
+use crate::dedup::Dedup;
 use crate::manager::event_stream::{ManagerEventStreamState, StreamDebug};
 use crate::protocols::{TopicLogSync, TopicLogSyncError, TopicLogSyncEvent};
 use crate::traits::Manager;
@@ -48,6 +49,13 @@ pub type ToTopicSync<E> = ToSync<Operation<E>>;
 /// A handle can be acquired to a sync session via the session_handle method for sending any live
 /// mode operations to a specific session. It's expected that users map sessions (by their id) to
 /// any topic subscriptions in order to understand the correct mappings.  
+///
+/// There are two points where message deduplication occurs; 1) per-subscription deduplication of
+/// received operations across all sessions for this manager occurs in the event stream 2)
+/// per-session deduplication occurs on sending operations to a remote, this is especially
+/// required during live-mode when we may receive the same new operation from several sources. The
+/// former stops any local consumers from receiving the same operation more than once, the latter
+/// reduces unnecessary noise on the network.
 #[allow(clippy::type_complexity)]
 #[derive(Debug)]
 pub struct TopicSyncManager<T, S, L, E>
@@ -203,6 +211,7 @@ where
             manager_rx,
             session_rx_set,
             session_topic_map: self.session_topic_map.clone(),
+            dedup: Dedup::default(),
         };
 
         let stream = ManagerEventStream {
@@ -422,25 +431,28 @@ mod tests {
         let mut peer_a = Peer::new(0).await;
         let body_a = Body::new("Hello from A".as_bytes());
         let (peer_a_header_0, _) = peer_a.create_operation(&body_a, LOG_ID).await;
-        let logs = BTreeMap::from([(peer_a.id(), vec![LOG_ID])]);
-        peer_a.associate(&topic, &logs).await;
         let mut manager_a = TestTopicSyncManager::new(peer_a.store.clone());
 
         // Peer B
         let mut peer_b = Peer::new(1).await;
         let body_b = Body::new("Hello from B".as_bytes());
         let (peer_b_header_0, _) = peer_b.create_operation(&body_b, LOG_ID).await;
-        let logs = BTreeMap::from([(peer_b.id(), vec![LOG_ID])]);
-        peer_b.associate(&topic, &logs).await;
         let mut manager_b = TestTopicSyncManager::new(peer_b.store.clone());
 
         // Peer C
         let mut peer_c = Peer::new(2).await;
         let body_c = Body::new("Hello from C".as_bytes());
         let (peer_c_header_0, _) = peer_c.create_operation(&body_c, LOG_ID).await;
-        let logs = BTreeMap::from([(peer_c.id(), vec![LOG_ID])]);
-        peer_c.associate(&topic, &logs).await;
         let mut manager_c = TestTopicSyncManager::new(peer_c.store.clone());
+
+        let logs = BTreeMap::from([
+            (peer_a.id(), vec![LOG_ID]),
+            (peer_b.id(), vec![LOG_ID]),
+            (peer_c.id(), vec![LOG_ID]),
+        ]);
+        peer_a.associate(&topic, &logs).await;
+        peer_b.associate(&topic, &logs).await;
+        peer_c.associate(&topic, &logs).await;
 
         // Session A -> B
         let mut config = SessionConfig {
@@ -450,7 +462,7 @@ mod tests {
         };
         let session_ab = manager_a.session(SESSION_AB, &config).await;
         config.remote = peer_a.id();
-        let session_b = manager_b.session(SESSION_BA, &config).await;
+        let session_ba = manager_b.session(SESSION_BA, &config).await;
 
         // Session A -> C
         let mut config = SessionConfig {
@@ -460,7 +472,7 @@ mod tests {
         };
         let session_ac = manager_a.session(SESSION_AC, &config).await;
         config.remote = peer_a.id();
-        let session_c = manager_c.session(SESSION_CA, &config).await;
+        let session_ca = manager_c.session(SESSION_CA, &config).await;
 
         let mut event_stream_a = manager_a.subscribe();
         let mut event_stream_b = manager_b.subscribe();
@@ -479,7 +491,7 @@ mod tests {
                     .unwrap();
             });
             tokio::spawn(async move {
-                session_b
+                session_ba
                     .run(&mut remote_message_tx, &mut local_message_rx)
                     .await
                     .unwrap();
@@ -498,7 +510,7 @@ mod tests {
                     .unwrap();
             });
             tokio::spawn(async move {
-                session_c
+                session_ca
                     .run(&mut remote_message_tx, &mut local_message_rx)
                     .await
                     .unwrap();
@@ -551,51 +563,41 @@ mod tests {
                 tokio::select! {
                     Some(event) = event_stream_a.next() => {
                         if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
-                            operations_a.push(*operation.clone());
+                            println!("A received operation: {}", operation.hash);
+                            operations_a.push(operation.header().clone());
                         }
                     }
                     Some(event) = event_stream_b.next() => {
                         if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
-                            operations_b.push(*operation.clone());
+                            println!("B received operation: {}", operation.hash);
+                            operations_b.push(operation.header().clone());
                         }
                     }
                     Some(event) = event_stream_c.next() => {
                         if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
-                            operations_c.push(*operation.clone());
+                            operations_c.push(operation.header().clone());
                         }
                     }
-                    else => tokio::time::sleep(Duration::from_millis(5)).await
+                    else => tokio::time::sleep(Duration::from_millis(20)).await
                 }
             }
         })
         .await;
 
-        // All peers received 4 messages; B & C received each other's messages via A,
-        // and nobody received their own messages.
+        // A receives 2 operations each from B & C
         assert_eq!(operations_a.len(), 4);
+        // B receives 2 operations each from A & C (via A)
         assert_eq!(operations_b.len(), 4);
+        // C receives 2 operations each from A & B (via A)
         assert_eq!(operations_c.len(), 4);
-        assert!(
-            operations_a
-                .iter()
-                .find(|operation| operation.header == peer_a_header_0
-                    || operation.header == peer_a_header_1)
-                .is_none()
-        );
-        assert!(
-            operations_b
-                .iter()
-                .find(|operation| operation.header == peer_b_header_0
-                    || operation.header == peer_b_header_1)
-                .is_none()
-        );
-        assert!(
-            operations_c
-                .iter()
-                .find(|operation| operation.header == peer_c_header_0
-                    || operation.header == peer_c_header_1)
-                .is_none()
-        );
+
+        // No peers received their own operations back again.
+        assert!(!operations_a.contains(&peer_a_header_0));
+        assert!(!operations_a.contains(&peer_a_header_1));
+        assert!(!operations_b.contains(&peer_b_header_0));
+        assert!(!operations_b.contains(&peer_b_header_1));
+        assert!(!operations_c.contains(&peer_c_header_0));
+        assert!(!operations_c.contains(&peer_c_header_1));
     }
 
     #[tokio::test]

--- a/p2panda-sync/src/protocols/log_sync.rs
+++ b/p2panda-sync/src/protocols/log_sync.rs
@@ -259,7 +259,10 @@ where
                                         let body = body.map(|ref bytes| Body::new(bytes));
 
                                         // Insert message hash into deduplication buffer.
-                                        dedup.insert(header.hash());
+                                        if !dedup.insert(header.hash()) {
+                                            trace!(phase = "sync", operation_id = ?header.hash().fmt_short(), "ignore duplicate operation sent from remote");
+                                            continue;
+                                        }
 
                                         trace!(
                                             phase = "sync",

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -481,3 +481,53 @@ async fn import_external_stream() {
     );
     assert!(end_received);
 }
+
+#[tokio::test]
+async fn deduplicate_events() {
+    setup_logging();
+
+    let chat_id = Topic::new();
+
+    let panda = p2panda::builder().spawn().await.unwrap();
+    let icebear = p2panda::builder().spawn().await.unwrap();
+
+    // Panda joins the chat.
+    let (panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
+
+    // Icebear joins the chat and waits for a message of panda.
+    let (_icebear_tx, mut icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
+
+    panda_tx.publish("Hello, Icebear!".into()).await.unwrap();
+    panda_tx
+        .publish("Hello, Icebear again!".into())
+        .await
+        .unwrap();
+    panda_tx
+        .publish("Hello, Icebear and again!".into())
+        .await
+        .unwrap();
+
+    let mut received = vec![];
+
+    loop {
+        let event = icebear_rx.next().await.unwrap();
+        if let StreamEvent::SyncStarted { .. } = event {
+            break;
+        }
+    }
+
+    loop {
+        tokio::select! {
+            Some(event) = icebear_rx.next() => {
+                if let StreamEvent::Processed { operation, .. } = event {
+                    received.push(operation);
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_secs(2)) => {
+                break;
+            }
+        }
+    }
+
+    assert_eq!(received.len(), 3);
+}


### PR DESCRIPTION
This change fixes a bug where deduplication was only occurring per-session and when sending operations. An additional deduplication buffer is now created per sync manager event stream subscription and operations receive from any session are deduplicated.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
