### PR TITLE
Show features on docs.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Highlights are marked with a pancake 🥞
 ### Added
 
 - Emit started & ended events with total operations count when re-playing topic stream [#1175](https://github.com/p2panda/p2panda/pull/1175)
+- Show Rust feature flags on docs.rs [#1185](https://github.com/p2panda/p2panda/pull/1185)
 
 ### Changed
 

--- a/p2panda-auth/Cargo.toml
+++ b/p2panda-auth/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["auth", "access-control", "groups", "crdt", "offline-first"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["processor"]

--- a/p2panda-auth/src/lib.rs
+++ b/p2panda-auth/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! `p2panda-auth` provides decentralised group management with fine-grained, per-member
 //! permissions.
 //!

--- a/p2panda-blobs/Cargo.toml
+++ b/p2panda-blobs/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["storage", "streaming", "blobs", "bao", "blake3"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/p2panda-blobs/src/lib.rs
+++ b/p2panda-blobs/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#![cfg_attr(doctest, doc=include_str!("../README.md"))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // TODO: Needs refactoring since p2panda-net refactor.

--- a/p2panda-core/Cargo.toml
+++ b/p2panda-core/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["p2p", "data-types", "blake3", "cbor", "ed25519"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/p2panda-core/src/lib.rs
+++ b/p2panda-core/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 #![cfg_attr(doctest, doc=include_str!("../README.md"))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Core data types used across the p2panda stack to offer distributed, secure and efficient data
 //! transfer between peers.

--- a/p2panda-discovery/Cargo.toml
+++ b/p2panda-discovery/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["p2p", "discovery", "confidential"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/p2panda-discovery/src/lib.rs
+++ b/p2panda-discovery/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Traits and implementation of p2panda's confidential discovery protocol.
 //!
 //! ## Motivation

--- a/p2panda-encryption/Cargo.toml
+++ b/p2panda-encryption/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["p2p", "encryption", "groups", "double-ratchet"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/p2panda-encryption/src/lib.rs
+++ b/p2panda-encryption/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! `p2panda-encryption` provides decentralized, secure data- and message encryption for groups
 //! with post-compromise security and optional forward secrecy.
 //!

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["p2p", "local-first", "sync", "gossip", "discovery"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Data-type-agnostic p2p networking, discovery, gossip and local-first sync.
 //!
 //! ## Features

--- a/p2panda-spaces/Cargo.toml
+++ b/p2panda-spaces/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/p2panda-spaces/src/lib.rs
+++ b/p2panda-spaces/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 mod auth;
 mod config;
 mod credentials;

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["local-first", "p2p", "database", "sqlite", "transactions"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Trait definitions and SQLite implementations for persistent stores used by p2panda.
 //!
 //! This crate provides generic trait definitions to flexibly express storage and query behaviour

--- a/p2panda-stream/Cargo.toml
+++ b/p2panda-stream/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["eventsourcing", "processing", "p2p", "local-first", "stream"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/p2panda-stream/src/lib.rs
+++ b/p2panda-stream/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Interfaces to implement and compose event processors on top of data streams with some p2panda
 //! implementations out-of-the-box, wrapping existing p2panda crates for causal message ordering,
 //! log validation, access control and group encryption CRDTs which might come in handy for some

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["p2p", "local-first", "sync", "replication"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/p2panda-sync/src/lib.rs
+++ b/p2panda-sync/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Data-type agnostic interfaces for implementing sync protocols and managers which can be used
 //! stand-alone or as part of the local-first stack provided by
 //! [`p2panda-net`].

--- a/p2panda/Cargo.toml
+++ b/p2panda/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["p2p", "local-first", "sync", "event-sourcing"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/p2panda/src/lib.rs
+++ b/p2panda/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! p2panda's high-level Node API is an opinionated, out-of-the-box peer-to-peer stack which
 //! orchestrates all individual [p2panda] modules.
 //!


### PR DESCRIPTION
We want to render a little feature flag symbol next to each method which requires one on docs.rs. This needs to be enabled

doc_cfg is (still) a nightly feature, see:

<https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html>.

docs.rs fortunately runs on nightly, but we don't want to enforce it for our workspace. We're gating this feature to be used in the docs.rs builder only using Cargo.toml.

Closes: https://github.com/p2panda/p2panda/issues/1170

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
