### PR TITLE
Linting rules against unused `&mut` arguments and async methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Highlights are marked with a pancake 🥞
 ### Fixed
 
 - encryption: Update hpke-rs to 0.6.1 to fix RUSTSEC [#1233](https://github.com/p2panda/p2panda/pull/1233)
+- ci: Check for unused mut and async, fix affected methods [#1163](https://github.com/p2panda/p2panda/pull/1163)
 
 ## [0.6.1] - 22/05/2026
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ members = [
     "p2panda-sync",
 ]
 
-[workspace.lints.rust]
+[workspace.lints.clippy]
+unused_async = "warn"
+needless_pass_by_ref_mut = "warn"
 
 [workspace.dependencies]
 blake3 = { version = "1.8.5" }

--- a/p2panda-auth/examples/groups.rs
+++ b/p2panda-auth/examples/groups.rs
@@ -222,7 +222,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     process_tx.send(operation.clone()).unwrap();
                     print_group(&store, &operation).await;
 
-                    sync_tx.publish(operation).await.unwrap();
+                    sync_tx.publish(operation).unwrap();
                 }
             });
 

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -319,7 +319,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap();
             store.commit(permit).await.unwrap();
 
-            sync_tx.publish(operation).await.unwrap();
+            sync_tx.publish(operation).unwrap();
 
             seq_num += 1;
             backlink = Some(hash);

--- a/p2panda-net/src/discovery/actors/manager.rs
+++ b/p2panda-net/src/discovery/actors/manager.rs
@@ -608,7 +608,7 @@ impl ThreadLocalActor for DiscoveryManager {
 /// Populates the address book with results from discovery session and returns number of newly
 /// learned transport infos.
 async fn insert_address_book(
-    state: &mut DiscoveryManagerState,
+    state: &DiscoveryManagerState,
     discovery_result: DiscoveryResult<NodeId, NodeInfo>,
 ) -> usize {
     // Populate address book with hopefully new transport info.

--- a/p2panda-net/src/sync/handle.rs
+++ b/p2panda-net/src/sync/handle.rs
@@ -45,7 +45,7 @@ where
     }
 
     /// Publishes a message to the stream.
-    pub async fn publish(&self, data: M) -> Result<(), SyncHandleError<M, E>> {
+    pub fn publish(&self, data: M) -> Result<(), SyncHandleError<M, E>> {
         // This would likely be a critical failure for this stream handle, since we are unable to
         // send messages to the sync manager.
         self.topic_manager_ref

--- a/p2panda-net/src/sync/log_sync/tests.rs
+++ b/p2panda-net/src/sync/log_sync/tests.rs
@@ -132,7 +132,6 @@ async fn e2e_log_sync() {
             header,
             body: Some(body),
         })
-        .await
         .unwrap();
 
     // Bob receives Alice's live message.
@@ -292,7 +291,6 @@ async fn e2e_three_party_sync() {
             header,
             body: Some(body),
         })
-        .await
         .unwrap();
 
     // Bob receives Alice's live message.

--- a/p2panda-spaces/src/identity.rs
+++ b/p2panda-spaces/src/identity.rs
@@ -49,7 +49,8 @@ where
     F: Forge<C>,
     C: Conditions,
 {
-    pub async fn new(
+    #[allow(clippy::result_large_err)]
+    pub fn new(
         key_store: S,
         forge: F,
         credentials: Credentials,
@@ -74,14 +75,14 @@ where
     /// The local actor id and their long-term key bundle.
     ///
     /// Note: Key bundle will be rotated if the latest is reaching it's configured expiry date.
-    pub(crate) async fn me(&mut self) -> Result<Member, IdentityError<F, C>> {
+    pub(crate) async fn me(&self) -> Result<Member, IdentityError<F, C>> {
         Ok(Member::new(self.id(), self.key_bundle().await?))
     }
 
     /// Returns "latest", publishable key bundle of us or automatically generates a new one if
     /// either nothing was generated yet, if previous bundles expired or are about to be expired
     /// (given an additional "pessimistic" rotation window).
-    async fn key_bundle(&mut self) -> Result<LongTermKeyBundle, IdentityError<F, C>> {
+    async fn key_bundle(&self) -> Result<LongTermKeyBundle, IdentityError<F, C>> {
         let key_manager_y = self.key_manager().await?;
 
         let valid_bundle = match KeyManager::prekey_bundle(&key_manager_y) {
@@ -303,10 +304,8 @@ mod tests {
         let store = SqliteStore::temporary().await;
         let forge = TestForge::new(store.clone(), credentials.signing_key());
 
-        let mut identity_manager =
-            IdentityManager::new(store, forge, credentials.clone(), config, &rng)
-                .await
-                .unwrap();
+        let identity_manager =
+            IdentityManager::new(store, forge, credentials.clone(), config, &rng).unwrap();
 
         let me = identity_manager.me().await.unwrap();
         let bundle: &LongTermKeyBundle = me.key_bundle();
@@ -327,9 +326,7 @@ mod tests {
         let forge = TestForge::new(store.clone(), credentials.signing_key());
 
         let mut identity_manager =
-            IdentityManager::new(store, forge, credentials.clone(), config, &rng)
-                .await
-                .unwrap();
+            IdentityManager::new(store, forge, credentials.clone(), config, &rng).unwrap();
 
         let msg = identity_manager.key_bundle_message().await.unwrap();
 
@@ -359,7 +356,6 @@ mod tests {
             alice_config,
             &alice_rng,
         )
-        .await
         .unwrap();
 
         let bob_rng = Rng::from_seed([2; 32]);
@@ -369,14 +365,13 @@ mod tests {
         let bob_store = SqliteStore::temporary().await;
         let bob_forge = TestForge::new(bob_store.clone(), bob_credentials.signing_key());
 
-        let mut bob_identity_manager = IdentityManager::new(
+        let bob_identity_manager = IdentityManager::new(
             bob_store,
             bob_forge,
             bob_credentials.clone(),
             bob_config,
             &bob_rng,
         )
-        .await
         .unwrap();
         let bob_id = bob_credentials.verifying_key().into();
 
@@ -409,9 +404,7 @@ mod tests {
         let forge = TestForge::new(store.clone(), credentials.signing_key());
 
         let mut alice_identity_manager =
-            IdentityManager::new(store, forge, credentials, config, &rng)
-                .await
-                .unwrap();
+            IdentityManager::new(store, forge, credentials, config, &rng).unwrap();
 
         let alice_1 = alice_identity_manager.me().await.unwrap();
         let bundle_1 = alice_1.key_bundle().clone();

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -87,18 +87,18 @@ where
 {
     /// Instantiate a new manager.
     #[allow(clippy::result_large_err)]
-    pub async fn new(
+    pub fn new(
         store: S,
         forge: F,
         credentials: Credentials,
         rng: Rng,
     ) -> Result<Self, ManagerError<F, C, RS>> {
-        Self::new_with_config(store, forge, credentials, &Config::default(), rng).await
+        Self::new_with_config(store, forge, credentials, &Config::default(), rng)
     }
 
     /// Instantiate a new manager with custom configuration.
     #[allow(clippy::result_large_err)]
-    pub async fn new_with_config(
+    pub fn new_with_config(
         store: S,
         forge: F,
         credentials: Credentials,
@@ -107,7 +107,7 @@ where
     ) -> Result<Self, ManagerError<F, C, RS>> {
         let actor_id: ActorId = credentials.verifying_key();
         let identity =
-            IdentityManager::new(store.clone(), forge, credentials, config.clone(), &rng).await?;
+            IdentityManager::new(store.clone(), forge, credentials, config.clone(), &rng)?;
         let inner = ManagerInner {
             store,
             identity,
@@ -302,7 +302,7 @@ where
     ///
     /// Note: Key bundle will be rotated if the latest is reaching it's configured expiry date.
     pub async fn me(&self) -> Result<Member, ManagerError<F, C, RS>> {
-        let mut manager = self.inner.write().await;
+        let manager = self.inner.write().await;
         manager
             .identity
             .me()

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -212,8 +212,7 @@ where
                 current_members.clone(),
                 next_members.clone(),
                 &manager.rng,
-            )
-            .await?
+            )?
         } else {
             (y.encryption_y, vec![])
         };
@@ -395,9 +394,10 @@ where
     /// Apply a group membership change to the group encryption state.
     ///
     /// For "add" and "remove" actions, the difference between the current and next secret group
-    /// members (those with "read" access) is computed and only the diff processed on the
-    /// encryption group.
-    async fn apply_secret_member_change(
+    /// members (those with "read" access) is computed and only the diff processed on the encryption
+    /// group.
+    #[allow(clippy::result_large_err)]
+    fn apply_secret_member_change(
         mut encryption_y: EncryptionGroupState,
         auth_message: &AuthMessage<C>,
         current_members: Vec<ActorId>,

--- a/p2panda-spaces/src/test_utils/mod.rs
+++ b/p2panda-spaces/src/test_utils/mod.rs
@@ -75,7 +75,6 @@ impl TestPeer {
             config,
             rng,
         )
-        .await
         .unwrap();
 
         Self {

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -658,7 +658,7 @@ mod tests {
         run_protocol(peer_a_session, peer_b_session).await.unwrap();
 
         // Assert Peer B's events.
-        let events = drain_stream(event_stream).await;
+        let events = drain_stream(event_stream);
         assert_eq!(events.len(), 6);
         for (index, event) in events.into_iter().enumerate() {
             match index {

--- a/p2panda-sync/src/test_utils.rs
+++ b/p2panda-sync/src/test_utils.rs
@@ -201,7 +201,7 @@ where
     Ok((result, remote_message_rx))
 }
 
-pub async fn drain_stream<S>(mut stream: S) -> Vec<S::Item>
+pub fn drain_stream<S>(mut stream: S) -> Vec<S::Item>
 where
     S: Stream + Unpin,
 {

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -671,7 +671,6 @@ where
         // sync protocol.
         self.sync_handle
             .publish(operation)
-            .await
             .map_err(|err| PublishError::SyncHandle(err.to_string()))?;
 
         Ok(PublishFuture { hash, processed_rx })


### PR DESCRIPTION
Add the following to the workspace lints table:

```toml
[workspace.lints.clippy]
unused_async = "warn"
needless_pass_by_ref_mut = "warn"
```

closes: #1063 #1089 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
