### PR TITLE
Fix pruning logic in LWW TODO example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove pruning logic in LWW TODO example [#1172](https://github.com/p2panda/p2panda/pull/1172)
+
 ## [0.6.0] - 18/05/2026
 
 ### Added

--- a/p2panda/examples/todo.rs
+++ b/p2panda/examples/todo.rs
@@ -297,11 +297,6 @@ async fn main() -> Result<()> {
 
             // Parse user input via stdin. These inputs trigger our "commands" which again will
             // create and publish single events into the topic stream via `tx`.
-            //
-            // We "prune" on every published event, which will automatically remove all previously
-            // published messages (also for other nodes) from us. Since we are working with a
-            // LWW-logic, we don't need to keep around old messages, keeping storage usage to a
-            // minimum.
             Some(input) = line_rx.recv() => {
                 // Create a new todo list item.
                 //
@@ -310,7 +305,7 @@ async fn main() -> Result<()> {
                 // ```
                 if let Some(description) = input.strip_prefix("/create") {
                     let event = todo_list.create(description.trim());
-                    tx.prune(Some(event)).await?;
+                    tx.publish(event).await?;
                 }
 
                 // Update an existing todo list item.
@@ -344,7 +339,7 @@ async fn main() -> Result<()> {
 
                     match todo_list.update(item_id, description.trim()) {
                         Ok(event) => {
-                            tx.prune(Some(event)).await?;
+                            tx.publish(event).await?;
                         }
                         Err(err) => {
                             println!("err: {}", err);
@@ -372,7 +367,7 @@ async fn main() -> Result<()> {
 
                     match todo_list.delete(item_id) {
                         Ok(event) => {
-                            tx.prune(Some(event)).await?;
+                            tx.publish(event).await?;
                         }
                         Err(err) => {
                             println!("✖ err: {err}");


### PR DESCRIPTION
Pruning the log on every event removes all previous events and will not allow late-coming users to sync past data.

If we would like to prune on every published change we would need to keep a log per todo item, but this is not part of this example.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
