### PR TITLE
Rename core types and methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Highlights are marked with a pancake 🥞
 - Forge result is never `None` or duplicate [#1132](https://github.com/p2panda/p2panda/pull/1132)
 - Update iroh to v0.98.2 [#1137](https://github.com/p2panda/p2panda/pull/1137)
 - Move shared dependencies into workspace Cargo.toml [#1150](https://github.com/p2panda/p2panda/pull/1150)
+- Rename core data types and methods [#1158](https://github.com/p2panda/p2panda/pull/1158)
 
 ### Fixed
 

--- a/fuzz/fuzz_targets/header_e2e.rs
+++ b/fuzz/fuzz_targets/header_e2e.rs
@@ -4,14 +4,14 @@
 
 use libfuzzer_sys::fuzz_target;
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
-use p2panda_core::{Header, PrivateKey};
+use p2panda_core::{Header, SigningKey};
 
 // Create arbitrary header, sign, serialize and deserialize it.
 fuzz_target!(|header: Header<()>| {
-    let private_key = PrivateKey::new();
+    let signing_key = SigningKey::generate();
 
     let mut header = header;
-    header.sign(&private_key);
+    header.sign(&signing_key);
     header.verify();
 
     let bytes = encode_cbor(&header).expect("header encoding");

--- a/p2panda-auth/examples/groups.rs
+++ b/p2panda-auth/examples/groups.rs
@@ -36,7 +36,7 @@ use p2panda_auth::traits::Operation as GroupsOperationTrait;
 use p2panda_auth::{Access, AccessError};
 use p2panda_core::test_utils::TestLog;
 use p2panda_core::{
-    Extension, Hash, Header, IdentityError, Operation, PrivateKey, PublicKey, Topic,
+    Extension, Hash, Header, IdentityError, Operation, SigningKey, Topic, VerifyingKey,
 };
 use p2panda_net::iroh_mdns::MdnsDiscoveryMode;
 use p2panda_net::utils::ShortFormat;
@@ -52,7 +52,7 @@ use tokio::task::LocalSet;
 use tracing::{debug, info};
 
 type LogId = u64;
-type GroupsState = GroupCrdtState<PublicKey, Hash, GroupsOperation<()>, ()>;
+type GroupsState = GroupCrdtState<VerifyingKey, Hash, GroupsOperation<()>, ()>;
 type GroupsProcessor = p2panda_auth::processor::GroupsProcessor<Topic, AppExtensions, LogId>;
 
 /// This application maintains only one log per author, this is why we can hard-code it.
@@ -86,8 +86,8 @@ impl Extension<LogId> for AppExtensions {
 async fn main() -> Result<()> {
     setup_logging();
 
-    let private_key = PrivateKey::new();
-    let public_key = private_key.public_key();
+    let signing_key = SigningKey::generate();
+    let verifying_key = signing_key.verifying_key();
     let topic = Topic::from(TOPIC);
 
     // Setup p2panda networking stack.
@@ -95,11 +95,11 @@ async fn main() -> Result<()> {
     let address_book = AddressBook::builder().spawn().await?;
 
     let endpoint = Endpoint::builder(address_book.clone())
-        .private_key(private_key.clone())
+        .signing_key(signing_key.clone())
         .spawn()
         .await?;
 
-    println!("public key: {}", public_key.to_hex());
+    println!("public key: {}", verifying_key.to_hex());
 
     let _discovery = Discovery::builder(address_book.clone(), endpoint.clone())
         .spawn()
@@ -168,10 +168,10 @@ async fn main() -> Result<()> {
         let local = LocalSet::new();
 
         local.spawn_local(async move {
-            let log = TestLog::from_private_key(private_key);
+            let log = TestLog::from_signing_key(signing_key);
 
             while let Some(text) = line_rx.recv().await {
-                let (group_id, action) = match text_2_action(&store, public_key, text).await {
+                let (group_id, action) = match text_2_action(&store, verifying_key, text).await {
                     Ok(action) => action,
                     Err(err) => {
                         debug!("error: {err:?}");
@@ -248,9 +248,9 @@ enum Text2ActionError {
 
 async fn text_2_action(
     store: &SqliteStore,
-    me: PublicKey,
+    me: VerifyingKey,
     text: String,
-) -> Result<(PublicKey, GroupAction<PublicKey>), Text2ActionError> {
+) -> Result<(VerifyingKey, GroupAction<VerifyingKey>), Text2ActionError> {
     let y = tx_unwrap!(store, {
         store
             .get_groups_state(&GROUPS_STATE_ID)
@@ -259,7 +259,7 @@ async fn text_2_action(
             .unwrap_or_default()
     });
     let args = if let Some(_text) = text.strip_prefix("create") {
-        let group_id = PrivateKey::new().public_key();
+        let group_id = SigningKey::generate().verifying_key();
         (
             group_id,
             GroupAction::Create {
@@ -282,7 +282,7 @@ async fn text_2_action(
             ));
         };
 
-        let group_id: PublicKey = group_id.trim().parse()?;
+        let group_id: VerifyingKey = group_id.trim().parse()?;
 
         let Some(access) = args.pop_front() else {
             return Err(Text2ActionError::InvalidArgs(
@@ -308,7 +308,7 @@ async fn text_2_action(
             ));
         };
 
-        let group_id: PublicKey = group_id.trim().parse()?;
+        let group_id: VerifyingKey = group_id.trim().parse()?;
         let action = GroupAction::Remove { member };
         (group_id, action)
     } else {
@@ -321,8 +321,8 @@ async fn text_2_action(
 fn parse_member(
     y: &GroupsState,
     member_id: &str,
-) -> Result<GroupMember<PublicKey>, Text2ActionError> {
-    let member_id: PublicKey = member_id.trim().parse()?;
+) -> Result<GroupMember<VerifyingKey>, Text2ActionError> {
+    let member_id: VerifyingKey = member_id.trim().parse()?;
 
     // Check if this member is a group or individual.
     let member = if y.has_group(member_id) {
@@ -338,7 +338,7 @@ async fn print_group(store: &SqliteStore, operation: &Operation<AppExtensions>) 
     let args = operation.header.extension::<GroupsArgs>().unwrap();
     let groups_operation = GroupsOperation {
         id: operation.hash,
-        author: operation.header.public_key,
+        author: operation.header.verifying_key,
         dependencies: args.dependencies,
         group_id: args.group_id,
         action: args.action,

--- a/p2panda-auth/src/processor/args.rs
+++ b/p2panda-auth/src/processor/args.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Arguments required for constructing groups `GroupsOperation`.
-use p2panda_core::{Hash, PublicKey};
+use p2panda_core::{Hash, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 use crate::group::GroupAction;
@@ -9,7 +9,7 @@ use crate::group::GroupAction;
 /// Additional arguments which can be attached to a p2panda operation in their extensions.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GroupsArgs<C = ()> {
-    pub group_id: PublicKey,
-    pub action: GroupAction<PublicKey, C>,
+    pub group_id: VerifyingKey,
+    pub action: GroupAction<VerifyingKey, C>,
     pub dependencies: Vec<Hash>,
 }

--- a/p2panda-auth/src/processor/operation.rs
+++ b/p2panda-auth/src/processor/operation.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use p2panda_core::{Hash, PublicKey};
+use p2panda_core::{Hash, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 use crate::group::GroupAction;
@@ -10,14 +10,14 @@ use crate::traits::{Conditions, Operation};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GroupsOperation<C = ()> {
     pub id: Hash,
-    pub author: PublicKey,
+    pub author: VerifyingKey,
     pub dependencies: Vec<Hash>,
-    pub group_id: PublicKey,
-    pub action: GroupAction<PublicKey, C>,
+    pub group_id: VerifyingKey,
+    pub action: GroupAction<VerifyingKey, C>,
 }
 
 /// Implementation of groups Operation trait.
-impl<C> Operation<PublicKey, Hash, C> for GroupsOperation<C>
+impl<C> Operation<VerifyingKey, Hash, C> for GroupsOperation<C>
 where
     C: Conditions,
 {
@@ -25,7 +25,7 @@ where
         self.id
     }
 
-    fn author(&self) -> PublicKey {
+    fn author(&self) -> VerifyingKey {
         self.author
     }
 
@@ -33,11 +33,11 @@ where
         self.dependencies.clone()
     }
 
-    fn group_id(&self) -> PublicKey {
+    fn group_id(&self) -> VerifyingKey {
         self.group_id
     }
 
-    fn action(&self) -> GroupAction<PublicKey, C> {
+    fn action(&self) -> GroupAction<VerifyingKey, C> {
         self.action.clone()
     }
 }

--- a/p2panda-auth/src/processor/processor.rs
+++ b/p2panda-auth/src/processor/processor.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use p2panda_core::{Extension, Extensions, Hash, LogId, Operation, PublicKey};
+use p2panda_core::{Extension, Extensions, Hash, LogId, Operation, VerifyingKey};
 use p2panda_store::groups::GroupsStore;
 use p2panda_store::operations::OperationStore;
 use p2panda_store::{SqliteError, SqliteStore, Transaction};
@@ -17,13 +17,13 @@ use crate::group;
 use crate::processor::{GroupsArgs, GroupsOperation};
 use crate::traits::{Conditions, IdentityHandle, Operation as GroupsOperationTrait, OperationId};
 
-type GroupsCrdt<C> = group::GroupCrdt<PublicKey, Hash, GroupsOperation<C>, C, StrongRemove<C>>;
+type GroupsCrdt<C> = group::GroupCrdt<VerifyingKey, Hash, GroupsOperation<C>, C, StrongRemove<C>>;
 type GroupsCrdtError<C> =
-    group::GroupCrdtError<PublicKey, Hash, GroupsOperation<C>, C, StrongRemove<C>>;
-type StrongRemove<C> = group::resolver::StrongRemove<PublicKey, Hash, GroupsOperation<C>, C>;
-type GroupsState<C> = group::GroupCrdtState<PublicKey, Hash, GroupsOperation<C>, C>;
+    group::GroupCrdtError<VerifyingKey, Hash, GroupsOperation<C>, C, StrongRemove<C>>;
+type StrongRemove<C> = group::resolver::StrongRemove<VerifyingKey, Hash, GroupsOperation<C>, C>;
+type GroupsState<C> = group::GroupCrdtState<VerifyingKey, Hash, GroupsOperation<C>, C>;
 
-impl IdentityHandle for PublicKey {}
+impl IdentityHandle for VerifyingKey {}
 impl OperationId for Hash {}
 
 /// Processor for groups operations.
@@ -86,7 +86,7 @@ where
 
         let groups_operation = GroupsOperation {
             id: operation.hash,
-            author: operation.header.public_key,
+            author: operation.header.verifying_key,
             dependencies: args.dependencies,
             group_id: args.group_id,
             action: args.action,
@@ -162,7 +162,7 @@ where
 
             GroupsOperation {
                 id: operation.hash,
-                author: operation.header.public_key,
+                author: operation.header.verifying_key,
                 dependencies: args.dependencies,
                 group_id: args.group_id,
                 action: args.action,
@@ -205,7 +205,7 @@ where
 mod tests {
     use p2panda_core::test_utils::TestLog;
     use p2panda_core::traits::Digest;
-    use p2panda_core::{Extension, Hash, Header, Operation, PrivateKey, PublicKey, Topic};
+    use p2panda_core::{Extension, Hash, Header, Operation, SigningKey, Topic, VerifyingKey};
     use p2panda_store::groups::GroupsStore;
     use p2panda_store::{SqliteStore, Transaction};
     use serde::{Deserialize, Serialize};
@@ -216,7 +216,7 @@ mod tests {
     use crate::test_utils::setup_logging;
 
     type LogId = u64;
-    type GroupsState = GroupCrdtState<PublicKey, Hash, GroupsOperation, ()>;
+    type GroupsState = GroupCrdtState<VerifyingKey, Hash, GroupsOperation, ()>;
     type GroupsProcessor = crate::processor::GroupsProcessor<Topic, TestExtensions, LogId>;
 
     const LOG_ID: u64 = 0;
@@ -251,7 +251,7 @@ mod tests {
     #[tokio::test]
     async fn ooo_operations() {
         setup_logging();
-        let topic = Topic::new();
+        let topic = Topic::random();
 
         let alice_log = TestLog::new();
         let alice = alice_log.author();
@@ -261,7 +261,7 @@ mod tests {
         let cathy = cathy_log.author();
 
         let state_id = 0;
-        let group_id = PrivateKey::new().public_key();
+        let group_id = SigningKey::generate().verifying_key();
 
         let args = GroupsArgs {
             group_id,

--- a/p2panda-core/README.md
+++ b/p2panda-core/README.md
@@ -52,14 +52,14 @@ Stability guarantees will improve with the release of v1.0.0.
 ### Create and sign operation
 
 ```rust
-use p2panda_core::{Body, Header, PrivateKey, Timestamp};
+use p2panda_core::{Body, Header, SigningKey, Timestamp};
 
-let private_key = PrivateKey::new();
+let signing_key = SigningKey::generate();
 
 let body = Body::new("Hello, Panda!".as_bytes());
 let mut header = Header {
     version: 1,
-    public_key: private_key.public_key(),
+    verifying_key: signing_key.verifying_key(),
     signature: None,
     payload_size: body.size(),
     payload_hash: Some(body.hash()),
@@ -69,7 +69,7 @@ let mut header = Header {
     extensions: (),
 };
 
-header.sign(&private_key);
+header.sign(&signing_key);
 ```
 
 ### Custom extensions
@@ -78,7 +78,7 @@ Custom functionality can be added using extensions, for example, access-control
 tokens, self-destructing messages, or encryption schemas.
 
 ```rust
-use p2panda_core::{Extension, Header, PrivateKey};
+use p2panda_core::{Extension, Header};
 use serde::{Serialize, Deserialize};
 
 // Extend our operations with an "expiry" field we can use to implement

--- a/p2panda-core/examples/basic.rs
+++ b/p2panda-core/examples/basic.rs
@@ -3,11 +3,11 @@
 //! We create a new body containing a data payload, as well as a header, and then sign the header
 //! with an Ed25519 private key. The signed header and body are then used to create an operation.
 //! Finally, we validate the operation.
-use p2panda_core::{Body, Header, Operation, PrivateKey, Timestamp, validate_operation};
+use p2panda_core::{Body, Header, Operation, SigningKey, Timestamp, validate_operation};
 
 fn main() {
     // Create a new Ed25519 signing key.
-    let private_key = PrivateKey::new();
+    let signing_key = SigningKey::generate();
 
     // An operation body contains application data.
     let body = Body::new("Hello, Sloth!".as_bytes());
@@ -15,7 +15,7 @@ fn main() {
     // Create a header.
     let mut header = Header {
         version: 1,
-        public_key: private_key.public_key(),
+        verifying_key: signing_key.verifying_key(),
         signature: None,
         payload_size: body.size(),
         payload_hash: Some(body.hash()),
@@ -26,7 +26,7 @@ fn main() {
     };
 
     // Sign the header.
-    header.sign(&private_key);
+    header.sign(&signing_key);
 
     // An operation containing the header hash (the operation id), the header itself and an optional body.
     let operation = Operation {

--- a/p2panda-core/examples/extensions.rs
+++ b/p2panda-core/examples/extensions.rs
@@ -5,7 +5,7 @@
 //! `Extension` trait to define the means of extracting each value from a p2panda header.
 use serde::{Deserialize, Serialize};
 
-use p2panda_core::{Body, Extension, Hash, Header, PrivateKey, Timestamp};
+use p2panda_core::{Body, Extension, Hash, Header, SigningKey, Timestamp};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct LogId(Hash);
@@ -41,12 +41,12 @@ fn main() {
         expires: Expiry(0123456),
     };
 
-    let private_key = PrivateKey::new();
+    let signing_key = SigningKey::generate();
     let body: Body = Body::new("Hello, Sloth!".as_bytes());
 
     let mut header = Header {
         version: 1,
-        public_key: private_key.public_key(),
+        verifying_key: signing_key.verifying_key(),
         signature: None,
         payload_size: body.size(),
         payload_hash: Some(body.hash()),
@@ -56,7 +56,7 @@ fn main() {
         extensions: extensions.clone(),
     };
 
-    header.sign(&private_key);
+    header.sign(&signing_key);
 
     let log_id: LogId = header.extension().unwrap();
     let expiry: Expiry = header.extension().unwrap();

--- a/p2panda-core/src/cbor.rs
+++ b/p2panda-core/src/cbor.rs
@@ -96,21 +96,21 @@ impl From<DeserializeError<std::io::Error>> for DecodeError {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Body, Header, PrivateKey};
+    use crate::{Body, Header, SigningKey};
 
     use super::{DecodeError, decode_cbor, encode_cbor};
 
     #[test]
     fn encode_decode() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let body = Body::new(&[1, 2, 3]);
         let mut header = Header::<()> {
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             payload_size: body.size(),
             payload_hash: Some(body.hash()),
             ..Default::default()
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         let bytes = encode_cbor(&header).unwrap();
         let header_again: Header<()> = decode_cbor(&bytes[..]).unwrap();

--- a/p2panda-core/src/cursor.rs
+++ b/p2panda-core/src/cursor.rs
@@ -66,16 +66,16 @@ where
 #[cfg(test)]
 mod tests {
     use crate::logs::LogHeights;
-    use crate::{PrivateKey, PublicKey};
+    use crate::{SigningKey, VerifyingKey};
 
     use super::Cursor;
 
     #[test]
     fn advance_log_height() {
-        let author_1 = PrivateKey::new().public_key();
-        let author_2 = PrivateKey::new().public_key();
+        let author_1 = SigningKey::generate().verifying_key();
+        let author_2 = SigningKey::generate().verifying_key();
 
-        let mut cursor = Cursor::<PublicKey, u64>::new("test", LogHeights::default());
+        let mut cursor = Cursor::<VerifyingKey, u64>::new("test", LogHeights::default());
         assert_eq!(cursor.name(), "test");
 
         assert!(cursor.log_height(&author_1, &0).is_none());
@@ -94,8 +94,8 @@ mod tests {
 
     #[test]
     fn strict_monotonic_incremental() {
-        let author = PrivateKey::new().public_key();
-        let mut cursor = Cursor::<PublicKey, u64>::new("test", LogHeights::default());
+        let author = SigningKey::generate().verifying_key();
+        let mut cursor = Cursor::<VerifyingKey, u64>::new("test", LogHeights::default());
 
         // Ignore attempts to move the cursor "backwards".
         cursor.advance(author, 0, 10);
@@ -105,12 +105,12 @@ mod tests {
 
     #[test]
     fn compare() {
-        let author = PrivateKey::new().public_key();
+        let author = SigningKey::generate().verifying_key();
         let log_id_1 = 1;
         let log_id_2 = 2;
 
-        let mut cursor_1 = Cursor::<PublicKey, u64>::new("one", LogHeights::default());
-        let mut cursor_2 = Cursor::<PublicKey, u64>::new("two", LogHeights::default());
+        let mut cursor_1 = Cursor::<VerifyingKey, u64>::new("one", LogHeights::default());
+        let mut cursor_2 = Cursor::<VerifyingKey, u64>::new("two", LogHeights::default());
 
         cursor_1.advance(author, log_id_1, 121);
         cursor_1.advance(author, log_id_2, 13);

--- a/p2panda-core/src/extensions.rs
+++ b/p2panda-core/src/extensions.rs
@@ -4,8 +4,8 @@
 //!
 //! User-defined extensions can be added to an operation's `Header` in order to extend the basic
 //! functionality of the core p2panda data types or to encode application-specific fields which
-//! should not be contained in the [`Body`](crate::Body). Extension values can themselves be
-//! derived from other header material, such as `PublicKey` or a headers' `Hash`.
+//! should not be contained in the [`Body`](crate::Body). Extension values can themselves be derived
+//! from other header material, such as `VerifingKey` or a headers' `Hash`.
 //!
 //! At a lower level this might be information relating to capabilities or group encryption schemes
 //! which is required to enforce access-control restrictions during sync. Alternatively, extensions
@@ -14,10 +14,9 @@
 //! enforce a single approach to such areas where there are rightly many different approaches, with
 //! the most suitable being dependent on specific use-case requirements.
 //!
-//! Interfaces which use p2panda core data types can require certain extensions to be present on
-//! any headers that their APIs accept using trait bounds. `p2panda-stream`, for example, uses the
-//! [`PruneFlag`](crate::PruneFlag) in order to implement automatic network-wide garbage
-//! collection.
+//! Interfaces which use p2panda core data types can require certain extensions to be present on any
+//! headers that their APIs accept using trait bounds. `p2panda-stream`, for example, uses the
+//! [`PruneFlag`](crate::PruneFlag) in order to implement automatic network-wide garbage collection.
 //!
 //! Extensions are encoded on a header and sent over the wire. We need to satisfy all trait
 //! requirements that `Header` requires, including `Serialize` and `Deserialize`.
@@ -25,7 +24,7 @@
 //! //! ## Example
 //!
 //! ```
-//! use p2panda_core::{Body, Hash, Extension, Header, PrivateKey, Timestamp};
+//! use p2panda_core::{Body, Hash, Extension, Header, SigningKey, Timestamp};
 //! use serde::{Serialize, Deserialize};
 //!
 //! #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -61,12 +60,12 @@
 //!     expires: Expiry(0123456),
 //! };
 //!
-//! let private_key = PrivateKey::new();
+//! let signing_key = SigningKey::generate();
 //! let body: Body = Body::new("Hello, Sloth!".as_bytes());
 //!
 //! let mut header = Header {
 //!     version: 1,
-//!     public_key: private_key.public_key(),
+//!     verifying_key: signing_key.verifying_key(),
 //!     signature: None,
 //!     payload_size: body.size(),
 //!     payload_hash: Some(body.hash()),
@@ -76,7 +75,7 @@
 //!     extensions: extensions.clone(),
 //! };
 //!
-//! header.sign(&private_key);
+//! header.sign(&signing_key);
 //!
 //! let log_id: LogId = header.extension().unwrap();
 //! let expiry: Expiry = header.extension().unwrap();

--- a/p2panda-core/src/hash.rs
+++ b/p2panda-core/src/hash.rs
@@ -8,7 +8,7 @@
 //! use p2panda_core::Hash;
 //!
 //! let bytes: &[u8] = b"A very important message.";
-//! let hash = Hash::new(bytes);
+//! let hash = Hash::digest(bytes);
 //!
 //! assert_eq!(
 //!     "8d3ca6d66651182cd6a9c1fc5dad0260a0ee29fe9ed494734e60d259430ae8a4",
@@ -33,7 +33,7 @@ pub struct Hash(blake3::Hash);
 
 impl Hash {
     /// Calculate the hash of the provided bytes.
-    pub fn new(buf: impl AsRef<[u8]>) -> Self {
+    pub fn digest(buf: impl AsRef<[u8]>) -> Self {
         Self(blake3::hash(buf.as_ref()))
     }
 
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn hashing() {
-        let hash = Hash::new([1, 2, 3]);
+        let hash = Hash::digest([1, 2, 3]);
 
         assert_eq!(
             hash.as_bytes(),

--- a/p2panda-core/src/identity.rs
+++ b/p2panda-core/src/identity.rs
@@ -2,7 +2,7 @@
 
 //! Ed25519 key pairs and signatures.
 //!
-//! The `PrivateKey` is used for creating digital signatures and the `PublicKey` is used for
+//! The `SigningKey` is used for creating digital signatures and the `VerifyingKey` is used for
 //! verifying that a signature was indeed created by it's private counterpart. The private part of
 //! a key pair is typically kept securely on one device and never transported, whereas the public
 //! part acts as a peer's unique identifier and can be shared freely.
@@ -10,15 +10,15 @@
 //! ## Example
 //!
 //! ```
-//! use p2panda_core::identity::PrivateKey;
+//! use p2panda_core::identity::SigningKey;
 //!
-//! let private_key = PrivateKey::new();
-//! let public_key = private_key.public_key();
+//! let signing_key = SigningKey::generate();
+//! let verifying_key = signing_key.verifying_key();
 //!
 //! let bytes: &[u8] = b"A very important message.";
-//! let signature = private_key.sign(bytes);
+//! let signature = signing_key.sign(bytes);
 //!
-//! assert!(public_key.verify(bytes, &signature))
+//! assert!(verifying_key.verify(bytes, &signature))
 //! ```
 use std::fmt;
 use std::hash::Hash as StdHash;
@@ -34,11 +34,11 @@ use thiserror::Error;
 /// The length of an Ed25519 `Signature`, in bytes.
 pub const SIGNATURE_LEN: usize = ed25519_dalek::SIGNATURE_LENGTH;
 
-/// The length of an Ed25519 `PrivateKey`, in bytes.
-pub const PRIVATE_KEY_LEN: usize = ed25519_dalek::SECRET_KEY_LENGTH;
+/// The length of an Ed25519 `SigningKey`, in bytes.
+pub const SIGNING_KEY_LEN: usize = ed25519_dalek::SECRET_KEY_LENGTH;
 
-/// The length of an Ed25519 `PublicKey`, in bytes.
-pub const PUBLIC_KEY_LEN: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
+/// The length of an Ed25519 `VerifyingKey`, in bytes.
+pub const VERIFYING_KEY_LEN: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
 
 pub trait Author:
     Clone + PartialEq + Ord + StdHash + Serialize + for<'de> Deserialize<'de>
@@ -47,126 +47,134 @@ pub trait Author:
 
 /// Private Ed25519 key used for digital signatures.
 #[derive(Clone, Eq, PartialEq)]
-pub struct PrivateKey(ed25519_dalek::SigningKey);
+pub struct SigningKey(ed25519_dalek::SigningKey);
 
-impl Default for PrivateKey {
+impl Default for SigningKey {
     fn default() -> Self {
-        Self::new()
+        Self::generate()
     }
 }
 
-impl PrivateKey {
-    /// Generates a new private key using the system's random number generator (CSPRNG) as a seed.
-    pub fn new() -> Self {
+impl SigningKey {
+    /// Generates a new signing key using the system's random number generator (CSPRNG) as a seed.
+    pub fn generate() -> Self {
         let mut csprng: OsRng = OsRng;
-        let private_key = ed25519_dalek::SigningKey::generate(&mut csprng);
-        Self(private_key)
+        let signing_key = ed25519_dalek::SigningKey::generate(&mut csprng);
+        Self(signing_key)
     }
 
-    /// Create a `PrivateKey` from its raw bytes representation.
-    pub fn from_bytes(bytes: &[u8; PRIVATE_KEY_LEN]) -> Self {
+    /// Create a `SigningKey` from its raw bytes representation.
+    pub fn from_bytes(bytes: &[u8; SIGNING_KEY_LEN]) -> Self {
         Self(ed25519_dalek::SigningKey::from_bytes(bytes))
     }
 
-    /// Bytes of the private key.
-    pub fn as_bytes(&self) -> &[u8; PRIVATE_KEY_LEN] {
+    /// Bytes of the signing key.
+    pub fn as_bytes(&self) -> &[u8; SIGNING_KEY_LEN] {
         self.0.as_bytes()
     }
 
-    /// Convert the private key to a hex string.
+    /// Convert the signing key to a hex string.
     pub fn to_hex(&self) -> String {
         hex::encode(self.0.as_bytes())
     }
 
-    /// Returns public key using this private counterpart.
-    pub fn public_key(&self) -> PublicKey {
+    /// Returns public key using this signing counterpart.
+    pub fn verifying_key(&self) -> VerifyingKey {
         self.0.verifying_key().into()
     }
 
-    /// Sign the provided bytestring using this private key returning a digital signature.
+    /// Sign the provided bytestring using this signing key returning a digital signature.
     pub fn sign(&self, bytes: &[u8]) -> Signature {
         self.0.sign(bytes).into()
     }
 }
 
-impl fmt::Display for PrivateKey {
+impl fmt::Display for SigningKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_hex())
     }
 }
 
-impl fmt::Debug for PrivateKey {
+#[cfg(any(test, feature = "test_utils"))]
+impl fmt::Debug for SigningKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("PrivateKey")
+        f.debug_tuple("SigningKey")
             .field(self.0.as_bytes())
             .finish()
     }
 }
 
-impl From<[u8; PRIVATE_KEY_LEN]> for PrivateKey {
-    fn from(value: [u8; PRIVATE_KEY_LEN]) -> Self {
+#[cfg(not(any(test, feature = "test_utils")))]
+impl fmt::Debug for SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SigningKey").field(&"***").finish()
+    }
+}
+
+impl From<[u8; SIGNING_KEY_LEN]> for SigningKey {
+    fn from(value: [u8; SIGNING_KEY_LEN]) -> Self {
         Self::from_bytes(&value)
     }
 }
 
-impl From<PrivateKey> for [u8; PRIVATE_KEY_LEN] {
-    fn from(value: PrivateKey) -> Self {
+impl From<SigningKey> for [u8; SIGNING_KEY_LEN] {
+    fn from(value: SigningKey) -> Self {
         *value.as_bytes()
     }
 }
 
-impl From<&[u8; PRIVATE_KEY_LEN]> for PrivateKey {
-    fn from(value: &[u8; PRIVATE_KEY_LEN]) -> Self {
+impl From<&[u8; SIGNING_KEY_LEN]> for SigningKey {
+    fn from(value: &[u8; SIGNING_KEY_LEN]) -> Self {
         Self::from_bytes(value)
     }
 }
 
-impl TryFrom<&[u8]> for PrivateKey {
+impl TryFrom<&[u8]> for SigningKey {
     type Error = IdentityError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         let value_len = value.len();
 
-        let checked_value: [u8; PRIVATE_KEY_LEN] = value
+        let checked_value: [u8; SIGNING_KEY_LEN] = value
             .try_into()
-            .map_err(|_| IdentityError::InvalidLength(value_len, PRIVATE_KEY_LEN))?;
+            .map_err(|_| IdentityError::InvalidLength(value_len, SIGNING_KEY_LEN))?;
 
         Ok(Self::from(checked_value))
     }
 }
 
 #[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for PrivateKey {
+impl<'a> Arbitrary<'a> for SigningKey {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let bytes = <[u8; PRIVATE_KEY_LEN] as Arbitrary>::arbitrary(u)?;
-        Ok(PrivateKey::from_bytes(&bytes))
+        let bytes = <[u8; SIGNING_KEY_LEN] as Arbitrary>::arbitrary(u)?;
+        Ok(SigningKey::from_bytes(&bytes))
     }
 }
 
 /// Public Ed25519 key used for identifying peers and verifying signed data.
 #[derive(Default, Hash, PartialEq, Eq, Copy, Clone)]
-pub struct PublicKey(ed25519_dalek::VerifyingKey);
+pub struct VerifyingKey(ed25519_dalek::VerifyingKey);
 
-impl PartialOrd for PublicKey {
+impl PartialOrd for VerifyingKey {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for PublicKey {
+impl Ord for VerifyingKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.to_hex().cmp(&other.to_hex())
     }
 }
 
-impl PublicKey {
-    /// Create a `PublicKey` from its raw bytes representation.
-    pub fn from_bytes(bytes: &[u8; PUBLIC_KEY_LEN]) -> Result<Self, IdentityError> {
+impl VerifyingKey {
+    /// Create a `VerifyingKey` from its raw bytes representation.
+    pub fn from_bytes(bytes: &[u8; VERIFYING_KEY_LEN]) -> Result<Self, IdentityError> {
         Ok(Self(ed25519_dalek::VerifyingKey::from_bytes(bytes)?))
     }
 
     /// Bytes of the public key.
-    pub fn as_bytes(&self) -> &[u8; PUBLIC_KEY_LEN] {
+    pub fn as_bytes(&self) -> &[u8; VERIFYING_KEY_LEN] {
         self.0.as_bytes()
     }
 
@@ -181,67 +189,69 @@ impl PublicKey {
     }
 }
 
-impl fmt::Display for PublicKey {
+impl fmt::Display for VerifyingKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_hex())
     }
 }
 
-impl fmt::Debug for PublicKey {
+impl fmt::Debug for VerifyingKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("PublicKey").field(self.0.as_bytes()).finish()
+        f.debug_tuple("VerifyingKey")
+            .field(self.0.as_bytes())
+            .finish()
     }
 }
 
-impl From<PublicKey> for ed25519_dalek::VerifyingKey {
-    fn from(value: PublicKey) -> Self {
+impl From<VerifyingKey> for ed25519_dalek::VerifyingKey {
+    fn from(value: VerifyingKey) -> Self {
         value.0
     }
 }
 
-impl From<ed25519_dalek::VerifyingKey> for PublicKey {
+impl From<ed25519_dalek::VerifyingKey> for VerifyingKey {
     fn from(value: ed25519_dalek::VerifyingKey) -> Self {
         Self(value)
     }
 }
 
-impl TryFrom<[u8; PUBLIC_KEY_LEN]> for PublicKey {
+impl TryFrom<[u8; VERIFYING_KEY_LEN]> for VerifyingKey {
     type Error = IdentityError;
 
-    fn try_from(value: [u8; PUBLIC_KEY_LEN]) -> Result<Self, Self::Error> {
+    fn try_from(value: [u8; VERIFYING_KEY_LEN]) -> Result<Self, Self::Error> {
         Self::from_bytes(&value)
     }
 }
 
-impl From<PublicKey> for [u8; PUBLIC_KEY_LEN] {
-    fn from(value: PublicKey) -> Self {
+impl From<VerifyingKey> for [u8; VERIFYING_KEY_LEN] {
+    fn from(value: VerifyingKey) -> Self {
         *value.as_bytes()
     }
 }
 
-impl TryFrom<&[u8; PUBLIC_KEY_LEN]> for PublicKey {
+impl TryFrom<&[u8; VERIFYING_KEY_LEN]> for VerifyingKey {
     type Error = IdentityError;
 
-    fn try_from(value: &[u8; PUBLIC_KEY_LEN]) -> Result<Self, Self::Error> {
+    fn try_from(value: &[u8; VERIFYING_KEY_LEN]) -> Result<Self, Self::Error> {
         Self::from_bytes(value)
     }
 }
 
-impl TryFrom<&[u8]> for PublicKey {
+impl TryFrom<&[u8]> for VerifyingKey {
     type Error = IdentityError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         let value_len = value.len();
 
-        let checked_value: [u8; PUBLIC_KEY_LEN] = value
+        let checked_value: [u8; VERIFYING_KEY_LEN] = value
             .try_into()
-            .map_err(|_| IdentityError::InvalidLength(value_len, PUBLIC_KEY_LEN))?;
+            .map_err(|_| IdentityError::InvalidLength(value_len, VERIFYING_KEY_LEN))?;
 
         Self::try_from(checked_value)
     }
 }
 
-impl FromStr for PublicKey {
+impl FromStr for VerifyingKey {
     type Err = IdentityError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
@@ -249,15 +259,15 @@ impl FromStr for PublicKey {
     }
 }
 
-impl Author for PublicKey {}
+impl Author for VerifyingKey {}
 
 #[cfg(feature = "arbitrary")]
-impl<'a> Arbitrary<'a> for PublicKey {
+impl<'a> Arbitrary<'a> for VerifyingKey {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let bytes = <[u8; PUBLIC_KEY_LEN] as Arbitrary>::arbitrary(u)?;
-        let public_key =
-            PublicKey::from_bytes(&bytes).map_err(|_| arbitrary::Error::IncorrectFormat)?;
-        Ok(public_key)
+        let bytes = <[u8; VERIFYING_KEY_LEN] as Arbitrary>::arbitrary(u)?;
+        let verifying_key =
+            VerifyingKey::from_bytes(&bytes).map_err(|_| arbitrary::Error::IncorrectFormat)?;
+        Ok(verifying_key)
     }
 }
 
@@ -369,7 +379,7 @@ pub enum IdentityError {
     /// * Being given bytes with a length different to what was expected.
     ///
     /// * A problem decompressing `r`, a curve point, in the `Signature`, or the curve point for a
-    ///   `PublicKey`.
+    ///   `VerifyingKey`.
     ///
     /// * Failure of a signature to satisfy the verification equation.
     #[error("invalid signature: {0}")]
@@ -378,21 +388,21 @@ pub enum IdentityError {
 
 #[cfg(test)]
 mod tests {
-    use super::PrivateKey;
+    use super::SigningKey;
 
     #[test]
     fn signing() {
-        let private_key = PrivateKey::new();
-        let public_key = private_key.public_key();
+        let signing_key = SigningKey::generate();
+        let verifying_key = signing_key.verifying_key();
         let bytes = b"test";
-        let signature = private_key.sign(bytes);
-        assert!(public_key.verify(bytes, &signature));
+        let signature = signing_key.sign(bytes);
+        assert!(verifying_key.verify(bytes, &signature));
 
         // Invalid data
-        assert!(!public_key.verify(b"not test", &signature));
+        assert!(!verifying_key.verify(b"not test", &signature));
 
         // Invalid public key
-        let public_key_2 = PrivateKey::new().public_key();
-        assert!(!public_key_2.verify(bytes, &signature));
+        let verifying_key_2 = SigningKey::generate().verifying_key();
+        assert!(!verifying_key_2.verify(bytes, &signature));
     }
 }

--- a/p2panda-core/src/lib.rs
+++ b/p2panda-core/src/lib.rs
@@ -49,19 +49,19 @@
 //! ## Example
 //!
 //! ```
-//! use p2panda_core::{Body, Header, Operation, PrivateKey, Timestamp};
+//! use p2panda_core::{Body, Header, Operation, SigningKey, Timestamp};
 //!
 //! // Every operation is cryptographically authenticated by an author by signing it with an
 //! // Ed25519 key pair. This method generates a new private key for us which needs to be securely
 //! // stored for re-use.
-//! let private_key = PrivateKey::new();
+//! let signing_key = SigningKey::generate();
 //!
 //! // Operations consist of an body (with the actual application data) and a header,
 //! // enhancing the data to be used in distributed networks.
 //! let body = Body::new("Hello, Sloth!".as_bytes());
 //! let mut header = Header {
 //!     version: 1,
-//!     public_key: private_key.public_key(),
+//!     verifying_key: signing_key.verifying_key(),
 //!     signature: None,
 //!     payload_size: body.size(),
 //!     payload_hash: Some(body.hash()),
@@ -72,7 +72,7 @@
 //! };
 //!
 //! // Sign the header with the author's private key. From now on it's ready to be sent!
-//! header.sign(&private_key);
+//! header.sign(&signing_key);
 //! ```
 pub mod cbor;
 pub mod cursor;
@@ -93,7 +93,7 @@ pub mod traits;
 pub use cursor::Cursor;
 pub use extensions::{Extension, Extensions};
 pub use hash::{Hash, HashError};
-pub use identity::{IdentityError, PrivateKey, PublicKey, Signature};
+pub use identity::{IdentityError, Signature, SigningKey, VerifyingKey};
 pub use logs::{LogId, SeqNum};
 pub use operation::{
     Body, Header, Operation, OperationError, RawOperation, validate_backlink, validate_header,

--- a/p2panda-core/src/logs.rs
+++ b/p2panda-core/src/logs.rs
@@ -70,15 +70,15 @@ where
     let mut remote_needs: LogRanges<A, L> = BTreeMap::default();
 
     // Iterate over all authors.
-    for (public_key, local_logs) in local {
-        let Some(remote_logs) = remote.get(public_key) else {
+    for (verifying_key, local_logs) in local {
+        let Some(remote_logs) = remote.get(verifying_key) else {
             // If the remote did not know of this author, then they need all entries in all of
             // their logs that the local knows of.
             let needs = local_logs
                 .iter()
                 .map(|(log_id, log_height)| (log_id.clone(), (None, Some(*log_height))))
                 .collect();
-            remote_needs.insert(public_key.to_owned(), needs);
+            remote_needs.insert(verifying_key.to_owned(), needs);
             continue;
         };
 
@@ -93,7 +93,7 @@ where
                 // If the remote did not know of this log, then they need all entries from the
                 // local.
                 remote_needs
-                    .entry(public_key.to_owned())
+                    .entry(verifying_key.to_owned())
                     .or_default()
                     .insert(log_id.clone(), (None, Some(*local_log_height)));
                 continue;
@@ -103,7 +103,7 @@ where
             // need in the diff.
             if remote_log_height < local_log_height {
                 remote_needs
-                    .entry(public_key.to_owned())
+                    .entry(verifying_key.to_owned())
                     .or_default()
                     .insert(
                         log_id.clone(),

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -4,7 +4,7 @@
 //!
 //! Operations are used to carry any data from one peer to another (distributed), while assuming no
 //! reliable network connection (offline-first) and untrusted machines (cryptographically secure).
-//! The author of an operation uses it's [`PrivateKey`] to cryptographically sign every operation.
+//! The author of an operation uses it's [`SigningKey`] to cryptographically sign every operation.
 //! This can be verified and used for authentication by any other peer.
 //!
 //! Every operation consists of a [`Header`] and an optional [`Body`]. The body holds arbitrary
@@ -29,14 +29,14 @@
 //! ### Construct and sign a header
 //!
 //! ```
-//! use p2panda_core::{Body, Header, PrivateKey, Timestamp};
+//! use p2panda_core::{Body, Header, SigningKey, Timestamp};
 //!
-//! let private_key = PrivateKey::new();
+//! let signing_key = SigningKey::generate();
 //!
 //! let body = Body::new("Hello, Sloth!".as_bytes());
 //! let mut header = Header {
 //!     version: 1,
-//!     public_key: private_key.public_key(),
+//!     verifying_key: signing_key.verifying_key(),
 //!     signature: None,
 //!     payload_size: body.size(),
 //!     payload_hash: Some(body.hash()),
@@ -46,16 +46,16 @@
 //!     extensions: (),
 //! };
 //!
-//! header.sign(&private_key);
+//! header.sign(&signing_key);
 //! ```
 //!
 //! ### Custom extensions
 //!
 //! ```
-//! use p2panda_core::{Body, Extension, Header, PrivateKey, PruneFlag, Timestamp};
+//! use p2panda_core::{Body, Extension, Header, SigningKey, PruneFlag, Timestamp};
 //! use serde::{Serialize, Deserialize};
 //!
-//! let private_key = PrivateKey::new();
+//! let signing_key = SigningKey::generate();
 //!
 //! #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 //! struct CustomExtensions {
@@ -75,7 +75,7 @@
 //! let body = Body::new("Prune from here please!".as_bytes());
 //! let mut header = Header {
 //!     version: 1,
-//!     public_key: private_key.public_key(),
+//!     verifying_key: signing_key.verifying_key(),
 //!     signature: None,
 //!     payload_size: body.size(),
 //!     payload_hash: Some(body.hash()),
@@ -85,7 +85,7 @@
 //!     extensions,
 //! };
 //!
-//! header.sign(&private_key);
+//! header.sign(&signing_key);
 //!
 //! let prune_flag: PruneFlag = header.extension().unwrap();
 //! assert!(prune_flag.is_set())
@@ -97,7 +97,7 @@ use thiserror::Error;
 use crate::cbor::{DecodeError, decode_cbor, encode_cbor};
 use crate::extensions::{Extension, Extensions};
 use crate::hash::Hash;
-use crate::identity::{PrivateKey, PublicKey, Signature};
+use crate::identity::{Signature, SigningKey, VerifyingKey};
 use crate::logs::SeqNum;
 use crate::timestamp::Timestamp;
 use crate::traits::Digest;
@@ -170,14 +170,14 @@ impl<E> Digest<Hash> for Operation<E> {
 /// ## Example
 ///
 /// ```
-/// use p2panda_core::{Body, Header, Operation, PrivateKey, Timestamp};
+/// use p2panda_core::{Body, Header, Operation, SigningKey, Timestamp};
 ///
-/// let private_key = PrivateKey::new();
+/// let signing_key = SigningKey::generate();
 ///
 /// let body = Body::new("Hello, Sloth!".as_bytes());
 /// let mut header = Header {
 ///     version: 1,
-///     public_key: private_key.public_key(),
+///     verifying_key: signing_key.verifying_key(),
 ///     signature: None,
 ///     payload_size: body.size(),
 ///     payload_hash: Some(body.hash()),
@@ -188,7 +188,7 @@ impl<E> Digest<Hash> for Operation<E> {
 /// };
 ///
 /// // Sign the header with the author's private key.
-/// header.sign(&private_key);
+/// header.sign(&signing_key);
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -197,7 +197,7 @@ pub struct Header<E = ()> {
     pub version: u64,
 
     /// Author of this operation.
-    pub public_key: PublicKey,
+    pub verifying_key: VerifyingKey,
 
     /// Signature by author over all fields in header, providing authenticity.
     pub signature: Option<Signature>,
@@ -231,7 +231,7 @@ impl<E: Default> Default for Header<E> {
     fn default() -> Self {
         Self {
             version: 1,
-            public_key: PublicKey::default(),
+            verifying_key: VerifyingKey::default(),
             signature: None,
             payload_size: 0,
             payload_hash: None,
@@ -255,16 +255,16 @@ where
             .expect("CBOR encoder failed due to an critical IO error")
     }
 
-    /// Add a signature to the header using the provided `PrivateKey`.
+    /// Add a signature to the header using the provided `SigningKey`.
     ///
     /// This method signs the byte representation of a header with any existing signature removed
     /// before adding back the newly generated signature.
-    pub fn sign(&mut self, private_key: &PrivateKey) {
+    pub fn sign(&mut self, signing_key: &SigningKey) {
         // Make sure the signature is not already set before we encode
         self.signature = None;
 
         let bytes = self.to_bytes();
-        self.signature = Some(private_key.sign(&bytes));
+        self.signature = Some(signing_key.sign(&bytes));
     }
 
     /// Verify that the signature contained in this `Header` was generated by the claimed
@@ -275,7 +275,8 @@ where
                 let mut unsigned_header = self.clone();
                 unsigned_header.signature = None;
                 let unsigned_bytes = unsigned_header.to_bytes();
-                self.public_key.verify(&unsigned_bytes, &claimed_signature)
+                self.verifying_key
+                    .verify(&unsigned_bytes, &claimed_signature)
             }
             None => false,
         }
@@ -285,7 +286,7 @@ where
     ///
     /// This hash is used as the unique identifier of an operation, aka the Operation Id.
     pub fn hash(&self) -> Hash {
-        Hash::new(self.to_bytes())
+        Hash::digest(self.to_bytes())
     }
 
     /// Extract an extension value from the header.
@@ -351,7 +352,7 @@ impl Body {
 
     /// BLAKE3 hash of the body bytes.
     pub fn hash(&self) -> Hash {
-        Hash::new(&self.0)
+        Hash::digest(&self.0)
     }
 
     /// Size of body bytes.
@@ -499,7 +500,7 @@ where
     let past_header = past_header.borrow();
     let header = header.borrow();
 
-    if past_header.public_key != header.public_key {
+    if past_header.verifying_key != header.verifying_key {
         return Err(OperationError::TooManyAuthors);
     }
 
@@ -528,17 +529,17 @@ where
 mod tests {
     use serde::{Deserialize, Serialize};
 
-    use crate::{Extension, PrivateKey};
+    use crate::{Extension, SigningKey};
 
     use super::*;
 
     #[test]
     fn simple_extension_type_parameter() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let body = Body::new("Hello, Sloth!".as_bytes());
         let mut header = Header {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: body.size(),
             payload_hash: Some(body.hash()),
@@ -548,18 +549,18 @@ mod tests {
             extensions: (),
         };
 
-        header.sign(&private_key);
+        header.sign(&signing_key);
     }
 
     #[test]
     fn sign_and_verify() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let body = Body::new("Hello, Sloth!".as_bytes());
         type CustomExtensions = ();
 
         let mut header = Header {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: body.size(),
             payload_hash: Some(body.hash()),
@@ -570,7 +571,7 @@ mod tests {
         };
         assert!(!header.verify());
 
-        header.sign(&private_key);
+        header.sign(&signing_key);
         assert!(header.verify());
 
         let operation = Operation {
@@ -583,11 +584,11 @@ mod tests {
 
     #[test]
     fn valid_backlink_header() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
 
         let mut header_0 = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: 0,
             payload_hash: None,
@@ -596,12 +597,12 @@ mod tests {
             backlink: None,
             extensions: (),
         };
-        header_0.sign(&private_key);
+        header_0.sign(&signing_key);
         assert!(validate_header(&header_0).is_ok());
 
         let mut header_1 = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: 0,
             payload_hash: None,
@@ -610,7 +611,7 @@ mod tests {
             backlink: Some(header_0.hash()),
             extensions: (),
         };
-        header_1.sign(&private_key);
+        header_1.sign(&signing_key);
         assert!(validate_header(&header_1).is_ok());
 
         assert!(validate_backlink(&header_0, &header_1).is_ok());
@@ -618,12 +619,12 @@ mod tests {
 
     #[test]
     fn invalid_operations() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let body: Body = Body::new("Hello, Sloth!".as_bytes());
 
         let header_base = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: body.size(),
             payload_hash: Some(body.hash()),
@@ -636,7 +637,7 @@ mod tests {
         // Incompatible operation format
         let mut header = header_base.clone();
         header.version = 0;
-        header.sign(&private_key);
+        header.sign(&signing_key);
         assert!(matches!(
             validate_header(&header),
             Err(OperationError::UnsupportedVersion(0, 1))
@@ -644,8 +645,8 @@ mod tests {
 
         // Signature doesn't match public key
         let mut header = header_base.clone();
-        header.public_key = PrivateKey::new().public_key();
-        header.sign(&private_key);
+        header.verifying_key = SigningKey::generate().verifying_key();
+        header.sign(&signing_key);
         assert!(matches!(
             validate_header(&header),
             Err(OperationError::SignatureMismatch)
@@ -654,7 +655,7 @@ mod tests {
         // Backlink missing
         let mut header = header_base.clone();
         header.seq_num = 1;
-        header.sign(&private_key);
+        header.sign(&signing_key);
         assert!(matches!(
             validate_header(&header),
             Err(OperationError::BacklinkMissing)
@@ -662,8 +663,8 @@ mod tests {
 
         // Backlink given but sequence number indicates none
         let mut header = header_base.clone();
-        header.backlink = Some(Hash::new(vec![4, 5, 6]));
-        header.sign(&private_key);
+        header.backlink = Some(Hash::digest(vec![4, 5, 6]));
+        header.sign(&signing_key);
         assert!(matches!(
             validate_header(&header),
             Err(OperationError::SeqNumMismatch)
@@ -672,7 +673,7 @@ mod tests {
         // Payload size does not match
         let mut header = header_base.clone();
         header.payload_size = 11;
-        header.sign(&private_key);
+        header.sign(&signing_key);
         assert!(matches!(
             validate_operation(&Operation {
                 hash: header.hash(),
@@ -684,8 +685,8 @@ mod tests {
 
         // Payload hash does not match
         let mut header = header_base.clone();
-        header.payload_hash = Some(Hash::new(vec![4, 5, 6]));
-        header.sign(&private_key);
+        header.payload_hash = Some(Hash::digest(vec![4, 5, 6]));
+        header.sign(&signing_key);
         assert!(matches!(
             validate_operation(&Operation {
                 hash: header.hash(),
@@ -731,12 +732,12 @@ mod tests {
             expires: Expiry(0123456),
         };
 
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let body: Body = Body::new("Hello, Sloth!".as_bytes());
 
         let mut header = Header {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: body.size(),
             payload_hash: Some(body.hash()),
@@ -746,7 +747,7 @@ mod tests {
             extensions: extensions.clone(),
         };
 
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         // Thanks to blanket implementation of Extension<T> on Header we can extract the extension
         // value from the header itself.

--- a/p2panda-core/src/prune.rs
+++ b/p2panda-core/src/prune.rs
@@ -105,20 +105,20 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use crate::cbor::{decode_cbor, encode_cbor};
-    use crate::{Hash, Header, PrivateKey};
+    use crate::{Hash, Header, SigningKey};
 
     use super::{PruneFlag, validate_prunable_backlink};
 
     #[test]
     fn validate_pruned_log() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let mut header = Header::<()> {
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             seq_num: 7,
-            backlink: Some(Hash::new([1, 2, 3])),
+            backlink: Some(Hash::digest([1, 2, 3])),
             ..Default::default()
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         // When no pruning flag was set we expect a backlink for this operation at seq_num = 7,
         // otherwise not
@@ -128,12 +128,12 @@ mod tests {
 
     #[test]
     fn seq_num_zero() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let mut header = Header::<()> {
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             ..Default::default()
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         // Everything is fine at the beginning of the log
         assert!(validate_prunable_backlink(None, &header, false).is_ok());
@@ -142,21 +142,21 @@ mod tests {
 
     #[test]
     fn strictly_growing_log() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
 
         let mut header_0 = Header::<()> {
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             ..Default::default()
         };
-        header_0.sign(&private_key);
+        header_0.sign(&signing_key);
 
         let mut header_1 = Header::<()> {
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             seq_num: 1,
             backlink: Some(header_0.hash()),
             ..Default::default()
         };
-        header_1.sign(&private_key);
+        header_1.sign(&signing_key);
 
         // log reached seq_num 1 and got pruned.
         assert!(validate_prunable_backlink(Some(&header_0), &header_1, true).is_ok());

--- a/p2panda-core/src/serde.rs
+++ b/p2panda-core/src/serde.rs
@@ -10,7 +10,7 @@ use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};
 
 use crate::cursor::Cursor;
 use crate::hash::{Hash, HashError};
-use crate::identity::{Author, IdentityError, PrivateKey, PublicKey, Signature};
+use crate::identity::{Author, IdentityError, Signature, SigningKey, VerifyingKey};
 use crate::logs::LogHeights;
 use crate::operation::{Body, Header};
 use crate::timestamp::Timestamp;
@@ -67,7 +67,7 @@ impl<'de> Deserialize<'de> for Hash {
     }
 }
 
-impl Serialize for PrivateKey {
+impl Serialize for SigningKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -76,7 +76,7 @@ impl Serialize for PrivateKey {
     }
 }
 
-impl<'de> Deserialize<'de> for PrivateKey {
+impl<'de> Deserialize<'de> for SigningKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -90,7 +90,7 @@ impl<'de> Deserialize<'de> for PrivateKey {
     }
 }
 
-impl Serialize for PublicKey {
+impl Serialize for VerifyingKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -99,7 +99,7 @@ impl Serialize for PublicKey {
     }
 }
 
-impl<'de> Deserialize<'de> for PublicKey {
+impl<'de> Deserialize<'de> for VerifyingKey {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -146,7 +146,7 @@ where
     {
         let mut seq = serializer.serialize_seq(Some(self.field_count()))?;
         seq.serialize_element(&self.version)?;
-        seq.serialize_element(&self.public_key)?;
+        seq.serialize_element(&self.verifying_key)?;
 
         if let Some(signature) = &self.signature {
             seq.serialize_element(signature)?;
@@ -202,7 +202,7 @@ where
                     .next_element()?
                     .ok_or(SerdeError::custom("version missing"))?;
 
-                let public_key: PublicKey = seq
+                let verifying_key: VerifyingKey = seq
                     .next_element()?
                     .ok_or(SerdeError::custom("public key missing"))?;
 
@@ -256,7 +256,7 @@ where
 
                 Ok(Header {
                     version,
-                    public_key,
+                    verifying_key,
                     signature: Some(signature),
                     payload_hash,
                     payload_size,
@@ -385,7 +385,7 @@ mod tests {
 
     use crate::Body;
     use crate::hash::Hash;
-    use crate::identity::{PrivateKey, PublicKey};
+    use crate::identity::{SigningKey, VerifyingKey};
     use crate::operation::Header;
 
     use super::{deserialize_hex, serialize_hex};
@@ -420,7 +420,7 @@ mod tests {
     fn serialize_hash() {
         // Serialize CBOR (non human-readable byte encoding)
         let mut bytes: Vec<u8> = Vec::new();
-        let hash = Hash::new([1, 2, 3]);
+        let hash = Hash::digest([1, 2, 3]);
         ciborium::ser::into_writer(&hash, &mut bytes).unwrap();
         assert_eq!(
             bytes,
@@ -446,24 +446,24 @@ mod tests {
             155, 118, 91, 153, 198, 230, 14, 203, 250, 231, 66, 222, 73, 101, 67,
         ];
         let hash: Hash = ciborium::de::from_reader(&bytes[..]).unwrap();
-        assert_eq!(hash, Hash::new([1, 2, 3]));
+        assert_eq!(hash, Hash::digest([1, 2, 3]));
 
         // Deserialize JSON (human-readable hex encoding)
         let json = "\"b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543\"";
         let hash: Hash = serde_json::from_str(json).unwrap();
-        assert_eq!(hash, Hash::new([1, 2, 3]));
+        assert_eq!(hash, Hash::digest([1, 2, 3]));
     }
 
     #[test]
-    fn serialize_public_key() {
+    fn serialize_verifying_key() {
         // Serialize CBOR (non human-readable byte encoding)
         let mut bytes: Vec<u8> = Vec::new();
-        let public_key = PublicKey::from_bytes(&[
+        let verifying_key = VerifyingKey::from_bytes(&[
             215, 90, 152, 1, 130, 177, 10, 183, 213, 75, 254, 211, 201, 100, 7, 58, 14, 225, 114,
             243, 218, 166, 35, 37, 175, 2, 26, 104, 247, 7, 81, 26,
         ])
         .unwrap();
-        ciborium::ser::into_writer(&public_key, &mut bytes).unwrap();
+        ciborium::ser::into_writer(&verifying_key, &mut bytes).unwrap();
         assert_eq!(
             bytes,
             vec![
@@ -473,7 +473,7 @@ mod tests {
         );
 
         // Serialize JSON (human-readable hex encoding)
-        let json = serde_json::to_string(&public_key).unwrap();
+        let json = serde_json::to_string(&verifying_key).unwrap();
         assert_eq!(
             json,
             "\"d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a\""
@@ -484,9 +484,9 @@ mod tests {
         E: Clone + std::fmt::Debug + PartialEq + Serialize + DeserializeOwned,
     >(
         mut header: Header<E>,
-        private_key: &PrivateKey,
+        signing_key: &SigningKey,
     ) {
-        header.sign(private_key);
+        header.sign(signing_key);
 
         let mut bytes = Vec::new();
         ciborium::ser::into_writer(&header, &mut bytes).unwrap();
@@ -502,27 +502,27 @@ mod tests {
         }
 
         let extensions = CustomExtensions { custom_field: 12 };
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
 
         assert_serde_roundtrip(
             Header::<CustomExtensions> {
                 version: 1,
-                public_key: private_key.public_key(),
+                verifying_key: signing_key.verifying_key(),
                 payload_size: 123,
-                payload_hash: Some(Hash::new(vec![1, 2, 3])),
+                payload_hash: Some(Hash::digest(vec![1, 2, 3])),
                 timestamp: 0.into(),
                 seq_num: 0,
                 backlink: None,
                 extensions: extensions.clone(),
                 signature: None,
             },
-            &private_key,
+            &signing_key,
         );
 
         assert_serde_roundtrip(
             Header::<CustomExtensions> {
                 version: 1,
-                public_key: private_key.public_key(),
+                verifying_key: signing_key.verifying_key(),
                 payload_size: 0,
                 payload_hash: None,
                 timestamp: 0.into(),
@@ -531,18 +531,18 @@ mod tests {
                 extensions: extensions,
                 signature: None,
             },
-            &private_key,
+            &signing_key,
         );
     }
 
     #[test]
     fn expected_de_error() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
 
         // payload size given without payload hash
         let mut header = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: 2829099,
             payload_hash: None,
@@ -551,7 +551,7 @@ mod tests {
             backlink: None,
             extensions: (),
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
         assert!(result.is_err());
@@ -559,16 +559,16 @@ mod tests {
         // payload hash given without payload size
         let mut header = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: 0,
-            payload_hash: Some(Hash::new([0, 1, 2])),
+            payload_hash: Some(Hash::digest([0, 1, 2])),
             timestamp: 0.into(),
             seq_num: 0,
             backlink: None,
             extensions: (),
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
         assert!(result.is_err());
@@ -576,16 +576,16 @@ mod tests {
         // backlink given with seq number 0
         let mut header = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: 0,
             payload_hash: None,
             timestamp: 0.into(),
             seq_num: 0,
-            backlink: Some(Hash::new([0, 1, 2])),
+            backlink: Some(Hash::digest([0, 1, 2])),
             extensions: (),
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
         assert!(result.is_err());
@@ -593,7 +593,7 @@ mod tests {
         // backlink not given with seq number > 0
         let mut header = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: 0,
             payload_hash: None,
@@ -602,7 +602,7 @@ mod tests {
             backlink: None,
             extensions: (),
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
         assert!(result.is_err());
@@ -610,7 +610,7 @@ mod tests {
 
     #[test]
     fn serde_header_with_other_types() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
 
         #[derive(Debug, PartialEq, Serialize, Deserialize)]
         struct Message {
@@ -621,7 +621,7 @@ mod tests {
         let body = Body::new(b"hello");
         let mut header = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: body.size(),
             payload_hash: Some(body.hash()),
@@ -630,7 +630,7 @@ mod tests {
             backlink: None,
             extensions: (),
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         let message = Message { header, body };
 
@@ -643,7 +643,7 @@ mod tests {
 
     #[test]
     fn fixtures() {
-        let private_key = PrivateKey::from_bytes(&[
+        let signing_key = SigningKey::from_bytes(&[
             244, 123, 85, 215, 161, 204, 94, 227, 239, 253, 128, 164, 228, 160, 195, 49, 18, 49,
             125, 4, 50, 218, 157, 230, 174, 1, 154, 231, 231, 142, 22, 170,
         ]);
@@ -651,7 +651,7 @@ mod tests {
         // header at seq num 0
         let mut header_0 = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: 0,
             payload_hash: None,
@@ -660,7 +660,7 @@ mod tests {
             backlink: None,
             extensions: (),
         };
-        header_0.sign(&private_key);
+        header_0.sign(&signing_key);
 
         let bytes = [
             135, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
@@ -678,7 +678,7 @@ mod tests {
         let body = Body::new("Hello, Sloth!".as_bytes());
         let mut header_0_with_body = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: body.size(),
             payload_hash: Some(body.hash()),
@@ -687,7 +687,7 @@ mod tests {
             backlink: None,
             extensions: (),
         };
-        header_0_with_body.sign(&private_key);
+        header_0_with_body.sign(&signing_key);
 
         let bytes = [
             136, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
@@ -706,7 +706,7 @@ mod tests {
         // header at seq num 1 with backlink
         let mut header_1 = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: 0,
             payload_hash: None,
@@ -715,7 +715,7 @@ mod tests {
             backlink: Some(header_0.hash()),
             extensions: (),
         };
-        header_1.sign(&private_key);
+        header_1.sign(&signing_key);
 
         let bytes = [
             136, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
@@ -734,11 +734,11 @@ mod tests {
 
     #[test]
     fn decode_non_map_extensions() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
 
         let mut header = Header::<()> {
             version: 1,
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             signature: None,
             payload_size: 0,
             payload_hash: None,
@@ -747,7 +747,7 @@ mod tests {
             backlink: None,
             extensions: (),
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
         assert!(result.is_ok());

--- a/p2panda-core/src/test_utils.rs
+++ b/p2panda-core/src/test_utils.rs
@@ -4,11 +4,11 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::timestamp::Timestamp;
-use crate::{Body, Extensions, Hash, Header, Operation, PrivateKey, PublicKey, Topic};
+use crate::{Body, Extensions, Hash, Header, Operation, SigningKey, Topic, VerifyingKey};
 
 #[derive(Clone, Default)]
 pub struct TestLog {
-    private_key: PrivateKey,
+    signing_key: SigningKey,
     backlink: Rc<RefCell<Option<Hash>>>,
     seq_num: Rc<RefCell<u64>>,
     log_id: Topic,
@@ -17,16 +17,16 @@ pub struct TestLog {
 impl TestLog {
     pub fn new() -> Self {
         Self {
-            private_key: PrivateKey::new(),
+            signing_key: SigningKey::generate(),
             backlink: Rc::default(),
             seq_num: Rc::default(),
-            log_id: Topic::new(),
+            log_id: Topic::random(),
         }
     }
 
-    pub fn from_private_key(private_key: PrivateKey) -> Self {
+    pub fn from_signing_key(signing_key: SigningKey) -> Self {
         let mut log = TestLog::new();
-        log.private_key = private_key;
+        log.signing_key = signing_key;
         log
     }
 
@@ -34,8 +34,8 @@ impl TestLog {
         self.log_id
     }
 
-    pub fn author(&self) -> PublicKey {
-        self.private_key.public_key()
+    pub fn author(&self) -> VerifyingKey {
+        self.signing_key.verifying_key()
     }
 
     pub fn operation<E: Extensions>(&self, body: &[u8], extensions: E) -> Operation<E> {
@@ -45,7 +45,7 @@ impl TestLog {
         let mut backlink = self.backlink.borrow_mut();
 
         let mut header = Header::<E> {
-            public_key: self.private_key.public_key(),
+            verifying_key: self.signing_key.verifying_key(),
             version: 1,
             signature: None,
             payload_size: body.size(),
@@ -59,7 +59,7 @@ impl TestLog {
             backlink: *backlink,
             extensions,
         };
-        header.sign(&self.private_key);
+        header.sign(&self.signing_key);
 
         *backlink = Some(header.hash());
         *seq_num += 1;

--- a/p2panda-core/src/topic.rs
+++ b/p2panda-core/src/topic.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 use rand::rngs::OsRng;
 use thiserror::Error;
 
-use crate::{Hash, PublicKey};
+use crate::{Hash, VerifyingKey};
 
 pub const TOPIC_LENGTH: usize = 32;
 
@@ -27,13 +27,17 @@ pub const TOPIC_LENGTH: usize = 32;
 pub struct Topic(pub(crate) [u8; TOPIC_LENGTH]);
 
 impl Topic {
-    pub fn new() -> Self {
+    pub fn random() -> Self {
         let mut rng = OsRng;
         Self::from_rng(&mut rng)
     }
 
     pub fn from_rng<R: Rng>(rng: &mut R) -> Self {
         Self(rng.r#gen())
+    }
+
+    pub fn from_bytes(&self, bytes: &[u8]) -> Result<Self, TopicError> {
+        Self::try_from(bytes)
     }
 
     pub fn as_bytes(&self) -> &[u8; TOPIC_LENGTH] {
@@ -43,11 +47,15 @@ impl Topic {
     pub fn to_bytes(self) -> [u8; TOPIC_LENGTH] {
         self.0
     }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
 }
 
 impl Default for Topic {
     fn default() -> Self {
-        Self::new()
+        Self::random()
     }
 }
 
@@ -75,8 +83,8 @@ impl From<Topic> for Hash {
     }
 }
 
-impl From<PublicKey> for Topic {
-    fn from(value: PublicKey) -> Self {
+impl From<VerifyingKey> for Topic {
+    fn from(value: VerifyingKey) -> Self {
         Self(*value.as_bytes())
     }
 }

--- a/p2panda-discovery/src/psi_hash.rs
+++ b/p2panda-discovery/src/psi_hash.rs
@@ -406,7 +406,7 @@ mod tests {
 
     use futures_channel::mpsc;
     use futures_util::{SinkExt, StreamExt};
-    use p2panda_core::PrivateKey;
+    use p2panda_core::SigningKey;
     use p2panda_store::address_book::AddressBookStore;
     use p2panda_store::address_book::test_utils::{TestNodeId, TestNodeInfo};
     use p2panda_store::{SqliteStore, tx_unwrap};
@@ -420,8 +420,8 @@ mod tests {
 
     #[tokio::test]
     async fn topic_discovery() {
-        let alice = PrivateKey::new().public_key();
-        let bob = PrivateKey::new().public_key();
+        let alice = SigningKey::generate().verifying_key();
+        let bob = SigningKey::generate().verifying_key();
 
         let mut alice_subscription = TestSubscription::default();
         alice_subscription.topics.insert([1; 32].into());
@@ -477,8 +477,8 @@ mod tests {
 
     #[tokio::test]
     async fn topic_out_of_order_alice() {
-        let alice = PrivateKey::new().public_key();
-        let bob = PrivateKey::new().public_key();
+        let alice = SigningKey::generate().verifying_key();
+        let bob = SigningKey::generate().verifying_key();
 
         let mut alice_subscription = TestSubscription::default();
         alice_subscription.topics.insert([1; 32].into());
@@ -511,8 +511,8 @@ mod tests {
 
     #[tokio::test]
     async fn topic_out_of_order_bob() {
-        let alice = PrivateKey::new().public_key();
-        let bob = PrivateKey::new().public_key();
+        let alice = SigningKey::generate().verifying_key();
+        let bob = SigningKey::generate().verifying_key();
 
         let mut bob_subscription = TestSubscription::default();
         bob_subscription.topics.insert([1; 32].into());
@@ -546,10 +546,10 @@ mod tests {
     async fn transport_info() {
         let mut rng = ChaCha20Rng::from_seed([1; 32]);
 
-        let alice = PrivateKey::new().public_key();
-        let bob = PrivateKey::new().public_key();
-        let charlie = PrivateKey::new().public_key();
-        let daphne = PrivateKey::new().public_key();
+        let alice = SigningKey::generate().verifying_key();
+        let bob = SigningKey::generate().verifying_key();
+        let charlie = SigningKey::generate().verifying_key();
+        let daphne = SigningKey::generate().verifying_key();
 
         // Alice, Bob and Charlie share the same topic [1; 32] while only Bob and Daphne share
         // topic [2; 32]. Alice should _not_ learn transport info about Daphne and only about

--- a/p2panda-discovery/src/random_walk.rs
+++ b/p2panda-discovery/src/random_walk.rs
@@ -250,7 +250,7 @@ where
 mod tests {
     use std::collections::{HashMap, HashSet};
 
-    use p2panda_core::PrivateKey;
+    use p2panda_core::SigningKey;
     use p2panda_store::address_book::AddressBookStore;
     use p2panda_store::address_book::test_utils::{TestNodeId, TestNodeInfo};
     use p2panda_store::{SqliteStore, tx_unwrap};
@@ -266,7 +266,7 @@ mod tests {
         let node_ids = {
             let mut map = Vec::with_capacity(9);
             for _ in 0..9 {
-                map.push(PrivateKey::new().public_key());
+                map.push(SigningKey::generate().verifying_key());
             }
             map
         };
@@ -341,7 +341,7 @@ mod tests {
         let node_ids = {
             let mut map = Vec::with_capacity(NUM_NODES);
             for _ in 0..NUM_NODES {
-                map.push(PrivateKey::new().public_key());
+                map.push(SigningKey::generate().verifying_key());
             }
             map
         };
@@ -398,7 +398,7 @@ mod tests {
         let rng = ChaCha20Rng::from_seed([1; 32]);
         let store = SqliteStore::temporary().await;
 
-        let node_id = PrivateKey::new().public_key();
+        let node_id = SigningKey::generate().verifying_key();
 
         tx_unwrap!(store, {
             store

--- a/p2panda-discovery/src/tests.rs
+++ b/p2panda-discovery/src/tests.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use futures_channel::mpsc;
 use futures_util::StreamExt;
-use p2panda_core::PrivateKey;
+use p2panda_core::SigningKey;
 use p2panda_store::address_book::AddressBookStore;
 use p2panda_store::address_book::test_utils::{TestNodeId, TestNodeInfo, TestTransportInfo};
 use p2panda_store::{SqliteStore, tx_unwrap};
@@ -175,7 +175,7 @@ async fn peer_discovery_in_network() {
         let nodes = {
             let mut result = HashMap::new();
             for idx in 0..NUM_NODES {
-                let id = PrivateKey::new().public_key();
+                let id = SigningKey::generate().verifying_key();
 
                 nodes_id_map.insert(id, idx);
 

--- a/p2panda-encryption/src/crypto/hpke.rs
+++ b/p2panda-encryption/src/crypto/hpke.rs
@@ -33,7 +33,7 @@ pub struct HpkeCiphertext {
 /// key, some information `info` and additional data `aad` to bind the encryption to a certain
 /// context, as well as the payload `plaintext`.
 pub fn hpke_seal(
-    public_key: &PublicKey,
+    verifying_key: &PublicKey,
     info: Option<&[u8]>,
     aad: Option<&[u8]>,
     plaintext: &[u8],
@@ -46,7 +46,7 @@ pub fn hpke_seal(
         KdfAlgorithm::HkdfSha256,
         AeadAlgorithm::ChaCha20Poly1305,
     );
-    let pk_r = HpkePublicKey::new(public_key.as_bytes().to_vec());
+    let pk_r = HpkePublicKey::new(verifying_key.as_bytes().to_vec());
     let (kem_output, ciphertext) = hpke
         .seal(
             &pk_r,
@@ -118,11 +118,12 @@ mod tests {
         let rng = Rng::from_seed([1; 32]);
 
         let secret_key = SecretKey::from_bytes(rng.random_array().unwrap());
-        let public_key = secret_key.public_key().unwrap();
+        let verifying_key = secret_key.verifying_key().unwrap();
 
         let info = b"some info";
         let aad = b"some aad";
-        let ciphertext = hpke_seal(&public_key, Some(info), Some(aad), b"Hello, Panda!").unwrap();
+        let ciphertext =
+            hpke_seal(&verifying_key, Some(info), Some(aad), b"Hello, Panda!").unwrap();
         let plaintext = hpke_open(&ciphertext, &secret_key, Some(info), Some(aad)).unwrap();
 
         assert_eq!(plaintext, b"Hello, Panda!");
@@ -133,11 +134,12 @@ mod tests {
         let rng = Rng::from_seed([1; 32]);
 
         let valid_secret_key = SecretKey::from_bytes(rng.random_array().unwrap());
-        let public_key = valid_secret_key.public_key().unwrap();
+        let verifying_key = valid_secret_key.verifying_key().unwrap();
 
         let info = b"some info";
         let aad = b"some aad";
-        let ciphertext = hpke_seal(&public_key, Some(info), Some(aad), b"Hello, Panda!").unwrap();
+        let ciphertext =
+            hpke_seal(&verifying_key, Some(info), Some(aad), b"Hello, Panda!").unwrap();
 
         // Invalid secret key.
         let invalid_secret_key = SecretKey::from_bytes(rng.random_array().unwrap());

--- a/p2panda-encryption/src/crypto/x25519.rs
+++ b/p2panda-encryption/src/crypto/x25519.rs
@@ -43,10 +43,10 @@ impl SecretKey {
         self.0.as_bytes()
     }
 
-    pub fn public_key(&self) -> Result<PublicKey, X25519Error> {
+    pub fn verifying_key(&self) -> Result<PublicKey, X25519Error> {
         let static_secret = x25519_dalek::StaticSecret::from(*self.0.as_bytes());
-        let public_key = x25519_dalek::PublicKey::from(&static_secret);
-        Ok(PublicKey(public_key.to_bytes()))
+        let verifying_key = x25519_dalek::PublicKey::from(&static_secret);
+        Ok(PublicKey(verifying_key.to_bytes()))
     }
 
     pub fn calculate_agreement(
@@ -65,8 +65,8 @@ impl SecretKey {
 pub struct PublicKey(#[serde(with = "serde_bytes")] [u8; PUBLIC_KEY_SIZE]);
 
 impl PublicKey {
-    pub fn from_bytes(public_key: [u8; PUBLIC_KEY_SIZE]) -> Self {
-        Self(public_key)
+    pub fn from_bytes(verifying_key: [u8; PUBLIC_KEY_SIZE]) -> Self {
+        Self(verifying_key)
     }
 
     pub fn as_bytes(&self) -> &[u8; PUBLIC_KEY_SIZE] {
@@ -105,16 +105,16 @@ mod tests {
         let rng = Rng::from_seed([1; 32]);
 
         let alice_secret_key = SecretKey::from_bytes(rng.random_array().unwrap());
-        let alice_public_key = alice_secret_key.public_key().unwrap();
+        let alice_verifying_key = alice_secret_key.verifying_key().unwrap();
 
         let bob_secret_key = SecretKey::from_bytes(rng.random_array().unwrap());
-        let bob_public_key = bob_secret_key.public_key().unwrap();
+        let bob_verifying_key = bob_secret_key.verifying_key().unwrap();
 
         let alice_shared_secret = alice_secret_key
-            .calculate_agreement(&bob_public_key)
+            .calculate_agreement(&bob_verifying_key)
             .unwrap();
         let bob_shared_secret = bob_secret_key
-            .calculate_agreement(&alice_public_key)
+            .calculate_agreement(&alice_verifying_key)
             .unwrap();
 
         assert_eq!(alice_shared_secret, bob_shared_secret);

--- a/p2panda-encryption/src/crypto/xeddsa.rs
+++ b/p2panda-encryption/src/crypto/xeddsa.rs
@@ -113,14 +113,14 @@ pub fn xeddsa_sign(
 /// Verifies a XEdDSA signature on provided data using the X25519 public counter-part.
 pub fn xeddsa_verify(
     bytes: &[u8],
-    their_public_key: &PublicKey,
+    their_verifying_key: &PublicKey,
     signature: &XSignature,
 ) -> Result<(), XEdDSAError> {
     // M = Message to sign (byte sequence)
     let cap_m = bytes;
 
     // u = Montgomery public key (byte sequence of b bits).
-    let u = their_public_key;
+    let u = their_verifying_key;
 
     // R || s = Signature to verify (byte sequence of 2b bits)
     let mut cap_r = [0u8; 32];
@@ -197,10 +197,10 @@ mod tests {
         let rng = Rng::from_seed([1; 32]);
 
         let secret_key = SecretKey::from_bytes(rng.random_array().unwrap());
-        let public_key = secret_key.public_key().unwrap();
+        let verifying_key = secret_key.verifying_key().unwrap();
 
         let signature = xeddsa_sign(b"Hello, Panda!", &secret_key, &rng).unwrap();
-        assert!(xeddsa_verify(b"Hello, Panda!", &public_key, &signature).is_ok());
+        assert!(xeddsa_verify(b"Hello, Panda!", &verifying_key, &signature).is_ok());
     }
 
     #[test]
@@ -208,26 +208,26 @@ mod tests {
         let rng = Rng::from_seed([1; 32]);
 
         let secret_key = SecretKey::from_bytes(rng.random_array().unwrap());
-        let public_key = secret_key.public_key().unwrap();
+        let verifying_key = secret_key.verifying_key().unwrap();
         let signature = xeddsa_sign(b"Hello, Panda!", &secret_key, &rng).unwrap();
 
         let invalid_secret_key = SecretKey::from_bytes(rng.random_array().unwrap());
-        let invalid_public_key = invalid_secret_key.public_key().unwrap();
+        let invalid_verifying_key = invalid_secret_key.verifying_key().unwrap();
         let invalid_signature = xeddsa_sign(b"Hello, Panda!", &invalid_secret_key, &rng).unwrap();
 
-        assert_ne!(public_key, invalid_public_key);
+        assert_ne!(verifying_key, invalid_verifying_key);
         assert_ne!(signature, invalid_signature);
 
         assert!(matches!(
-            xeddsa_verify(b"Invalid Data", &public_key, &signature),
+            xeddsa_verify(b"Invalid Data", &verifying_key, &signature),
             Err(XEdDSAError::VerificationFailed)
         ));
         assert!(matches!(
-            xeddsa_verify(b"Hello, Panda!", &invalid_public_key, &signature),
+            xeddsa_verify(b"Hello, Panda!", &invalid_verifying_key, &signature),
             Err(XEdDSAError::VerificationFailed)
         ));
         assert!(matches!(
-            xeddsa_verify(b"Hello, Panda!", &public_key, &invalid_signature),
+            xeddsa_verify(b"Hello, Panda!", &verifying_key, &invalid_signature),
             Err(XEdDSAError::VerificationFailed)
         ));
     }

--- a/p2panda-encryption/src/key_bundle/key_bundle.rs
+++ b/p2panda-encryption/src/key_bundle/key_bundle.rs
@@ -211,17 +211,17 @@ mod tests {
         let rng = Rng::from_seed([1; 32]);
 
         let secret_key = SecretKey::from_bytes(rng.random_array().unwrap());
-        let identity_key = secret_key.public_key().unwrap();
+        let identity_key = secret_key.verifying_key().unwrap();
 
         let signed_prekey_secret = SecretKey::from_bytes(rng.random_array().unwrap());
         let signed_prekey = PreKey::new(
-            signed_prekey_secret.public_key().unwrap(),
+            signed_prekey_secret.verifying_key().unwrap(),
             Lifetime::default(),
         );
         let prekey_signature = xeddsa_sign(signed_prekey.as_bytes(), &secret_key, &rng).unwrap();
 
         let onetime_prekey_secret = SecretKey::from_bytes(rng.random_array().unwrap());
-        let onetime_prekey = OneTimePreKey::new(onetime_prekey_secret.public_key().unwrap(), 1);
+        let onetime_prekey = OneTimePreKey::new(onetime_prekey_secret.verifying_key().unwrap(), 1);
 
         // Valid key-bundles.
         assert!(
@@ -242,7 +242,7 @@ mod tests {
 
         // Invalid lifetime of pre-key.
         let signed_prekey = PreKey::new(
-            signed_prekey_secret.public_key().unwrap(),
+            signed_prekey_secret.verifying_key().unwrap(),
             Lifetime::from_range(0, 0),
         );
         assert!(

--- a/p2panda-encryption/src/key_manager.rs
+++ b/p2panda-encryption/src/key_manager.rs
@@ -117,7 +117,7 @@ impl PreKeyBundle {
         rng: &Rng,
     ) -> Result<Self, KeyManagerError> {
         let secret = SecretKey::from_bytes(rng.random_array()?);
-        let prekey = PreKey::new(secret.public_key()?, lifetime);
+        let prekey = PreKey::new(secret.verifying_key()?, lifetime);
         let signature = prekey.sign(identity_secret, rng)?;
 
         Ok(Self {
@@ -140,7 +140,7 @@ impl KeyManager {
     /// Returns newly initialised key-manager state, holding our identity secret.
     pub fn init(identity_secret: &SecretKey) -> Result<KeyManagerState, KeyManagerError> {
         Ok(KeyManagerState {
-            identity_key: identity_secret.public_key()?,
+            identity_key: identity_secret.verifying_key()?,
             identity_secret: identity_secret.clone(),
             prekeys: PreKeyBundlesState::new(),
             onetime_secrets: HashMap::new(),
@@ -155,7 +155,7 @@ impl KeyManager {
         prekeys: PreKeyBundlesState,
     ) -> Result<KeyManagerState, KeyManagerError> {
         Ok(KeyManagerState {
-            identity_key: identity_secret.public_key()?,
+            identity_key: identity_secret.verifying_key()?,
             identity_secret: identity_secret.clone(),
             prekeys,
             onetime_secrets: HashMap::new(),
@@ -175,7 +175,7 @@ impl KeyManager {
         let prekeys = PreKeyBundlesState::new().insert(bundle);
 
         Ok(KeyManagerState {
-            identity_key: identity_secret.public_key()?,
+            identity_key: identity_secret.verifying_key()?,
             identity_secret: identity_secret.clone(),
             prekeys,
             onetime_secrets: HashMap::new(),
@@ -258,7 +258,7 @@ impl PreKeyManager for KeyManager {
             .ok_or(KeyManagerError::NoPreKeysAvailable)?;
 
         let onetime_secret = SecretKey::from_bytes(rng.random_array()?);
-        let onetime_key = OneTimePreKey::new(onetime_secret.public_key()?, y.onetime_next_id);
+        let onetime_key = OneTimePreKey::new(onetime_secret.verifying_key()?, y.onetime_next_id);
 
         {
             let existing_key = y
@@ -351,7 +351,7 @@ mod tests {
             bundle_1.signed_prekey(),
             &KeyManager::prekey_secret(&state, bundle_1.signed_prekey())
                 .expect("non-expired prekey exists")
-                .public_key()
+                .verifying_key()
                 .unwrap()
         );
         assert_eq!(bundle_1.signed_prekey(), bundle_2.signed_prekey());
@@ -359,11 +359,11 @@ mod tests {
         // Identity key matches the identity secret.
         assert_eq!(
             bundle_1.identity_key(),
-            &identity_secret.public_key().unwrap()
+            &identity_secret.verifying_key().unwrap()
         );
         assert_eq!(
             bundle_2.identity_key(),
-            &identity_secret.public_key().unwrap()
+            &identity_secret.verifying_key().unwrap()
         );
 
         // Signature is correct.
@@ -394,11 +394,11 @@ mod tests {
         // One-time prekeys match the secret.
         assert_eq!(
             bundle_1.onetime_prekey().unwrap(),
-            &onetime_secret_1.unwrap().public_key().unwrap()
+            &onetime_secret_1.unwrap().verifying_key().unwrap()
         );
         assert_eq!(
             bundle_2.onetime_prekey().unwrap(),
-            &onetime_secret_2.unwrap().public_key().unwrap()
+            &onetime_secret_2.unwrap().verifying_key().unwrap()
         );
 
         // One-time prekeys are unique.

--- a/p2panda-encryption/src/key_registry.rs
+++ b/p2panda-encryption/src/key_registry.rs
@@ -226,13 +226,13 @@ mod tests {
         let bundle_1 = {
             let prekey_secret = SecretKey::from_bytes(rng.random_array().unwrap());
             let prekey = PreKey::new(
-                prekey_secret.public_key().unwrap(),
+                prekey_secret.verifying_key().unwrap(),
                 Lifetime::from_range(now - 60, now + 60),
             );
             let prekey_signature = prekey.sign(&identity_secret, &rng).unwrap();
 
             LongTermKeyBundle::new(
-                identity_secret.public_key().unwrap(),
+                identity_secret.verifying_key().unwrap(),
                 prekey,
                 prekey_signature,
             )
@@ -242,13 +242,13 @@ mod tests {
         let bundle_2 = {
             let prekey_secret = SecretKey::from_bytes(rng.random_array().unwrap());
             let prekey = PreKey::new(
-                prekey_secret.public_key().unwrap(),
+                prekey_secret.verifying_key().unwrap(),
                 Lifetime::from_range(now - 60, now + 30),
             );
             let prekey_signature = prekey.sign(&identity_secret, &rng).unwrap();
 
             LongTermKeyBundle::new(
-                identity_secret.public_key().unwrap(),
+                identity_secret.verifying_key().unwrap(),
                 prekey,
                 prekey_signature,
             )
@@ -284,13 +284,13 @@ mod tests {
         let invalid_bundle = {
             let prekey_secret = SecretKey::from_bytes(rng.random_array().unwrap());
             let prekey = PreKey::new(
-                prekey_secret.public_key().unwrap(),
+                prekey_secret.verifying_key().unwrap(),
                 Lifetime::from_range(now - 60, now - 30),
             );
             let prekey_signature = prekey.sign(&identity_secret, &rng).unwrap();
 
             LongTermKeyBundle::new(
-                identity_secret.public_key().unwrap(),
+                identity_secret.verifying_key().unwrap(),
                 prekey,
                 prekey_signature,
             )
@@ -333,13 +333,13 @@ mod tests {
         let invalid_bundle = {
             let prekey_secret = SecretKey::from_bytes(rng.random_array().unwrap());
             let prekey = PreKey::new(
-                prekey_secret.public_key().unwrap(),
+                prekey_secret.verifying_key().unwrap(),
                 Lifetime::from_range(now - 60, now - 30),
             );
             let prekey_signature = prekey.sign(&identity_secret, &rng).unwrap();
 
             LongTermKeyBundle::new(
-                identity_secret.public_key().unwrap(),
+                identity_secret.verifying_key().unwrap(),
                 prekey,
                 prekey_signature,
             )
@@ -348,13 +348,13 @@ mod tests {
         let valid_bundle = {
             let prekey_secret = SecretKey::from_bytes(rng.random_array().unwrap());
             let prekey = PreKey::new(
-                prekey_secret.public_key().unwrap(),
+                prekey_secret.verifying_key().unwrap(),
                 Lifetime::from_range(now - 60, now + 60),
             );
             let prekey_signature = prekey.sign(&identity_secret, &rng).unwrap();
 
             LongTermKeyBundle::new(
-                identity_secret.public_key().unwrap(),
+                identity_secret.verifying_key().unwrap(),
                 prekey,
                 prekey_signature,
             )

--- a/p2panda-encryption/src/two_party/two_party.rs
+++ b/p2panda-encryption/src/two_party/two_party.rs
@@ -115,7 +115,7 @@ pub struct TwoPartyState<KB: KeyBundle> {
     their_prekey_bundle: Option<KB>,
 
     /// Last known public key of the other peer. We use it to encrypt a message towards them.
-    their_public_key: Option<PublicKey>,
+    their_verifying_key: Option<PublicKey>,
 }
 
 // Public methods.
@@ -133,7 +133,7 @@ where
             our_secret_keys: HashMap::new(),
             our_received_secret_key: None,
             their_identity_key: *their_prekey_bundle.identity_key(),
-            their_public_key: None,
+            their_verifying_key: None,
             their_next_key_used: KeyUsed::PreKey,
             their_prekey_bundle: Some(their_prekey_bundle),
         }
@@ -151,7 +151,7 @@ where
         let plaintext_message = TwoPartyPlaintext {
             plaintext: plaintext.to_vec(),
             receiver_new_secret: for_them.their_new_secret.clone(),
-            sender_new_public_key: for_them.our_new_public_key,
+            sender_new_verifying_key: for_them.our_new_verifying_key,
             sender_next_index: y.our_next_key_index,
         };
         let plaintext_bytes = plaintext_message.to_bytes()?;
@@ -167,7 +167,7 @@ where
             .insert(y_i.our_next_key_index, for_us.our_new_secret);
         y_i.our_next_key_index += 1;
 
-        y_i.their_public_key = Some(for_us.their_new_public_key);
+        y_i.their_verifying_key = Some(for_us.their_new_verifying_key);
 
         y_i.their_next_key_used = KeyUsed::ReceivedKey;
 
@@ -184,7 +184,7 @@ where
             Self::decrypt(y, y_manager, message.ciphertext, message.key_used)?;
         let plaintext_message = TwoPartyPlaintext::from_bytes(&plaintext_bytes)?;
 
-        y_i.their_public_key = Some(plaintext_message.sender_new_public_key);
+        y_i.their_verifying_key = Some(plaintext_message.sender_new_verifying_key);
         y_i.their_next_key_used = KeyUsed::OwnKey(plaintext_message.sender_next_index);
         y_i.our_received_secret_key = Some(plaintext_message.receiver_new_secret);
 
@@ -237,7 +237,7 @@ pub struct TwoPartyPlaintext {
     receiver_new_secret: SecretKey,
 
     /// Newly generated public key of the sender, to be used in future 2SM rounds.
-    sender_new_public_key: PublicKey,
+    sender_new_verifying_key: PublicKey,
 
     /// Index of the newly generated key of the sender, the receiver refers to it when using it in
     /// future 2SM rounds.
@@ -269,7 +269,7 @@ where
         plaintext: &[u8],
         rng: &Rng,
     ) -> TwoPartyResult<(TwoPartyState<KB>, TwoPartyCiphertext)> {
-        let ciphertext = match &y.their_public_key {
+        let ciphertext = match &y.their_verifying_key {
             None => {
                 // Establish secret via X3DH from prekey when no secret is given yet.
                 let their_prekey_bundle = y
@@ -284,8 +284,8 @@ where
                 )?;
                 TwoPartyCiphertext::PreKey(ciphertext)
             }
-            Some(their_public_key) => {
-                let ciphertext = hpke_seal(their_public_key, None, None, plaintext)?;
+            Some(their_verifying_key) => {
+                let ciphertext = hpke_seal(their_verifying_key, None, None, plaintext)?;
                 TwoPartyCiphertext::Hpke(ciphertext)
             }
         };
@@ -371,18 +371,18 @@ impl<KMG, KB> TwoParty<KMG, KB> {
     /// secret message. Each party prepares the received keys to be available for future rounds.
     fn generate_keys(rng: &Rng) -> TwoPartyResult<(NewKeysForUs, NewKeysForThem)> {
         let our_new_secret = SecretKey::from_bytes(rng.random_array()?);
-        let our_new_public_key = our_new_secret.public_key()?;
+        let our_new_verifying_key = our_new_secret.verifying_key()?;
 
         let their_new_secret = SecretKey::from_bytes(rng.random_array()?);
-        let their_new_public_key = their_new_secret.public_key()?;
+        let their_new_verifying_key = their_new_secret.verifying_key()?;
 
         Ok((
             NewKeysForUs {
                 our_new_secret,
-                their_new_public_key,
+                their_new_verifying_key,
             },
             NewKeysForThem {
-                our_new_public_key,
+                our_new_verifying_key,
                 their_new_secret,
             },
         ))
@@ -391,11 +391,11 @@ impl<KMG, KB> TwoParty<KMG, KB> {
 
 struct NewKeysForUs {
     our_new_secret: SecretKey,
-    their_new_public_key: PublicKey,
+    their_new_verifying_key: PublicKey,
 }
 
 struct NewKeysForThem {
-    our_new_public_key: PublicKey,
+    our_new_verifying_key: PublicKey,
     their_new_secret: SecretKey,
 }
 
@@ -499,7 +499,7 @@ mod tests {
 
         // Alice also generated the secret key for Bob, so Alice also knows their public key
         // for the future already.
-        assert!(alice_2sm.their_public_key.is_some());
+        assert!(alice_2sm.their_verifying_key.is_some());
 
         // Alice didn't receive anything from Bob yet.
         assert!(alice_2sm.our_received_secret_key.is_none());
@@ -522,13 +522,13 @@ mod tests {
         // Bob learned about the new public key (1) of Alice.
         assert_eq!(
             bob_2sm
-                .their_public_key
+                .their_verifying_key
                 .expect("bob learned about public key of alice"),
             alice_2sm
                 .our_secret_keys
                 .get(&1)
                 .expect("alice has one secret key")
-                .public_key()
+                .verifying_key()
                 .unwrap()
         );
 
@@ -561,13 +561,13 @@ mod tests {
         // Bob learned about the new public key (2) of Alice.
         assert_eq!(
             bob_2sm
-                .their_public_key
+                .their_verifying_key
                 .expect("bob learned about public key of alice"),
             alice_2sm
                 .our_secret_keys
                 .get(&2)
                 .expect("alice has one secret key")
-                .public_key()
+                .verifying_key()
                 .unwrap()
         );
 
@@ -666,7 +666,7 @@ mod tests {
             LongTermTwoParty::send(alice_2sm_a, &alice_manager, b"Hello, Bob!", &rng).unwrap();
 
         // Public key of "Bob" for the first round in Group A.
-        let bob_public_key_1 = alice_2sm_a.their_public_key;
+        let bob_verifying_key_1 = alice_2sm_a.their_verifying_key;
 
         let (bob_2sm_a, bob_manager, receive_1) =
             LongTermTwoParty::receive(bob_2sm_a, bob_manager, message_1).unwrap();
@@ -691,7 +691,7 @@ mod tests {
                 .unwrap();
 
         // Public key of "Bob" for the first round in Group B.
-        let bob_public_key_2 = alice_2sm_b.their_public_key;
+        let bob_verifying_key_2 = alice_2sm_b.their_verifying_key;
 
         let (bob_2sm_b, bob_manager, receive_1) =
             LongTermTwoParty::receive(bob_2sm_b, bob_manager, message_1).unwrap();
@@ -706,7 +706,7 @@ mod tests {
 
         // The keys for the first round should be different across groups.
 
-        assert_ne!(bob_public_key_1, bob_public_key_2);
+        assert_ne!(bob_verifying_key_1, bob_verifying_key_2);
     }
 
     #[test]

--- a/p2panda-encryption/src/two_party/x3dh.rs
+++ b/p2panda-encryption/src/two_party/x3dh.rs
@@ -54,10 +54,10 @@ pub fn x3dh_encrypt<KB: KeyBundle>(
     // Ensure we're not using an expired bundle of receiver.
     their_prekey_bundle.verify()?;
 
-    let our_identity_key = our_identity_secret.public_key()?;
+    let our_identity_key = our_identity_secret.verifying_key()?;
 
     let our_ephemeral_secret = SecretKey::from_bytes(rng.random_array()?);
-    let our_ephemeral_key = our_ephemeral_secret.public_key()?;
+    let our_ephemeral_key = our_ephemeral_secret.verifying_key()?;
 
     let mut ikm = Vec::with_capacity({
         if their_prekey_bundle.onetime_prekey().is_none() {
@@ -129,7 +129,7 @@ pub fn x3dh_decrypt(
     our_prekey_secret: &SecretKey,
     our_onetime_secret: Option<&SecretKey>,
 ) -> Result<Vec<u8>, X3dhError> {
-    let our_identity_key = our_identity_secret.public_key()?;
+    let our_identity_key = our_identity_secret.verifying_key()?;
 
     let mut ikm = Vec::with_capacity(if our_onetime_secret.is_none() {
         32 * 4
@@ -212,16 +212,18 @@ mod tests {
         let bob_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
 
         let bob_prekey_secret = SecretKey::from_bytes(rng.random_array().unwrap());
-        let bob_signed_prekey =
-            PreKey::new(bob_prekey_secret.public_key().unwrap(), Lifetime::default());
+        let bob_signed_prekey = PreKey::new(
+            bob_prekey_secret.verifying_key().unwrap(),
+            Lifetime::default(),
+        );
 
         let bob_onetime_secret = SecretKey::from_bytes(rng.random_array().unwrap());
-        let bob_onetime_prekey = OneTimePreKey::new(bob_onetime_secret.public_key().unwrap(), 2);
+        let bob_onetime_prekey = OneTimePreKey::new(bob_onetime_secret.verifying_key().unwrap(), 2);
 
         let bob_prekey_signature = bob_signed_prekey.sign(&bob_identity_secret, &rng).unwrap();
 
         let bob_prekey_bundle = OneTimeKeyBundle::new(
-            bob_identity_secret.public_key().unwrap(),
+            bob_identity_secret.verifying_key().unwrap(),
             bob_signed_prekey,
             bob_prekey_signature,
             Some(bob_onetime_prekey),
@@ -255,13 +257,15 @@ mod tests {
         let bob_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
 
         let bob_prekey_secret = SecretKey::from_bytes(rng.random_array().unwrap());
-        let bob_signed_prekey =
-            PreKey::new(bob_prekey_secret.public_key().unwrap(), Lifetime::default());
+        let bob_signed_prekey = PreKey::new(
+            bob_prekey_secret.verifying_key().unwrap(),
+            Lifetime::default(),
+        );
 
         let bob_prekey_signature = bob_signed_prekey.sign(&bob_identity_secret, &rng).unwrap();
 
         let bob_prekey_bundle = LongTermKeyBundle::new(
-            bob_identity_secret.public_key().unwrap(),
+            bob_identity_secret.verifying_key().unwrap(),
             bob_signed_prekey,
             bob_prekey_signature,
         );

--- a/p2panda-net/README.md
+++ b/p2panda-net/README.md
@@ -57,7 +57,7 @@ use p2panda_net::iroh_mdns::MdnsDiscoveryMode;
 use p2panda_net::{AddressBook, Discovery, Endpoint, MdnsDiscovery, Gossip};
 
 // Topics are used to discover other nodes and establish connections around them.
-let topic = Hash::new(b"shirokuma-cafe").into();
+let topic = Hash::digest(b"shirokuma-cafe").into();
 
 // Maintain an address book of newly discovered or manually added nodes.
 let address_book = AddressBook::builder().spawn().await?;

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -34,9 +34,9 @@ use clap::Parser;
 use futures_util::StreamExt;
 use iroh::EndpointAddr;
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
-use p2panda_core::{Body, Hash, Header, Operation, PrivateKey, PublicKey, Timestamp, Topic};
+use p2panda_core::{Body, Hash, Header, Operation, SigningKey, Timestamp, Topic, VerifyingKey};
 use p2panda_net::addrs::NodeInfo;
-use p2panda_net::iroh_endpoint::from_public_key;
+use p2panda_net::iroh_endpoint::from_verifying_key;
 use p2panda_net::iroh_mdns::MdnsDiscoveryMode;
 use p2panda_net::utils::ShortFormat;
 use p2panda_net::{AddressBook, Discovery, Endpoint, Gossip, LogSync, MdnsDiscovery, NodeId};
@@ -61,13 +61,13 @@ const RELAY_URL: &str = "https://euc1-1.relay.n0.iroh-canary.iroh.link.";
 /// Heartbeat message to be sent over gossip (ephemeral messaging).
 #[derive(Debug, Serialize, Deserialize)]
 struct Heartbeat {
-    sender: PublicKey,
+    sender: VerifyingKey,
     online: bool,
     rnd: u64,
 }
 
 impl Heartbeat {
-    fn new(sender: PublicKey, online: bool) -> Self {
+    fn new(sender: VerifyingKey, online: bool) -> Self {
         Self {
             sender,
             online,
@@ -105,15 +105,15 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    let private_key = PrivateKey::new();
-    let public_key = private_key.public_key();
+    let signing_key = SigningKey::generate();
+    let verifying_key = signing_key.verifying_key();
 
     // Retrieve the chat topic ID from the provided arguments, otherwise generate a new, random,
     // cryptographically-secure identifier.
     let topic: Topic = if let Some(topic_str) = args.chat_topic_id {
         topic_str.parse().expect("topic id should be 32 bytes")
     } else {
-        Topic::new()
+        Topic::random()
     };
 
     // Create a temporary SQLite database to store topic associations and operations.
@@ -121,7 +121,7 @@ async fn main() -> Result<()> {
 
     // Associate our local log with the chat topic and commit it to the database.
     let permit = store.begin().await?;
-    store.associate(&topic, &public_key, &LOG_ID).await?;
+    store.associate(&topic, &verifying_key, &LOG_ID).await?;
     store.commit(permit).await?;
 
     // Prepare address book.
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
 
     // Add a bootstrap node to our address book if one was supplied by the user.
     if let Some(id) = args.bootstrap_id {
-        let endpoint_addr = EndpointAddr::new(from_public_key(id));
+        let endpoint_addr = EndpointAddr::new(from_verifying_key(id));
         let endpoint_addr = endpoint_addr.with_relay_url(RELAY_URL.parse()?);
         address_book
             .insert_node_info(NodeInfo::from(endpoint_addr).bootstrap())
@@ -137,14 +137,14 @@ async fn main() -> Result<()> {
     }
 
     let endpoint = Endpoint::builder(address_book.clone())
-        .private_key(private_key.clone())
+        .signing_key(signing_key.clone())
         .relay_url(RELAY_URL.parse().unwrap())
         .spawn()
         .await?;
 
     println!("network id: {}", endpoint.network_id().fmt_short());
     println!("chat topic: {}", topic);
-    println!("public key: {}", public_key.to_hex());
+    println!("public key: {}", verifying_key.to_hex());
     println!("relay url: {}", RELAY_URL);
 
     let _discovery = Discovery::builder(address_book.clone(), endpoint.clone())
@@ -172,7 +172,7 @@ async fn main() -> Result<()> {
     let final_heartbeat_tx = heartbeat_tx.clone();
 
     // Mapping of public key to nickname.
-    let nicknames = Arc::new(RwLock::new(HashMap::<PublicKey, String>::new()));
+    let nicknames = Arc::new(RwLock::new(HashMap::<VerifyingKey, String>::new()));
 
     // Mapping of public key to the instant that the last heartbeat message was received.
     let status = Arc::new(RwLock::new(HashMap::new()));
@@ -181,7 +181,7 @@ async fn main() -> Result<()> {
     tokio::task::spawn(async move {
         loop {
             // Create and serialize a heartbeat message.
-            let msg = Heartbeat::new(public_key, true);
+            let msg = Heartbeat::new(verifying_key, true);
             let encoded_msg = encode_cbor(&msg).unwrap();
 
             // Publish the message to the gossip topic.
@@ -261,8 +261,8 @@ async fn main() -> Result<()> {
                             continue;
                         }
 
-                        let remote_public_key = operation.header.public_key;
-                        let remote_id = remote_public_key.fmt_short();
+                        let remote_verifying_key = operation.header.verifying_key;
+                        let remote_id = remote_verifying_key.fmt_short();
 
                         let text =
                             String::from_utf8(operation.body.as_ref().unwrap().to_bytes()).unwrap();
@@ -270,7 +270,7 @@ async fn main() -> Result<()> {
                         // Check if the text of this operation is setting a nickname.
                         if let Some(nick) = text.strip_prefix("/nick ") {
                             if let Some(previous_nick) =
-                                nicknames.read().await.get(&remote_public_key)
+                                nicknames.read().await.get(&remote_verifying_key)
                             {
                                 print!("-> {} is now known as: {}", previous_nick, nick);
                             } else {
@@ -281,7 +281,7 @@ async fn main() -> Result<()> {
                             nicknames
                                 .write()
                                 .await
-                                .insert(remote_public_key, nick.trim().to_owned());
+                                .insert(remote_verifying_key, nick.trim().to_owned());
                         } else {
                             // Print a regular chat message.
                             print!(
@@ -289,7 +289,7 @@ async fn main() -> Result<()> {
                                 nicknames
                                     .read()
                                     .await
-                                    .get(&remote_public_key)
+                                    .get(&remote_verifying_key)
                                     .unwrap_or(&remote_id),
                                 text
                             )
@@ -297,7 +297,7 @@ async fn main() -> Result<()> {
 
                         let permit = store.begin().await.unwrap();
                         let id = operation.hash;
-                        let author = operation.header.public_key;
+                        let author = operation.header.verifying_key;
                         store
                             .insert_operation(&id, &operation, &LOG_ID)
                             .await
@@ -322,7 +322,7 @@ async fn main() -> Result<()> {
     tokio::task::spawn(async move {
         while let Some(text) = line_rx.recv().await {
             let body = Body::new(text.as_bytes());
-            let (hash, operation) = create_operation(&private_key, &body, seq_num, backlink);
+            let (hash, operation) = create_operation(&signing_key, &body, seq_num, backlink);
             let permit = store.begin().await.unwrap();
             store
                 .insert_operation(&hash, &operation, &LOG_ID)
@@ -348,7 +348,7 @@ async fn main() -> Result<()> {
     // Create and serialize a final heartbeat message.
     //
     // This informs other chatters that we are going offline.
-    let msg = Heartbeat::new(public_key, false);
+    let msg = Heartbeat::new(verifying_key, false);
     let encoded_msg = encode_cbor(&msg)?;
 
     final_heartbeat_tx.publish(&encoded_msg[..]).await?;
@@ -370,14 +370,14 @@ fn input_loop(line_tx: mpsc::Sender<String>) -> Result<()> {
 }
 
 fn create_operation(
-    private_key: &PrivateKey,
+    signing_key: &SigningKey,
     body: &Body,
     seq_num: u64,
     backlink: Option<Hash>,
 ) -> (Hash, Operation) {
     let mut header = Header {
         version: 1,
-        public_key: private_key.public_key(),
+        verifying_key: signing_key.verifying_key(),
         signature: None,
         payload_size: body.size(),
         payload_hash: Some(body.hash()),
@@ -387,7 +387,7 @@ fn create_operation(
         extensions: (),
     };
 
-    header.sign(private_key);
+    header.sign(signing_key);
     let hash = header.hash();
 
     let operation = Operation {

--- a/p2panda-net/src/address_book/actor.rs
+++ b/p2panda-net/src/address_book/actor.rs
@@ -373,7 +373,7 @@ impl ThreadLocalActor for AddressBookActor {
 
 #[cfg(test)]
 mod tests {
-    use p2panda_core::PrivateKey;
+    use p2panda_core::SigningKey;
     use p2panda_store::SqliteStore;
     use p2panda_store::address_book::NodeInfo as _;
     use ractor::call;
@@ -398,38 +398,42 @@ mod tests {
             .unwrap();
 
         // Insert new node info.
-        let node_info = NodeInfo::new(args.public_key.clone());
+        let node_info = NodeInfo::new(args.verifying_key.clone());
         let result = call!(actor, ToAddressBookActor::InsertNodeInfo, node_info).unwrap();
         assert!(result.is_ok());
         assert!(result.unwrap());
 
         // Overwriting node info should return "false".
-        let mut node_info = NodeInfo::new(args.public_key.clone());
+        let mut node_info = NodeInfo::new(args.verifying_key.clone());
         node_info.bootstrap = true;
         let result = call!(actor, ToAddressBookActor::InsertNodeInfo, node_info).unwrap();
         assert!(result.is_ok());
         assert!(!result.unwrap());
 
         // Bootstrap should be set to "true", as node info was still overwritten.
-        let result = call!(actor, ToAddressBookActor::NodeInfo, args.public_key.clone())
-            .unwrap()
-            .expect("node info exists in store");
+        let result = call!(
+            actor,
+            ToAddressBookActor::NodeInfo,
+            args.verifying_key.clone()
+        )
+        .unwrap()
+        .expect("node info exists in store");
         assert!(result.bootstrap);
         assert!(result.transports().is_none());
 
         // Inserting invalid node info should fail.
         let node_info = {
             NodeInfo {
-                node_id: args.public_key.clone(),
+                node_id: args.verifying_key.clone(),
                 bootstrap: false,
                 transports: Some({
                     let mut unsigned = UnsignedTransportInfo::new();
                     unsigned.add_addr(TransportAddress::from_iroh(
-                        args.public_key.clone(),
+                        args.verifying_key.clone(),
                         Some("https://my.relay.net".parse().unwrap()),
                         [],
                     ));
-                    let mut transport_info = unsigned.sign(&args.private_key.clone()).unwrap();
+                    let mut transport_info = unsigned.sign(&args.signing_key.clone()).unwrap();
                     transport_info.timestamp = 1234.into(); // Manipulate timestamp to make signature invalid
                     transport_info.into()
                 }),
@@ -441,7 +445,7 @@ mod tests {
         assert!(result.is_err());
 
         // Inserting transport info should not overwrite "local" data.
-        let mut node_info = NodeInfo::new(args.public_key.clone());
+        let mut node_info = NodeInfo::new(args.verifying_key.clone());
         node_info.bootstrap = true;
         let result = call!(actor, ToAddressBookActor::InsertNodeInfo, node_info).unwrap();
         assert!(result.is_ok());
@@ -449,25 +453,29 @@ mod tests {
         let transport_info = {
             let mut unsigned = UnsignedTransportInfo::new();
             unsigned.add_addr(TransportAddress::from_iroh(
-                args.public_key.clone(),
+                args.verifying_key.clone(),
                 Some("https://my.relay.net".parse().unwrap()),
                 [],
             ));
-            unsigned.sign(&args.private_key).unwrap()
+            unsigned.sign(&args.signing_key).unwrap()
         };
         let result = call!(
             actor,
             ToAddressBookActor::InsertTransportInfo,
-            args.public_key.clone(),
+            args.verifying_key.clone(),
             transport_info.into()
         )
         .unwrap();
         assert!(result.is_ok());
 
         // Even after insertion of new transport info, the "local" bootstrap config is still true.
-        let result = call!(actor, ToAddressBookActor::NodeInfo, args.public_key.clone())
-            .unwrap()
-            .expect("node info exists in store");
+        let result = call!(
+            actor,
+            ToAddressBookActor::NodeInfo,
+            args.verifying_key.clone()
+        )
+        .unwrap()
+        .expect("node info exists in store");
         assert!(result.bootstrap);
 
         // Transport info was set.
@@ -477,46 +485,46 @@ mod tests {
         let transport_info = {
             let mut unsigned = UnsignedTransportInfo::new();
             unsigned.add_addr(TransportAddress::from_iroh(
-                args.public_key.clone(),
+                args.verifying_key.clone(),
                 Some("https://my.relay.net".parse().unwrap()),
                 [],
             ));
-            let mut transport_info = unsigned.sign(&args.private_key.clone()).unwrap();
+            let mut transport_info = unsigned.sign(&args.signing_key.clone()).unwrap();
             transport_info.timestamp = 1234.into(); // Manipulate timestamp to make signature invalid
             transport_info
         };
-        assert!(transport_info.verify(&args.public_key).is_err());
+        assert!(transport_info.verify(&args.verifying_key).is_err());
         let result = call!(
             actor,
             ToAddressBookActor::InsertTransportInfo,
-            args.public_key.clone(),
+            args.verifying_key.clone(),
             transport_info.into()
         )
         .unwrap();
         assert!(result.is_err());
 
         // Inserting new transport info just creates a "default" object.
-        let private_key = PrivateKey::new();
-        let public_key = private_key.public_key();
+        let signing_key = SigningKey::generate();
+        let verifying_key = signing_key.verifying_key();
         let transport_info = {
             let mut unsigned = UnsignedTransportInfo::new();
             unsigned.add_addr(TransportAddress::from_iroh(
-                public_key,
+                verifying_key,
                 Some("https://my.relay.net".parse().unwrap()),
                 [],
             ));
-            unsigned.sign(&private_key).unwrap()
+            unsigned.sign(&signing_key).unwrap()
         };
         let result = call!(
             actor,
             ToAddressBookActor::InsertTransportInfo,
-            public_key,
+            verifying_key,
             transport_info.into()
         )
         .unwrap();
         assert!(result.is_ok());
 
-        let result = call!(actor, ToAddressBookActor::NodeInfo, public_key)
+        let result = call!(actor, ToAddressBookActor::NodeInfo, verifying_key)
             .unwrap()
             .expect("node info exists in store");
         assert!(!result.bootstrap);

--- a/p2panda-net/src/addrs.rs
+++ b/p2panda-net/src/addrs.rs
@@ -26,15 +26,15 @@ use std::net::SocketAddr;
 
 use p2panda_core::cbor::encode_cbor;
 use p2panda_core::timestamp::{HybridTimestamp, Timestamp};
-use p2panda_core::{PrivateKey, Signature};
+use p2panda_core::{Signature, SigningKey};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::NodeId;
 #[cfg(any(test, feature = "test_utils"))]
-use crate::iroh_endpoint::from_public_key;
+use crate::iroh_endpoint::from_verifying_key;
 #[cfg(feature = "iroh_endpoint")]
-use crate::iroh_endpoint::to_public_key;
+use crate::iroh_endpoint::to_verifying_key;
 
 /// Record of a node we store locally in the address book.
 ///
@@ -142,7 +142,7 @@ impl TryFrom<NodeInfo> for iroh::EndpointAddr {
 #[cfg(feature = "iroh_endpoint")]
 impl From<iroh::EndpointAddr> for NodeInfo {
     fn from(addr: iroh::EndpointAddr) -> Self {
-        let node_id = to_public_key(addr.id);
+        let node_id = to_verifying_key(addr.id);
         let transports = TransportInfo::from(TrustedTransportInfo::from(addr));
 
         Self {
@@ -463,7 +463,7 @@ impl UnsignedTransportInfo {
     /// Authenticate transport info by signining it with our secret key.
     pub fn sign(
         self,
-        signing_key: &PrivateKey,
+        signing_key: &SigningKey,
     ) -> Result<AuthenticatedTransportInfo, NodeInfoError> {
         Ok(AuthenticatedTransportInfo {
             timestamp: self.timestamp,
@@ -621,7 +621,7 @@ impl TransportAddress {
         let transport_addrs = direct_addresses.into_iter().map(iroh::TransportAddr::Ip);
 
         let mut endpoint_addr =
-            iroh::EndpointAddr::new(from_public_key(node_id)).with_addrs(transport_addrs);
+            iroh::EndpointAddr::new(from_verifying_key(node_id)).with_addrs(transport_addrs);
 
         if let Some(url) = relay_url {
             endpoint_addr = endpoint_addr.with_relay_url(url);
@@ -635,7 +635,7 @@ impl TransportAddress {
         #[allow(irrefutable_let_patterns)]
         #[cfg(feature = "iroh_endpoint")]
         if let TransportAddress::Iroh(endpoint_addr) = self
-            && &to_public_key(endpoint_addr.id) != node_id
+            && &to_verifying_key(endpoint_addr.id) != node_id
         {
             return Err(NodeInfoError::NodeIdMismatch);
         }
@@ -717,7 +717,7 @@ mod tests {
     use std::time::Duration;
 
     use mock_instant::thread_local::MockClock;
-    use p2panda_core::PrivateKey;
+    use p2panda_core::SigningKey;
 
     use crate::addrs::NodeTransportInfo;
 
@@ -727,8 +727,8 @@ mod tests {
 
     #[test]
     fn deduplicate_transport_address() {
-        let signing_key_1 = PrivateKey::new();
-        let node_id_1 = signing_key_1.public_key();
+        let signing_key_1 = SigningKey::generate();
+        let node_id_1 = signing_key_1.verifying_key();
 
         // De-duplicate addresses when transport is the same.
         let mut info = AuthenticatedTransportInfo::new_unsigned();
@@ -744,8 +744,8 @@ mod tests {
 
     #[test]
     fn authenticate_address_infos() {
-        let signing_key_1 = PrivateKey::new();
-        let node_id_1 = signing_key_1.public_key();
+        let signing_key_1 = SigningKey::generate();
+        let node_id_1 = signing_key_1.verifying_key();
 
         let mut unsigned = UnsignedTransportInfo::new();
         unsigned.add_addr(TransportAddress::from_iroh(
@@ -758,8 +758,8 @@ mod tests {
         assert!(info.verify(&node_id_1).is_ok());
 
         // Fails when node id does not match.
-        let signing_key_2 = PrivateKey::new();
-        let node_id_2 = signing_key_2.public_key();
+        let signing_key_2 = SigningKey::generate();
+        let node_id_2 = signing_key_2.verifying_key();
         assert!(info.verify(&node_id_2).is_err());
 
         // Fails when information got changed.
@@ -770,11 +770,11 @@ mod tests {
 
     #[test]
     fn node_id_mismatch() {
-        let signing_key_1 = PrivateKey::new();
-        let node_id_1 = signing_key_1.public_key();
+        let signing_key_1 = SigningKey::generate();
+        let node_id_1 = signing_key_1.verifying_key();
 
-        let signing_key_2 = PrivateKey::new();
-        let node_id_2 = signing_key_2.public_key();
+        let signing_key_2 = SigningKey::generate();
+        let node_id_2 = signing_key_2.verifying_key();
 
         // Create transport info for node 1.
         let mut unsigned = UnsignedTransportInfo::new();
@@ -798,8 +798,8 @@ mod tests {
 
     #[test]
     fn latest_transport_info_wins() {
-        let signing_key_1 = PrivateKey::new();
-        let node_id_1 = signing_key_1.public_key();
+        let signing_key_1 = SigningKey::generate();
+        let node_id_1 = signing_key_1.verifying_key();
 
         // Create "newer" transport info.
         let transport_info_1 = {
@@ -843,8 +843,8 @@ mod tests {
 
     #[test]
     fn stale_nodes() {
-        let signing_key = PrivateKey::new();
-        let node_id = signing_key.public_key();
+        let signing_key = SigningKey::generate();
+        let node_id = signing_key.verifying_key();
 
         let mut node_info = NodeInfo {
             node_id,

--- a/p2panda-net/src/cbor.rs
+++ b/p2panda-net/src/cbor.rs
@@ -188,7 +188,7 @@ impl From<std::io::Error> for CborCodecError {
 #[cfg(test)]
 mod tests {
     use futures_util::{FutureExt, SinkExt, StreamExt};
-    use p2panda_core::{Body, Hash, Header, PrivateKey, Timestamp};
+    use p2panda_core::{Body, Hash, Header, SigningKey, Timestamp};
     use tokio::io::AsyncWriteExt;
     use tokio_util::codec::FramedRead;
 
@@ -263,7 +263,7 @@ mod tests {
         type Payload = (Header<()>, Option<Body>);
 
         fn create_operation(
-            private_key: &PrivateKey,
+            signing_key: &SigningKey,
             body: &[u8],
             seq_num: u64,
             backlink: Option<Hash>,
@@ -271,7 +271,7 @@ mod tests {
             let body = Body::from(body);
             let mut header = Header {
                 version: 1,
-                public_key: private_key.public_key(),
+                verifying_key: signing_key.verifying_key(),
                 signature: None,
                 payload_size: body.size(),
                 payload_hash: Some(body.hash()),
@@ -280,7 +280,7 @@ mod tests {
                 backlink,
                 extensions: (),
             };
-            header.sign(private_key);
+            header.sign(signing_key);
             (header, Some(body))
         }
 
@@ -291,14 +291,14 @@ mod tests {
 
         // Create 100 operations, encode them as CBOR and send bytes to receiver.
         tokio::task::spawn(async move {
-            let private_key = PrivateKey::new();
+            let signing_key = SigningKey::generate();
 
             let mut seq_num = 0;
             let mut backlink = None;
 
             for _ in 0..100 {
                 let (header, body) =
-                    create_operation(&private_key, b"boom boom boom", seq_num, backlink);
+                    create_operation(&signing_key, b"boom boom boom", seq_num, backlink);
                 seq_num += 1;
                 backlink = Some(header.hash());
 

--- a/p2panda-net/src/discovery/actors/manager.rs
+++ b/p2panda-net/src/discovery/actors/manager.rs
@@ -32,7 +32,7 @@ use crate::discovery::actors::session::{
 };
 use crate::discovery::actors::walker::{DiscoveryWalker, ToDiscoveryWalker, WalkFromHere};
 use crate::discovery::events::{DiscoveryEvent, SessionRole};
-use crate::iroh_endpoint::{Endpoint, to_public_key};
+use crate::iroh_endpoint::{Endpoint, to_verifying_key};
 use crate::utils::ShortFormat;
 
 /// Maximum duration of inactivity to accept before timing out the connection.
@@ -661,7 +661,7 @@ impl ProtocolHandler for DiscoveryProtocolHandler {
     ) -> Result<(), iroh::protocol::AcceptError> {
         self.manager_ref
             .send_message(ToDiscoveryManager::AcceptSession(
-                to_public_key(connection.remote_id()),
+                to_verifying_key(connection.remote_id()),
                 connection,
             ))
             .map_err(|err| iroh::protocol::AcceptError::from_err(err))

--- a/p2panda-net/src/gossip/actors/healer.rs
+++ b/p2panda-net/src/gossip/actors/healer.rs
@@ -13,7 +13,7 @@ use crate::NodeId;
 use crate::address_book::AddressBook;
 use crate::addrs::NodeInfo;
 use crate::gossip::actors::session::ToGossipSession;
-use crate::iroh_endpoint::from_public_key;
+use crate::iroh_endpoint::from_verifying_key;
 use crate::watchers::WatcherReceiver;
 
 pub enum ToGossipHealer {
@@ -114,7 +114,7 @@ impl ThreadLocalActor for GossipHealer {
                         state.topic_endpoint_ids = Vec::from_iter(event.value.into_iter().filter_map(|node_id| {
                             // Remove ourselves from list.
                             if node_id != state.my_node_id {
-                                Some(from_public_key(node_id))
+                                Some(from_verifying_key(node_id))
                             } else {
                                 None
                             }

--- a/p2panda-net/src/gossip/actors/manager.rs
+++ b/p2panda-net/src/gossip/actors/manager.rs
@@ -16,7 +16,7 @@ use crate::gossip::GossipConfig;
 use crate::gossip::actors::session::{GossipSession, ToGossipSession};
 use crate::gossip::events::GossipEvent;
 use crate::hash_protocol_id_with_network_id;
-use crate::iroh_endpoint::{Endpoint, from_public_key};
+use crate::iroh_endpoint::{Endpoint, from_verifying_key};
 use crate::utils::ShortFormat;
 
 pub enum ToGossipManager {
@@ -200,7 +200,7 @@ impl ThreadLocalActor for GossipManager {
                 // Convert p2panda public keys to iroh endpoint ids.
                 let nodes = nodes
                     .iter()
-                    .map(|key: &NodeId| from_public_key(*key))
+                    .map(|key: &NodeId| from_verifying_key(*key))
                     .collect();
 
                 // Subscribe to the gossip topic (without waiting for a connection).
@@ -290,7 +290,7 @@ impl ThreadLocalActor for GossipManager {
                 // Convert p2panda public keys to iroh endpoint ids.
                 let nodes: Vec<iroh::EndpointId> = nodes
                     .iter()
-                    .map(|key: &NodeId| from_public_key(*key))
+                    .map(|key: &NodeId| from_verifying_key(*key))
                     .collect();
 
                 if let Some(session) = state.sessions.sessions_by_topic.get(&topic) {

--- a/p2panda-net/src/gossip/actors/session.rs
+++ b/p2panda-net/src/gossip/actors/session.rs
@@ -23,7 +23,7 @@ use crate::gossip::actors::joiner::{GossipJoiner, ToGossipJoiner};
 use crate::gossip::actors::listener::GossipListener;
 use crate::gossip::actors::receiver::{GossipReceiver, ToGossipReceiver};
 use crate::gossip::actors::sender::{GossipSender, ToGossipSender};
-use crate::iroh_endpoint::to_public_key;
+use crate::iroh_endpoint::to_verifying_key;
 use crate::utils::ShortFormat;
 
 pub enum ToGossipSession {
@@ -166,7 +166,7 @@ impl ThreadLocalActor for GossipSession {
         match message {
             ToGossipSession::ProcessJoined(nodes) => {
                 let topic = state.topic;
-                let nodes: Vec<NodeId> = nodes.into_iter().map(to_public_key).collect();
+                let nodes: Vec<NodeId> = nodes.into_iter().map(to_verifying_key).collect();
                 let session_id = myself.get_id();
 
                 let _ = state.gossip_actor.cast(ToGossipManager::Joined {
@@ -181,7 +181,7 @@ impl ThreadLocalActor for GossipSession {
                 }
                 IrohEvent::Received(msg) => {
                     let bytes = msg.content.into();
-                    let delivered_from = to_public_key(msg.delivered_from);
+                    let delivered_from = to_verifying_key(msg.delivered_from);
                     let delivery_scope = msg.scope;
                     let topic = state.topic;
                     let session_id = myself.get_id();
@@ -195,7 +195,7 @@ impl ThreadLocalActor for GossipSession {
                     });
                 }
                 IrohEvent::NeighborUp(peer) => {
-                    let node_id = to_public_key(peer);
+                    let node_id = to_verifying_key(peer);
                     let session_id = myself.get_id();
 
                     let _ = state.gossip_actor.cast(ToGossipManager::NeighborUp {
@@ -204,7 +204,7 @@ impl ThreadLocalActor for GossipSession {
                     });
                 }
                 IrohEvent::NeighborDown(peer) => {
-                    let node_id = to_public_key(peer);
+                    let node_id = to_verifying_key(peer);
                     let session_id = myself.get_id();
 
                     let _ = state.gossip_actor.cast(ToGossipManager::NeighborDown {

--- a/p2panda-net/src/gossip/tests.rs
+++ b/p2panda-net/src/gossip/tests.rs
@@ -27,13 +27,13 @@ async fn joined_and_left_events_are_received() {
 
     let ant_endpoint = Endpoint::builder(ant_address_book.clone())
         .config(ant_args.iroh_config.clone())
-        .private_key(ant_args.private_key.clone())
+        .signing_key(ant_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
     let bat_endpoint = Endpoint::builder(bat_address_book.clone())
         .config(bat_args.iroh_config.clone())
-        .private_key(bat_args.private_key.clone())
+        .signing_key(bat_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
@@ -113,19 +113,19 @@ async fn join_without_bootstrap() {
     // Create endpoints.
     let ant_endpoint = Endpoint::builder(ant_address_book.clone())
         .config(ant_args.iroh_config.clone())
-        .private_key(ant_args.private_key.clone())
+        .signing_key(ant_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
     let bat_endpoint = Endpoint::builder(bat_address_book.clone())
         .config(bat_args.iroh_config.clone())
-        .private_key(bat_args.private_key.clone())
+        .signing_key(bat_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
     let cat_endpoint = Endpoint::builder(cat_address_book.clone())
         .config(cat_args.iroh_config.clone())
-        .private_key(cat_args.private_key.clone())
+        .signing_key(cat_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
@@ -196,7 +196,7 @@ async fn join_without_bootstrap() {
 
     assert_eq!(
         neighbours,
-        HashSet::from([bat_args.public_key, cat_args.public_key])
+        HashSet::from([bat_args.verifying_key, cat_args.verifying_key])
     );
 }
 
@@ -223,13 +223,13 @@ async fn two_peer_gossip() {
     // Create endpoints.
     let ant_endpoint = Endpoint::builder(ant_address_book.clone())
         .config(ant_args.iroh_config.clone())
-        .private_key(ant_args.private_key.clone())
+        .signing_key(ant_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
     let bat_endpoint = Endpoint::builder(bat_address_book.clone())
         .config(bat_args.iroh_config.clone())
-        .private_key(bat_args.private_key.clone())
+        .signing_key(bat_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
@@ -309,19 +309,19 @@ async fn third_peer_joins_non_bootstrap() {
     // Create endpoints.
     let ant_endpoint = Endpoint::builder(ant_address_book.clone())
         .config(ant_args.iroh_config.clone())
-        .private_key(ant_args.private_key.clone())
+        .signing_key(ant_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
     let bat_endpoint = Endpoint::builder(bat_address_book.clone())
         .config(bat_args.iroh_config.clone())
-        .private_key(bat_args.private_key.clone())
+        .signing_key(bat_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
     let cat_endpoint = Endpoint::builder(cat_address_book.clone())
         .config(cat_args.iroh_config.clone())
-        .private_key(cat_args.private_key.clone())
+        .signing_key(cat_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
@@ -441,19 +441,19 @@ async fn three_peer_gossip_with_rejoin() {
     // Create endpoints.
     let ant_endpoint = Endpoint::builder(ant_address_book.clone())
         .config(ant_args.iroh_config.clone())
-        .private_key(ant_args.private_key.clone())
+        .signing_key(ant_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
     let bat_endpoint = Endpoint::builder(bat_address_book.clone())
         .config(bat_args.iroh_config.clone())
-        .private_key(bat_args.private_key.clone())
+        .signing_key(bat_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
     let cat_endpoint = Endpoint::builder(cat_address_book.clone())
         .config(cat_args.iroh_config.clone())
-        .private_key(cat_args.private_key.clone())
+        .signing_key(cat_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
@@ -597,13 +597,13 @@ async fn leave_overlay_on_drop() {
 
     let ant_endpoint = Endpoint::builder(ant_address_book.clone())
         .config(ant_args.iroh_config.clone())
-        .private_key(ant_args.private_key.clone())
+        .signing_key(ant_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
     let bat_endpoint = Endpoint::builder(bat_address_book.clone())
         .config(bat_args.iroh_config.clone())
-        .private_key(bat_args.private_key.clone())
+        .signing_key(bat_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
@@ -732,7 +732,7 @@ async fn large_message_error() {
 
     let args = test_args();
 
-    let topic = Topic::new();
+    let topic = Topic::random();
 
     // Create address book.
     let address_book = AddressBook::builder().spawn().await.unwrap();
@@ -740,7 +740,7 @@ async fn large_message_error() {
     // Create endpoint.
     let endpoint = Endpoint::builder(address_book.clone())
         .config(args.iroh_config.clone())
-        .private_key(args.private_key.clone())
+        .signing_key(args.signing_key.clone())
         .spawn()
         .await
         .unwrap();

--- a/p2panda-net/src/iroh_endpoint/actors/connection.rs
+++ b/p2panda-net/src/iroh_endpoint/actors/connection.rs
@@ -9,7 +9,7 @@ use tracing::{Instrument, debug, info_span, warn};
 
 use crate::address_book::report::{ConnectionOutcome, ConnectionRole};
 use crate::iroh_endpoint::actors::endpoint::{ConnectError, ProtocolMap, ToIrohEndpoint};
-use crate::iroh_endpoint::to_public_key;
+use crate::iroh_endpoint::to_verifying_key;
 use crate::utils::ShortFormat;
 use crate::{NodeId, ProtocolId};
 
@@ -99,7 +99,7 @@ async fn establish_connection(
             reply,
         } => {
             tracing::Span::current().record("alpn", alpn.fmt_short());
-            let remote_node_id = to_public_key(endpoint_addr.id);
+            let remote_node_id = to_verifying_key(endpoint_addr.id);
 
             let mut connect_options = ConnectOptions::default();
             if let Some(config) = quic_transport_config {
@@ -197,7 +197,7 @@ async fn establish_connection(
 
             // Inform endpoint actor about this successful, incoming connection attempt.
             let _ = endpoint_ref.send_message(ToIrohEndpoint::Report {
-                remote_node_id: to_public_key(connection.remote_id()),
+                remote_node_id: to_verifying_key(connection.remote_id()),
                 role: ConnectionRole::Accept,
                 outcome: ConnectionOutcome::Successful,
             });

--- a/p2panda-net/src/iroh_endpoint/actors/endpoint.rs
+++ b/p2panda-net/src/iroh_endpoint/actors/endpoint.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use iroh::endpoint::{QuicTransportConfig, presets};
 use iroh::protocol::DynProtocolHandler;
-use p2panda_core::PrivateKey;
+use p2panda_core::SigningKey;
 use ractor::thread_local::{ThreadLocalActor, ThreadLocalActorSpawner};
 use ractor::{ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent};
 use thiserror::Error;
@@ -25,7 +25,7 @@ use crate::iroh_endpoint::actors::connection::{
 use crate::iroh_endpoint::actors::is_globally_reachable_endpoint;
 use crate::iroh_endpoint::config::IrohConfig;
 use crate::iroh_endpoint::discovery::AddressBookDiscovery;
-use crate::iroh_endpoint::from_private_key;
+use crate::iroh_endpoint::from_signing_key;
 use crate::utils::ShortFormat;
 use crate::{NetworkId, NodeId, ProtocolId, hash_protocol_id_with_network_id};
 
@@ -83,7 +83,7 @@ pub type ProtocolMap = Arc<RwLock<BTreeMap<ProtocolId, Box<dyn DynProtocolHandle
 
 pub struct IrohState {
     network_id: NetworkId,
-    private_key: PrivateKey,
+    signing_key: SigningKey,
     config: IrohConfig,
     relay_map: iroh::RelayMap,
     address_book: AddressBook,
@@ -96,7 +96,7 @@ pub struct IrohState {
 
 pub type IrohEndpointArgs = (
     NetworkId,
-    PrivateKey,
+    SigningKey,
     IrohConfig,
     iroh::RelayMap,
     AddressBook,
@@ -117,14 +117,14 @@ impl ThreadLocalActor for IrohEndpoint {
         myself: ActorRef<Self::Msg>,
         args: Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
-        let (network_id, private_key, config, relay_map, address_book) = args;
+        let (network_id, signing_key, config, relay_map, address_book) = args;
 
         // Automatically bind iroh endpoint after actor start.
         myself.send_message(ToIrohEndpoint::Bind)?;
 
         Ok(IrohState {
             network_id,
-            private_key,
+            signing_key,
             config,
             relay_map,
             address_book,
@@ -189,7 +189,7 @@ impl ThreadLocalActor for IrohEndpoint {
                 // Connect iroh's endpoint with our own address book to "publish" our changed iroh
                 // address directly and "resolve" endpoint id's.
                 let address_book_discovery = AddressBookDiscovery::new(
-                    state.private_key.clone(),
+                    state.signing_key.clone(),
                     state.address_book.clone(),
                 );
 
@@ -197,7 +197,7 @@ impl ThreadLocalActor for IrohEndpoint {
                 let endpoint = iroh::Endpoint::builder(presets::Minimal)
                     .relay_mode(relay_mode)
                     .address_lookup(address_book_discovery)
-                    .secret_key(from_private_key(state.private_key.clone()))
+                    .secret_key(from_signing_key(state.signing_key.clone()))
                     .transport_config(quic_transport_config)
                     .bind_addr(socket_address_v4)?
                     .bind_addr(socket_address_v6)?
@@ -271,7 +271,7 @@ impl ThreadLocalActor for IrohEndpoint {
                 IrohConnection::spawn_linked(
                     None,
                     (
-                        state.private_key.public_key(),
+                        state.signing_key.verifying_key(),
                         IrohConnectionArgs::Connect {
                             endpoint: state.endpoint
                                 .clone()
@@ -300,7 +300,7 @@ impl ThreadLocalActor for IrohEndpoint {
                 IrohConnection::spawn_linked(
                     None,
                     (
-                        state.private_key.public_key(),
+                        state.signing_key.verifying_key(),
                         IrohConnectionArgs::Accept {
                             incoming,
                             protocols: state.protocols.clone(),

--- a/p2panda-net/src/iroh_endpoint/api.rs
+++ b/p2panda-net/src/iroh_endpoint/api.rs
@@ -26,7 +26,7 @@ use crate::{NetworkId, NodeId};
 /// # let address_book = AddressBook::builder().spawn().await?;
 /// #
 /// // Generate Ed25519 key which will be used to authenticate node.
-/// let private_key = p2panda_core::PrivateKey::new();
+/// let signing_key = p2panda_core::SigningKey::generate();
 ///
 /// // Use this iroh relay as a "home relay".
 /// let relay_url = "https://my.relay.org".parse().expect("valid relay url");
@@ -34,7 +34,7 @@ use crate::{NetworkId, NodeId};
 /// // Initialise endpoint with custom network identifier.
 /// let endpoint = Endpoint::builder(address_book)
 ///     .network_id([1; 32])
-///     .private_key(private_key)
+///     .signing_key(signing_key)
 ///     .relay_url(relay_url)
 ///     .spawn()
 ///     .await?;
@@ -123,7 +123,7 @@ impl Endpoint {
     }
 
     pub fn node_id(&self) -> NodeId {
-        self.args.1.public_key()
+        self.args.1.verifying_key()
     }
 
     /// Register protocol handler for a given ALPN (protocol identifier).

--- a/p2panda-net/src/iroh_endpoint/builder.rs
+++ b/p2panda-net/src/iroh_endpoint/builder.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use p2panda_core::PrivateKey;
+use p2panda_core::SigningKey;
 use ractor::thread_local::{ThreadLocalActor, ThreadLocalActorSpawner};
 
 use crate::address_book::AddressBook;
@@ -13,7 +13,7 @@ use crate::{DEFAULT_NETWORK_ID, NetworkId};
 
 pub struct Builder {
     network_id: Option<NetworkId>,
-    private_key: Option<PrivateKey>,
+    signing_key: Option<SigningKey>,
     config: Option<IrohConfig>,
     relay_urls: HashSet<iroh::RelayUrl>,
     address_book: AddressBook,
@@ -23,7 +23,7 @@ impl Builder {
     pub fn new(address_book: AddressBook) -> Self {
         Self {
             network_id: None,
-            private_key: None,
+            signing_key: None,
             config: None,
             address_book,
             relay_urls: HashSet::new(),
@@ -35,8 +35,8 @@ impl Builder {
         self
     }
 
-    pub fn private_key(mut self, private_key: PrivateKey) -> Self {
-        self.private_key = Some(private_key);
+    pub fn signing_key(mut self, signing_key: SigningKey) -> Self {
+        self.signing_key = Some(signing_key);
         self
     }
 
@@ -70,12 +70,12 @@ impl Builder {
 
     pub(crate) fn build_args(self) -> IrohEndpointArgs {
         let network_id = self.network_id.unwrap_or(DEFAULT_NETWORK_ID);
-        let private_key = self.private_key.unwrap_or_default();
+        let signing_key = self.signing_key.unwrap_or_default();
         let config = self.config.unwrap_or_default();
         let relay_map = iroh::RelayMap::from_iter(self.relay_urls);
         (
             network_id,
-            private_key,
+            signing_key,
             config,
             relay_map,
             self.address_book,

--- a/p2panda-net/src/iroh_endpoint/discovery.rs
+++ b/p2panda-net/src/iroh_endpoint/discovery.rs
@@ -8,7 +8,7 @@ use futures_util::{FutureExt, Stream, StreamExt};
 use iroh::address_lookup::Error as AddressLookupError;
 use iroh::address_lookup::Item as AddressLookupItem;
 use iroh::address_lookup::{AddressLookup, EndpointData, EndpointInfo};
-use p2panda_core::PrivateKey;
+use p2panda_core::SigningKey;
 use p2panda_store::address_book::NodeInfo as _;
 use tokio::sync::Semaphore;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -16,7 +16,7 @@ use tracing::{Instrument, error, info_span, trace, warn};
 
 use crate::address_book::AddressBook;
 use crate::addrs::{NodeTransportInfo, UnsignedTransportInfo};
-use crate::iroh_endpoint::{from_public_key, to_public_key};
+use crate::iroh_endpoint::{from_verifying_key, to_verifying_key};
 
 /// Discovery service for iroh connecting iroh's endpoint with our address book actor. This
 /// implements iroh's `Discovery` trait.
@@ -25,7 +25,7 @@ use crate::iroh_endpoint::{from_public_key, to_public_key};
 /// about our own, changed address (for example if the home relay changed or we got an direct IP
 /// address, etc., in iroh this is called "publish").
 pub struct AddressBookDiscovery {
-    private_key: PrivateKey,
+    signing_key: SigningKey,
     address_book: AddressBook,
     semaphore: Arc<Semaphore>,
 }
@@ -41,9 +41,9 @@ impl std::fmt::Debug for AddressBookDiscovery {
 const PROVENANCE: &str = "address_book";
 
 impl AddressBookDiscovery {
-    pub fn new(private_key: PrivateKey, address_book: AddressBook) -> Self {
+    pub fn new(signing_key: SigningKey, address_book: AddressBook) -> Self {
         Self {
-            private_key,
+            signing_key,
             address_book,
             semaphore: Arc::new(Semaphore::new(1)),
         }
@@ -52,8 +52,8 @@ impl AddressBookDiscovery {
 
 impl AddressLookup for AddressBookDiscovery {
     fn publish(&self, data: &EndpointData) {
-        let private_key = self.private_key.clone();
-        let public_key = private_key.public_key();
+        let signing_key = self.signing_key.clone();
+        let verifying_key = signing_key.verifying_key();
         let data = data.to_owned();
         let semaphore = self.semaphore.clone();
         let address_book = self.address_book.clone();
@@ -66,7 +66,7 @@ impl AddressLookup for AddressBookDiscovery {
                 return;
             };
 
-            let Ok(node_info) = address_book.node_info(public_key).await else {
+            let Ok(node_info) = address_book.node_info(verifying_key).await else {
                 error!("failed getting own transport info from address book");
                 return;
             };
@@ -77,7 +77,7 @@ impl AddressLookup for AddressBookDiscovery {
             // other nodes about this.
             let Ok(transport_info) = if data.has_addrs() {
                 UnsignedTransportInfo::from_addrs([iroh::EndpointAddr {
-                    id: from_public_key(public_key),
+                    id: from_verifying_key(verifying_key),
                     addrs: BTreeSet::from_iter(data.addrs().cloned()),
                 }
                 .into()])
@@ -85,7 +85,7 @@ impl AddressLookup for AddressBookDiscovery {
                 UnsignedTransportInfo::new()
             }
             .increment_timestamp(previous_transport_info.as_ref())
-            .sign(&private_key) else {
+            .sign(&signing_key) else {
                 error!("failed signing own transport info");
                 return;
             };
@@ -100,7 +100,7 @@ impl AddressLookup for AddressBookDiscovery {
             // Update entry about ourselves in address book to allow this information to propagate
             // in other discovery mechanisms or side-channels outside of iroh.
             if let Err(err) = address_book
-                .insert_transport_info(public_key, transport_info.clone().into())
+                .insert_transport_info(verifying_key, transport_info.clone().into())
                 .await
             {
                 warn!("could not update address book with own transport info: {err:#?}");
@@ -119,7 +119,7 @@ impl AddressLookup for AddressBookDiscovery {
 
         let stream = async move {
             let subscription = address_book
-                .watch_node_info(to_public_key(endpoint_id), false)
+                .watch_node_info(to_verifying_key(endpoint_id), false)
                 .await
                 .map_err(|_| {
                     AddressLookupError::from_err_any(

--- a/p2panda-net/src/iroh_endpoint/mod.rs
+++ b/p2panda-net/src/iroh_endpoint/mod.rs
@@ -20,16 +20,16 @@ pub use builder::Builder;
 pub use config::IrohConfig;
 
 /// Converts an `iroh` public key type to the `p2panda-core` implementation.
-pub fn to_public_key(key: iroh_base::PublicKey) -> p2panda_core::PublicKey {
-    p2panda_core::PublicKey::from_bytes(key.as_bytes()).expect("already validated public key")
+pub fn to_verifying_key(key: iroh_base::PublicKey) -> p2panda_core::VerifyingKey {
+    p2panda_core::VerifyingKey::from_bytes(key.as_bytes()).expect("already validated public key")
 }
 
 /// Converts a `p2panda-core` public key to the "iroh" type.
-pub fn from_public_key(key: p2panda_core::PublicKey) -> iroh_base::PublicKey {
+pub fn from_verifying_key(key: p2panda_core::VerifyingKey) -> iroh_base::PublicKey {
     iroh_base::PublicKey::from_bytes(key.as_bytes()).expect("already validated public key")
 }
 
 /// Converts a `p2panda-core` private key to the "iroh" type.
-pub fn from_private_key(key: p2panda_core::PrivateKey) -> iroh_base::SecretKey {
+pub fn from_signing_key(key: p2panda_core::SigningKey) -> iroh_base::SecretKey {
     iroh_base::SecretKey::from_bytes(key.as_bytes())
 }

--- a/p2panda-net/src/iroh_endpoint/tests.rs
+++ b/p2panda-net/src/iroh_endpoint/tests.rs
@@ -42,14 +42,14 @@ async fn establish_connection() {
     // Spawn both endpoint actors.
     let alice_endpoint = Endpoint::builder(alice_address_book)
         .config(alice_args.iroh_config.clone())
-        .private_key(alice_args.private_key.clone())
+        .signing_key(alice_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
 
     let bob_endpoint = Endpoint::builder(bob_address_book.clone())
         .config(bob_args.iroh_config.clone())
-        .private_key(bob_args.private_key.clone())
+        .signing_key(bob_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
@@ -68,7 +68,7 @@ async fn establish_connection() {
 
     // Bob connects to Alice using the "echo" protocol.
     let connection = bob_endpoint
-        .connect(alice_args.public_key, ECHO_PROTOCOL_ID)
+        .connect(alice_args.verifying_key, ECHO_PROTOCOL_ID)
         .await
         .expect("connection establishment should not fail");
 

--- a/p2panda-net/src/iroh_endpoint/user_data.rs
+++ b/p2panda-net/src/iroh_endpoint/user_data.rs
@@ -125,18 +125,18 @@ pub enum UserDataInfoError {
 #[cfg(test)]
 mod tests {
     use iroh::address_lookup::UserData;
-    use p2panda_core::PrivateKey;
+    use p2panda_core::SigningKey;
 
-    use crate::iroh_endpoint::from_public_key;
+    use crate::iroh_endpoint::from_verifying_key;
 
     use super::{AuthenticatedTransportInfo, UserDataTransportInfo};
 
     #[test]
     fn transport_info_to_user_data() {
         // Create simple transport info object without any addresses attached.
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let transport_info = AuthenticatedTransportInfo::new_unsigned()
-            .sign(&private_key)
+            .sign(&signing_key)
             .unwrap();
 
         // Extract information we want for our TXT record.
@@ -152,10 +152,10 @@ mod tests {
 
     #[test]
     fn transport_info_to_user_data_with_relay_url() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let mut transport_info = AuthenticatedTransportInfo::new_unsigned();
         transport_info.add_addr(
-            iroh::EndpointAddr::new(from_public_key(private_key.public_key()))
+            iroh::EndpointAddr::new(from_verifying_key(signing_key.verifying_key()))
                 .with_ip_addr("127.0.0.1:8080".parse().unwrap())
                 .with_relay_url(
                     "https://euc1-1.relay.n0.iroh-canary.iroh.link./"
@@ -164,7 +164,7 @@ mod tests {
                 )
                 .into(),
         );
-        let transport_info = transport_info.sign(&private_key).unwrap();
+        let transport_info = transport_info.sign(&signing_key).unwrap();
 
         // Extract information we want for our TXT record.
         let txt_info = UserDataTransportInfo::from_transport_info(transport_info);

--- a/p2panda-net/src/iroh_mdns/actor.rs
+++ b/p2panda-net/src/iroh_mdns/actor.rs
@@ -12,7 +12,7 @@ use crate::NodeId;
 use crate::address_book::AddressBook;
 use crate::addrs::{AuthenticatedTransportInfo, NodeInfo, NodeTransportInfo, TransportInfo};
 use crate::iroh_endpoint::user_data::UserDataTransportInfo;
-use crate::iroh_endpoint::{Endpoint, from_public_key, to_public_key};
+use crate::iroh_endpoint::{Endpoint, from_verifying_key, to_verifying_key};
 use crate::iroh_mdns::MdnsDiscoveryMode;
 
 const MDNS_SERVICE_NAME: &str = "p2pandav1";
@@ -64,7 +64,7 @@ impl ThreadLocalActor for MdnsActor {
         let my_node_id = endpoint.node_id();
 
         // Automatically initialise mDNS service after starting actor.
-        myself.send_message(ToMdns::Initialise(from_public_key(my_node_id), mode))?;
+        myself.send_message(ToMdns::Initialise(from_verifying_key(my_node_id), mode))?;
 
         Ok(MdnsState {
             my_node_id,
@@ -210,7 +210,10 @@ impl ThreadLocalActor for MdnsActor {
                         };
 
                         // Check authenticity.
-                        if transport_info.verify(&to_public_key(endpoint_id)).is_err() {
+                        if transport_info
+                            .verify(&to_verifying_key(endpoint_id))
+                            .is_err()
+                        {
                             warn!(
                                 %endpoint_id,
                                 "found invalid transport info coming from iroh's services"
@@ -223,7 +226,7 @@ impl ThreadLocalActor for MdnsActor {
                         if let Err(err) = state
                             .address_book
                             .insert_transport_info(
-                                to_public_key(endpoint_id),
+                                to_verifying_key(endpoint_id),
                                 transport_info.into(),
                             )
                             .await

--- a/p2panda-net/src/iroh_mdns/tests.rs
+++ b/p2panda-net/src/iroh_mdns/tests.rs
@@ -19,26 +19,26 @@ async fn mdns_discovery() {
     // Spawn both endpoint actors.
     let alice_endpoint = Endpoint::builder(alice_address_book.clone())
         .config(alice_args.iroh_config.clone())
-        .private_key(alice_args.private_key.clone())
+        .signing_key(alice_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
     let bob_endpoint = Endpoint::builder(bob_address_book.clone())
         .config(bob_args.iroh_config.clone())
-        .private_key(bob_args.private_key.clone())
+        .signing_key(bob_args.signing_key.clone())
         .spawn()
         .await
         .unwrap();
 
     // Alice and Bob do not yet know about one another.
     let result = bob_address_book
-        .node_info(alice_args.public_key)
+        .node_info(alice_args.verifying_key)
         .await
         .unwrap();
     assert!(result.is_none());
 
     let result = alice_address_book
-        .node_info(bob_args.public_key)
+        .node_info(bob_args.verifying_key)
         .await
         .unwrap();
     assert!(result.is_none());
@@ -73,13 +73,13 @@ async fn mdns_discovery() {
 
     // Alice should be in Bob's address book and vice-versa.
     let result = bob_address_book
-        .node_info(alice_args.public_key)
+        .node_info(alice_args.verifying_key)
         .await
         .unwrap();
     assert!(result.is_some());
 
     let result = alice_address_book
-        .node_info(bob_args.public_key)
+        .node_info(bob_args.verifying_key)
         .await
         .unwrap();
     assert!(result.is_some());

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -31,7 +31,7 @@
 //! use p2panda_net::{AddressBook, Discovery, Endpoint, MdnsDiscovery, Gossip};
 //!
 //! // Topics are used to discover other nodes and establish connections around them.
-//! let topic = Hash::new(b"shirokuma-cafe").into();
+//! let topic = Hash::digest(b"shirokuma-cafe").into();
 //!
 //! // Maintain an address book of newly discovered or manually added nodes.
 //! let address_book = AddressBook::builder().spawn().await?;
@@ -278,7 +278,7 @@ pub use sync::LogSync;
 ///
 /// Each node in p2panda has a unique identifier created as a cryptographic key to globally
 /// identify it and encrypt network traffic for this node only.
-pub type NodeId = p2panda_core::PublicKey;
+pub type NodeId = p2panda_core::VerifyingKey;
 
 /// Identifier for a network.
 ///
@@ -317,7 +317,7 @@ fn hash_protocol_id_with_network_id(
     protocol_id: impl AsRef<[u8]>,
     network_id: NetworkId,
 ) -> Vec<u8> {
-    p2panda_core::Hash::new([protocol_id.as_ref(), &network_id].concat())
+    p2panda_core::Hash::digest([protocol_id.as_ref(), &network_id].concat())
         .as_bytes()
         .to_vec()
 }

--- a/p2panda-net/src/sync/actors/manager.rs
+++ b/p2panda-net/src/sync/actors/manager.rs
@@ -22,7 +22,7 @@ use tracing::{debug, warn};
 
 use crate::cbor::{into_cbor_sink, into_cbor_stream};
 use crate::gossip::{Gossip, GossipEvent, GossipHandle};
-use crate::iroh_endpoint::{Endpoint, to_public_key};
+use crate::iroh_endpoint::{Endpoint, to_verifying_key};
 use crate::sync::actors::{ToTopicManager, TopicManager};
 use crate::utils::ShortFormat;
 use crate::{NodeId, ProtocolId};
@@ -511,7 +511,7 @@ where
         &self,
         connection: iroh::endpoint::Connection,
     ) -> Result<(), iroh::protocol::AcceptError> {
-        let node_id = to_public_key(connection.remote_id());
+        let node_id = to_verifying_key(connection.remote_id());
         let (tx, rx) = connection.accept_bi().await?;
 
         // As we are accepting a sync session here we don't yet know the topic which the initiator
@@ -548,5 +548,5 @@ where
 
 /// Hash the concatenation of a topic with a given value to derive new topic.
 fn derive_topic(topic: Topic, value: impl AsRef<[u8]>) -> Topic {
-    p2panda_core::Hash::new([topic.as_bytes(), value.as_ref()].concat()).into()
+    p2panda_core::Hash::digest([topic.as_bytes(), value.as_ref()].concat()).into()
 }

--- a/p2panda-net/src/sync/log_sync/api.rs
+++ b/p2panda-net/src/sync/log_sync/api.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use p2panda_core::{Extensions, Hash, LogId, Operation, PublicKey, Topic};
+use p2panda_core::{Extensions, Hash, LogId, Operation, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
 use p2panda_sync::protocols::TopicLogSyncEvent;
@@ -40,8 +40,8 @@ use crate::sync::log_sync::Builder;
 #[derive(Clone, Debug)]
 pub struct LogSync<S, L, E>
 where
-    S: LogStore<Operation<E>, PublicKey, L, u64, Hash>
-        + TopicStore<Topic, PublicKey, L>
+    S: LogStore<Operation<E>, VerifyingKey, L, u64, Hash>
+        + TopicStore<Topic, VerifyingKey, L>
         + Clone
         + Send
         + 'static,
@@ -63,8 +63,8 @@ where
 
 impl<S, L, E> LogSync<S, L, E>
 where
-    S: LogStore<Operation<E>, PublicKey, L, u64, Hash>
-        + TopicStore<Topic, PublicKey, L>
+    S: LogStore<Operation<E>, VerifyingKey, L, u64, Hash>
+        + TopicStore<Topic, VerifyingKey, L>
         + Clone
         + Send
         + 'static,

--- a/p2panda-net/src/sync/log_sync/builder.rs
+++ b/p2panda-net/src/sync/log_sync/builder.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use p2panda_core::{Extensions, Hash, LogId, Operation, PublicKey, Topic};
+use p2panda_core::{Extensions, Hash, LogId, Operation, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
 use p2panda_sync::manager::TopicSyncManager;
@@ -16,8 +16,8 @@ use crate::sync::log_sync::{LOG_SYNC_PROTOCOL_ID, LogSync, LogSyncError};
 
 pub struct Builder<S, L, E>
 where
-    S: LogStore<Operation<E>, PublicKey, L, u64, Hash>
-        + TopicStore<Topic, PublicKey, L>
+    S: LogStore<Operation<E>, VerifyingKey, L, u64, Hash>
+        + TopicStore<Topic, VerifyingKey, L>
         + Clone
         + Send
         + 'static,
@@ -32,8 +32,8 @@ where
 
 impl<S, L, E> Builder<S, L, E>
 where
-    S: LogStore<Operation<E>, PublicKey, L, u64, Hash>
-        + TopicStore<Topic, PublicKey, L>
+    S: LogStore<Operation<E>, VerifyingKey, L, u64, Hash>
+        + TopicStore<Topic, VerifyingKey, L>
         + Clone
         + Send
         + 'static,

--- a/p2panda-net/src/sync/log_sync/tests.rs
+++ b/p2panda-net/src/sync/log_sync/tests.rs
@@ -408,7 +408,7 @@ async fn panic_on_sink_closure_after_error_regression() {
     // transport. Here we use a connection between two iroh endpoints.
     setup_logging();
 
-    let topic = Topic::new();
+    let topic = Topic::random();
     let mut peer = Peer::new(0).await;
     peer.associate(&topic, &Logs::default()).await;
 

--- a/p2panda-net/src/sync/tests.rs
+++ b/p2panda-net/src/sync/tests.rs
@@ -50,7 +50,7 @@ impl FailingNode {
 
         let endpoint = Endpoint::builder(address_book.clone())
             .config(args.iroh_config.clone())
-            .private_key(args.private_key.clone())
+            .signing_key(args.signing_key.clone())
             .spawn()
             .await
             .unwrap();
@@ -74,7 +74,7 @@ impl FailingNode {
     }
 
     pub fn node_id(&self) -> NodeId {
-        self.args.public_key
+        self.args.verifying_key
     }
 
     pub fn shutdown(&self) {

--- a/p2panda-net/src/test_utils.rs
+++ b/p2panda-net/src/test_utils.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use p2panda_core::{Body, Hash, Header, Operation, PrivateKey, PublicKey, Topic};
+use p2panda_core::{Body, Hash, Header, Operation, SigningKey, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
 use p2panda_store::topics::TopicStore;
@@ -26,8 +26,8 @@ pub const TEST_NETWORK_ID: NetworkId = [1; 32];
 pub struct ApplicationArguments {
     pub network_id: NetworkId,
     pub rng: ChaCha20Rng,
-    pub private_key: PrivateKey,
-    pub public_key: PublicKey,
+    pub signing_key: SigningKey,
+    pub verifying_key: VerifyingKey,
     pub iroh_config: IrohConfig,
     pub discovery_config: DiscoveryConfig,
     pub mdns_mode: MdnsDiscoveryMode,
@@ -37,13 +37,13 @@ pub struct ApplicationArguments {
 impl ApplicationArguments {
     pub fn node_info(&mut self) -> NodeInfo {
         let transport_info = TrustedTransportInfo::from_addrs([TransportAddress::from_iroh(
-            self.public_key,
+            self.verifying_key,
             None,
             [(self.iroh_config.bind_ip_v4, self.iroh_config.bind_port_v4).into()],
         )]);
 
         NodeInfo {
-            node_id: self.public_key,
+            node_id: self.verifying_key,
             bootstrap: false,
             transports: Some(transport_info.into()),
             metrics: NodeMetrics::default(),
@@ -54,7 +54,7 @@ impl ApplicationArguments {
 pub struct ArgsBuilder {
     network_id: NetworkId,
     rng: Option<ChaCha20Rng>,
-    private_key: Option<PrivateKey>,
+    signing_key: Option<SigningKey>,
     iroh_config: Option<IrohConfig>,
     discovery_config: Option<DiscoveryConfig>,
     mdns_mode: Option<MdnsDiscoveryMode>,
@@ -65,7 +65,7 @@ impl ArgsBuilder {
         Self {
             network_id,
             rng: None,
-            private_key: None,
+            signing_key: None,
             iroh_config: None,
             discovery_config: None,
             mdns_mode: None,
@@ -97,20 +97,20 @@ impl ArgsBuilder {
         self
     }
 
-    pub fn with_private_key(mut self, private_key: PrivateKey) -> Self {
-        self.private_key = Some(private_key);
+    pub fn with_signing_key(mut self, signing_key: SigningKey) -> Self {
+        self.signing_key = Some(signing_key);
         self
     }
 
     pub fn build(self) -> ApplicationArguments {
-        let private_key = self.private_key.unwrap_or_default();
+        let signing_key = self.signing_key.unwrap_or_default();
         ApplicationArguments {
             network_id: self.network_id,
             rng: self
                 .rng
                 .unwrap_or(ChaCha20Rng::try_from_rng(&mut SysRng).unwrap()),
-            public_key: private_key.public_key(),
-            private_key,
+            verifying_key: signing_key.verifying_key(),
+            signing_key,
             iroh_config: self.iroh_config.unwrap_or_default(),
             discovery_config: self.discovery_config.unwrap_or_default(),
             mdns_mode: self.mdns_mode.unwrap_or_default(),
@@ -125,9 +125,9 @@ pub fn test_args() -> ApplicationArguments {
 
 pub fn test_args_from_seed(seed: [u8; 32]) -> ApplicationArguments {
     let mut rng = ChaCha20Rng::from_seed(seed);
-    let private_key_bytes: [u8; 32] = rng.random();
+    let signing_key_bytes: [u8; 32] = rng.random();
     ArgsBuilder::new(TEST_NETWORK_ID)
-        .with_private_key(PrivateKey::from_bytes(&private_key_bytes))
+        .with_signing_key(SigningKey::from_bytes(&signing_key_bytes))
         .with_iroh_config(IrohConfig {
             bind_ip_v4: Ipv4Addr::LOCALHOST,
             bind_port_v4: rng.random_range(49152..65535),
@@ -151,7 +151,7 @@ pub fn setup_logging() {
 fn deterministic_args() {
     let args_1 = test_args_from_seed([0; 32]);
     let args_2 = test_args_from_seed([0; 32]);
-    assert_eq!(args_1.public_key, args_2.public_key);
+    assert_eq!(args_1.verifying_key, args_2.verifying_key);
     assert_eq!(args_1.iroh_config, args_2.iroh_config);
 }
 
@@ -177,7 +177,7 @@ impl TestNode {
     ) -> Self {
         let client = TestClient::new(
             // The identity of the "author" or client has a different private key from the node.
-            PrivateKey::from_bytes(&args.rng.random::<[u8; 32]>()),
+            SigningKey::from_bytes(&args.rng.random::<[u8; 32]>()),
         )
         .await;
 
@@ -193,7 +193,7 @@ impl TestNode {
 
         let endpoint = Endpoint::builder(address_book.clone())
             .config(args.iroh_config.clone())
-            .private_key(args.private_key.clone())
+            .signing_key(args.signing_key.clone())
             .spawn()
             .await
             .unwrap();
@@ -234,14 +234,14 @@ impl TestNode {
     }
 
     pub fn node_id(&self) -> NodeId {
-        self.args.public_key
+        self.args.verifying_key
     }
 
     pub fn node_info(&mut self) -> NodeInfo {
         self.args.node_info()
     }
 
-    pub fn client_id(&self) -> PublicKey {
+    pub fn client_id(&self) -> VerifyingKey {
         self.client.id()
     }
 }
@@ -259,19 +259,19 @@ pub type TestTopicSyncManager = TopicSyncManager<Topic, SqliteStore, TestLogId, 
 #[derive(Clone)]
 pub struct TestClient {
     pub store: SqliteStore,
-    pub private_key: PrivateKey,
+    pub signing_key: SigningKey,
 }
 
 impl TestClient {
-    pub async fn new(private_key: PrivateKey) -> Self {
+    pub async fn new(signing_key: SigningKey) -> Self {
         let store = SqliteStore::temporary().await;
 
-        Self { store, private_key }
+        Self { store, signing_key }
     }
 
     /// The public key of this client.
-    pub fn id(&self) -> PublicKey {
-        self.private_key.public_key()
+    pub fn id(&self) -> VerifyingKey {
+        self.signing_key.verifying_key()
     }
 
     /// Create and insert an operation to the store.
@@ -308,25 +308,25 @@ impl TestClient {
         let (header, header_bytes, body) = tx_unwrap!(&self.store, {
             let (seq_num, backlink) = <SqliteStore as LogStore<
                 Operation<TestExtensions>,
-                PublicKey,
+                VerifyingKey,
                 u64,
                 u64,
                 p2panda_core::Hash,
             >>::get_latest_entry_tx(
-                &self.store, &self.private_key.public_key(), &log_id
+                &self.store, &self.signing_key.verifying_key(), &log_id
             )
             .await
             .unwrap()
             .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
             .unwrap_or((0, None));
 
-            create_operation(&self.private_key, body, seq_num, seq_num, backlink)
+            create_operation(&self.signing_key, body, seq_num, seq_num, backlink)
         });
 
         (header, header_bytes, body)
     }
 
-    pub async fn associate(&mut self, topic: &Topic, logs: &HashMap<PublicKey, Vec<u64>>) {
+    pub async fn associate(&mut self, topic: &Topic, logs: &HashMap<VerifyingKey, Vec<u64>>) {
         let permit = self.store.begin().await.unwrap();
         for (author, logs) in logs {
             for log_id in logs {
@@ -339,7 +339,7 @@ impl TestClient {
 
 /// Create a single operation.
 pub fn create_operation(
-    private_key: &PrivateKey,
+    signing_key: &SigningKey,
     body: &[u8],
     seq_num: u64,
     timestamp: u64,
@@ -349,7 +349,7 @@ pub fn create_operation(
 
     let mut header = Header::<()> {
         version: 1,
-        public_key: private_key.public_key(),
+        verifying_key: signing_key.verifying_key(),
         signature: None,
         payload_size: body.size(),
         payload_hash: Some(body.hash()),
@@ -359,7 +359,7 @@ pub fn create_operation(
         extensions: (),
     };
 
-    header.sign(private_key);
+    header.sign(signing_key);
     let header_bytes = header.to_bytes();
 
     (header, header_bytes, body)

--- a/p2panda-net/tests/api.rs
+++ b/p2panda-net/tests/api.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use futures_util::StreamExt;
-use p2panda_core::PrivateKey;
+use p2panda_core::SigningKey;
 use p2panda_net::iroh_mdns::MdnsDiscoveryMode;
 use p2panda_net::sync::SyncSubscription;
 use p2panda_net::{AddressBook, Discovery, Endpoint, Gossip, LogSync, MdnsDiscovery};
@@ -10,12 +10,12 @@ use p2panda_sync::protocols::TopicLogSyncEvent;
 
 #[tokio::test]
 async fn modular_api() {
-    let private_key = PrivateKey::new();
+    let signing_key = SigningKey::generate();
 
     let address_book = AddressBook::builder().spawn().await.unwrap();
 
     let endpoint = Endpoint::builder(address_book.clone())
-        .private_key(private_key)
+        .signing_key(signing_key)
         .network_id([42; 32])
         .spawn()
         .await

--- a/p2panda-spaces/src/credentials.rs
+++ b/p2panda-spaces/src/credentials.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use p2panda_core::{PrivateKey, PublicKey};
+use p2panda_core::{SigningKey, VerifyingKey};
 use p2panda_encryption::crypto::x25519::SecretKey;
 use p2panda_encryption::{Rng, RngError};
 use serde::{Deserialize, Serialize};
@@ -17,33 +17,33 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
 pub struct Credentials {
-    pub(crate) private_key: PrivateKey,
+    pub(crate) signing_key: SigningKey,
     pub(crate) identity_secret: SecretKey,
 }
 
 impl Credentials {
     pub fn from_rng(rng: &Rng) -> Result<Self, RngError> {
-        let private_key = PrivateKey::from_bytes(&rng.random_array()?);
+        let signing_key = SigningKey::from_bytes(&rng.random_array()?);
         let identity_secret = SecretKey::from_rng(rng)?;
         Ok(Self {
-            private_key,
+            signing_key,
             identity_secret,
         })
     }
 
-    pub fn from_keys(private_key: PrivateKey, identity_secret: SecretKey) -> Self {
+    pub fn from_keys(signing_key: SigningKey, identity_secret: SecretKey) -> Self {
         Self {
-            private_key,
+            signing_key,
             identity_secret,
         }
     }
 
-    pub fn private_key(&self) -> PrivateKey {
-        self.private_key.clone()
+    pub fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
     }
 
-    pub fn public_key(&self) -> PublicKey {
-        self.private_key.public_key()
+    pub fn verifying_key(&self) -> VerifyingKey {
+        self.signing_key.verifying_key()
     }
 
     pub fn identity_secret(&self) -> SecretKey {

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use p2panda_auth::Access;
 use p2panda_auth::group::GroupAction;
 use p2panda_auth::traits::{Conditions, Operation};
-use p2panda_core::PrivateKey;
+use p2panda_core::SigningKey;
 use p2panda_encryption::RngError;
 use thiserror::Error;
 
@@ -85,8 +85,8 @@ where
         // Generate random group id.
         let group_id: ActorId = {
             let manager = manager_ref.inner.read().await;
-            let private_key = PrivateKey::from_bytes(&manager.rng.random_array()?);
-            private_key.public_key().into()
+            let signing_key = SigningKey::from_bytes(&manager.rng.random_array()?);
+            signing_key.verifying_key().into()
         };
 
         let initial_members = typed_members(manager_ref.clone(), initial_members)

--- a/p2panda-spaces/src/identity.rs
+++ b/p2panda-spaces/src/identity.rs
@@ -67,7 +67,7 @@ where
 
     /// The public key of the local actor.
     pub(crate) fn id(&self) -> ActorId {
-        self.credentials.public_key().into()
+        self.credentials.verifying_key().into()
     }
 
     /// The local actor id and their long-term key bundle.
@@ -278,7 +278,7 @@ mod tests {
 
         let message_store = TestStore::new();
         let key_store = TestKeyStore::new();
-        let forge = TestForge::new(message_store, credentials.private_key());
+        let forge = TestForge::new(message_store, credentials.signing_key());
 
         let mut identity_manager =
             IdentityManager::new(key_store, forge, credentials.clone(), &config, &rng)
@@ -287,7 +287,7 @@ mod tests {
 
         let me = identity_manager.me().await.unwrap();
         let bundle: &LongTermKeyBundle = me.key_bundle();
-        let actor_id: ActorId = credentials.public_key().into();
+        let actor_id: ActorId = credentials.verifying_key().into();
 
         assert_eq!(me.id(), actor_id);
         assert!(bundle.verify().is_ok());
@@ -302,7 +302,7 @@ mod tests {
 
         let message_store = TestStore::new();
         let key_store = TestKeyStore::new();
-        let forge = TestForge::new(message_store, credentials.private_key());
+        let forge = TestForge::new(message_store, credentials.signing_key());
 
         let mut identity_manager =
             IdentityManager::new(key_store, forge, credentials.clone(), &config, &rng)
@@ -311,7 +311,7 @@ mod tests {
 
         let msg = identity_manager.key_bundle_message().await.unwrap();
 
-        let actor_id: ActorId = credentials.private_key().public_key().into();
+        let actor_id: ActorId = credentials.signing_key().verifying_key().into();
         assert_eq!(msg.author(), actor_id);
         match msg.args() {
             SpacesArgs::KeyBundle { key_bundle } => {
@@ -329,7 +329,7 @@ mod tests {
 
         let alice_message_store = TestStore::new();
         let alice_key_store = TestKeyStore::new();
-        let alice_forge = TestForge::new(alice_message_store, alice_credentials.private_key());
+        let alice_forge = TestForge::new(alice_message_store, alice_credentials.signing_key());
 
         let mut alice_identity_manager = IdentityManager::new(
             alice_key_store,
@@ -347,7 +347,7 @@ mod tests {
 
         let bob_message_store = TestStore::new();
         let bob_key_store = TestKeyStore::new();
-        let bob_forge = TestForge::new(bob_message_store, bob_credentials.private_key());
+        let bob_forge = TestForge::new(bob_message_store, bob_credentials.signing_key());
 
         let mut bob_identity_manager = IdentityManager::new(
             bob_key_store,
@@ -358,7 +358,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let bob_id = bob_credentials.public_key().into();
+        let bob_id = bob_credentials.verifying_key().into();
 
         let bob_member = bob_identity_manager.me().await.unwrap();
         let bob_bundle = bob_member.key_bundle();
@@ -375,7 +375,7 @@ mod tests {
         assert_eq!(bundle_identity_key, *bob_bundle.identity_key());
         assert_eq!(
             bundle_identity_key,
-            bob_credentials.identity_secret().public_key().unwrap()
+            bob_credentials.identity_secret().verifying_key().unwrap()
         );
     }
 
@@ -387,7 +387,7 @@ mod tests {
 
         let message_store = TestStore::new();
         let key_store = TestKeyStore::new();
-        let forge = TestForge::new(message_store, credentials.private_key());
+        let forge = TestForge::new(message_store, credentials.signing_key());
 
         let mut alice_identity_manager =
             IdentityManager::new(key_store, forge, credentials, &config, &rng)

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -107,7 +107,7 @@ where
         config: &Config,
         rng: Rng,
     ) -> Result<Self, ManagerError<ID, S, K, F, M, C, RS>> {
-        let actor_id: ActorId = credentials.public_key().into();
+        let actor_id: ActorId = credentials.verifying_key().into();
         let identity = IdentityManager::new(key_store, forge, credentials, config, &rng).await?;
         let inner = ManagerInner {
             store,

--- a/p2panda-spaces/src/test_utils/forge.rs
+++ b/p2panda-spaces/src/test_utils/forge.rs
@@ -3,7 +3,7 @@
 use std::convert::Infallible;
 use std::sync::Arc;
 
-use p2panda_core::{PrivateKey, PublicKey};
+use p2panda_core::{SigningKey, VerifyingKey};
 use tokio::sync::RwLock;
 
 use crate::message::SpacesArgs;
@@ -13,7 +13,7 @@ use crate::traits::{AuthoredMessage, Forge, MessageStore};
 
 #[derive(Debug, Clone)]
 pub struct TestForge<S> {
-    public_key: PublicKey,
+    verifying_key: VerifyingKey,
     store: S,
     inner: Arc<RwLock<TestForgeInner>>,
 }
@@ -22,13 +22,13 @@ impl<S> TestForge<S>
 where
     S: MessageStore<TestMessage>,
 {
-    pub fn new(store: S, private_key: PrivateKey) -> Self {
+    pub fn new(store: S, signing_key: SigningKey) -> Self {
         Self {
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             store,
             inner: Arc::new(RwLock::new(TestForgeInner {
                 next_seq_num: 0,
-                private_key,
+                signing_key,
             })),
         }
     }
@@ -39,7 +39,7 @@ pub struct TestForgeInner {
     #[allow(unused)]
     next_seq_num: SeqNum,
     #[allow(unused)]
-    private_key: PrivateKey,
+    signing_key: SigningKey,
 }
 
 impl<S> Forge<TestSpaceId, TestMessage, TestConditions> for TestForge<S>
@@ -48,8 +48,8 @@ where
 {
     type Error = Infallible;
 
-    fn public_key(&self) -> PublicKey {
-        self.public_key
+    fn verifying_key(&self) -> VerifyingKey {
+        self.verifying_key
     }
 
     async fn forge(
@@ -65,7 +65,7 @@ where
 
         let message = TestMessage {
             seq_num,
-            public_key: self.public_key,
+            verifying_key: self.verifying_key,
             spaces_args: args,
         };
 

--- a/p2panda-spaces/src/test_utils/message.rs
+++ b/p2panda-spaces/src/test_utils/message.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use p2panda_core::{Hash, PublicKey};
+use p2panda_core::{Hash, VerifyingKey};
 
 use crate::message::SpacesArgs;
 use crate::test_utils::{TestConditions, TestSpaceId};
@@ -12,19 +12,19 @@ pub type SeqNum = u64;
 #[derive(Clone, Debug)]
 pub struct TestMessage {
     pub seq_num: SeqNum,
-    pub public_key: PublicKey,
+    pub verifying_key: VerifyingKey,
     pub spaces_args: SpacesArgs<TestSpaceId, TestConditions>,
 }
 
 impl AuthoredMessage for TestMessage {
     fn id(&self) -> OperationId {
-        let mut buffer: Vec<u8> = self.public_key.as_bytes().to_vec();
+        let mut buffer: Vec<u8> = self.verifying_key.as_bytes().to_vec();
         buffer.extend_from_slice(&self.seq_num.to_be_bytes());
-        Hash::new(buffer).into()
+        Hash::digest(buffer).into()
     }
 
     fn author(&self) -> ActorId {
-        self.public_key.into()
+        self.verifying_key.into()
     }
 }
 

--- a/p2panda-spaces/src/test_utils/mod.rs
+++ b/p2panda-spaces/src/test_utils/mod.rs
@@ -74,7 +74,7 @@ impl TestPeer {
     ) -> Self {
         let spaces_store = TestStore::new();
         let key_store = TestKeyStore::new();
-        let forge = TestForge::new(spaces_store.clone(), credentials.private_key());
+        let forge = TestForge::new(spaces_store.clone(), credentials.signing_key());
 
         let manager = TestManager::new_with_config(
             spaces_store,

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -2006,7 +2006,7 @@ async fn add_expired_member_to_group() {
         // Generate pre-key & sign it.
         let prekey_secret = SecretKey::from_rng(&rng).unwrap();
         let prekey = PreKey::new(
-            prekey_secret.public_key().unwrap(),
+            prekey_secret.verifying_key().unwrap(),
             Lifetime::from_range(now - 60, now + 1),
         );
         let signature = prekey
@@ -2015,7 +2015,7 @@ async fn add_expired_member_to_group() {
 
         // Wrap it in key bundle.
         let bundle = LongTermKeyBundle::new(
-            bob.credentials.identity_secret().public_key().unwrap(),
+            bob.credentials.identity_secret().verifying_key().unwrap(),
             prekey,
             signature,
         );
@@ -2056,7 +2056,7 @@ async fn process_operation_from_expired_member() {
         // Generate pre-key & sign it.
         let prekey_secret = SecretKey::from_rng(&rng).unwrap();
         let prekey = PreKey::new(
-            prekey_secret.public_key().unwrap(),
+            prekey_secret.verifying_key().unwrap(),
             Lifetime::from_range(now - 60, now + 1),
         );
         let signature = prekey
@@ -2065,7 +2065,7 @@ async fn process_operation_from_expired_member() {
 
         // Wrap it in key bundle.
         let bundle = LongTermKeyBundle::new(
-            bob.credentials.identity_secret().public_key().unwrap(),
+            bob.credentials.identity_secret().verifying_key().unwrap(),
             prekey,
             signature,
         );

--- a/p2panda-spaces/src/traits/forge.rs
+++ b/p2panda-spaces/src/traits/forge.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Debug;
 
-use p2panda_core::PublicKey;
+use p2panda_core::VerifyingKey;
 
 use crate::message::SpacesArgs;
 
@@ -11,7 +11,7 @@ pub trait Forge<ID, M, C> {
     type Error: Debug;
 
     /// Public key of the local peer.
-    fn public_key(&self) -> PublicKey;
+    fn verifying_key(&self) -> VerifyingKey;
 
     /// Forge and persist a new message.
     fn forge(&self, args: SpacesArgs<ID, C>) -> impl Future<Output = Result<M, Self::Error>>;

--- a/p2panda-spaces/src/types.rs
+++ b/p2panda-spaces/src/types.rs
@@ -10,7 +10,7 @@ use p2panda_auth::traits::{
     Conditions, IdentityHandle as AuthIdentityHandle, OperationId as AuthOperationId, Resolver,
 };
 use p2panda_core::hash::{HASH_LEN, Hash};
-use p2panda_core::identity::{PUBLIC_KEY_LEN, PublicKey};
+use p2panda_core::identity::{VERIFYING_KEY_LEN, VerifyingKey};
 use p2panda_core::{HashError, IdentityError};
 use p2panda_encryption::key_manager::KeyManager;
 use p2panda_encryption::key_registry::KeyRegistry;
@@ -24,12 +24,12 @@ use crate::auth::message::AuthMessage;
 use crate::encryption::dgm::EncryptionGroupMembership;
 use crate::encryption::orderer::EncryptionOrderer;
 
-pub const ACTOR_ID_SIZE: usize = PUBLIC_KEY_LEN;
+pub const ACTOR_ID_SIZE: usize = VERIFYING_KEY_LEN;
 pub const OPERATION_ID_SIZE: usize = HASH_LEN;
 
 /// Identifier for an actor.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct ActorId(pub(crate) PublicKey);
+pub struct ActorId(pub(crate) VerifyingKey);
 
 impl AuthIdentityHandle for ActorId {}
 
@@ -37,7 +37,7 @@ impl EncryptionIdentityHandle for ActorId {}
 
 impl ActorId {
     pub fn from_bytes(bytes: &[u8; ACTOR_ID_SIZE]) -> Result<Self, ActorIdError> {
-        Ok(Self(PublicKey::from_bytes(bytes)?))
+        Ok(Self(VerifyingKey::from_bytes(bytes)?))
     }
 
     pub fn as_bytes(&self) -> &[u8; ACTOR_ID_SIZE] {
@@ -52,8 +52,8 @@ impl ActorId {
     // not known and not required. In these cases we need to satisfy the trait interfaces using a
     // placeholder value.
     pub(crate) fn placeholder() -> Self {
-        static PLACEHOLDER_PUBLIC_KEY: LazyLock<PublicKey> = LazyLock::new(|| {
-            PublicKey::from_bytes(&[0; PUBLIC_KEY_LEN])
+        static PLACEHOLDER_PUBLIC_KEY: LazyLock<VerifyingKey> = LazyLock::new(|| {
+            VerifyingKey::from_bytes(&[0; VERIFYING_KEY_LEN])
                 .expect("can create public key from constant bytes")
         });
         Self(*PLACEHOLDER_PUBLIC_KEY)
@@ -66,9 +66,9 @@ impl Display for ActorId {
     }
 }
 
-impl From<PublicKey> for ActorId {
-    fn from(public_key: PublicKey) -> Self {
-        Self(public_key)
+impl From<VerifyingKey> for ActorId {
+    fn from(verifying_key: VerifyingKey) -> Self {
+        Self(verifying_key)
     }
 }
 
@@ -76,7 +76,7 @@ impl TryFrom<[u8; ACTOR_ID_SIZE]> for ActorId {
     type Error = ActorIdError;
 
     fn try_from(bytes: [u8; ACTOR_ID_SIZE]) -> Result<Self, Self::Error> {
-        Ok(Self(PublicKey::from_bytes(&bytes)?))
+        Ok(Self(VerifyingKey::from_bytes(&bytes)?))
     }
 }
 
@@ -84,15 +84,15 @@ impl TryFrom<&[u8]> for ActorId {
     type Error = ActorIdError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self(PublicKey::try_from(bytes)?))
+        Ok(Self(VerifyingKey::try_from(bytes)?))
     }
 }
 
-impl TryFrom<ActorId> for PublicKey {
+impl TryFrom<ActorId> for VerifyingKey {
     type Error = ActorIdError;
 
     fn try_from(actor_id: ActorId) -> Result<Self, Self::Error> {
-        Ok(PublicKey::from_bytes(actor_id.as_bytes())?)
+        Ok(VerifyingKey::from_bytes(actor_id.as_bytes())?)
     }
 }
 
@@ -100,7 +100,7 @@ impl FromStr for ActorId {
     type Err = ActorIdError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(Self(PublicKey::from_str(value)?))
+        Ok(Self(VerifyingKey::from_str(value)?))
     }
 }
 
@@ -242,30 +242,30 @@ pub type EncryptionGroupOutput<M> = p2panda_encryption::data_scheme::GroupOutput
 
 #[cfg(test)]
 mod tests {
-    use p2panda_core::{PrivateKey, PublicKey};
+    use p2panda_core::{SigningKey, VerifyingKey};
     use p2panda_encryption::Rng;
 
     use crate::ActorId;
 
     #[test]
     fn from_actor_id() {
-        let private_key = PrivateKey::new();
-        let public_key = private_key.public_key();
+        let signing_key = SigningKey::generate();
+        let verifying_key = signing_key.verifying_key();
 
-        let actor_id: ActorId = public_key.to_hex().parse().unwrap();
+        let actor_id: ActorId = verifying_key.to_hex().parse().unwrap();
 
-        assert_eq!(PublicKey::try_from(actor_id).unwrap(), public_key);
+        assert_eq!(VerifyingKey::try_from(actor_id).unwrap(), verifying_key);
     }
 
     #[test]
     fn actor_id_from_rng() {
-        let rng = Rng::from_seed(*PrivateKey::new().as_bytes());
+        let rng = Rng::from_seed(*SigningKey::generate().as_bytes());
 
-        let private_key = PrivateKey::from_bytes(&rng.random_array().unwrap());
-        let public_key = private_key.public_key();
+        let signing_key = SigningKey::from_bytes(&rng.random_array().unwrap());
+        let verifying_key = signing_key.verifying_key();
 
-        let actor_id: ActorId = public_key.to_hex().parse().unwrap();
+        let actor_id: ActorId = verifying_key.to_hex().parse().unwrap();
 
-        assert_eq!(PublicKey::try_from(actor_id).unwrap(), public_key);
+        assert_eq!(VerifyingKey::try_from(actor_id).unwrap(), verifying_key);
     }
 }

--- a/p2panda-store/migrations/20260515072908_rename_public_key_to_verifying_key.sql
+++ b/p2panda-store/migrations/20260515072908_rename_public_key_to_verifying_key.sql
@@ -1,0 +1,4 @@
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+ALTER TABLE operations_v1
+RENAME COLUMN public_key to verifying_key;

--- a/p2panda-store/src/address_book/sqlite.rs
+++ b/p2panda-store/src/address_book/sqlite.rs
@@ -6,16 +6,16 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
-use p2panda_core::{PublicKey, Topic};
+use p2panda_core::{Topic, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use sqlx::{query, query_as, query_scalar};
 
 use crate::address_book::{AddressBookStore, NodeInfo};
 use crate::sqlite::{SqliteError, SqliteStore};
 
-impl<N> AddressBookStore<PublicKey, N> for SqliteStore
+impl<N> AddressBookStore<VerifyingKey, N> for SqliteStore
 where
-    N: NodeInfo<PublicKey> + Serialize + for<'de> Deserialize<'de>,
+    N: NodeInfo<VerifyingKey> + Serialize + for<'de> Deserialize<'de>,
 {
     type Error = SqliteError;
 
@@ -68,7 +68,7 @@ where
         Ok(!is_upsert)
     }
 
-    async fn remove_node_info(&self, id: &PublicKey) -> Result<bool, Self::Error> {
+    async fn remove_node_info(&self, id: &VerifyingKey) -> Result<bool, Self::Error> {
         // Remove node's info.
         let result = self
             .tx(async |tx| {
@@ -149,7 +149,7 @@ where
         Ok(node_ids.len())
     }
 
-    async fn node_info(&self, id: &PublicKey) -> Result<Option<N>, Self::Error> {
+    async fn node_info(&self, id: &VerifyingKey) -> Result<Option<N>, Self::Error> {
         let result = self
             .execute(async |pool| {
                 query_as::<_, (Vec<u8>,)>(
@@ -172,7 +172,7 @@ where
         decode_node_info(result)
     }
 
-    async fn node_topics(&self, id: &PublicKey) -> Result<HashSet<Topic>, Self::Error> {
+    async fn node_topics(&self, id: &VerifyingKey) -> Result<HashSet<Topic>, Self::Error> {
         let result = self
             .execute(async |pool| {
                 query_as::<_, (String,)>(
@@ -263,7 +263,7 @@ where
         Ok(count as usize)
     }
 
-    async fn selected_node_infos(&self, ids: &[PublicKey]) -> Result<Vec<N>, Self::Error> {
+    async fn selected_node_infos(&self, ids: &[VerifyingKey]) -> Result<Vec<N>, Self::Error> {
         let result = self
             .execute(async |pool| {
                 query_as::<_, (Vec<u8>,)>(&format!(
@@ -286,7 +286,11 @@ where
         decode_node_infos(result)
     }
 
-    async fn set_topics(&self, id: PublicKey, topics: HashSet<Topic>) -> Result<(), Self::Error> {
+    async fn set_topics(
+        &self,
+        id: VerifyingKey,
+        topics: HashSet<Topic>,
+    ) -> Result<(), Self::Error> {
         // Remove all previous topics set for this node id and replace it with new values. Both
         // updates will be executed inside the same atomic transaction.
         self.tx(async |tx| {
@@ -409,7 +413,7 @@ where
 impl SqliteStore {
     pub async fn set_last_changed(
         &self,
-        id: &PublicKey,
+        id: &VerifyingKey,
         timestamp: u64,
     ) -> Result<(), SqliteError> {
         self.tx(async |tx| {
@@ -453,7 +457,7 @@ fn in_op_str<T: Display>(list: &[T]) -> String {
 /// Deserialize multiple rows containing encoded node info.
 fn decode_node_infos<N>(result: Vec<(Vec<u8>,)>) -> Result<Vec<N>, SqliteError>
 where
-    N: NodeInfo<PublicKey> + Serialize + for<'a> Deserialize<'a>,
+    N: NodeInfo<VerifyingKey> + Serialize + for<'a> Deserialize<'a>,
 {
     result
         .iter()
@@ -467,7 +471,7 @@ where
 /// Deserialize single row maybe containing encoded node info.
 fn decode_node_info<N>(result: Option<(Vec<u8>,)>) -> Result<Option<N>, SqliteError>
 where
-    N: NodeInfo<PublicKey> + Serialize + for<'a> Deserialize<'a>,
+    N: NodeInfo<VerifyingKey> + Serialize + for<'a> Deserialize<'a>,
 {
     match result {
         Some((bytes,)) => {

--- a/p2panda-store/src/address_book/test_utils.rs
+++ b/p2panda-store/src/address_book/test_utils.rs
@@ -3,14 +3,14 @@
 use std::hash::Hash as StdHash;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use p2panda_core::PublicKey;
+use p2panda_core::VerifyingKey;
 use rand::RngExt;
 use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 
 use crate::address_book::traits::NodeInfo;
 
-pub type TestNodeId = PublicKey;
+pub type TestNodeId = VerifyingKey;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, StdHash, Serialize, Deserialize)]
 pub struct TestNodeInfo {

--- a/p2panda-store/src/address_book/tests.rs
+++ b/p2panda-store/src/address_book/tests.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
-use p2panda_core::PrivateKey;
+use p2panda_core::SigningKey;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 
@@ -17,7 +17,7 @@ async fn insert_node_info() {
 
     let permit = store.begin().await.unwrap();
 
-    let node_id = PrivateKey::new().public_key();
+    let node_id = SigningKey::generate().verifying_key();
     let node_info = TestNodeInfo::new(node_id);
 
     let result = store.insert_node_info(node_info.clone()).await.unwrap();
@@ -35,9 +35,9 @@ async fn insert_node_info() {
 async fn set_and_query_topics() {
     let store = SqliteStore::temporary().await;
 
-    let billie = PrivateKey::new().public_key();
-    let daphne = PrivateKey::new().public_key();
-    let carlos = PrivateKey::new().public_key();
+    let billie = SigningKey::generate().verifying_key();
+    let daphne = SigningKey::generate().verifying_key();
+    let carlos = SigningKey::generate().verifying_key();
 
     let cats = [100; 32].into();
     let dogs = [102; 32].into();
@@ -126,8 +126,8 @@ async fn set_and_query_topics() {
 async fn remove_outdated_node_infos() {
     let store = SqliteStore::temporary().await;
 
-    let billie = PrivateKey::new().public_key();
-    let daphne = PrivateKey::new().public_key();
+    let billie = SigningKey::generate().verifying_key();
+    let daphne = SigningKey::generate().verifying_key();
 
     let permit = store.begin().await.unwrap();
 
@@ -184,7 +184,7 @@ async fn sample_random_nodes() {
     let permit = store.begin().await.unwrap();
 
     for _ in 0..100 {
-        let id = PrivateKey::new().public_key();
+        let id = SigningKey::generate().verifying_key();
         store
             .insert_node_info(TestNodeInfo::new(id).with_random_address(&mut rng))
             .await
@@ -192,7 +192,7 @@ async fn sample_random_nodes() {
     }
 
     for _ in 200..300 {
-        let id = PrivateKey::new().public_key();
+        let id = SigningKey::generate().verifying_key();
         store
             .insert_node_info(TestNodeInfo::new_bootstrap(id).with_random_address(&mut rng))
             .await

--- a/p2panda-store/src/cursors/tests.rs
+++ b/p2panda-store/src/cursors/tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use p2panda_core::logs::LogHeights;
-use p2panda_core::{Cursor, PrivateKey, PublicKey};
+use p2panda_core::{Cursor, SigningKey, VerifyingKey};
 
 use crate::cursors::CursorStore;
 use crate::{SqliteStore, tx_unwrap};
@@ -10,7 +10,7 @@ use crate::{SqliteStore, tx_unwrap};
 async fn get_and_set_cursor() {
     let store = SqliteStore::temporary().await;
 
-    let mut cursor = Cursor::<PublicKey, u64>::new("test", LogHeights::default());
+    let mut cursor = Cursor::<VerifyingKey, u64>::new("test", LogHeights::default());
 
     // First insert.
     tx_unwrap!(store, {
@@ -23,7 +23,7 @@ async fn get_and_set_cursor() {
     );
 
     // Second insert should be an upsert.
-    let author = PrivateKey::new().public_key();
+    let author = SigningKey::generate().verifying_key();
     let log_id = 2;
     let log_height = 22;
 
@@ -33,7 +33,7 @@ async fn get_and_set_cursor() {
         store.set_cursor(&cursor).await.unwrap();
     });
 
-    let cursor_2: Cursor<PublicKey, u64> = store
+    let cursor_2: Cursor<VerifyingKey, u64> = store
         .get_cursor("test")
         .await
         .unwrap()
@@ -43,13 +43,13 @@ async fn get_and_set_cursor() {
 
     // Remove cursor.
     tx_unwrap!(store, {
-        <SqliteStore as CursorStore<PublicKey, u64>>::delete_cursor(&store, "test")
+        <SqliteStore as CursorStore<VerifyingKey, u64>>::delete_cursor(&store, "test")
             .await
             .unwrap();
     });
 
     assert!(
-        <SqliteStore as CursorStore<PublicKey, u64>>::get_cursor(&store, "test")
+        <SqliteStore as CursorStore<VerifyingKey, u64>>::get_cursor(&store, "test")
             .await
             .unwrap()
             .is_none()

--- a/p2panda-store/src/logs/sqlite/mod.rs
+++ b/p2panda-store/src/logs/sqlite/mod.rs
@@ -7,7 +7,7 @@ mod tests;
 use std::collections::BTreeMap;
 
 use p2panda_core::cbor::encode_cbor;
-use p2panda_core::{Extensions, Hash, LogId, Operation, PublicKey, SeqNum};
+use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
 use sqlx::{query, query_as};
 
 use crate::logs::LogStore;
@@ -23,13 +23,13 @@ const GET_LATEST_ENTRY: &str = "
     FROM
         operations_v1
     WHERE
-        public_key = ?
+        verifying_key = ?
         AND log_id = ?
     ORDER BY
         CAST(seq_num AS NUMERIC) DESC LIMIT 1
 ";
 
-impl<L, E> LogStore<Operation<E>, PublicKey, L, SeqNum, Hash> for SqliteStore
+impl<L, E> LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash> for SqliteStore
 where
     E: Extensions,
     L: LogId,
@@ -39,7 +39,7 @@ where
     /// Retrieve the latest entry in an author's log.
     async fn get_latest_entry(
         &self,
-        author: &PublicKey,
+        author: &VerifyingKey,
         log_id: &L,
     ) -> Result<Option<Operation<E>>, Self::Error> {
         if let Some(latest) = query_as::<_, OperationRow>(GET_LATEST_ENTRY)
@@ -69,7 +69,7 @@ where
     // See: https://github.com/p2panda/p2panda/issues/1065
     async fn get_latest_entry_tx(
         &self,
-        author: &PublicKey,
+        author: &VerifyingKey,
         log_id: &L,
     ) -> Result<Option<Operation<E>>, Self::Error> {
         let result = self
@@ -98,7 +98,7 @@ where
     /// Retrieve the latest sequence number for a set of author's logs.
     async fn get_log_heights(
         &self,
-        author: &PublicKey,
+        author: &VerifyingKey,
         logs: &[L],
     ) -> Result<Option<BTreeMap<L, SeqNum>>, Self::Error> {
         let mut encoded_log_ids = Vec::new();
@@ -119,7 +119,7 @@ where
             FROM
                 operations_v1
             WHERE
-                public_key = ?
+                verifying_key = ?
                 AND log_id IN ( {} )
             GROUP BY
                 log_id
@@ -154,7 +154,7 @@ where
     /// Retrieve the count and total byte size of all operations in an author's log.
     async fn get_log_size(
         &self,
-        author: &PublicKey,
+        author: &VerifyingKey,
         log_id: &L,
         after: Option<SeqNum>,
         until: Option<SeqNum>,
@@ -171,7 +171,7 @@ where
             FROM
                 operations_v1
             WHERE
-                public_key = ?
+                verifying_key = ?
                 AND log_id = ?
                 AND CAST(seq_num AS NUMERIC) {} CAST(? as NUMERIC)
                 AND CAST(seq_num AS NUMERIC) <= CAST(? as NUMERIC)
@@ -206,7 +206,7 @@ where
     /// Retrieve log entries representing operations from an author's log.
     async fn get_log_entries(
         &self,
-        author: &PublicKey,
+        author: &VerifyingKey,
         log_id: &L,
         after: Option<SeqNum>,
         until: Option<SeqNum>,
@@ -224,7 +224,7 @@ where
             FROM
                 operations_v1
             WHERE
-                public_key = ?
+                verifying_key = ?
                 AND log_id = ?
                 AND CAST(seq_num AS NUMERIC) {} CAST(? as NUMERIC)
                 AND CAST(seq_num AS NUMERIC) <= CAST(? as NUMERIC)
@@ -263,7 +263,7 @@ where
     /// Pruning involves deletion of the entry bodies (ie. payloads) from the database.
     async fn prune_entries(
         &self,
-        author: &PublicKey,
+        author: &VerifyingKey,
         log_id: &L,
         until: &SeqNum,
     ) -> Result<u64, Self::Error> {
@@ -273,7 +273,7 @@ where
             FROM
                 operations_v1
             WHERE
-                public_key = ?
+                verifying_key = ?
                 AND log_id = ?
                 AND CAST(seq_num AS NUMERIC) < CAST(? as NUMERIC)
             ",

--- a/p2panda-store/src/logs/sqlite/tests.rs
+++ b/p2panda-store/src/logs/sqlite/tests.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use p2panda_core::test_utils::TestLog;
-use p2panda_core::{Operation, PrivateKey};
+use p2panda_core::{Operation, SigningKey};
 
 use crate::logs::LogStore;
 use crate::operations::OperationStore;
@@ -62,11 +62,11 @@ async fn get_log_heights() {
         .await
         .unwrap();
 
-    let private_key = PrivateKey::new();
+    let signing_key = SigningKey::generate();
 
     // Create two separate logs which share the same author.
-    let log_1 = TestLog::from_private_key(private_key.clone());
-    let log_2 = TestLog::from_private_key(private_key.clone());
+    let log_1 = TestLog::from_signing_key(signing_key.clone());
+    let log_2 = TestLog::from_signing_key(signing_key.clone());
 
     let operation_1 = log_1.operation(b"first", ());
     let operation_2 = log_1.operation(b"second", ());
@@ -97,7 +97,7 @@ async fn get_log_heights() {
 
     let result = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_log_heights(
         &store,
-        &private_key.public_key(),
+        &signing_key.verifying_key(),
         &[log_1.id(), log_2.id()],
     )
     .await

--- a/p2panda-store/src/operations/sqlite.rs
+++ b/p2panda-store/src/operations/sqlite.rs
@@ -51,7 +51,7 @@ where
                             hash,
                             log_id,
                             version,
-                            public_key,
+                            verifying_key,
                             signature,
                             payload_size,
                             payload_hash,
@@ -71,7 +71,7 @@ where
                         .map_err(|err| SqliteError::Encode("log id".to_string(), err))?,
                 )
                 .bind(operation.header.version.to_string())
-                .bind(operation.header.public_key.to_hex())
+                .bind(operation.header.verifying_key.to_hex())
                 .bind(operation.header.signature.map(|sig| sig.to_hex()))
                 .bind(operation.header.payload_size.to_string())
                 .bind(operation.header.payload_hash.map(|hash| hash.to_hex()))

--- a/p2panda-store/src/orderer/sqlite.rs
+++ b/p2panda-store/src/orderer/sqlite.rs
@@ -126,7 +126,7 @@ where
             parent_ids.sort();
 
             // Derive a hash from id (child) and all it's dependencies (parents).
-            let set_digest = Hash::new({
+            let set_digest = Hash::digest({
                 let mut buf: Vec<u8> = Vec::new();
                 buf.extend_from_slice(child_id.as_bytes());
                 for id in &parent_ids {

--- a/p2panda-store/src/orderer/tests.rs
+++ b/p2panda-store/src/orderer/tests.rs
@@ -9,9 +9,9 @@ use crate::{SqliteStore, Transaction};
 async fn ready() {
     let store = SqliteStore::temporary().await;
 
-    let hash_1 = Hash::new(b"tick");
-    let hash_2 = Hash::new(b"trick");
-    let hash_3 = Hash::new(b"track");
+    let hash_1 = Hash::digest(b"tick");
+    let hash_2 = Hash::digest(b"trick");
+    let hash_3 = Hash::digest(b"track");
 
     let permit = store.begin().await.unwrap();
 
@@ -47,10 +47,10 @@ async fn ready() {
 async fn pending() {
     let store = SqliteStore::temporary().await;
 
-    let hash_1 = Hash::new(b"piff");
-    let hash_2 = Hash::new(b"puff");
-    let hash_3 = Hash::new(b"paff");
-    let hash_4 = Hash::new(b"peff");
+    let hash_1 = Hash::digest(b"piff");
+    let hash_2 = Hash::digest(b"puff");
+    let hash_3 = Hash::digest(b"paff");
+    let hash_4 = Hash::digest(b"peff");
 
     let permit = store.begin().await.unwrap();
 

--- a/p2panda-store/src/topics/sqlite.rs
+++ b/p2panda-store/src/topics/sqlite.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
-use p2panda_core::{LogId, PublicKey};
+use p2panda_core::{LogId, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use sqlx::{query, query_as};
 
@@ -12,7 +12,7 @@ use crate::topics::TopicStore;
 
 /// SQLite `TopicStore` implementation that can be used to map a topic to a set of (generic)
 /// per-author data identifiers.
-impl<T, S> TopicStore<T, PublicKey, S> for SqliteStore
+impl<T, S> TopicStore<T, VerifyingKey, S> for SqliteStore
 where
     T: Serialize + for<'de> Deserialize<'de>,
     S: LogId,
@@ -22,7 +22,7 @@ where
     async fn associate(
         &self,
         topic: &T,
-        author: &PublicKey,
+        author: &VerifyingKey,
         data_id: &S,
     ) -> Result<bool, SqliteError> {
         let result = self
@@ -60,7 +60,7 @@ where
     async fn remove(
         &self,
         topic: &T,
-        author: &PublicKey,
+        author: &VerifyingKey,
         data_id: &S,
     ) -> Result<bool, SqliteError> {
         let result = self
@@ -92,7 +92,7 @@ where
         Ok(result.rows_affected() > 0)
     }
 
-    async fn resolve(&self, topic: &T) -> Result<BTreeMap<PublicKey, Vec<S>>, Self::Error> {
+    async fn resolve(&self, topic: &T) -> Result<BTreeMap<VerifyingKey, Vec<S>>, Self::Error> {
         let data_ids = self
             .execute(async |pool| {
                 query_as::<_, (String, Vec<u8>)>(
@@ -116,10 +116,10 @@ where
             })
             .await?;
 
-        let mut result: BTreeMap<PublicKey, Vec<S>> = BTreeMap::new();
+        let mut result: BTreeMap<VerifyingKey, Vec<S>> = BTreeMap::new();
 
         for (author, data_id) in data_ids {
-            let author: PublicKey = author
+            let author: VerifyingKey = author
                 .parse()
                 .map_err(|_| SqliteError::Decode("author".into(), DecodeError::FromStr))?;
 

--- a/p2panda-store/src/topics/tests.rs
+++ b/p2panda-store/src/topics/tests.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use p2panda_core::{PrivateKey, Topic};
+use p2panda_core::{SigningKey, Topic};
 
 use crate::topics::TopicStore;
 use crate::{SqliteStore, Transaction};
@@ -11,14 +11,14 @@ use crate::{SqliteStore, Transaction};
 async fn update_and_resolve_topic_mapping() {
     let store = SqliteStore::temporary().await;
 
-    let topic = Topic::new();
+    let topic = Topic::random();
 
     // The log id is the same as the topic, in a use case like this there will be one log
     // per-author in each topic.
     let log_id = topic;
 
-    let alice = PrivateKey::from_bytes(&[1u8; 32]).public_key();
-    let bob = PrivateKey::from_bytes(&[2u8; 32]).public_key();
+    let alice = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
+    let bob = SigningKey::from_bytes(&[2u8; 32]).verifying_key();
 
     let permit = store.begin().await.unwrap();
 
@@ -48,15 +48,15 @@ async fn update_and_resolve_topic_mapping() {
 async fn path_based_log_ids() {
     let store = SqliteStore::temporary().await;
 
-    let topic = Topic::new();
+    let topic = Topic::random();
 
     // Here we demonstrate use cases where there are multiple logs per-author in each topic.
     let log_id_kittens = "kittens".to_string();
     let log_id_kittens_sleepy = "kittens.sleepy".to_string();
     let log_id_puppies = "puppies".to_string();
 
-    let alice = PrivateKey::from_bytes(&[1u8; 32]).public_key();
-    let bob = PrivateKey::from_bytes(&[2u8; 32]).public_key();
+    let alice = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
+    let bob = SigningKey::from_bytes(&[2u8; 32]).verifying_key();
 
     let permit = store.begin().await.unwrap();
 
@@ -93,13 +93,13 @@ async fn path_based_log_ids() {
 async fn remove_association() {
     let store = SqliteStore::temporary().await;
 
-    let topic = Topic::new();
+    let topic = Topic::random();
 
     // Here we demonstrate use cases where there are multiple logs per-author in each topic.
     let log_id_kittens = "kittens".to_string();
     let log_id_kittens_sleepy = "kittens.sleepy".to_string();
 
-    let alice = PrivateKey::from_bytes(&[1u8; 32]).public_key();
+    let alice = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
 
     let permit = store.begin().await.unwrap();
 

--- a/p2panda-stream/src/ingest/operation.rs
+++ b/p2panda-stream/src/ingest/operation.rs
@@ -5,7 +5,7 @@ use std::borrow::Borrow;
 
 use p2panda_core::prune::validate_prunable_backlink;
 use p2panda_core::{
-    Extensions, Hash, LogId, Operation, OperationError, PublicKey, SeqNum, validate_operation,
+    Extensions, Hash, LogId, Operation, OperationError, SeqNum, VerifyingKey, validate_operation,
 };
 use p2panda_store::Transaction;
 use p2panda_store::logs::LogStore;
@@ -27,8 +27,8 @@ pub async fn ingest_operation<S, T, L, E, TP>(
 where
     S: Transaction
         + OperationStore<Operation<E>, Hash, L>
-        + LogStore<Operation<E>, PublicKey, L, SeqNum, Hash>
-        + TopicStore<TP, PublicKey, L>,
+        + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+        + TopicStore<TP, VerifyingKey, L>,
     T: Borrow<Operation<E>>,
     L: LogId,
     E: Extensions,
@@ -60,7 +60,7 @@ where
 
     // Validate log integrity.
     let past_header = store
-        .get_latest_entry_tx(&operation.header.public_key, log_id)
+        .get_latest_entry_tx(&operation.header.verifying_key, log_id)
         .await
         .map_err(|err| IngestError::StoreError(err.to_string()))?
         .map(|operation| operation.header);
@@ -71,14 +71,14 @@ where
 
     // Insert operation into store and associate its log with the given topic.
     let id = operation.hash;
-    let public_key = operation.header.public_key;
+    let verifying_key = operation.header.verifying_key;
 
     store
         .insert_operation(&id, operation, log_id)
         .await
         .map_err(|err| IngestError::StoreError(err.to_string()))?;
 
-    <S as TopicStore<TP, PublicKey, L>>::associate(store, topic, &public_key, log_id)
+    <S as TopicStore<TP, VerifyingKey, L>>::associate(store, topic, &verifying_key, log_id)
         .await
         .map_err(|err| IngestError::StoreError(err.to_string()))?;
 
@@ -106,7 +106,7 @@ pub enum IngestError {
 #[cfg(test)]
 mod tests {
     use p2panda_core::test_utils::TestLog;
-    use p2panda_core::{Hash, Header, Operation, PrivateKey, PublicKey, SeqNum, Timestamp};
+    use p2panda_core::{Hash, Header, Operation, SeqNum, SigningKey, Timestamp, VerifyingKey};
     use p2panda_store::SqliteStore;
     use p2panda_store::logs::LogStore;
     use p2panda_store::topics::TopicStore;
@@ -180,7 +180,7 @@ mod tests {
 
         // Topic "dogs" contains two logs: 0 with two operations and 1 with one operation.
         let authors =
-            <SqliteStore as TopicStore<[u8; 32], PublicKey, usize>>::resolve(&store, &dogs)
+            <SqliteStore as TopicStore<[u8; 32], VerifyingKey, usize>>::resolve(&store, &dogs)
                 .await
                 .unwrap();
         assert_eq!(*authors.get(&log_0.author()).unwrap(), [0]);
@@ -188,7 +188,7 @@ mod tests {
 
         let operation = <SqliteStore as LogStore<
             Operation<()>,
-            PublicKey,
+            VerifyingKey,
             usize,
             SeqNum,
             Hash,
@@ -200,14 +200,14 @@ mod tests {
 
         // Topic "cats" contains one log: 2 with four operations.
         let authors =
-            <SqliteStore as TopicStore<[u8; 32], PublicKey, usize>>::resolve(&store, &cats)
+            <SqliteStore as TopicStore<[u8; 32], VerifyingKey, usize>>::resolve(&store, &cats)
                 .await
                 .unwrap();
         assert_eq!(*authors.get(&log_2.author()).unwrap(), [2]);
 
         let operation = <SqliteStore as LogStore<
             Operation<()>,
-            PublicKey,
+            VerifyingKey,
             usize,
             SeqNum,
             Hash,
@@ -221,22 +221,22 @@ mod tests {
     #[tokio::test]
     async fn missing_prefix() {
         let store = SqliteStore::temporary().await;
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
 
         // Create an operation which has already advanced in the log (it has a backlink and higher
         // sequence number).
         let mut header = Header {
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             version: 1,
             signature: None,
             payload_size: 0,
             payload_hash: None,
             timestamp: Timestamp::now(),
             seq_num: 12, // we'll be missing 11 operations between the first and this one
-            backlink: Some(Hash::new(b"mock operation")),
+            backlink: Some(Hash::digest(b"mock operation")),
             extensions: (),
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         let operation = Operation {
             hash: header.hash(),
@@ -251,22 +251,22 @@ mod tests {
     #[tokio::test]
     async fn ignore_outdated_pruned_operations() {
         let store = SqliteStore::temporary().await;
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
 
         // 1. Create an advanced operation in a log which assumes that all previous operations have
         //    been pruned.
         let mut header = Header {
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             version: 1,
             signature: None,
             payload_size: 0,
             payload_hash: None,
             timestamp: Timestamp::now(),
             seq_num: 1,
-            backlink: Some(Hash::new(b"mock operation")),
+            backlink: Some(Hash::digest(b"mock operation")),
             extensions: (),
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         let operation = Operation {
             hash: header.hash(),
@@ -280,7 +280,7 @@ mod tests {
 
         // 2. Create an operation which is from an "outdated" seq from before the log was pruned.
         let mut header = Header {
-            public_key: private_key.public_key(),
+            verifying_key: signing_key.verifying_key(),
             version: 1,
             signature: None,
             payload_size: 0,
@@ -290,7 +290,7 @@ mod tests {
             backlink: None,
             extensions: (),
         };
-        header.sign(&private_key);
+        header.sign(&signing_key);
 
         let operation = Operation {
             hash: header.hash(),

--- a/p2panda-stream/src/ingest/processor.rs
+++ b/p2panda-stream/src/ingest/processor.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 
-use p2panda_core::{Extensions, Hash, LogId, Operation, PublicKey, SeqNum};
+use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
 use p2panda_store::Transaction;
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
@@ -27,8 +27,8 @@ impl<S, T, L, E, TP> Ingest<S, T, L, E, TP>
 where
     S: Transaction
         + OperationStore<Operation<E>, Hash, L>
-        + LogStore<Operation<E>, PublicKey, L, SeqNum, Hash>
-        + TopicStore<TP, PublicKey, L>,
+        + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+        + TopicStore<TP, VerifyingKey, L>,
     L: LogId,
     E: Extensions,
 {
@@ -46,8 +46,8 @@ impl<S, T, L, E, TP> Processor<T> for Ingest<S, T, L, E, TP>
 where
     S: Transaction
         + OperationStore<Operation<E>, Hash, L>
-        + LogStore<Operation<E>, PublicKey, L, SeqNum, Hash>
-        + TopicStore<TP, PublicKey, L>,
+        + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+        + TopicStore<TP, VerifyingKey, L>,
     T: Borrow<Operation<E>> + Borrow<IngestArgs<L, TP>>,
     L: LogId,
     E: Extensions,
@@ -152,7 +152,7 @@ mod tests {
                 let operation_2 = log.operation(b"Ho", ());
 
                 let log_id = 0;
-                let topic = Topic::new();
+                let topic = Topic::random();
 
                 let mut stream = stream::iter(vec![
                     Event {

--- a/p2panda-stream/src/log_prune/processor.rs
+++ b/p2panda-stream/src/log_prune/processor.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 
-use p2panda_core::{Extensions, Hash, LogId, Operation, PublicKey, SeqNum};
+use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use thiserror::Error;
 use tokio::sync::Notify;
@@ -22,7 +22,7 @@ pub struct LogPrune<S, T, L, E> {
 
 impl<S, T, L, E> LogPrune<S, T, L, E>
 where
-    S: LogStore<Operation<E>, PublicKey, L, SeqNum, Hash>,
+    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>,
     L: LogId,
     E: Extensions,
 {
@@ -38,8 +38,8 @@ where
 
 impl<S, T, L, E> Processor<T> for LogPrune<S, T, L, E>
 where
-    S: LogStore<Operation<E>, PublicKey, L, SeqNum, Hash>,
-    T: Borrow<LogPruneArgs<PublicKey, L, SeqNum>>,
+    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>,
+    T: Borrow<LogPruneArgs<VerifyingKey, L, SeqNum>>,
     L: LogId,
     E: Extensions,
 {
@@ -48,7 +48,7 @@ where
     type Error = (T, LogPruneError);
 
     async fn process(&self, input: T) -> Result<(), Self::Error> {
-        let args: &LogPruneArgs<PublicKey, L, SeqNum> = input.borrow();
+        let args: &LogPruneArgs<VerifyingKey, L, SeqNum> = input.borrow();
 
         let result = if let LogPruneArgs::PruneEntriesUntil {
             author,

--- a/p2panda-stream/src/orderer/processor.rs
+++ b/p2panda-stream/src/orderer/processor.rs
@@ -124,7 +124,7 @@ where
 #[cfg(test)]
 mod tests {
     use futures_util::stream;
-    use p2panda_core::{Body, Hash, Header, Operation, PrivateKey, Topic};
+    use p2panda_core::{Body, Hash, Header, Operation, SigningKey, Topic};
     use p2panda_store::operations::OperationStore;
     use p2panda_store::{SqliteStore, tx_unwrap};
     use serde::{Deserialize, Serialize};
@@ -151,13 +151,13 @@ mod tests {
         // Create two operations, one by Panda and one by Icebear. Panda's operation points at
         // Icebear's.
         let operation_panda = {
-            let private_key = PrivateKey::new();
-            let public_key = private_key.public_key();
+            let signing_key = SigningKey::generate();
+            let verifying_key = signing_key.verifying_key();
 
             let body: Body = b"Hi, Icebear".to_vec().into();
 
             let mut header = Header {
-                public_key,
+                verifying_key,
                 payload_size: body.size(),
                 payload_hash: Some(body.hash()),
                 extensions: TestExtension {
@@ -165,7 +165,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            header.sign(&private_key);
+            header.sign(&signing_key);
 
             Operation {
                 hash: header.hash(),
@@ -175,13 +175,13 @@ mod tests {
         };
 
         let operation_icebear = {
-            let private_key = PrivateKey::new();
-            let public_key = private_key.public_key();
+            let signing_key = SigningKey::generate();
+            let verifying_key = signing_key.verifying_key();
 
             let body: Body = b"Hello, Pandasan!".to_vec().into();
 
             let mut header = Header {
-                public_key,
+                verifying_key,
                 payload_size: body.size(),
                 payload_hash: Some(body.hash()),
                 extensions: TestExtension {
@@ -189,7 +189,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            header.sign(&private_key);
+            header.sign(&signing_key);
 
             Operation {
                 hash: header.hash(),
@@ -206,7 +206,7 @@ mod tests {
 
                 // Insert operations into store.
                 tx_unwrap!(store, {
-                    let log_id = Topic::new();
+                    let log_id = Topic::random();
 
                     store
                         .insert_operation(&operation_panda.hash, &operation_panda, &log_id)

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -18,7 +18,7 @@
 //! [`p2panda-net`] stack.
 //!
 //! [`p2panda-net`]: https://docs.rs/p2panda-net/latest/p2panda_net/
-use p2panda_core::PublicKey;
+use p2panda_core::VerifyingKey;
 
 mod dedup;
 pub mod manager;
@@ -32,7 +32,7 @@ pub mod traits;
 #[derive(Clone, Debug)]
 pub struct SessionConfig<T> {
     pub topic: T,
-    pub remote: PublicKey,
+    pub remote: VerifyingKey,
     pub live_mode: bool,
 }
 
@@ -47,7 +47,7 @@ pub enum ToSync<M> {
 #[derive(Clone, PartialEq, Debug)]
 pub struct FromSync<E> {
     pub session_id: u64,
-    pub remote: PublicKey,
+    pub remote: VerifyingKey,
     pub event: E,
 }
 
@@ -60,7 +60,7 @@ impl<E> FromSync<E> {
         &self.event
     }
 
-    pub fn remote(&self) -> &PublicKey {
+    pub fn remote(&self) -> &VerifyingKey {
         &self.remote
     }
 }

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -21,7 +21,7 @@ use futures::channel::mpsc;
 use futures::future::ready;
 use futures::stream::SelectAll;
 use futures::{Sink, SinkExt, Stream, StreamExt};
-use p2panda_core::{Extensions, Hash, LogId, Operation, PublicKey};
+use p2panda_core::{Extensions, Hash, LogId, Operation, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -65,8 +65,8 @@ where
 {
     store: S,
     session_topic_map: SessionTopicMap<T, mpsc::Sender<ToTopicSync<E>>>,
-    from_session_tx: HashMap<(u64, PublicKey), broadcast::Sender<TopicLogSyncEvent<E>>>,
-    from_session_rx: HashMap<(u64, PublicKey), broadcast::Receiver<TopicLogSyncEvent<E>>>,
+    from_session_tx: HashMap<(u64, VerifyingKey), broadcast::Sender<TopicLogSyncEvent<E>>>,
+    from_session_rx: HashMap<(u64, VerifyingKey), broadcast::Receiver<TopicLogSyncEvent<E>>>,
     manager_tx: Vec<mpsc::Sender<SessionStream<T, E>>>,
     _phantom: PhantomData<L>,
 }
@@ -79,7 +79,7 @@ where
 {
     pub session_id: u64,
     pub topic: T,
-    pub remote: PublicKey,
+    pub remote: VerifyingKey,
     pub event_rx: broadcast::Receiver<TopicLogSyncEvent<E>>,
     pub live_tx: mpsc::Sender<ToTopicSync<E>>,
 }
@@ -104,8 +104,8 @@ where
 impl<T, S, L, E> Manager<T> for TopicSyncManager<T, S, L, E>
 where
     T: Clone + Debug + Eq + StdHash + Serialize + for<'a> Deserialize<'a> + Send + 'static,
-    S: LogStore<Operation<E>, PublicKey, L, u64, Hash>
-        + TopicStore<T, PublicKey, L>
+    S: LogStore<Operation<E>, VerifyingKey, L, u64, Hash>
+        + TopicStore<T, VerifyingKey, L>
         + Clone
         + Send
         + 'static,
@@ -266,7 +266,7 @@ mod tests {
         const LOG_ID: u64 = 0;
         const SESSION_ID: u64 = 0;
 
-        let topic = Topic::new();
+        let topic = Topic::random();
 
         // Setup Peer A
         let mut peer_a = Peer::new(0).await;
@@ -425,7 +425,7 @@ mod tests {
         const SESSION_BA: u64 = 2;
         const SESSION_CA: u64 = 3;
 
-        let topic = Topic::new();
+        let topic = Topic::random();
 
         // Peer A
         let mut peer_a = Peer::new(0).await;
@@ -605,7 +605,7 @@ mod tests {
         const LOG_ID: u64 = 0;
         const SESSION_ID: u64 = 0;
 
-        let topic = Topic::new();
+        let topic = Topic::random();
 
         // Setup Peer A
         let mut peer_a = Peer::new(0).await;

--- a/p2panda-sync/src/manager/session_map.rs
+++ b/p2panda-sync/src/manager/session_map.rs
@@ -106,7 +106,7 @@ mod tests {
     fn insert_with_topic() {
         let (tx, _rx) = mpsc::channel::<()>(128);
         let mut map = SessionTopicMap::default();
-        let topic_a = Topic::new();
+        let topic_a = Topic::random();
 
         map.insert_with_topic(SESSION1, topic_a, tx.clone());
 
@@ -124,8 +124,8 @@ mod tests {
     fn drop_session() {
         let (tx, _rx) = mpsc::channel::<()>(128);
         let mut map = SessionTopicMap::default();
-        let topic_a = Topic::new();
-        let topic_b = Topic::new();
+        let topic_a = Topic::random();
+        let topic_b = Topic::random();
 
         map.insert_with_topic(SESSION1, topic_a, tx.clone());
         map.insert_with_topic(SESSION2, topic_a, tx.clone());
@@ -152,7 +152,7 @@ mod tests {
         let (tx2, _rx2) = mpsc::channel::<()>(128);
         let mut map = SessionTopicMap::default();
 
-        let topic_a = Topic::new();
+        let topic_a = Topic::random();
 
         map.insert_with_topic(SESSION1, topic_a, tx1);
         map.insert_with_topic(SESSION2, topic_a, tx2);

--- a/p2panda-sync/src/protocols/log_sync.rs
+++ b/p2panda-sync/src/protocols/log_sync.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 use futures::{Sink, SinkExt, Stream, StreamExt, stream};
 use p2panda_core::cbor::{DecodeError, decode_cbor};
 use p2panda_core::logs::{LogHeights, LogRanges, compare};
-use p2panda_core::{Body, Extensions, Hash, Header, LogId, Operation, PublicKey};
+use p2panda_core::{Body, Extensions, Hash, Header, LogId, Operation, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -20,7 +20,7 @@ use crate::dedup::{DEFAULT_BUFFER_CAPACITY, DeduplicationBuffer};
 use crate::traits::Protocol;
 
 /// A map of author logs.
-pub type Logs<L> = BTreeMap<PublicKey, Vec<L>>;
+pub type Logs<L> = BTreeMap<VerifyingKey, Vec<L>>;
 
 /// Sync session life-cycle states.
 #[derive(Debug, Default)]
@@ -33,16 +33,16 @@ enum State<L> {
     SendHave,
 
     /// Receive have message from remote and calculate operation diff.
-    ReceiveHave { local: LogHeights<PublicKey, L> },
+    ReceiveHave { local: LogHeights<VerifyingKey, L> },
 
     /// Send PreSync message to remote or Done if we have nothing to send.
     SendPreSync {
-        remote_needs: LogRanges<PublicKey, L>,
+        remote_needs: LogRanges<VerifyingKey, L>,
     },
 
     /// Receive PreSync message from remote or Done if they have nothing to send.
     ReceivePreSyncOrDone {
-        remote_needs: LogRanges<PublicKey, L>,
+        remote_needs: LogRanges<VerifyingKey, L>,
         outbound_operations: u64,
         outbound_bytes: u64,
     },
@@ -50,7 +50,7 @@ enum State<L> {
     /// Enter sync loop where we exchange operations with the remote, moves onto next state when
     /// both peers have send Done messages.
     Sync {
-        remote_needs: LogRanges<PublicKey, L>,
+        remote_needs: LogRanges<VerifyingKey, L>,
         metrics: LogSyncMetrics,
     },
 
@@ -95,7 +95,7 @@ impl<L, E, S, Evt> Protocol for LogSync<L, E, S, Evt>
 where
     L: LogId + Debug + Send + 'static,
     E: Extensions + Send + 'static,
-    S: LogStore<Operation<E>, PublicKey, L, u64, Hash> + Clone + Send + 'static,
+    S: LogStore<Operation<E>, VerifyingKey, L, u64, Hash> + Clone + Send + 'static,
     Evt: Debug + From<LogSyncEvent<E>> + Send + 'static,
 {
     type Error = LogSyncError;
@@ -140,11 +140,11 @@ where
                 State::SendPreSync { remote_needs } => {
                     let mut outbound_operations = 0;
                     let mut outbound_bytes = 0;
-                    for (public_key, log_range) in remote_needs.iter() {
+                    for (verifying_key, log_range) in remote_needs.iter() {
                         for (log_id, (after, until)) in log_range.iter() {
                             if let Some((inner_outbound_operations, inner_outbound_bytes)) = self
                                 .store
-                                .get_log_size(public_key, log_id, *after, *until)
+                                .get_log_size(verifying_key, log_id, *after, *until)
                                 .await
                                 .map_err(|err| LogSyncError::OperationStore(format!("{err}")))?
                             {
@@ -323,7 +323,7 @@ where
 
                                         trace!(
                                             phase = "sync",
-                                            public_key = %author.fmt_short(),
+                                            verifying_key = %author.fmt_short(),
                                             log_id = ?log_id,
                                             seq_num = header.seq_num,
                                             id = %hash.fmt_short(),
@@ -346,7 +346,7 @@ where
                                 if send_logs_len == 0 {
                                     trace!(
                                         phase = "sync",
-                                        public_key = %author.fmt_short(),
+                                        verifying_key = %author.fmt_short(),
                                         "send sync done message",
                                     );
                                     sink.send(LogSyncMessage::Done)
@@ -382,21 +382,21 @@ where
 async fn get_log_heights<L, E, S>(
     store: &S,
     logs: &Logs<L>,
-) -> Result<LogHeights<PublicKey, L>, LogSyncError>
+) -> Result<LogHeights<VerifyingKey, L>, LogSyncError>
 where
     L: LogId,
-    S: LogStore<Operation<E>, PublicKey, L, u64, Hash> + Clone + Send + 'static,
+    S: LogStore<Operation<E>, VerifyingKey, L, u64, Hash> + Clone + Send + 'static,
 {
     let mut result = BTreeMap::new();
-    for (public_key, log_ids) in logs {
+    for (verifying_key, log_ids) in logs {
         let Some(log_heights) = store
-            .get_log_heights(public_key, log_ids)
+            .get_log_heights(verifying_key, log_ids)
             .await
             .map_err(|err| LogSyncError::LogStore(format!("{err}")))?
         else {
             continue;
         };
-        result.insert(*public_key, log_heights);
+        result.insert(*verifying_key, log_heights);
     }
 
     Ok(result)
@@ -410,7 +410,7 @@ pub enum LogSyncMessage<L>
 where
     L: LogId,
 {
-    Have(LogHeights<PublicKey, L>),
+    Have(LogHeights<VerifyingKey, L>),
     PreSync {
         total_operations: u64,
         total_bytes: u64,
@@ -498,7 +498,7 @@ pub trait ShortFormat {
     fn fmt_short(&self) -> String;
 }
 
-impl ShortFormat for PublicKey {
+impl ShortFormat for VerifyingKey {
     fn fmt_short(&self) -> String {
         self.to_hex()[0..10].to_string()
     }

--- a/p2panda-sync/src/protocols/topic_log_sync.rs
+++ b/p2panda-sync/src/protocols/topic_log_sync.rs
@@ -10,7 +10,7 @@ use std::task::{Context, Poll};
 
 use futures::channel::mpsc;
 use futures::{Sink, SinkExt, Stream, StreamExt};
-use p2panda_core::{Body, Extensions, Hash, Header, LogId, Operation, PublicKey};
+use p2panda_core::{Body, Extensions, Hash, Header, LogId, Operation, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
 use pin_project_lite::pin_project;
@@ -53,8 +53,8 @@ pub struct TopicLogSync<T, S, L, E> {
 impl<T, S, L, E> TopicLogSync<T, S, L, E>
 where
     T: Eq + StdHash + Serialize + for<'a> Deserialize<'a>,
-    S: LogStore<Operation<E>, PublicKey, L, u64, Hash>
-        + TopicStore<T, PublicKey, L>
+    S: LogStore<Operation<E>, VerifyingKey, L, u64, Hash>
+        + TopicStore<T, VerifyingKey, L>
         + Clone
         + Send
         + 'static,
@@ -100,8 +100,8 @@ where
 impl<T, S, L, E> Protocol for TopicLogSync<T, S, L, E>
 where
     T: Debug + Eq + StdHash + Serialize + for<'a> Deserialize<'a> + Send + 'static,
-    S: LogStore<Operation<E>, PublicKey, L, u64, Hash>
-        + TopicStore<T, PublicKey, L>
+    S: LogStore<Operation<E>, VerifyingKey, L, u64, Hash>
+        + TopicStore<T, VerifyingKey, L>
         + Clone
         + Send
         + 'static,
@@ -623,7 +623,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn sync_session_no_operations() {
-        let topic = Topic::new();
+        let topic = Topic::random();
         let mut peer = Peer::new(0).await;
         peer.associate(&topic, &BTreeMap::default()).await;
 
@@ -674,7 +674,7 @@ pub mod tests {
         setup_logging();
 
         let log_id = 0;
-        let topic = Topic::new();
+        let topic = Topic::random();
         let mut peer = Peer::new(0).await;
 
         let body = Body::new("Hello, Sloth!".as_bytes());
@@ -773,7 +773,7 @@ pub mod tests {
     #[tokio::test]
     async fn topic_log_sync_full_duplex() {
         setup_logging();
-        let topic = Topic::new();
+        let topic = Topic::random();
         let log_id = 0;
 
         let mut peer_a = Peer::new(0).await;
@@ -854,7 +854,7 @@ pub mod tests {
     #[tokio::test]
     async fn live_mode() {
         let log_id = 0;
-        let topic = Topic::new();
+        let topic = Topic::random();
         let mut peer_a = Peer::new(0).await;
         let mut peer_b = Peer::new(1).await;
 
@@ -965,7 +965,7 @@ pub mod tests {
     #[tokio::test]
     async fn dedup_live_mode_messages() {
         let log_id = 0;
-        let topic = Topic::new();
+        let topic = Topic::random();
         let mut peer_a = Peer::new(0).await;
         let mut peer_b = Peer::new(1).await;
 
@@ -1087,7 +1087,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn unexpected_stream_closure_sync() {
-        let topic = Topic::new();
+        let topic = Topic::random();
         let mut peer = Peer::new(0).await;
         peer.associate(&topic, &Default::default()).await;
 
@@ -1133,7 +1133,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn unexpected_stream_closure_live_mode() {
-        let topic = Topic::new();
+        let topic = Topic::random();
         let mut peer = Peer::new(0).await;
         peer.associate(&topic, &Default::default()).await;
 

--- a/p2panda-sync/src/test_utils.rs
+++ b/p2panda-sync/src/test_utils.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use futures::{FutureExt, SinkExt, Stream, StreamExt};
 
 use futures::channel::mpsc;
-use p2panda_core::{Body, Hash, Header, Operation, PrivateKey, PublicKey, Topic};
+use p2panda_core::{Body, Hash, Header, Operation, SigningKey, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
 use p2panda_store::topics::TopicStore;
@@ -44,20 +44,20 @@ pub type TestTopicSyncManager = TopicSyncManager<Topic, SqliteStore, u64, ()>;
 /// protocols.
 pub struct Peer {
     pub store: SqliteStore,
-    pub private_key: PrivateKey,
+    pub signing_key: SigningKey,
 }
 
 impl Peer {
     pub async fn new(peer_id: u64) -> Self {
         let store = SqliteStore::temporary().await;
         let mut rng = <StdRng as rand::SeedableRng>::seed_from_u64(peer_id);
-        let private_key = PrivateKey::from_bytes(&rng.random());
-        Self { store, private_key }
+        let signing_key = SigningKey::from_bytes(&rng.random());
+        Self { store, signing_key }
     }
 
     /// The public key of this peer.
-    pub fn id(&self) -> PublicKey {
-        self.private_key.public_key()
+    pub fn id(&self) -> VerifyingKey {
+        self.signing_key.verifying_key()
     }
 
     /// Return a topic sync protocol.
@@ -116,12 +116,12 @@ impl Peer {
     ) -> (Header<()>, Vec<u8>) {
         let (seq_num, backlink) = <SqliteStore as LogStore<
             Operation<()>,
-            PublicKey,
+            VerifyingKey,
             u64,
             u64,
             p2panda_core::Hash,
         >>::get_latest_entry(
-            &self.store, &self.private_key.public_key(), &log_id
+            &self.store, &self.signing_key.verifying_key(), &log_id
         )
         .await
         .unwrap()
@@ -129,12 +129,12 @@ impl Peer {
         .unwrap_or((0, None));
 
         let (header, header_bytes) =
-            create_operation(&self.private_key, body, seq_num, rand::random(), backlink);
+            create_operation(&self.signing_key, body, seq_num, rand::random(), backlink);
 
         (header, header_bytes)
     }
 
-    pub async fn associate(&mut self, topic: &Topic, logs: &BTreeMap<PublicKey, Vec<u64>>) {
+    pub async fn associate(&mut self, topic: &Topic, logs: &BTreeMap<VerifyingKey, Vec<u64>>) {
         let permit = self.store.begin().await.unwrap();
         for (author, logs) in logs {
             for log_id in logs {
@@ -213,7 +213,7 @@ where
 
 /// Create a single operation.
 pub fn create_operation(
-    private_key: &PrivateKey,
+    signing_key: &SigningKey,
     body: &Body,
     seq_num: u64,
     timestamp: u64,
@@ -221,7 +221,7 @@ pub fn create_operation(
 ) -> (Header<()>, Vec<u8>) {
     let mut header = Header::<()> {
         version: 1,
-        public_key: private_key.public_key(),
+        verifying_key: signing_key.verifying_key(),
         signature: None,
         payload_size: body.size(),
         payload_hash: Some(body.hash()),
@@ -230,7 +230,7 @@ pub fn create_operation(
         backlink,
         extensions: (),
     };
-    header.sign(private_key);
+    header.sign(signing_key);
     let header_bytes = header.to_bytes();
     (header, header_bytes)
 }

--- a/p2panda/examples/todo.rs
+++ b/p2panda/examples/todo.rs
@@ -134,7 +134,7 @@ struct TodoList {
 
 impl TodoList {
     pub fn new() -> Self {
-        Self::from_id(TodoListId::new())
+        Self::from_id(TodoListId::random())
     }
 
     pub fn from_id(id: TodoListId) -> Self {
@@ -175,7 +175,7 @@ impl TodoList {
 
     pub fn create(&mut self, description: &str) -> TodoEvent {
         TodoEvent {
-            id: Topic::new().into(),
+            id: Topic::random().into(),
             kind: TodoEventKind::Set {
                 description: description.into(),
             },

--- a/p2panda/src/builder.rs
+++ b/p2panda/src/builder.rs
@@ -2,11 +2,11 @@
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use p2panda_core::PrivateKey;
+use p2panda_core::SigningKey;
 use p2panda_net::addrs::TrustedTransportInfo;
 use p2panda_net::discovery::DiscoveryConfig;
 use p2panda_net::gossip::GossipConfig;
-use p2panda_net::iroh_endpoint::{EndpointAddr, RelayUrl, from_public_key};
+use p2panda_net::iroh_endpoint::{EndpointAddr, RelayUrl, from_verifying_key};
 use p2panda_net::{NetworkId, NodeId};
 use p2panda_store::SqliteStore;
 use p2panda_store::sqlite::{SqlitePool, SqliteStoreBuilder};
@@ -19,7 +19,7 @@ use crate::processor::{Pipeline, TaskTracker};
 
 #[derive(Default)]
 pub struct NodeBuilder {
-    private_key: Option<PrivateKey>,
+    signing_key: Option<SigningKey>,
     config: Config,
     store_options: StoreBuilderOptions,
 }
@@ -27,14 +27,14 @@ pub struct NodeBuilder {
 impl NodeBuilder {
     pub fn new() -> Self {
         NodeBuilder {
-            private_key: None,
+            signing_key: None,
             config: Config::default(),
             store_options: StoreBuilderOptions::default(),
         }
     }
 
-    pub fn private_key(mut self, private_key: PrivateKey) -> Self {
-        self.private_key = Some(private_key);
+    pub fn signing_key(mut self, signing_key: SigningKey) -> Self {
+        self.signing_key = Some(signing_key);
         self
     }
 
@@ -64,7 +64,8 @@ impl NodeBuilder {
     }
 
     pub fn bootstrap(mut self, node_id: NodeId, relay_url: RelayUrl) -> Self {
-        let endpoint_addr = EndpointAddr::new(from_public_key(node_id)).with_relay_url(relay_url);
+        let endpoint_addr =
+            EndpointAddr::new(from_verifying_key(node_id)).with_relay_url(relay_url);
         self.config
             .network
             .bootstraps
@@ -108,7 +109,7 @@ impl NodeBuilder {
     }
 
     pub async fn spawn(self) -> Result<Node, SpawnError> {
-        let private_key = self.private_key.unwrap_or_default();
+        let signing_key = self.signing_key.unwrap_or_default();
         let store = match self.store_options {
             StoreBuilderOptions::Memory => SqliteStoreBuilder::new().build().await?,
             StoreBuilderOptions::Url(url) => {
@@ -116,7 +117,7 @@ impl NodeBuilder {
             }
             StoreBuilderOptions::Pool(pool) => SqliteStore::from_pool(pool),
         };
-        let forge = OperationForge::from_private_key(private_key, store.clone());
+        let forge = OperationForge::from_signing_key(signing_key, store.clone());
 
         let tasks = TaskTracker::new();
         let pipeline = Pipeline::new::<SqliteStore>(store.clone(), tasks);

--- a/p2panda/src/forge.rs
+++ b/p2panda/src/forge.rs
@@ -3,7 +3,7 @@
 use std::error::Error as StdError;
 use std::sync::Arc;
 
-use p2panda_core::{Body, Hash, PrivateKey, PublicKey, SeqNum, Timestamp, Topic};
+use p2panda_core::{Body, Hash, SeqNum, SigningKey, Timestamp, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
 use p2panda_store::topics::TopicStore;
@@ -16,9 +16,9 @@ use crate::operation::{Extensions, Header, LogId, Operation};
 pub trait Forge<TP, C, E> {
     type Error: StdError;
 
-    fn private_key(&self) -> &PrivateKey;
+    fn signing_key(&self) -> &SigningKey;
 
-    fn public_key(&self) -> PublicKey;
+    fn verifying_key(&self) -> VerifyingKey;
 
     fn create_operation(
         &self,
@@ -31,7 +31,7 @@ pub trait Forge<TP, C, E> {
 
 #[derive(Clone, Debug)]
 pub struct OperationForge {
-    private_key: Arc<PrivateKey>,
+    signing_key: Arc<SigningKey>,
     store: SqliteStore,
 }
 
@@ -42,13 +42,13 @@ impl OperationForge {
     /// The forge holds the private key used to sign operations. This method generates a new key
     /// using CSPRNG from the system.
     pub fn new(store: SqliteStore) -> Self {
-        Self::from_private_key(PrivateKey::new(), store)
+        Self::from_signing_key(SigningKey::generate(), store)
     }
 
     /// Create a forge using an existing private key.
-    pub fn from_private_key(private_key: PrivateKey, store: SqliteStore) -> Self {
+    pub fn from_signing_key(signing_key: SigningKey, store: SqliteStore) -> Self {
         Self {
-            private_key: Arc::new(private_key),
+            signing_key: Arc::new(signing_key),
             store,
         }
     }
@@ -57,12 +57,12 @@ impl OperationForge {
 impl Forge<Topic, LogId, Extensions> for OperationForge {
     type Error = ForgeError;
 
-    fn private_key(&self) -> &PrivateKey {
-        &self.private_key
+    fn signing_key(&self) -> &SigningKey {
+        &self.signing_key
     }
 
-    fn public_key(&self) -> PublicKey {
-        self.private_key.public_key()
+    fn verifying_key(&self) -> VerifyingKey {
+        self.signing_key.verifying_key()
     }
 
     /// Create a signed operation and insert it into the store.
@@ -94,12 +94,12 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
         let operation = tx!(self.store, {
             let (seq_num, backlink) = <SqliteStore as LogStore<
                 Operation,
-                PublicKey,
+                VerifyingKey,
                 LogId,
                 SeqNum,
                 Hash,
             >>::get_latest_entry_tx(
-                &self.store, &self.private_key.public_key(), &log_id
+                &self.store, &self.signing_key.verifying_key(), &log_id
             )
             .await?
             .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
@@ -107,7 +107,7 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
 
             let mut header = Header {
                 version: 1,
-                public_key: self.private_key.public_key(),
+                verifying_key: self.signing_key.verifying_key(),
                 signature: None,
                 payload_size,
                 payload_hash,
@@ -117,7 +117,7 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
                 extensions,
             };
 
-            header.sign(&self.private_key);
+            header.sign(&self.signing_key);
             let hash = header.hash();
 
             let operation = Operation {
@@ -126,10 +126,10 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
                 body,
             };
 
-            <SqliteStore as TopicStore<Topic, PublicKey, LogId>>::associate(
+            <SqliteStore as TopicStore<Topic, VerifyingKey, LogId>>::associate(
                 &self.store,
                 &topic,
-                &self.private_key.public_key(),
+                &self.signing_key.verifying_key(),
                 &log_id,
             )
             .await?;
@@ -169,7 +169,7 @@ mod tests {
         let store = SqliteStore::temporary().await;
         let forge = OperationForge::new(store.clone());
 
-        let topic = Topic::new();
+        let topic = Topic::random();
         let log_id = LogId::from_topic(topic);
         let extensions = Extensions::from_topic(topic);
 
@@ -195,7 +195,7 @@ mod tests {
 
         let result = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_log_heights(
             &store,
-            &forge.public_key(),
+            &forge.verifying_key(),
             &[log_id],
         )
         .await

--- a/p2panda/src/lib.rs
+++ b/p2panda/src/lib.rs
@@ -12,7 +12,7 @@ pub mod test_utils;
 
 // Useful external types we want to re-export for convenience.
 #[doc(no_inline)]
-pub use p2panda_core::{Cursor, Hash, PrivateKey, PublicKey, Topic};
+pub use p2panda_core::{Cursor, Hash, SigningKey, Topic, VerifyingKey};
 #[doc(no_inline)]
 pub use p2panda_net::iroh_endpoint::{EndpointAddr, RelayUrl};
 #[doc(no_inline)]

--- a/p2panda/src/network.rs
+++ b/p2panda/src/network.rs
@@ -3,13 +3,13 @@
 use std::collections::HashSet;
 use std::fmt::Debug;
 
-use p2panda_core::{PrivateKey, Topic};
+use p2panda_core::{SigningKey, Topic};
 use p2panda_net::address_book::AddressBookError;
 use p2panda_net::addrs::{NodeInfo, TrustedTransportInfo};
 use p2panda_net::discovery::{DiscoveryConfig, DiscoveryError};
 use p2panda_net::gossip::{GossipConfig, GossipError};
 use p2panda_net::iroh_endpoint::{
-    EndpointAddr, EndpointError, IrohConfig, RelayUrl, from_public_key,
+    EndpointAddr, EndpointError, IrohConfig, RelayUrl, from_verifying_key,
 };
 use p2panda_net::iroh_mdns::MdnsDiscoveryError;
 use p2panda_net::sync::LogSyncError;
@@ -36,7 +36,7 @@ pub(crate) struct Network {
 impl Network {
     pub async fn spawn(
         config: NetworkConfig,
-        private_key: PrivateKey,
+        signing_key: SigningKey,
         store: SqliteStore,
     ) -> Result<Self, NetworkError> {
         // TODO: Supervision of actors.
@@ -52,7 +52,7 @@ impl Network {
 
         let mut endpoint = Endpoint::builder(address_book.clone())
             .config(config.iroh)
-            .private_key(private_key)
+            .signing_key(signing_key)
             .network_id(config.network_id);
 
         for url in &config.relay_urls {
@@ -112,7 +112,8 @@ impl Network {
         relay_url: RelayUrl,
     ) -> Result<(), NetworkError> {
         let mut node_info = NodeInfo::new(node_id).bootstrap();
-        let endpoint_addr = EndpointAddr::new(from_public_key(node_id)).with_relay_url(relay_url);
+        let endpoint_addr =
+            EndpointAddr::new(from_verifying_key(node_id)).with_relay_url(relay_url);
         let transport_info = TrustedTransportInfo::from(endpoint_addr);
 
         if node_info.update_transports(transport_info.into()).is_ok() {

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -66,7 +66,7 @@ impl Node {
     ) -> Result<Self, NetworkError> {
         let network = Network::spawn(
             config.network.clone(),
-            forge.private_key().clone(),
+            forge.signing_key().clone(),
             store.clone(),
         )
         .await?;
@@ -184,7 +184,7 @@ impl Node {
     /// # use p2panda_core::Topic;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let topic = Topic::new();
+    /// # let topic = Topic::random();
     /// # let node = p2panda::builder().spawn().await?;
     /// #
     /// let (tx, _) = node.stream::<String>(topic).await?;
@@ -337,7 +337,7 @@ impl Node {
     }
 
     pub fn id(&self) -> NodeId {
-        self.forge.public_key()
+        self.forge.verifying_key()
     }
 
     pub fn network_id(&self) -> NetworkId {

--- a/p2panda/src/operation.rs
+++ b/p2panda/src/operation.rs
@@ -52,7 +52,7 @@ impl LogId {
     ///
     /// To keep topic itself private we derive it with a BLAKE3 digest.
     pub fn from_topic(topic: Topic) -> Self {
-        LogId(Hash::new(topic.as_bytes()))
+        LogId(Hash::digest(topic.as_bytes()))
     }
 
     pub fn as_bytes(&self) -> &[u8; HASH_LEN] {
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn derive_from_topic() {
-        let topic = Topic::new();
+        let topic = Topic::random();
         let log_id = LogId::from_topic(topic);
         assert_ne!(topic.as_bytes(), log_id.as_bytes());
     }

--- a/p2panda/src/processor/event.rs
+++ b/p2panda/src/processor/event.rs
@@ -3,7 +3,7 @@
 use std::borrow::Borrow;
 
 use p2panda_core::traits::Digest;
-use p2panda_core::{Body, Hash, Header, LogId, Operation, PruneFlag, PublicKey, SeqNum};
+use p2panda_core::{Body, Hash, Header, LogId, Operation, PruneFlag, SeqNum, VerifyingKey};
 use p2panda_stream::ingest::{IngestArgs, IngestError, IngestResult};
 use p2panda_stream::log_prune::{LogPruneArgs, LogPruneError, LogPruneResult};
 use thiserror::Error;
@@ -35,7 +35,7 @@ pub struct Event<L, E, TP> {
     pub(crate) ingest: ProcessorStatus<IngestResult, IngestError>,
 
     /// Input arguments for the "log prune" processor.
-    log_prune_args: LogPruneArgs<PublicKey, L, SeqNum>,
+    log_prune_args: LogPruneArgs<VerifyingKey, L, SeqNum>,
 
     /// Status of the "log prune" processor.
     pub(crate) log_prune: ProcessorStatus<LogPruneResult, LogPruneError>,
@@ -61,7 +61,7 @@ where
             ingest: ProcessorStatus::Pending,
             log_prune_args: if prune_flag.is_set() {
                 LogPruneArgs::PruneEntriesUntil {
-                    author: operation.header.public_key,
+                    author: operation.header.verifying_key,
                     log_id,
                     seq_num: operation.header.seq_num,
                 }
@@ -138,12 +138,12 @@ where
     }
 }
 
-impl<L, E, TP> Borrow<LogPruneArgs<PublicKey, L, SeqNum>> for Event<L, E, TP>
+impl<L, E, TP> Borrow<LogPruneArgs<VerifyingKey, L, SeqNum>> for Event<L, E, TP>
 where
     L: LogId,
     TP: Clone,
 {
-    fn borrow(&self) -> &LogPruneArgs<PublicKey, L, SeqNum> {
+    fn borrow(&self) -> &LogPruneArgs<VerifyingKey, L, SeqNum> {
         &self.log_prune_args
     }
 }

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use futures_util::StreamExt;
 use p2panda_core::traits::Digest;
-use p2panda_core::{Extensions, Hash, LogId, Operation, PublicKey, SeqNum};
+use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
 use p2panda_store::Transaction;
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
@@ -85,8 +85,8 @@ where
         S: Clone
             + Transaction
             + OperationStore<Operation<E>, Hash, L>
-            + LogStore<Operation<E>, PublicKey, L, SeqNum, Hash>
-            + TopicStore<TP, PublicKey, L>
+            + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+            + TopicStore<TP, VerifyingKey, L>
             + Send
             + 'static,
     {
@@ -180,7 +180,7 @@ where
 mod tests {
     use p2panda_core::test_utils::TestLog;
     use p2panda_core::traits::Digest;
-    use p2panda_core::{PrivateKey, PruneFlag, Topic};
+    use p2panda_core::{PruneFlag, SigningKey, Topic};
     use p2panda_store::SqliteStore;
 
     use crate::operation::LogId;
@@ -195,7 +195,7 @@ mod tests {
         let processor = Pipeline::<LogId, (), Topic>::new(store, tasks);
 
         let log = TestLog::new();
-        let topic = Topic::new();
+        let topic = Topic::random();
 
         let mut operation = log.operation(b"test", ());
 
@@ -214,7 +214,7 @@ mod tests {
         assert!(!result.is_failed());
 
         // Replace public key of operation to make it invalid. We expect the processor to fail.
-        operation.header.public_key = PrivateKey::new().public_key();
+        operation.header.verifying_key = SigningKey::generate().verifying_key();
 
         let result = processor
             .process(Event::new(

--- a/p2panda/src/streams/acked.rs
+++ b/p2panda/src/streams/acked.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use p2panda_core::logs::{LogHeights, LogRanges};
-use p2panda_core::{Cursor, Hash, PublicKey, SeqNum, Topic};
+use p2panda_core::{Cursor, Hash, SeqNum, Topic, VerifyingKey};
 use p2panda_store::cursors::CursorStore;
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
@@ -16,7 +16,7 @@ use tokio::sync::Semaphore;
 use crate::operation::{Header, LogId, Operation};
 use crate::streams::StreamFrom;
 
-pub type Logs = BTreeMap<PublicKey, Vec<LogId>>;
+pub type Logs = BTreeMap<VerifyingKey, Vec<LogId>>;
 
 /// Tracks a named cursor for a given topic and persists it in the store.
 #[derive(Clone, Debug)]
@@ -52,15 +52,15 @@ impl Acked {
         &self.cursor_name
     }
 
-    pub async fn cursor(&self) -> Result<Cursor<PublicKey, LogId>, AckedError> {
+    pub async fn cursor(&self) -> Result<Cursor<VerifyingKey, LogId>, AckedError> {
         let cursor = self.store.get_cursor(&self.cursor_name).await?;
         Ok(cursor.unwrap_or(Cursor::new(&self.cursor_name, LogHeights::default())))
     }
 
     async fn replace_cursor(
         &self,
-        new_cursor: Cursor<PublicKey, LogId>,
-    ) -> Result<Cursor<PublicKey, LogId>, AckedError> {
+        new_cursor: Cursor<VerifyingKey, LogId>,
+    ) -> Result<Cursor<VerifyingKey, LogId>, AckedError> {
         // Fail if we try to use a cursor for a different acked state. This should help developers
         // to identify bugs.
         if new_cursor.name() != self.cursor_name {
@@ -81,7 +81,7 @@ impl Acked {
     pub async fn nacked_log_ranges(
         &self,
         from: StreamFrom,
-    ) -> Result<LogRanges<PublicKey, LogId>, AckedError> {
+    ) -> Result<LogRanges<VerifyingKey, LogId>, AckedError> {
         let _permit = self.semaphore.acquire().await;
 
         // Get state vector of local replica for all logs related to this topic.
@@ -125,7 +125,11 @@ impl Acked {
         }
 
         let mut cursor = self.cursor().await?;
-        cursor.advance(header.public_key, header.extensions.log_id, header.seq_num);
+        cursor.advance(
+            header.verifying_key,
+            header.extensions.log_id,
+            header.seq_num,
+        );
 
         tx!(self.store, {
             self.store.set_cursor(&cursor).await?;
@@ -152,20 +156,22 @@ impl Eq for Acked {}
 async fn get_log_heights(
     store: &SqliteStore,
     logs: &Logs,
-) -> Result<LogHeights<PublicKey, LogId>, SqliteError> {
+) -> Result<LogHeights<VerifyingKey, LogId>, SqliteError> {
     let mut result = BTreeMap::new();
 
-    for (public_key, log_ids) in logs {
+    for (verifying_key, log_ids) in logs {
         let Some(log_heights) =
-            LogStore::<Operation, PublicKey, LogId, SeqNum, Hash>::get_log_heights(
-                store, public_key, log_ids,
+            LogStore::<Operation, VerifyingKey, LogId, SeqNum, Hash>::get_log_heights(
+                store,
+                verifying_key,
+                log_ids,
             )
             .await?
         else {
             continue;
         };
 
-        result.insert(*public_key, log_heights);
+        result.insert(*verifying_key, log_heights);
     }
 
     Ok(result)
@@ -196,7 +202,7 @@ mod tests {
 
     #[tokio::test]
     async fn nacked_log_ranges() {
-        let topic = Topic::new();
+        let topic = Topic::random();
         let store = SqliteStore::temporary().await;
         let forge = OperationForge::new(store.clone());
         let log_id = LogId::from_topic(topic);
@@ -230,7 +236,7 @@ mod tests {
         let ranges = acked.nacked_log_ranges(StreamFrom::Frontier).await.unwrap();
         assert_eq!(
             ranges
-                .get(&forge.public_key())
+                .get(&forge.verifying_key())
                 .unwrap()
                 .get(&log_id)
                 .unwrap(),
@@ -250,7 +256,7 @@ mod tests {
 
     #[tokio::test]
     async fn custom_name() {
-        let topic = Topic::new();
+        let topic = Topic::random();
         let store = SqliteStore::temporary().await;
         let forge = OperationForge::new(store.clone());
         let log_id = LogId::from_topic(topic);
@@ -288,7 +294,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             ranges_2
-                .get(&forge.public_key())
+                .get(&forge.verifying_key())
                 .unwrap()
                 .get(&log_id)
                 .unwrap(),
@@ -298,7 +304,7 @@ mod tests {
 
     #[tokio::test]
     async fn replaying_mutates_cursor_state() {
-        let topic = Topic::new();
+        let topic = Topic::random();
         let store = SqliteStore::temporary().await;
         let forge = OperationForge::new(store.clone());
         let log_id = LogId::from_topic(topic);
@@ -329,7 +335,7 @@ mod tests {
         let ranges = acked.nacked_log_ranges(StreamFrom::Start).await.unwrap();
         assert_eq!(
             ranges
-                .get(&forge.public_key())
+                .get(&forge.verifying_key())
                 .unwrap()
                 .get(&log_id)
                 .unwrap(),
@@ -340,7 +346,7 @@ mod tests {
         let ranges = acked.nacked_log_ranges(StreamFrom::Frontier).await.unwrap();
         assert_eq!(
             ranges
-                .get(&forge.public_key())
+                .get(&forge.verifying_key())
                 .unwrap()
                 .get(&log_id)
                 .unwrap(),

--- a/p2panda/src/streams/ephemeral_stream.rs
+++ b/p2panda/src/streams/ephemeral_stream.rs
@@ -8,7 +8,7 @@ use std::task::{Context, Poll};
 use futures_util::{Stream, StreamExt, ready};
 use p2panda_core::cbor::{DecodeError, EncodeError, decode_cbor, encode_cbor};
 use p2panda_core::timestamp::{HybridTimestamp, LamportTimestamp, Timestamp};
-use p2panda_core::{PrivateKey, PublicKey, Signature, Topic};
+use p2panda_core::{Signature, SigningKey, Topic, VerifyingKey};
 use p2panda_net::gossip::{GossipHandle, GossipSubscription};
 use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
@@ -31,7 +31,7 @@ const MESSAGE_VERSION: u64 = 1;
 /// ```plain
 /// (
 ///    version[u64],
-///    public_key[32 bytes],
+///    verifying_key[32 bytes],
 ///    signature[64 bytes],
 ///    timestamp[u64],
 ///    lamport_timestamp[u64],
@@ -41,7 +41,7 @@ const MESSAGE_VERSION: u64 = 1;
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct WrappedMessage<M> {
     version: u64,
-    public_key: PublicKey,
+    verifying_key: VerifyingKey,
     signature: Signature,
     timestamp: HybridTimestamp,
     body: M,
@@ -54,14 +54,14 @@ where
     pub fn new(
         body: M,
         timestamp: HybridTimestamp,
-        private_key: &PrivateKey,
+        signing_key: &SigningKey,
     ) -> Result<Self, EncodeError> {
-        let public_key = private_key.public_key();
-        let signature = Self::sign(private_key, public_key, timestamp, &body)?;
+        let verifying_key = signing_key.verifying_key();
+        let signature = Self::sign(signing_key, verifying_key, timestamp, &body)?;
 
         Ok(Self {
             version: MESSAGE_VERSION,
-            public_key,
+            verifying_key,
             signature,
             timestamp,
             body,
@@ -70,9 +70,9 @@ where
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, WrappedMessageError> {
         // Attempt deserializing message tuple. This fails if the encoding is invalid.
-        let (version, public_key, signature, timestamp, logical, body): (
+        let (version, verifying_key, signature, timestamp, logical, body): (
             u64,
-            PublicKey,
+            VerifyingKey,
             Signature,
             Timestamp,
             LamportTimestamp,
@@ -88,7 +88,7 @@ where
 
         let message = Self {
             version,
-            public_key,
+            verifying_key,
             signature,
             timestamp,
             body,
@@ -104,7 +104,7 @@ where
         let (timestamp, logical) = self.timestamp.to_parts();
         let message = (
             self.version,
-            self.public_key,
+            self.verifying_key,
             self.signature,
             timestamp,
             logical,
@@ -118,7 +118,7 @@ where
         let (timestamp, logical) = self.timestamp.to_parts();
         let message = (
             self.version,
-            self.public_key,
+            self.verifying_key,
             timestamp,
             logical,
             &self.body,
@@ -128,7 +128,7 @@ where
         // the data came from a remote (potentially malicious) node.
         let bytes = encode_cbor(&message).map_err(|_| WrappedMessageError::InvalidSignature)?;
 
-        if !self.public_key.verify(&bytes, &self.signature) {
+        if !self.verifying_key.verify(&bytes, &self.signature) {
             return Err(WrappedMessageError::InvalidSignature);
         }
 
@@ -136,15 +136,15 @@ where
     }
 
     fn sign(
-        private_key: &PrivateKey,
-        public_key: PublicKey,
+        signing_key: &SigningKey,
+        verifying_key: VerifyingKey,
         timestamp: HybridTimestamp,
         body: &M,
     ) -> Result<Signature, EncodeError> {
         let (timestamp, logical) = timestamp.to_parts();
-        let message = (MESSAGE_VERSION, public_key, timestamp, logical, body);
+        let message = (MESSAGE_VERSION, verifying_key, timestamp, logical, body);
         let bytes = encode_cbor(&message)?;
-        Ok(private_key.sign(&bytes))
+        Ok(signing_key.sign(&bytes))
     }
 }
 
@@ -174,8 +174,8 @@ where
         self.topic
     }
 
-    pub fn author(&self) -> PublicKey {
-        self.inner.public_key
+    pub fn author(&self) -> VerifyingKey {
+        self.inner.verifying_key
     }
 
     pub fn timestamp(&self) -> u64 {
@@ -249,7 +249,7 @@ where
         };
 
         let bytes = {
-            let wrapped = WrappedMessage::new(message, timestamp, self.forge.private_key())?;
+            let wrapped = WrappedMessage::new(message, timestamp, self.forge.signing_key())?;
             wrapped.to_bytes()?
         };
 
@@ -328,20 +328,20 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p2panda_core::PrivateKey;
+    use p2panda_core::SigningKey;
     use p2panda_core::timestamp::HybridTimestamp;
 
     use super::WrappedMessage;
 
     #[test]
     fn encoding() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let timestamp = HybridTimestamp::now();
 
         let message_1 = WrappedMessage::new(
             "This message is signed!".to_string(),
             timestamp,
-            &private_key,
+            &signing_key,
         )
         .unwrap();
 
@@ -353,13 +353,13 @@ mod tests {
 
     #[test]
     fn signatures() {
-        let private_key = PrivateKey::new();
+        let signing_key = SigningKey::generate();
         let timestamp = HybridTimestamp::now();
 
         let message = WrappedMessage::new(
             "This message is signed!".to_string(),
             timestamp,
-            &private_key,
+            &signing_key,
         )
         .unwrap();
 

--- a/p2panda/src/streams/replay.rs
+++ b/p2panda/src/streams/replay.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use p2panda_core::logs::LogRanges;
-use p2panda_core::{Cursor, PublicKey, Topic};
+use p2panda_core::{Cursor, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::{SqliteError, SqliteStore};
 use serde::{Deserialize, Serialize};
@@ -33,11 +33,11 @@ pub enum StreamFrom {
     Frontier,
 
     /// Stream all events from _after_ the given cursor position.
-    Cursor(Cursor<PublicKey, LogId>),
+    Cursor(Cursor<VerifyingKey, LogId>),
 }
 
-impl From<Cursor<PublicKey, LogId>> for StreamFrom {
-    fn from(cursor: Cursor<PublicKey, LogId>) -> Self {
+impl From<Cursor<VerifyingKey, LogId>> for StreamFrom {
+    fn from(cursor: Cursor<VerifyingKey, LogId>) -> Self {
         Self::Cursor(cursor)
     }
 }
@@ -50,7 +50,7 @@ pub(crate) async fn replay_log_ranges<M>(
     pipeline: &Pipeline<LogId, Extensions, Topic>,
     ack_policy: AckPolicy,
     acked: &Acked,
-    log_ranges: LogRanges<PublicKey, LogId>,
+    log_ranges: LogRanges<VerifyingKey, LogId>,
 ) -> Result<(), ReplayError>
 where
     M: Serialize + for<'a> Deserialize<'a> + Send + 'static,

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -11,7 +11,7 @@ use futures_util::stream::BoxStream;
 use futures_util::{FutureExt, Stream, StreamExt};
 use p2panda_core::cbor::{DecodeError, EncodeError, decode_cbor, encode_cbor};
 use p2panda_core::traits::Digest;
-use p2panda_core::{Hash, PublicKey, Topic};
+use p2panda_core::{Hash, Topic, VerifyingKey};
 use p2panda_net::NodeId;
 use p2panda_net::sync::SyncHandle;
 use p2panda_net::utils::ShortFormat;
@@ -779,8 +779,8 @@ impl<M> ProcessedOperation<M> {
         self.event.hash()
     }
 
-    pub fn author(&self) -> PublicKey {
-        self.event.header().public_key
+    pub fn author(&self) -> VerifyingKey {
+        self.event.header().verifying_key
     }
 
     pub fn timestamp(&self) -> u64 {

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -13,7 +13,7 @@ use p2panda::test_utils::setup_logging;
 use p2panda_core::cbor::encode_cbor;
 use p2panda_core::logs::LogHeights;
 use p2panda_core::test_utils::TestLog;
-use p2panda_core::{Cursor, Hash, PrivateKey, Topic};
+use p2panda_core::{Cursor, Hash, SigningKey, Topic};
 use p2panda_net::discovery::DiscoveryEvent;
 use p2panda_store::logs::LogStore;
 use tokio::task::JoinHandle;
@@ -33,7 +33,7 @@ async fn build_and_spawn() -> Result<(), Box<dyn std::error::Error>> {
     // Customizable "builder" setup flow.
     let _node = p2panda::builder()
         .database_url("sqlite::memory:")
-        .private_key(PrivateKey::new())
+        .signing_key(SigningKey::generate())
         .spawn()
         .await?;
 
@@ -42,7 +42,7 @@ async fn build_and_spawn() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn ephemeral_stream() {
-    let chat_id = Topic::new();
+    let chat_id = Topic::random();
 
     let panda = p2panda::spawn().await.unwrap();
     let icebear = p2panda::spawn().await.unwrap();
@@ -90,7 +90,7 @@ async fn ephemeral_stream() {
 async fn eventually_consistent_stream() {
     setup_logging();
 
-    let chat_id = Topic::new();
+    let chat_id = Topic::random();
 
     let panda = p2panda::builder().spawn().await.unwrap();
     let icebear = p2panda::builder().spawn().await.unwrap();
@@ -120,7 +120,7 @@ async fn eventually_consistent_stream() {
 async fn event_stream() {
     setup_logging();
 
-    let chat_id = Topic::new();
+    let chat_id = Topic::random();
 
     let panda = p2panda::builder().spawn().await.unwrap();
     let icebear = p2panda::builder().spawn().await.unwrap();
@@ -152,7 +152,7 @@ async fn event_stream() {
 async fn log_prefix_pruning() {
     setup_logging();
 
-    let topic = Topic::new();
+    let topic = Topic::random();
 
     let panda = p2panda::builder().spawn().await.unwrap();
     let icebear = p2panda::builder().spawn().await.unwrap();
@@ -217,7 +217,7 @@ async fn log_prefix_pruning() {
 async fn automatic_acking() {
     setup_logging();
 
-    let topic = Topic::new();
+    let topic = Topic::random();
     let node = p2panda::builder().spawn().await.unwrap();
 
     let (tx, mut rx) = node.stream::<String>(topic).await.unwrap();
@@ -254,7 +254,7 @@ async fn automatic_acking() {
 async fn explicit_acking() {
     setup_logging();
 
-    let topic = Topic::new();
+    let topic = Topic::random();
     let node = p2panda::builder()
         .ack_policy(AckPolicy::Explicit)
         .spawn()
@@ -299,7 +299,7 @@ async fn explicit_acking() {
 async fn replay_stream_from_start() {
     setup_logging();
 
-    let chat_id = Topic::new();
+    let chat_id = Topic::random();
 
     let panda = p2panda::builder().spawn().await.unwrap();
     let icebear = p2panda::builder().spawn().await.unwrap();
@@ -343,7 +343,7 @@ async fn replay_stream_from_start() {
 async fn replay_stream_from_cursor() {
     setup_logging();
 
-    let topic = Topic::new();
+    let topic = Topic::random();
     let node = p2panda::builder().spawn().await.unwrap();
 
     let (tx, rx) = node.stream::<String>(topic).await.unwrap();
@@ -391,7 +391,7 @@ async fn replay_stream_from_cursor() {
 async fn import_external_stream() {
     setup_logging();
 
-    let chat_id = Topic::new();
+    let chat_id = Topic::random();
 
     // Panda opens their app and publishes some messages into a chat.
     let panda_log = TestLog::new();
@@ -486,7 +486,7 @@ async fn import_external_stream() {
 async fn deduplicate_events() {
     setup_logging();
 
-    let chat_id = Topic::new();
+    let chat_id = Topic::random();
 
     let panda = p2panda::builder().spawn().await.unwrap();
     let icebear = p2panda::builder().spawn().await.unwrap();


### PR DESCRIPTION
* `PrivateKey` -> `SigningKey`
* `PublicKey` -> `VerifyingKey`
* `PrivateKey::new` -> `SigningKey::generate`
* `Hash::new` -> `Hash::digest`
* `Topic::new` -> `Topic::random`

Closes: #1151 and #1152

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
