### PR TITLE
Minor improvements to p2panda `Node` docs

### DIFF
--- a/p2panda/src/lib.rs
+++ b/p2panda/src/lib.rs
@@ -27,7 +27,7 @@
 //!   to a topic
 //! - Transport-agnostic event delivery architecture supporting Internet p2p today (QUIC/iroh) and
 //!   future mesh/radio transports such as BLE and LoRa
-//! - Built on single-writer append-only, fork-resistant CRDT operation logs with pruning,
+//! - Built on single-writer append-only, fork-tolerant CRDT operation logs with pruning,
 //!   multi-writer causal ordering, and efficient sync
 //! - Persistent local SQLite storage for operations, sync state, address books, stream cursors, and
 //!   soon encryption/access-control state

--- a/p2panda/src/network.rs
+++ b/p2panda/src/network.rs
@@ -124,7 +124,7 @@ impl Network {
 /// mDNS discovery mode.
 ///
 /// By default this is set to "active" meaning we are actively advertising our address and public
-/// key on local-area networks on local-area networks.
+/// key on local-area networks.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum MdnsDiscoveryMode {
     /// mDNS discovery disabled.

--- a/p2panda/src/processor/event.rs
+++ b/p2panda/src/processor/event.rs
@@ -83,13 +83,13 @@ where
         self.operation.body.as_ref()
     }
 
-    /// Returns true if event has been successfully processed by the whole pipeline.
+    /// Returns `true` if event has been successfully processed by the whole pipeline.
     pub fn is_completed(&self) -> bool {
         matches!(self.ingest, ProcessorStatus::Completed(_))
             && matches!(self.log_prune, ProcessorStatus::Completed(_))
     }
 
-    /// Returns true if event failed somewhere during processing.
+    /// Returns `true` if event failed somewhere during processing.
     pub fn is_failed(&self) -> bool {
         matches!(self.ingest, ProcessorStatus::Failed(_))
             || matches!(self.log_prune, ProcessorStatus::Failed(_))

--- a/p2panda/src/streams/sync_metrics.rs
+++ b/p2panda/src/streams/sync_metrics.rs
@@ -157,6 +157,14 @@ impl Aggregator {
 }
 
 /// Which phase of a sync session an operation arrived in.
+///
+/// Nodes running the sync protocol will first exchange messages in order to catch up on past
+/// state. Once this initial `Sync` phase is complete, both nodes will hold identical sets of
+/// operations for the topic over which the sync session is running.
+///
+/// The nodes then move into the `Live` phase, where any newly-published messages for the relevant
+/// topic will be sent immediately over the sync session - without the nodes first having to
+/// announce and synchronise over their respective states.
 #[derive(Clone, Debug)]
 pub enum SessionPhase {
     Sync,


### PR DESCRIPTION
Changes include the removal of duplicate text, highlighting of boolean return values, expanded documentation for the sync `SessionPhase` type and the use of fork-tolerant instead of -resistant.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
