### PR TITLE
Correct "Sync Ended" event semantics in Node API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Highlights are marked with a pancake 🥞
 - Race where replay state was determined late [#1104](https://github.com/p2panda/p2panda/pull/1104)
 - React to node address changes in mDNS test [#1141](https://github.com/p2panda/p2panda/pull/1141)
 - Ensure iroh Gossip is shut down gracefully [#1139](https://github.com/p2panda/p2panda/pull/1139)
+- Correct "Sync Ended" event semantics in Node API [#1154](https://github.com/p2panda/p2panda/pull/1154)
 
 ## [0.5.2] - 09/03/2026
 

--- a/p2panda/src/streams/sync_metrics.rs
+++ b/p2panda/src/streams/sync_metrics.rs
@@ -95,12 +95,6 @@ impl Aggregator {
                 self.session_metrics.insert(session_id, metrics.clone());
                 self.total_bytes_sent += metrics.sent_bytes();
                 self.total_bytes_received += metrics.received_bytes();
-                None
-            }
-            TopicLogSyncEvent::SessionFinished { metrics } => {
-                self.handle_session_end(session_id);
-                self.total_bytes_sent += metrics.sent_bytes();
-                self.total_bytes_received += metrics.received_bytes();
                 Some(SyncEvent::SyncEnded {
                     remote,
                     session_id,
@@ -112,6 +106,12 @@ impl Aggregator {
                     received_bytes_topic_total: self.total_bytes_received(),
                     error: None,
                 })
+            }
+            TopicLogSyncEvent::SessionFinished { metrics } => {
+                self.handle_session_end(session_id);
+                self.total_bytes_sent += metrics.sent_bytes();
+                self.total_bytes_received += metrics.received_bytes();
+                None
             }
             TopicLogSyncEvent::Failed { error } => {
                 let metrics = self.handle_session_end(session_id);


### PR DESCRIPTION
Sync events should be communicated to users as a moment where two peers exchange over their diffs in log state and replicate the missing parts.

After this exchange ended they optionally switch into a "live mode" where operations are eagerly pushed towards each other. This should _not_ be communicated as a sync session.

This fix makes sure that a "sync ended" event is triggered when the actual sync phase ends.

Application developers will then be able to show / hide an indicator in the UI when a sync session started and ended.

Closes: https://github.com/p2panda/p2panda/issues/1144

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
