### PR TITLE
Fix premature termination of `p2panda-sync` stream on duplicate events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
-### Fixed
-
-- Remove pruning logic in LWW TODO example [#1172](https://github.com/p2panda/p2panda/pull/1172)
-
 ### Changed
 
 - Deduplicate `setup_logging` test utility [#1178](https://github.com/p2panda/p2panda/pull/1178)
+
+### Fixed
+
+- Remove pruning logic in LWW TODO example [#1172](https://github.com/p2panda/p2panda/pull/1172)
+- Fix premature termination of p2panda-sync stream on duplicate events [#1182](https://github.com/p2panda/p2panda/pull/1182)
 
 ## [0.6.0] - 18/05/2026
 

--- a/p2panda-sync/src/manager/event_stream.rs
+++ b/p2panda-sync/src/manager/event_stream.rs
@@ -142,7 +142,7 @@ where
                         // it means we have received it before on this event stream and should not
                         // return it again to any consumers.
                         if !state.dedup.insert(operation.hash()) {
-                            return (state, None)
+                            continue;
                         }
                     }
 

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -562,13 +562,11 @@ mod tests {
                 tokio::select! {
                     Some(event) = event_stream_a.next() => {
                         if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
-                            println!("A received operation: {}", operation.hash);
                             operations_a.push(operation.header().clone());
                         }
                     }
                     Some(event) = event_stream_b.next() => {
                         if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
-                            println!("B received operation: {}", operation.hash);
                             operations_b.push(operation.header().clone());
                         }
                     }

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -310,8 +310,6 @@ async fn replay_stream_from_start() {
         panda_tx.publish("Hello, Icebear!".into()).await.unwrap();
     }
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
     // Panda subscribes again, this time asking to replay all messages.
     let (_panda_tx, mut panda_rx) = panda
         .stream_from::<String>(chat_id, StreamFrom::Start)


### PR DESCRIPTION
Closes #1181 and #1179 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
