### PR TITLE
Fix: revert dependency feature flags to previously working state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Highlights are marked with a pancake 🥞
 - Ensure iroh Gossip is shut down gracefully [#1139](https://github.com/p2panda/p2panda/pull/1139)
 - Correct "Sync Ended" event semantics in Node API [#1154](https://github.com/p2panda/p2panda/pull/1154)
 - Fix header CBOR encoding with correct field count [#1157](https://github.com/p2panda/p2panda/pull/1157)
+- Fix issues caused by dependency feature flag changes [#1164](https://github.com/p2panda/p2panda/pull/1164)
 
 ## [0.5.2] - 09/03/2026
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ members = [
 [workspace.lints.rust]
 
 [workspace.dependencies]
-ciborium = { version = "0.2.2", default-features = false}
+ciborium = { version = "0.2.2" }
 futures-util = { version = "0.3.32", default-features = false }
-hex = { version = "0.4.3", default-features = false }
+hex = { version = "0.4.3" }
 p2panda = { path = "p2panda", version = "0.5.2", default-features = false }
 p2panda-auth = { path = "p2panda-auth", version = "0.5.2", default-features = false }
 p2panda-core = { path = "p2panda-core", version = "0.5.2", default-features = false }
@@ -31,11 +31,11 @@ p2panda-spaces = { path = "p2panda-spaces", version = "0.5.2", default-features 
 p2panda-store = { path = "p2panda-store", version = "0.5.2", default-features = false }
 p2panda-stream = { path = "p2panda-stream", version = "0.5.2", default-features = false }
 p2panda-sync = { path = "p2panda-sync", version = "0.5.2", default-features = false }
-rand = { version = "0.10.1", default-features = false }
-rand_chacha = { version = "0.10.0", default-features = false }
-serde = { version = "1.0.228", default-features = false }
-thiserror = { version = "2.0.18", default-features = false }
+rand = { version = "0.10.1" }
+rand_chacha = { version = "0.10.0" }
+serde = { version = "1.0.228" }
+thiserror = { version = "2.0.18" }
 tokio = { version = "1.52.3", default-features = false }
-tokio-stream = { version = "0.1.18", default-features = false }
-tracing = { version = "0.1.44", default-features = false }
-tracing-subscriber = { version = "0.3.23", default-features = false }
+tokio-stream = { version = "0.1.18" }
+tracing = { version = "0.1.44" }
+tracing-subscriber = { version = "0.3.23" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,10 +9,10 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-p2panda-auth = { workspace = true, features = ["test_utils"] }
-p2panda-core = { workspace = true, features = ["arbitrary"] }
-p2panda-encryption = { workspace = true, features = ["test_utils"] }
-rand = { workspace = true, features = ["alloc"] }
+p2panda-auth = { workspace = true, default-features = true, features = ["test_utils"] }
+p2panda-core = { workspace = true, default-features = true, features = ["arbitrary"] }
+p2panda-encryption = { workspace = true, default-features = true, features = ["test_utils"] }
+rand = { workspace = true, default-features = true, features = ["alloc"] }
 
 [[bin]]
 name = "header_e2e"

--- a/p2panda-auth/Cargo.toml
+++ b/p2panda-auth/Cargo.toml
@@ -36,26 +36,26 @@ serde = ["dep:serde"]
 test = ["test_utils"]
 
 [dependencies]
-p2panda-core = { workspace = true, optional = true }
-p2panda-store = { workspace = true, optional = true }
-p2panda-stream = { workspace = true, optional = true }
+p2panda-core = { workspace = true, default-features = true, optional = true }
+p2panda-store = { workspace = true, default-features = true, optional = true }
+p2panda-stream = { workspace = true, default-features = true, optional = true }
 petgraph = { version = "0.8.3", features = ["serde-1"] }
 rand = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync", "signal"], optional = true }
+tokio = { workspace = true, default-features = true, features = ["sync", "signal"], optional = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.102"
-ciborium = { workspace = true }
-futures-util = { workspace = true }
-p2panda-auth = { workspace = true, features = ["test_utils"] }
-p2panda-core = { workspace = true, features = ["test_utils"] }
-p2panda-net = { workspace = true }
-p2panda-store = { workspace = true, features = ["test_utils"] }
-p2panda-sync = { workspace = true }
+ciborium = "0.2.2"
+futures-util = "0.3.32"
+p2panda-auth = { workspace = true, default-features = true, features = ["test_utils"] }
+p2panda-core = { workspace = true, default-features = true, features = ["test_utils"] }
+p2panda-net = { workspace = true, default-features = true }
+p2panda-store = { workspace = true, default-features = true, features = ["test_utils"] }
+p2panda-sync = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/p2panda-core/Cargo.toml
+++ b/p2panda-core/Cargo.toml
@@ -27,9 +27,9 @@ test_utils = ["dep:mock_instant"]
 [dependencies]
 arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
 blake3 = "1.8.1"
-ciborium = { workspace = true, default-features = true }
+ciborium = { workspace = true }
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
-hex = { workspace = true, features = ["serde"], default-features = true }
+hex = { workspace = true, features = ["serde"] }
 mock_instant = { version = "0.6.0", optional = true }
 rand = "0.8.5"
 serde = { workspace = true, features = ["derive"] }
@@ -37,5 +37,5 @@ serde_bytes = { version = "0.11.17" }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-p2panda-core = { workspace = true, features = ["test_utils"] }
+p2panda-core = { workspace = true, default-features = true, features = ["test_utils"] }
 serde_json = "1.0.140"

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -68,24 +68,22 @@ test_utils = [
 [dependencies]
 ciborium = { workspace = true }
 futures-channel = "0.3.31"
-futures-util = { workspace = true }
-hex = { workspace = true }
-iroh = { version = "0.98.2", default-features = false, features = [
-  "tls-ring",
-], optional = true }
+futures-util = { workspace = true, default-features = true }
+hex =  { workspace = true }
+iroh = { version = "0.98.2", default-features = false, features = ["tls-ring"], optional = true }
 iroh-base = { version = "0.98.0", optional = true }
 iroh-gossip = { version = "0.98.0", optional = true }
-p2panda-core = { workspace = true }
-p2panda-discovery = { workspace = true, optional = true, features = ["random_walk"] }
-p2panda-store = { workspace = true, optional = true }
-p2panda-sync = { workspace = true, optional = true }
+p2panda-core = { workspace = true, default-features = true }
+p2panda-discovery = { workspace = true, default-features = true, optional = true }
+p2panda-store = { workspace = true, default-features = true, optional= true }
+p2panda-sync = { workspace = true, default-features = true, optional = true }
 ractor = "0.15.8"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt", "sync"] }
-tokio-stream = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, default-features = true, features = ["rt", "sync"] }
+tokio-stream = { version = "0.1.17", features = ["sync"] }
 tokio-util = { version = "0.7.16", features = ["codec", "compat"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
@@ -96,9 +94,9 @@ assert_matches = "1.5.0"
 clap = { version = "4.5.54", features = ["derive"] }
 futures-test = "0.3.31"
 mock_instant = "0.6.0"
-p2panda-discovery = { workspace = true, features = ["test_utils"] }
-p2panda-net = { workspace = true, features = ["test_utils"] }
-p2panda-store = { workspace = true, features = ["test_utils"] }
-p2panda-sync = { workspace = true, features = ["test_utils"] }
-tokio = { workspace = true, features = ["rt", "sync", "time", "signal"] }
+p2panda-discovery = { workspace = true, default-features = true, features = ["test_utils"] }
+p2panda-net = { workspace = true, default-features = true, features = ["test_utils"] }
+p2panda-store = { workspace = true, default-features = true, features = ["test_utils"] }
+p2panda-sync = { workspace = true, default-features = true, features = ["test_utils"] }
+tokio = { workspace = true, default-features = true, features = ["rt", "sync", "time", "signal"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/p2panda-spaces/Cargo.toml
+++ b/p2panda-spaces/Cargo.toml
@@ -24,16 +24,16 @@ test_utils = [
 ]
 
 [dependencies]
-p2panda-auth = { workspace = true, features = ["serde"] }
-p2panda-core = { workspace = true }
-p2panda-encryption = { workspace = true, features = ["data_scheme"] }
+p2panda-auth = { workspace = true, features = ["serde"], default-features = false }
+p2panda-core = { workspace = true, default-features = false }
+p2panda-encryption = { workspace = true, features = ["data_scheme"], default-features = false }
 petgraph = "0.8.2"
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, default-features = true, features = ["sync"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-p2panda-auth = { workspace = true, features = ["test_utils"] }
-p2panda-encryption = { workspace = true, features = ["test_utils"] }
-tokio = { workspace = true, features = ["rt", "macros"] }
+p2panda-auth = { workspace = true, features = ["test_utils"], default-features = false }
+p2panda-encryption = { workspace = true, features = ["test_utils"], default-features = false }
+tokio = { workspace = true, default-features = true, features = ["rt", "macros"] }

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -39,15 +39,15 @@ test_utils = [
 
 [dependencies]
 p2panda-core = { workspace = true }
-rand = { workspace = true, default-features = true, optional = true }
-rand_chacha = { workspace = true, default-features = true, optional = true }
+rand = { workspace = true, optional = true }
+rand_chacha = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite"], optional = true }
 thiserror = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["sync"], optional = true }
+tokio = { workspace = true, default-features = true, features = ["sync"], optional = true }
 
 [dev-dependencies]
 futures-test = "0.3.31"
 p2panda-core = { workspace = true, features = ["test_utils"] }
-p2panda-store = { workspace = true, features = ["test_utils"] }
-tokio = { workspace = true, features = ["rt", "macros"] }
+p2panda-store = { workspace = true, default-features = true, features = ["test_utils"] }
+tokio = { workspace = true, default-features = true, features = ["rt", "macros"] }

--- a/p2panda-stream/Cargo.toml
+++ b/p2panda-stream/Cargo.toml
@@ -29,7 +29,7 @@ ingest = [
   "dep:p2panda-core",
 ]
 log_prune = [
-  "p2panda-core/prune",
+  "dep:p2panda-core",
 ]
 orderer = [
   "dep:p2panda-core",
@@ -39,17 +39,17 @@ orderer = [
 
 [dependencies]
 futures-core = { version = "0.3.31", default-features = false, features = ["alloc"] }
-p2panda-core = { workspace = true, optional = true }
-p2panda-store = { workspace = true, optional = true }
+p2panda-core = { workspace = true, default-features = true, optional = true }
+p2panda-store = { workspace = true, default-features = true, optional = true }
 pin-project = "1.1.10"
-thiserror = { version = "2.0.16", optional = true }
-tokio = { workspace = true, features = ["rt", "sync", "macros"] }
+thiserror = { workspace = true, optional = true }
+tokio = { workspace = true, default-features = false, features = ["rt", "sync", "macros"] }
 
 [dev-dependencies]
 futures-test = { version = "0.3.31" }
-futures-util = { workspace = true, features = ["alloc"] }
-p2panda-core = { workspace = true, features = ["test_utils"] }
-p2panda-store = { workspace = true, features = ["test_utils"] }
+futures-util = { workspace = true, default-features = false, features = ["alloc"] }
+p2panda-core = { workspace = true, default-features = true, features = ["test_utils"] }
+p2panda-store = { workspace = true, default-features = true, features = ["test_utils"] }
 serde = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
-tokio-stream = { workspace = true }
+tokio = { workspace = true, default-features = true, features = ["macros", "rt", "sync", "time"] }
+tokio-stream = { version = "0.1.17", default-features = false }

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -28,21 +28,21 @@ test_utils = [
 
 [dependencies]
 futures = "0.3.31"
-futures-util = { workspace = true }
-p2panda-core = { workspace = true }
-p2panda-store = { workspace = true }
+futures-util = { workspace = true, default-features = true }
+p2panda-core = { workspace = true, default-features = true }
+p2panda-store = { workspace = true, default-features = true }
 pin-project-lite = "0.2.16"
 rand = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "sync"] }
-tokio-stream = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, default-features = true, features = ["macros", "sync"] }
+tokio-stream = { version = "0.1.17", features = ["sync"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-p2panda-store = { workspace = true, features = ["test_utils"] }
+p2panda-store = { workspace = true, default-features = true, features = ["test_utils"] }
 rand = { workspace = true }
-tokio = { workspace = true, features = ["time", "rt", "macros", "sync"] }
+tokio = { workspace = true, default-features = true, features = ["time", "rt", "macros", "sync"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/p2panda/Cargo.toml
+++ b/p2panda/Cargo.toml
@@ -27,22 +27,22 @@ test_utils = [
 
 [dependencies]
 futures-util = { workspace = true }
-p2panda-core = { workspace = true }
+p2panda-core = { workspace = true, default-features = true }
 p2panda-net = { workspace = true, default-features = true }
 p2panda-store = { workspace = true, default-features = true }
-p2panda-stream = { workspace = true, features = ["ingest", "log_prune"] }
-p2panda-sync = { workspace = true }
+p2panda-stream = { workspace = true, default-features = true, features = ["ingest", "log_prune"] }
+p2panda-sync = { workspace = true, default-features = true }
 pin-project = "1.1.10"
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, default-features = true, features = ["sync"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
 
 [dev-dependencies]
 mock_instant = "0.6.0"
-p2panda = { workspace = true, features = ["test_utils"] }
-p2panda-core = { workspace = true, features = ["test_utils"] }
-p2panda-store = { workspace = true, features = ["test_utils"] }
-tokio = { workspace = true, features = ["macros", "rt"] }
+p2panda = { workspace = true, default-features = true, features = ["test_utils"] }
+p2panda-core = { workspace = true, default-features = true, features = ["test_utils"] }
+p2panda-store = { workspace = true, default-features = true, features = ["test_utils"] }
+tokio = { workspace = true, default-features = true, features = ["macros", "rt"] }


### PR DESCRIPTION
Revert feature flags for dependencies to state before 7f2c9da4e8ddff7319725b3f66b14eb2d239c269 while still using workplace level dependencies.

Run this command to view the diff between Cargo.toml files: `git diff 1e8883dc 18472def */Cargo.toml`

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`

