### PR TITLE
New forwards-compatible, safer and faster API to create, encode and decode operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Changed
 
+- core: New forwards-compatible, safer and faster API to create, encode and decode operations [#1200](https://github.com/p2panda/p2panda/pull/1200)
 - net: Update ractor to 0.16.2 [#1324](https://github.com/p2panda/p2panda/pull/1324)
 - sync: Tracing for sync state machine using instrument span [#1289](https://github.com/p2panda/p2panda/pull/1289)
 - auth: Replace `IdentityHandle` and `OperationId` with traits from `p2panda-core` [#1193](https://github.com/p2panda/p2panda/pull/1193)

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 p2panda-auth = { workspace = true, default-features = true, features = ["test_utils"] }
-p2panda-core = { workspace = true, default-features = true, features = ["arbitrary"] }
+p2panda-core = { workspace = true, default-features = true, features = ["test_utils", "arbitrary"] }
 p2panda-encryption = { workspace = true, default-features = true, features = ["test_utils"] }
 rand = { workspace = true, default-features = true, features = ["alloc"] }
 

--- a/fuzz/fuzz_targets/header_e2e.rs
+++ b/fuzz/fuzz_targets/header_e2e.rs
@@ -3,7 +3,6 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use p2panda_core::cbor::{decode_cbor, encode_cbor};
 use p2panda_core::{Header, SigningKey};
 
 // Create arbitrary header, sign, serialize and deserialize it.
@@ -11,11 +10,11 @@ fuzz_target!(|header: Header<()>| {
     let signing_key = SigningKey::generate();
 
     let mut header = header;
+    header.verifying_key = signing_key.verifying_key();
     header.sign(&signing_key);
-    header.verify();
 
-    let bytes = encode_cbor(&header).expect("header encoding");
-    let result: Result<Header<()>, _> = decode_cbor(&bytes[..]);
+    let bytes = header.encode();
+    let result: Result<Header<()>, _> = Header::<()>::decode(&bytes);
 
     // We expect these cases to fail:
     //

--- a/p2panda-core/Cargo.toml
+++ b/p2panda-core/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/p2panda/p2panda"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["p2p", "data-types", "blake3", "cbor", "ed25519"]
-rust-version = "1.94"
+rust-version = "1.96"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -22,20 +22,17 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [features]
-default = [
-  "prune",
-]
-prune = []
+default = []
 test_utils = [
   "dep:mock_instant",
   "dep:tracing-subscriber",
 ]
 
 [dependencies]
-arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
+arbitrary = { version = "1.4.2", optional = true, features = ["derive"] }
 blake3 = { workspace = true }
-ciborium = { version = "0.2.2" }
-ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
+cbor-core = { version = "0.10.1", features = ["serde"] }
+ed25519-dalek = { version = "2.2.0", features = ["rand_core"] }
 hex = { workspace = true, features = ["serde"] }
 mock_instant = { workspace = true, optional = true }
 rand = "0.8.5"
@@ -46,4 +43,4 @@ tracing-subscriber = { workspace = true, features = ["env-filter"], optional = t
 
 [dev-dependencies]
 p2panda-core = { path = ".", features = ["test_utils"] }
-serde_json = "1.0.140"
+serde_json = "1.0.150"

--- a/p2panda-core/Cargo.toml
+++ b/p2panda-core/Cargo.toml
@@ -22,20 +22,17 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [features]
-default = [
-  "prune",
-]
-prune = []
+default = []
 test_utils = [
   "dep:mock_instant",
   "dep:tracing-subscriber",
 ]
 
 [dependencies]
-arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
+arbitrary = { version = "1.4.2", optional = true, features = ["derive"] }
 blake3 = { workspace = true }
-ciborium = { version = "0.2.2" }
-ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
+cbor-core = { version = "0.10.1", features = ["serde"] }
+ed25519-dalek = { version = "2.2.0", features = ["rand_core"] }
 hex = { workspace = true, features = ["serde"] }
 mock_instant = { workspace = true, optional = true }
 rand = "0.8.5"
@@ -46,4 +43,4 @@ tracing-subscriber = { workspace = true, features = ["env-filter"], optional = t
 
 [dev-dependencies]
 p2panda-core = { path = ".", features = ["test_utils"] }
-serde_json = "1.0.140"
+serde_json = "1.0.150"

--- a/p2panda-core/Cargo.toml
+++ b/p2panda-core/Cargo.toml
@@ -23,6 +23,10 @@ workspace = true
 
 [features]
 default = []
+arbitrary = [
+  "dep:arbitrary",
+  "test_utils",
+]
 test_utils = [
   "dep:mock_instant",
   "dep:tracing-subscriber",

--- a/p2panda-core/README.md
+++ b/p2panda-core/README.md
@@ -52,23 +52,13 @@ extensible depending on your application requirements.
 ### Create and sign operation
 
 ```rust
-use p2panda_core::{Body, Header, SigningKey};
+use p2panda_core::{Header, SigningKey};
 
 let signing_key = SigningKey::generate();
 
-let body = Body::new("Hello, Panda!".as_bytes());
-let mut header = Header {
-    version: 1,
-    verifying_key: signing_key.verifying_key(),
-    signature: None,
-    payload_size: body.size(),
-    payload_hash: Some(body.hash()),
-    seq_num: 0,
-    backlink: None,
-    extensions: (),
-};
-
-header.sign(&signing_key);
+let header = Header::builder()
+    .body(b"Hello, Panda!")
+    .build(&signing_key, ());
 ```
 
 ### Custom extensions

--- a/p2panda-core/examples/basic.rs
+++ b/p2panda-core/examples/basic.rs
@@ -10,22 +10,10 @@ fn main() {
     let signing_key = SigningKey::generate();
 
     // An operation body contains application data.
-    let body = Body::new("Hello, Sloth!".as_bytes());
+    let body = Body::from_bytes("Hello, Sloth!".as_bytes());
 
-    // Create a header.
-    let mut header = Header {
-        version: 1,
-        verifying_key: signing_key.verifying_key(),
-        signature: None,
-        payload_size: body.size(),
-        payload_hash: Some(body.hash()),
-        seq_num: 0,
-        backlink: None,
-        extensions: None::<()>,
-    };
-
-    // Sign the header.
-    header.sign(&signing_key);
+    // Create and sign a header.
+    let header = Header::builder().body(&body).build(&signing_key, ());
 
     // An operation containing the header hash (the operation id), the header itself and an optional body.
     let operation = Operation {

--- a/p2panda-core/examples/extensions.rs
+++ b/p2panda-core/examples/extensions.rs
@@ -5,7 +5,7 @@
 //! `Extension` trait to define the means of extracting each value from a p2panda header.
 use serde::{Deserialize, Serialize};
 
-use p2panda_core::{Body, Extension, Hash, Header, SigningKey};
+use p2panda_core::{Extension, Hash, Header, SigningKey};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct LogId(Hash);
@@ -42,20 +42,10 @@ fn main() {
     };
 
     let signing_key = SigningKey::generate();
-    let body: Body = Body::new("Hello, Sloth!".as_bytes());
 
-    let mut header = Header {
-        version: 1,
-        verifying_key: signing_key.verifying_key(),
-        signature: None,
-        payload_size: body.size(),
-        payload_hash: Some(body.hash()),
-        seq_num: 0,
-        backlink: None,
-        extensions: extensions.clone(),
-    };
-
-    header.sign(&signing_key);
+    let header = Header::builder()
+        .body("Hello, Sloth".as_bytes())
+        .build(&signing_key, extensions.clone());
 
     let log_id: LogId = header.extension().unwrap();
     let expiry: Expiry = header.extension().unwrap();

--- a/p2panda-core/src/cbor.rs
+++ b/p2panda-core/src/cbor.rs
@@ -9,48 +9,26 @@
 use std::io::Read;
 use std::sync::Arc;
 
-use ciborium::de::Error as DeserializeError;
-use ciborium::ser::Error as SerializeError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Serializes a value into CBOR format.
 pub fn encode_cbor<T: Serialize>(value: &T) -> Result<Vec<u8>, EncodeError> {
-    let mut bytes = Vec::new();
-    ciborium::ser::into_writer(value, &mut bytes).map_err(Into::<EncodeError>::into)?;
-    Ok(bytes)
+    let value = cbor_core::Value::serialized(&value)?;
+    Ok(value.encode())
 }
 
 /// Deserializes a value which was formatted in CBOR.
 pub fn decode_cbor<T: for<'a> Deserialize<'a>, R: Read>(reader: R) -> Result<T, DecodeError> {
-    let value = ciborium::from_reader::<T, R>(reader).map_err(Into::<DecodeError>::into)?;
-    Ok(value)
+    let value =
+        cbor_core::Value::read_from(reader).map_err(|err| DecodeError::Io(Arc::new(err)))?;
+    Ok(cbor_core::Value::deserialized(&value)?)
 }
 
 /// An error occurred during CBOR serialization.
 #[derive(Debug, Error)]
-pub enum EncodeError {
-    /// An error occurred while writing bytes.
-    ///
-    /// Contains the underlying error returned while reading.
-    #[error("an error occurred while reading bytes: {0}")]
-    Io(std::io::Error),
-
-    /// An error indicating a value that cannot be serialized.
-    ///
-    /// Contains a description of the problem delivered from serde.
-    #[error("an error occurred while deserializing value: {0}")]
-    Value(String),
-}
-
-impl From<SerializeError<std::io::Error>> for EncodeError {
-    fn from(value: SerializeError<std::io::Error>) -> Self {
-        match value {
-            SerializeError::Io(err) => EncodeError::Io(err),
-            SerializeError::Value(err) => EncodeError::Value(err),
-        }
-    }
-}
+#[error(transparent)]
+pub struct EncodeError(#[from] cbor_core::SerdeError);
 
 /// An error occurred during CBOR deserialization.
 #[derive(Clone, Debug, Error)]
@@ -59,73 +37,8 @@ pub enum DecodeError {
     ///
     /// Contains the underlying error returned while reading.
     #[error("an error occurred while reading bytes: {0}")]
-    Io(Arc<std::io::Error>),
+    Io(Arc<cbor_core::IoError>),
 
-    /// An error occurred while parsing bytes.
-    ///
-    /// Contains the offset into the stream where the syntax error occurred.
-    #[error("an error occurred while parsing bytes at position {0}")]
-    Syntax(usize),
-
-    /// An error occurred while processing a parsed value.
-    ///
-    /// Contains a description of the error that occurred and (optionally) the offset into the
-    /// stream indicating the start of the item being processed when the error occurred.
-    #[error("an error occurred while processing a parsed value at position {0:?}: {1}")]
-    Semantic(Option<usize>, String),
-
-    /// The input caused serde to recurse too much.
-    ///
-    /// This error prevents a stack overflow.
-    #[error("recursion limit exceeded while decoding")]
-    RecursionLimitExceeded,
-}
-
-impl From<DeserializeError<std::io::Error>> for DecodeError {
-    fn from(value: DeserializeError<std::io::Error>) -> Self {
-        match value {
-            DeserializeError::Io(err) => DecodeError::Io(Arc::new(err)),
-            DeserializeError::Syntax(offset) => DecodeError::Syntax(offset),
-            DeserializeError::Semantic(offset, description) => {
-                DecodeError::Semantic(offset, description)
-            }
-            DeserializeError::RecursionLimitExceeded => DecodeError::RecursionLimitExceeded,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{Body, Header, SigningKey};
-
-    use super::{DecodeError, decode_cbor, encode_cbor};
-
-    #[test]
-    fn encode_decode() {
-        let signing_key = SigningKey::generate();
-        let body = Body::new(&[1, 2, 3]);
-        let mut header = Header::<()> {
-            verifying_key: signing_key.verifying_key(),
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            ..Default::default()
-        };
-        header.sign(&signing_key);
-
-        let bytes = encode_cbor(&header).unwrap();
-        let header_again: Header<()> = decode_cbor(&bytes[..]).unwrap();
-
-        assert_eq!(header.hash(), header_again.hash());
-    }
-
-    #[test]
-    fn decode_eof() {
-        // This is an incomplete byte sequence of a header / body tuple.
-        let bytes = hex::decode("828901582014d59877a250").unwrap();
-        let err = decode_cbor::<(Header<()>, Option<Body>), _>(&bytes[..]);
-
-        // We're expecting an "Unexpected EOF" error here. The underlying decoder should be able to
-        // detect that there's bytes missing.
-        assert!(matches!(err, Err(DecodeError::Io(_))));
-    }
+    #[error(transparent)]
+    Serde(#[from] cbor_core::SerdeError),
 }

--- a/p2panda-core/src/cbor.rs
+++ b/p2panda-core/src/cbor.rs
@@ -9,48 +9,26 @@
 use std::io::Read;
 use std::sync::Arc;
 
-use ciborium::de::Error as DeserializeError;
-use ciborium::ser::Error as SerializeError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Serializes a value into CBOR format.
 pub fn encode_cbor<T: Serialize>(value: &T) -> Result<Vec<u8>, EncodeError> {
-    let mut bytes = Vec::new();
-    ciborium::ser::into_writer(value, &mut bytes).map_err(Into::<EncodeError>::into)?;
-    Ok(bytes)
+    let value = cbor_core::Value::serialized(&value)?;
+    Ok(value.encode())
 }
 
 /// Deserializes a value which was formatted in CBOR.
 pub fn decode_cbor<T: for<'a> Deserialize<'a>, R: Read>(reader: R) -> Result<T, DecodeError> {
-    let value = ciborium::from_reader::<T, R>(reader).map_err(Into::<DecodeError>::into)?;
-    Ok(value)
+    let value =
+        cbor_core::Value::read_from(reader).map_err(|err| DecodeError::Io(Arc::new(err)))?;
+    Ok(cbor_core::Value::deserialized(&value)?)
 }
 
 /// An error occurred during CBOR serialization.
 #[derive(Debug, Error)]
-pub enum EncodeError {
-    /// An error occurred while writing bytes.
-    ///
-    /// Contains the underlying error returned while reading.
-    #[error("an error occurred while reading bytes: {0}")]
-    Io(std::io::Error),
-
-    /// An error indicating a value that cannot be serialized.
-    ///
-    /// Contains a description of the problem delivered from serde.
-    #[error("an error occurred while deserializing value: {0}")]
-    Value(String),
-}
-
-impl From<SerializeError<std::io::Error>> for EncodeError {
-    fn from(value: SerializeError<std::io::Error>) -> Self {
-        match value {
-            SerializeError::Io(err) => EncodeError::Io(err),
-            SerializeError::Value(err) => EncodeError::Value(err),
-        }
-    }
-}
+#[error(transparent)]
+pub struct EncodeError(#[from] cbor_core::SerdeError);
 
 /// An error occurred during CBOR deserialization.
 #[derive(Clone, Debug, Error)]
@@ -59,73 +37,8 @@ pub enum DecodeError {
     ///
     /// Contains the underlying error returned while reading.
     #[error("an error occurred while reading bytes: {0}")]
-    Io(Arc<std::io::Error>),
+    Io(Arc<cbor_core::IoError>),
 
-    /// An error occurred while parsing bytes.
-    ///
-    /// Contains the offset into the stream where the syntax error occurred.
-    #[error("an error occurred while parsing bytes at position {0}")]
-    Syntax(usize),
-
-    /// An error occurred while processing a parsed value.
-    ///
-    /// Contains a description of the error that occurred and (optionally) the offset into the
-    /// stream indicating the start of the item being processed when the error occurred.
-    #[error("an error occurred while processing a parsed value at position {0:?}: {1}")]
-    Semantic(Option<usize>, String),
-
-    /// The input caused serde to recurse too much.
-    ///
-    /// This error prevents a stack overflow.
-    #[error("recursion limit exceeded while decoding")]
-    RecursionLimitExceeded,
-}
-
-impl From<DeserializeError<std::io::Error>> for DecodeError {
-    fn from(value: DeserializeError<std::io::Error>) -> Self {
-        match value {
-            DeserializeError::Io(err) => DecodeError::Io(Arc::new(err)),
-            DeserializeError::Syntax(offset) => DecodeError::Syntax(offset),
-            DeserializeError::Semantic(offset, description) => {
-                DecodeError::Semantic(offset, description)
-            }
-            DeserializeError::RecursionLimitExceeded => DecodeError::RecursionLimitExceeded,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{Body, Header, SigningKey};
-
-    use super::{DecodeError, decode_cbor, encode_cbor};
-
-    #[test]
-    fn encode_decode() {
-        let signing_key = SigningKey::generate();
-        let body = Body::new(&[1, 2, 3]);
-        let mut header = Header::<()> {
-            verifying_key: signing_key.verifying_key(),
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            ..Default::default()
-        };
-        header.sign(&signing_key);
-
-        let bytes = encode_cbor(&header).unwrap();
-        let header_again: Header<()> = decode_cbor(&bytes[..]).unwrap();
-
-        assert_eq!(header.hash(), header_again.hash());
-    }
-
-    #[test]
-    fn decode_eof() {
-        // This is an incomplete byte sequence of a header / body tuple.
-        let bytes = hex::decode("828901582014d59877a250").unwrap();
-        let err = decode_cbor::<(Header<()>, Option<Body>), _>(&bytes[..]);
-
-        // We're expecting an "Unexpected EOF" error here. The underlying decoder should be able to
-        // detect that there's bytes missing.
-        std::assert_matches!(err, Err(DecodeError::Io(_)));
-    }
+    #[error(transparent)]
+    Serde(#[from] cbor_core::SerdeError),
 }

--- a/p2panda-core/src/extensions.rs
+++ b/p2panda-core/src/extensions.rs
@@ -61,20 +61,11 @@
 //! };
 //!
 //! let signing_key = SigningKey::generate();
-//! let body: Body = Body::new("Hello, Sloth!".as_bytes());
+//! let body: Body = Body::from_bytes("Hello, Sloth!".as_bytes());
 //!
-//! let mut header = Header {
-//!     version: 1,
-//!     verifying_key: signing_key.verifying_key(),
-//!     signature: None,
-//!     payload_size: body.size(),
-//!     payload_hash: Some(body.hash()),
-//!     seq_num: 0,
-//!     backlink: None,
-//!     extensions: extensions.clone(),
-//! };
-//!
-//! header.sign(&signing_key);
+//! let header = Header::builder()
+//!     .body("Hello, Sloth".as_bytes())
+//!     .build(&signing_key, extensions.clone());
 //!
 //! let log_id: LogId = header.extension().unwrap();
 //! let expiry: Expiry = header.extension().unwrap();

--- a/p2panda-core/src/extensions.rs
+++ b/p2panda-core/src/extensions.rs
@@ -61,20 +61,10 @@
 //! };
 //!
 //! let signing_key = SigningKey::generate();
-//! let body: Body = Body::new("Hello, Sloth!".as_bytes());
 //!
-//! let mut header = Header {
-//!     version: 1,
-//!     verifying_key: signing_key.verifying_key(),
-//!     signature: None,
-//!     payload_size: body.size(),
-//!     payload_hash: Some(body.hash()),
-//!     seq_num: 0,
-//!     backlink: None,
-//!     extensions: extensions.clone(),
-//! };
-//!
-//! header.sign(&signing_key);
+//! let header = Header::builder()
+//!     .body("Hello, Sloth".as_bytes())
+//!     .build(&signing_key, extensions.clone());
 //!
 //! let log_id: LogId = header.extension().unwrap();
 //! let expiry: Expiry = header.extension().unwrap();

--- a/p2panda-core/src/lib.rs
+++ b/p2panda-core/src/lib.rs
@@ -50,7 +50,7 @@
 //! ## Example
 //!
 //! ```
-//! use p2panda_core::{Body, Header, Operation, SigningKey};
+//! use p2panda_core::{Body, Header, SigningKey};
 //!
 //! // Every operation is cryptographically authenticated by an author by signing it with an
 //! // Ed25519 key pair. This method generates a new private key for us which needs to be securely
@@ -59,20 +59,12 @@
 //!
 //! // Operations consist of an body (with the actual application data) and a header,
 //! // enhancing the data to be used in distributed networks.
-//! let body = Body::new("Hello, Sloth!".as_bytes());
-//! let mut header = Header {
-//!     version: 1,
-//!     verifying_key: signing_key.verifying_key(),
-//!     signature: None,
-//!     payload_size: body.size(),
-//!     payload_hash: Some(body.hash()),
-//!     seq_num: 0,
-//!     backlink: None,
-//!     extensions: (),
-//! };
+//! let body = Body::from_bytes("Hello, Sloth!".as_bytes());
 //!
-//! // Sign the header with the author's private key. From now on it's ready to be sent!
-//! header.sign(&signing_key);
+//! let header = Header::builder()
+//!     .body(&body)
+//!     // Sign the header with the author's private key. From now on it's ready to be sent!
+//!     .build(&signing_key, ());
 //! ```
 pub mod cbor;
 pub mod cursor;
@@ -81,7 +73,6 @@ pub mod hash;
 pub mod identity;
 pub mod logs;
 pub mod operation;
-#[cfg(feature = "prune")]
 pub mod prune;
 mod serde;
 #[cfg(any(test, feature = "test_utils"))]
@@ -96,10 +87,9 @@ pub use hash::{Hash, HashError};
 pub use identity::{IdentityError, Signature, SigningKey, VerifyingKey};
 pub use logs::{LogId, SeqNum};
 pub use operation::{
-    Body, Header, Operation, OperationError, RawOperation, validate_backlink, validate_header,
-    validate_operation,
+    AnyHeader, AnyHeaderError, AnyOperation, Body, Header, Operation, OperationError, RawOperation,
+    validate_backlink, validate_header, validate_operation,
 };
-#[cfg(feature = "prune")]
 pub use prune::PruneFlag;
 pub use timestamp::Timestamp;
 pub use topic::Topic;

--- a/p2panda-core/src/lib.rs
+++ b/p2panda-core/src/lib.rs
@@ -50,7 +50,7 @@
 //! ## Example
 //!
 //! ```
-//! use p2panda_core::{Body, Header, Operation, SigningKey};
+//! use p2panda_core::{Body, Header, SigningKey};
 //!
 //! // Every operation is cryptographically authenticated by an author by signing it with an
 //! // Ed25519 key pair. This method generates a new private key for us which needs to be securely
@@ -59,20 +59,12 @@
 //!
 //! // Operations consist of an body (with the actual application data) and a header,
 //! // enhancing the data to be used in distributed networks.
-//! let body = Body::new("Hello, Sloth!".as_bytes());
-//! let mut header = Header {
-//!     version: 1,
-//!     verifying_key: signing_key.verifying_key(),
-//!     signature: None,
-//!     payload_size: body.size(),
-//!     payload_hash: Some(body.hash()),
-//!     seq_num: 0,
-//!     backlink: None,
-//!     extensions: (),
-//! };
+//! let body = Body::from_bytes("Hello, Sloth!".as_bytes());
 //!
-//! // Sign the header with the author's private key. From now on it's ready to be sent!
-//! header.sign(&signing_key);
+//! let header = Header::builder()
+//!     .body(&body)
+//!     // Sign the header with the author's private key. From now on it's ready to be sent!
+//!     .build(&signing_key, ());
 //! ```
 pub mod cbor;
 pub mod cursor;
@@ -81,7 +73,6 @@ pub mod hash;
 pub mod identity;
 pub mod logs;
 pub mod operation;
-#[cfg(feature = "prune")]
 pub mod prune;
 mod serde;
 #[cfg(any(test, feature = "test_utils"))]
@@ -96,10 +87,9 @@ pub use hash::{Hash, HashError};
 pub use identity::{IdentityError, Signature, SigningKey, VerifyingKey};
 pub use logs::{LogId, SeqNum};
 pub use operation::{
-    Body, Header, Operation, OperationError, RawOperation, validate_backlink, validate_header,
-    validate_operation,
+    AnyHeader, AnyOperation, Body, Header, HeaderError, Operation, OperationError, RawOperation,
+    validate_backlink, validate_header, validate_operation,
 };
-#[cfg(feature = "prune")]
 pub use prune::PruneFlag;
 pub use timestamp::Timestamp;
 pub use topic::Topic;

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -28,23 +28,13 @@
 //! ### Construct and sign a header
 //!
 //! ```
-//! use p2panda_core::{Body, Header, SigningKey};
+//! use p2panda_core::{Header, SigningKey};
 //!
 //! let signing_key = SigningKey::generate();
 //!
-//! let body = Body::new("Hello, Sloth!".as_bytes());
-//! let mut header = Header {
-//!     version: 1,
-//!     verifying_key: signing_key.verifying_key(),
-//!     signature: None,
-//!     payload_size: body.size(),
-//!     payload_hash: Some(body.hash()),
-//!     seq_num: 0,
-//!     backlink: None,
-//!     extensions: (),
-//! };
-//!
-//! header.sign(&signing_key);
+//! let header = Header::builder()
+//!     .body(b"Hello, Icebear!")
+//!     .build(&signing_key, ());
 //! ```
 //!
 //! ### Custom extensions
@@ -70,33 +60,26 @@
 //!     prune_flag: PruneFlag::new(true),
 //! };
 //!
-//! let body = Body::new("Prune from here please!".as_bytes());
-//! let mut header = Header {
-//!     version: 1,
-//!     verifying_key: signing_key.verifying_key(),
-//!     signature: None,
-//!     payload_size: body.size(),
-//!     payload_hash: Some(body.hash()),
-//!     seq_num: 0,
-//!     backlink: None,
-//!     extensions,
-//! };
-//!
-//! header.sign(&signing_key);
+//! let body = Body::from_bytes("Prune from here please!".as_bytes());
+//! let header = Header::builder()
+//!     .body(&body)
+//!     .build(&signing_key, extensions);
 //!
 //! let prune_flag: PruneFlag = header.extension().unwrap();
 //! assert!(prune_flag.is_set())
 //! ```
 use std::borrow::Borrow;
+use std::marker::PhantomData;
 
+use cbor_core::Value;
 use thiserror::Error;
 
-use crate::cbor::{DecodeError, decode_cbor, encode_cbor};
-use crate::extensions::{Extension, Extensions};
-use crate::hash::Hash;
-use crate::identity::{Signature, SigningKey, VerifyingKey};
+use crate::Extension;
+use crate::extensions::Extensions;
+use crate::hash::{HASH_LEN, Hash};
+use crate::identity::{SIGNATURE_LEN, Signature, SigningKey, VERIFYING_KEY_LEN, VerifyingKey};
 use crate::logs::SeqNum;
-use crate::traits::{Digest, Provenance};
+use crate::traits::{Chain, Digest, Offchain, Provenance};
 
 /// Encoded bytes of an operation header and optional body.
 pub type RawOperation = (Vec<u8>, Option<Vec<u8>>);
@@ -107,21 +90,6 @@ pub struct Operation<E = ()> {
     pub hash: Hash,
     pub header: Header<E>,
     pub body: Option<Body>,
-}
-
-impl<E> Operation<E>
-where
-    E: Extensions,
-{
-    /// Get a reference to the operation header.
-    pub fn header(&self) -> &Header<E> {
-        &self.header
-    }
-
-    /// Get a reference to the operation body.
-    pub fn body(&self) -> Option<&Body> {
-        self.body.as_ref()
-    }
 }
 
 impl<E> PartialEq for Operation<E> {
@@ -170,7 +138,223 @@ where
     }
 }
 
+impl<E> Chain<Hash> for Operation<E> {
+    fn backlink(&self) -> Option<Hash> {
+        self.header.backlink
+    }
+
+    fn seq_num(&self) -> SeqNum {
+        self.header.seq_num
+    }
+}
+
+impl<E> Offchain<Hash> for Operation<E> {
+    fn payload(&self) -> Option<&Body> {
+        self.body.as_ref()
+    }
+
+    fn payload_hash(&self) -> Option<Hash> {
+        self.header.payload_hash
+    }
+
+    fn payload_size(&self) -> PayloadSize {
+        self.header.payload_size
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AnyOperation {
+    pub hash: Hash,
+    pub header: AnyHeader,
+    pub body: Option<Body>,
+}
+
+impl Digest<Hash> for AnyOperation {
+    fn hash(&self) -> Hash {
+        self.hash
+    }
+}
+
+impl Provenance<VerifyingKey> for AnyOperation {
+    fn author(&self) -> VerifyingKey {
+        self.header.verifying_key
+    }
+
+    fn verify(&self) -> bool {
+        self.header.verify()
+    }
+}
+
+impl Chain<Hash> for AnyOperation {
+    fn backlink(&self) -> Option<Hash> {
+        self.header.backlink
+    }
+
+    fn seq_num(&self) -> SeqNum {
+        self.header.seq_num
+    }
+}
+
+impl Offchain<Hash> for AnyOperation {
+    fn payload(&self) -> Option<&Body> {
+        self.body.as_ref()
+    }
+
+    fn payload_hash(&self) -> Option<Hash> {
+        self.header.payload_hash
+    }
+
+    fn payload_size(&self) -> PayloadSize {
+        self.header.payload_size
+    }
+}
+
+impl TryFrom<RawOperation> for AnyOperation {
+    type Error = AnyHeaderError;
+
+    fn try_from(bytes: RawOperation) -> Result<Self, Self::Error> {
+        let (header_bytes, body_bytes) = bytes;
+        let header: AnyHeader = AnyHeader::decode(&header_bytes)?;
+
+        Ok(AnyOperation {
+            hash: header.hash(),
+            header,
+            body: body_bytes.map(Body::from),
+        })
+    }
+}
+
+impl<E> TryFrom<AnyOperation> for Operation<E>
+where
+    E: Extensions,
+{
+    type Error = AnyHeaderError;
+
+    fn try_from(any_operation: AnyOperation) -> Result<Self, Self::Error> {
+        let header: Header<E> = any_operation.header.try_into()?;
+        Ok(Operation {
+            header,
+            body: any_operation.body,
+            hash: any_operation.hash,
+        })
+    }
+}
+
 pub type Version = u16;
+
+pub type PayloadSize = u32;
+
+pub struct Builder<E> {
+    payload_size: PayloadSize,
+    payload_hash: Option<Hash>,
+    seq_num: SeqNum,
+    backlink: Option<Hash>,
+    _marker: PhantomData<E>,
+}
+
+impl<E> Default for Builder<E>
+where
+    E: Extensions,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E> Builder<E>
+where
+    E: Extensions,
+{
+    pub fn new() -> Self {
+        Self {
+            payload_size: 0,
+            payload_hash: None,
+            seq_num: 0,
+            backlink: None,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn body(mut self, bytes: impl AsRef<[u8]>) -> Self {
+        let bytes = bytes.as_ref();
+
+        self.payload_size = bytes.len() as PayloadSize;
+        self.payload_hash = if self.payload_size == 0 {
+            None
+        } else {
+            Some(Hash::digest(bytes))
+        };
+
+        self
+    }
+
+    pub fn chain(mut self, seq_num: SeqNum, backlink: Hash) -> Self {
+        self.seq_num = seq_num;
+
+        if self.seq_num > 0 {
+            self.backlink = Some(backlink);
+        } else {
+            // Ignore backlink if user tries to set one at seq_num = 0.
+            self.backlink = None;
+        }
+
+        self
+    }
+
+    pub fn build(self, signing_key: &SigningKey, extensions: E) -> Header<E> {
+        let version = 1;
+
+        let verifying_key = signing_key.verifying_key();
+
+        let extensions_cbor = if Header::<E>::has_non_zero_sized_extensions() {
+            let extensions_cbor = Value::serialized(&extensions).expect("serializable extensions");
+            Some(extensions_cbor)
+        } else {
+            None
+        };
+
+        let signing_bytes = encode_header(
+            version,
+            verifying_key,
+            None,
+            self.payload_size,
+            self.payload_hash,
+            self.seq_num,
+            self.backlink,
+            extensions_cbor.as_ref(),
+        );
+
+        let signature = signing_key.sign(&signing_bytes);
+
+        let bytes = encode_header(
+            version,
+            verifying_key,
+            Some(&signature),
+            self.payload_size,
+            self.payload_hash,
+            self.seq_num,
+            self.backlink,
+            extensions_cbor.as_ref(),
+        );
+
+        let digest = Hash::digest(&bytes);
+        let size = bytes.len() as u32;
+
+        Header {
+            version,
+            verifying_key,
+            signature,
+            payload_size: self.payload_size,
+            payload_hash: self.payload_hash,
+            seq_num: self.seq_num,
+            backlink: self.backlink,
+            extensions,
+            extensions_cbor,
+            digest,
+            size,
+        }
+    }
+}
 
 /// Header of a p2panda operation.
 ///
@@ -181,27 +365,16 @@ pub type Version = u16;
 /// ## Example
 ///
 /// ```
-/// use p2panda_core::{Body, Header, Operation, SigningKey};
+/// use p2panda_core::{Header, SigningKey};
 ///
 /// let signing_key = SigningKey::generate();
 ///
-/// let body = Body::new("Hello, Sloth!".as_bytes());
-/// let mut header = Header {
-///     version: 1,
-///     verifying_key: signing_key.verifying_key(),
-///     signature: None,
-///     payload_size: body.size(),
-///     payload_hash: Some(body.hash()),
-///     seq_num: 0,
-///     backlink: None,
-///     extensions: (),
-/// };
-///
-/// // Sign the header with the author's private key.
-/// header.sign(&signing_key);
+/// let header = Header::builder()
+///     .body(b"Hello, Icebear!")
+///      // Sign the header with the author's private key.
+///     .build(&signing_key, ());
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Header<E = ()> {
     /// Operation format version, allowing backwards compatibility when specification changes.
     pub version: Version,
@@ -210,10 +383,10 @@ pub struct Header<E = ()> {
     pub verifying_key: VerifyingKey,
 
     /// Signature by author over all fields in header, providing authenticity.
-    pub signature: Option<Signature>,
+    pub signature: Signature,
 
     /// Number of bytes of the body of this operation, must be zero if no body is given.
-    pub payload_size: u32,
+    pub payload_size: PayloadSize,
 
     /// Hash of the body of this operation, must be included if payload_size is non-zero and
     /// omitted otherwise.
@@ -241,19 +414,44 @@ pub struct Header<E = ()> {
     // An alternative would be to make this field an `Option` or introduce `E: Default` bounds to
     // allow initialisation in safe code which both are annoying to deal with.
     pub extensions: E,
+
+    /// Original extensions representation in CBOR AST.
+    ///
+    /// This allows us to correctly re-encode this header to bytes if necessary. If we would encode
+    /// the extensions from the Rust type `E` we might not be able to re-construct the original
+    /// bytes. A different system might have interpreted the extensions differently.
+    pub(crate) extensions_cbor: Option<cbor_core::Value<'static>>,
+
+    /// Size of header in encoded CBOR bytes.
+    pub(crate) size: u32,
+
+    /// BLAKE3 hash digest of header.
+    pub(crate) digest: Hash,
 }
 
-impl<E: Default> Default for Header<E> {
+#[cfg(any(test, feature = "test_utils"))]
+impl<E> Default for Header<E>
+where
+    E: Default,
+{
+    /// This is for hacky low-level access to this type, don't use this in production.
+    ///
+    /// Size and digest get re-computed whenever called in test environments. Note that we can't
+    /// re-encode `extensions_cbor` if `E` was changed in a test. Ideally you don't want to test
+    /// extensions-related code here anyway.
     fn default() -> Self {
         Self {
             version: 1,
             verifying_key: VerifyingKey::default(),
-            signature: None,
+            signature: Signature::from([0; SIGNATURE_LEN]),
             payload_size: 0,
             payload_hash: None,
             seq_num: 0,
             backlink: None,
             extensions: E::default(),
+            extensions_cbor: None,
+            size: 0,
+            digest: Hash::from([0; HASH_LEN]),
         }
     }
 }
@@ -262,46 +460,55 @@ impl<E> Header<E>
 where
     E: Extensions,
 {
-    /// Header encoded to bytes in CBOR format.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        encode_cbor(self)
-            // We can be sure that all values in this module are serializable and _if_ ciborium
-            // still fails then because of something really bad ..
-            .expect("CBOR encoder failed due to an critical IO error")
+    pub fn builder() -> Builder<E> {
+        Builder::new()
     }
 
-    /// Add a signature to the header using the provided `SigningKey`.
-    ///
-    /// This method signs the byte representation of a header with any existing signature removed
-    /// before adding back the newly generated signature.
-    pub fn sign(&mut self, signing_key: &SigningKey) {
-        // Make sure the signature is not already set before we encode
-        self.signature = None;
-
-        let bytes = self.to_bytes();
-        self.signature = Some(signing_key.sign(&bytes));
+    pub fn from_any(any_header: AnyHeader) -> Result<Self, AnyHeaderError> {
+        Self::try_from(any_header)
     }
 
-    /// Verify that the signature contained in this `Header` was generated by the claimed
-    /// public key.
-    pub fn verify(&self) -> bool {
-        match self.signature {
-            Some(claimed_signature) => {
-                let mut unsigned_header = self.clone();
-                unsigned_header.signature = None;
-                let unsigned_bytes = unsigned_header.to_bytes();
-                self.verifying_key
-                    .verify(&unsigned_bytes, &claimed_signature)
-            }
-            None => false,
-        }
+    pub fn encode(&self) -> Vec<u8> {
+        encode_header(
+            self.version,
+            self.verifying_key,
+            Some(&self.signature),
+            self.payload_size,
+            self.payload_hash,
+            self.seq_num,
+            self.backlink,
+            self.extensions_cbor.as_ref(),
+        )
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, AnyHeaderError> {
+        // Decode header.
+        let any_header = AnyHeader::decode(bytes)?;
+
+        // Decode extensions.
+        Self::from_any(any_header)
     }
 
     /// BLAKE3 hash of the header bytes.
     ///
     /// This hash is used as the unique identifier of an operation, aka the Operation Id.
     pub fn hash(&self) -> Hash {
-        Hash::digest(self.to_bytes())
+        // Re-calculate hash and size in test environments.
+        if cfg!(any(test, feature = "test_utils")) {
+            return Hash::digest(self.encode());
+        }
+
+        self.digest
+    }
+
+    /// Size of header when encoded as CBOR bytes.
+    pub fn size(&self) -> u32 {
+        // Re-calculate hash and size in test environments.
+        if cfg!(any(test, feature = "test_utils")) {
+            return self.encode().len() as u32;
+        }
+
+        self.size
     }
 
     /// Extract an extension value from the header.
@@ -327,32 +534,6 @@ impl<E> Header<E> {
         // no-op with no actual memory operations.
         unsafe { std::mem::zeroed() }
     }
-
-    /// Number of fields included in the header.
-    ///
-    /// Fields instantiated with `None` values are excluded from the count.
-    pub(crate) fn field_count(&self) -> usize {
-        // There will always be a minimum of 4 fields in an unsigned header.
-        let mut count = 4;
-
-        if self.signature.is_some() {
-            count += 1;
-        }
-
-        if self.payload_hash.is_some() {
-            count += 1;
-        }
-
-        if self.backlink.is_some() {
-            count += 1;
-        }
-
-        if Self::has_non_zero_sized_extensions() {
-            count += 1;
-        }
-
-        count
-    }
 }
 
 #[cfg(any(test, feature = "test_utils"))]
@@ -361,7 +542,70 @@ where
     E: Extensions,
 {
     pub fn to_hex(&self) -> String {
-        hex::encode(self.to_bytes())
+        hex::encode(self.encode())
+    }
+
+    fn encode_signing_bytes(&self) -> Vec<u8> {
+        encode_header(
+            self.version,
+            self.verifying_key,
+            None,
+            self.payload_size,
+            self.payload_hash,
+            self.seq_num,
+            self.backlink,
+            self.extensions_cbor.as_ref(),
+        )
+    }
+
+    pub fn sign(&mut self, signing_key: &SigningKey) {
+        let signing_bytes = self.encode_signing_bytes();
+        self.signature = signing_key.sign(&signing_bytes);
+    }
+
+    pub fn verify(&self) -> bool {
+        let signing_bytes = self.encode_signing_bytes();
+        self.verifying_key.verify(&signing_bytes, &self.signature)
+    }
+}
+
+impl<E> TryFrom<Header<E>> for AnyHeader
+where
+    E: Extensions,
+{
+    type Error = AnyHeaderError;
+
+    fn try_from(value: Header<E>) -> Result<Self, Self::Error> {
+        let extensions = if Header::<E>::has_non_zero_sized_extensions() {
+            Some(
+                cbor_core::Value::serialized(&value.extensions)
+                    .map_err(AnyHeaderError::EncodingExtensions)?,
+            )
+        } else {
+            None
+        };
+
+        Ok(AnyHeader {
+            version: value.version,
+            verifying_key: value.verifying_key,
+            signature: value.signature,
+            payload_size: value.payload_size,
+            payload_hash: value.payload_hash,
+            seq_num: value.seq_num,
+            backlink: value.backlink,
+            size: value.size,
+            digest: value.digest,
+            extensions,
+        })
+    }
+}
+
+impl<E> Digest<Hash> for Header<E>
+where
+    E: Extensions,
+{
+    fn hash(&self) -> Hash {
+        self.hash()
     }
 }
 
@@ -374,26 +618,494 @@ where
     }
 
     fn verify(&self) -> bool {
-        self.verify()
+        // Check signature in test environments as low-level access might have allowed users to
+        // tamper with the integrity.
+        if cfg!(any(test, feature = "test_utils")) {
+            return self.verify();
+        }
+
+        // Header was always created by us and has a valid signature.
+        true
     }
 }
 
-impl TryFrom<&[u8]> for Header {
-    type Error = DecodeError;
+impl<E> Chain<Hash> for Header<E>
+where
+    E: Extensions,
+{
+    fn backlink(&self) -> Option<Hash> {
+        self.backlink
+    }
+
+    fn seq_num(&self) -> SeqNum {
+        self.seq_num
+    }
+}
+
+impl<E> Offchain<Hash> for Header<E>
+where
+    E: Extensions,
+{
+    fn payload(&self) -> Option<&Body> {
+        None // We don't have the body here.
+    }
+
+    fn payload_hash(&self) -> Option<Hash> {
+        self.payload_hash
+    }
+
+    fn payload_size(&self) -> PayloadSize {
+        self.payload_size
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_header(
+    version: Version,
+    verifying_key: VerifyingKey,
+    signature: Option<&Signature>,
+    payload_size: PayloadSize,
+    payload_hash: Option<Hash>,
+    seq_num: SeqNum,
+    backlink: Option<Hash>,
+    extensions: Option<&Value<'static>>,
+) -> Vec<u8> {
+    let mut cbor = Value::array([Value::from(version), Value::from(verifying_key.as_bytes())]);
+
+    // Signature can be omitted to encode bytes for signing.
+    if let Some(signature) = &signature {
+        cbor.append(signature.to_bytes());
+    }
+
+    cbor.append(payload_size);
+
+    if let Some(payload_hash) = &payload_hash {
+        cbor.append(payload_hash.as_bytes());
+    }
+
+    cbor.append(seq_num);
+
+    if let Some(backlink) = &backlink {
+        cbor.append(backlink.as_bytes());
+    }
+
+    if let Some(extensions) = extensions {
+        cbor.append(extensions.to_owned());
+    }
+
+    cbor.encode()
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AnyHeader {
+    pub version: Version,
+    pub verifying_key: VerifyingKey,
+    pub signature: Signature,
+    pub payload_size: PayloadSize,
+    pub payload_hash: Option<Hash>,
+    pub seq_num: SeqNum,
+    pub backlink: Option<Hash>,
+    pub(crate) size: u32,
+    pub(crate) digest: Hash,
+    pub(crate) extensions: Option<cbor_core::Value<'static>>,
+}
+
+impl AnyHeader {
+    pub fn decode(bytes: &[u8]) -> Result<Self, AnyHeaderError> {
+        // Attempt decoding bytes as CBOR.
+        //
+        // The bytes are decoded in a zero-copy manner, only reading from the given byte slice.
+        let cbor = {
+            let strict = cbor_core::DecodeOptions::new()
+                // Reduce strictness as we can't enforce it for all possible ways users will encode
+                // their extensions. On top we want to uphold the robustness principle:
+                // "be conservative in what you do, be liberal in what you accept from others"
+                .strictness(cbor_core::Strictness {
+                    // We're fine with non-canonical encodings.
+                    allow_non_shortest_integers: true,
+                    allow_non_shortest_floats: true,
+                    allow_oversized_bigints: true,
+                    allow_unsorted_map_keys: true,
+                    // Can lead to undefined behaviour and is simply wrong.
+                    allow_duplicate_map_keys: false,
+                    // Respect length limit right from the beginning.
+                    allow_indefinite_length: false,
+                })
+                // Still, we want to make sure some attacks are mitigated and set rather low
+                // / pessimistic thresholds.
+                .recursion_limit(64)
+                .length_limit(512) // 0.5kb
+                .oom_mitigation(64);
+
+            strict
+                .decode(bytes)
+                .map_err(AnyHeaderError::DecodingHeader)?
+        };
+
+        // Validate each field in header based on p2panda specification and extract Rust types.
+        //
+        // Every header is a tuple (CBOR array). We iterate over each field and check if the
+        // expected CBOR and Rust type is given.
+        //
+        // The types are converted into owned objects (leaving the zero-copy nature of this process)
+        // and kept to allow further validation (log integrity) or conversion into the more
+        // specialised Header<E> type (where the Extensions are known).
+        //
+        // We don't keep the CBOR representation or bytes around anymore in the end (except of the
+        // decoded extensions) to not waste memory with duplicate representations of the same data.
+        let mut seq = cbor
+            .into_array()
+            .map_err(AnyHeaderError::UnexpectedHeaderType)?;
+        let mut iter = seq.iter();
+
+        let version = {
+            let next = iter.next().ok_or(AnyHeaderError::MissingField("version"))?;
+
+            Version::try_from(next)
+                .map_err(|err| AnyHeaderError::UnexpectedFieldType(err, "version"))?
+        };
+
+        if version != 1 {
+            return Err(AnyHeaderError::UnsupportedVersion(version, 1));
+        }
+
+        let verifying_key = {
+            let next = iter
+                .next()
+                .ok_or(AnyHeaderError::MissingField("verifying_key"))?;
+
+            let bytes = next
+                .as_bytes()
+                .map_err(|err| AnyHeaderError::UnexpectedFieldType(err, "verifying_key"))?;
+
+            let bytes: [u8; VERIFYING_KEY_LEN] = bytes.try_into().map_err(|_| {
+                AnyHeaderError::InvalidBytesLen("verifying_key", VERIFYING_KEY_LEN, bytes.len())
+            })?;
+
+            VerifyingKey::from_bytes(&bytes).map_err(AnyHeaderError::InvalidVerifyingKey)?
+        };
+
+        let signature = {
+            let next = iter
+                .next()
+                .ok_or(AnyHeaderError::MissingField("signature"))?;
+
+            let bytes = next
+                .as_bytes()
+                .map_err(|err| AnyHeaderError::UnexpectedFieldType(err, "signature"))?;
+
+            let bytes: [u8; SIGNATURE_LEN] = bytes.try_into().map_err(|_| {
+                AnyHeaderError::InvalidBytesLen("signature", SIGNATURE_LEN, bytes.len())
+            })?;
+
+            Signature::from(&bytes)
+        };
+
+        let payload_size = {
+            let next = iter
+                .next()
+                .ok_or(AnyHeaderError::MissingField("payload_size"))?;
+
+            PayloadSize::try_from(next)
+                .map_err(|err| AnyHeaderError::UnexpectedFieldType(err, "payload_size"))?
+        };
+
+        let payload_hash = if payload_size > 0 {
+            let next = iter
+                .next()
+                .ok_or(AnyHeaderError::MissingField("payload_hash"))?;
+
+            let bytes = next
+                .as_bytes()
+                .map_err(|err| AnyHeaderError::UnexpectedFieldType(err, "payload_hash"))?;
+
+            let bytes: [u8; HASH_LEN] = bytes.try_into().map_err(|_| {
+                AnyHeaderError::InvalidBytesLen("payload_hash", HASH_LEN, bytes.len())
+            })?;
+
+            Some(Hash::from(bytes))
+        } else {
+            None
+        };
+
+        let seq_num = {
+            let next = iter.next().ok_or(AnyHeaderError::MissingField("seq_num"))?;
+
+            SeqNum::try_from(next)
+                .map_err(|err| AnyHeaderError::UnexpectedFieldType(err, "seq_num"))?
+        };
+
+        let backlink = if seq_num > 0 {
+            let next = iter
+                .next()
+                .ok_or(AnyHeaderError::MissingField("backlink"))?;
+
+            let bytes = next
+                .as_bytes()
+                .map_err(|err| AnyHeaderError::UnexpectedFieldType(err, "backlink"))?;
+
+            let bytes: [u8; HASH_LEN] = bytes
+                .try_into()
+                .map_err(|_| AnyHeaderError::InvalidBytesLen("backlink", HASH_LEN, bytes.len()))?;
+
+            Some(Hash::from(bytes))
+        } else {
+            None
+        };
+
+        // Extract extensions and keep them for later, in case we need to deserialize them into
+        // Header<E> in the future.
+        //
+        // AnyHeader doesn't know the Rust type for E, only it's "raw" CBOR representation. To use
+        // extensions properly with Rust types we eventually want to convert into the concrete E
+        // type.
+        //
+        // Please note that at this stage we _don't know_ if this header is valid with the
+        // extensions set. We can only find out if this is correct if we know the concrete E type
+        // (if it's a ZST then there should not be an extensions field).
+        let extensions = iter.next().map(|value| value.to_owned());
+
+        // If anything came after all expected fields, something is wrong.
+        if iter.next().is_some() {
+            return Err(AnyHeaderError::ExcessiveFields);
+        }
+
+        // Verify signature.
+        //
+        // Extract signature from field position 2. It'll be removed from the CBOR value, so we can
+        // encode the bytes without it.
+        //
+        //  [0]      [1]            [2]
+        // (version, verifying_key, signature, ..)
+        //                          =========
+        seq.remove(2);
+
+        let verify_bytes = cbor_core::Value::from(seq).encode();
+        if !verifying_key.verify(&verify_bytes, &signature) {
+            return Err(AnyHeaderError::InvalidSignature);
+        }
+
+        // Calculate header size and generate hash digest.
+        //
+        // We keep these values around so if users of this object require the size or hash, it will
+        // not be re-computed again.
+        //
+        // Since we also have the bytes in our hands already we don't need to encode either.
+        let size = bytes.len() as u32;
+        let digest = Hash::digest(bytes);
+
+        Ok(Self {
+            version,
+            verifying_key,
+            signature,
+            payload_size,
+            payload_hash,
+            seq_num,
+            backlink,
+            size,
+            digest,
+            extensions,
+        })
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        encode_header(
+            self.version,
+            self.verifying_key,
+            Some(&self.signature),
+            self.payload_size,
+            self.payload_hash,
+            self.seq_num,
+            self.backlink,
+            self.extensions.as_ref(),
+        )
+    }
+
+    /// BLAKE3 hash of the header bytes.
+    ///
+    /// This hash is used as the unique identifier of an operation, aka the Operation Id.
+    pub fn hash(&self) -> Hash {
+        self.digest
+    }
+
+    /// Size of header when encoded as CBOR bytes.
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+}
+
+impl TryFrom<&[u8]> for AnyHeader {
+    type Error = AnyHeaderError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        decode_cbor(value)
+        Self::decode(value)
     }
+}
+
+impl TryFrom<Vec<u8>> for AnyHeader {
+    type Error = AnyHeaderError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::decode(&value)
+    }
+}
+
+impl<E> TryFrom<AnyHeader> for Header<E>
+where
+    E: Extensions,
+{
+    type Error = AnyHeaderError;
+
+    fn try_from(value: AnyHeader) -> Result<Self, Self::Error> {
+        let extensions = match value.extensions {
+            Some(ref cbor) => {
+                // For ZST extension types we don't expect the extensions field in the header to be
+                // set. Since we now know E we can assure that this is the case.
+                if !Header::<E>::has_non_zero_sized_extensions() {
+                    return Err(AnyHeaderError::UnexpectedExtensions);
+                }
+
+                // At this point we've already decoded the byte string into CBOR. Now we only need
+                // serde to iterate over these values to check if they match the given Rust type.
+                cbor.deserialized()
+                    .map_err(AnyHeaderError::DecodingExtensions)?
+            }
+            None => {
+                if Header::<E>::has_non_zero_sized_extensions() {
+                    return Err(AnyHeaderError::MissingExtensions);
+                } else {
+                    Header::<E>::zero_sized_extensions()
+                }
+            }
+        };
+
+        Ok(Header {
+            version: value.version,
+            verifying_key: value.verifying_key,
+            signature: value.signature,
+            payload_size: value.payload_size,
+            payload_hash: value.payload_hash,
+            seq_num: value.seq_num,
+            backlink: value.backlink,
+            extensions,
+            extensions_cbor: value.extensions,
+            size: value.size,
+            digest: value.digest,
+        })
+    }
+}
+
+impl<E> TryFrom<(AnyHeader, Option<Body>)> for Operation<E>
+where
+    E: Extensions,
+{
+    type Error = AnyHeaderError;
+
+    fn try_from(value: (AnyHeader, Option<Body>)) -> Result<Self, Self::Error> {
+        let (any_header, body) = value;
+
+        // Take the already computed hash from AnyHeader to save some time.
+        let hash = any_header.hash();
+
+        // Most fields have already been decoded, at this stage we only need to take the already
+        // decoded CBOR values into a Rust type representation.
+        let header: Header<E> = any_header.try_into()?;
+
+        Ok(Operation { header, body, hash })
+    }
+}
+
+impl Digest<Hash> for AnyHeader {
+    fn hash(&self) -> Hash {
+        self.hash()
+    }
+}
+
+impl Provenance<VerifyingKey> for AnyHeader {
+    fn author(&self) -> VerifyingKey {
+        self.verifying_key
+    }
+
+    fn verify(&self) -> bool {
+        // Was checked during decoding.
+        true
+    }
+}
+
+impl Chain<Hash> for AnyHeader {
+    fn backlink(&self) -> Option<Hash> {
+        self.backlink
+    }
+
+    fn seq_num(&self) -> SeqNum {
+        self.seq_num
+    }
+}
+
+impl Offchain<Hash> for AnyHeader {
+    fn payload(&self) -> Option<&Body> {
+        None
+    }
+
+    fn payload_hash(&self) -> Option<Hash> {
+        self.payload_hash
+    }
+
+    fn payload_size(&self) -> PayloadSize {
+        self.payload_size
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AnyHeaderError {
+    #[error("failed decoding CBOR byte string for header: {0}")]
+    DecodingHeader(cbor_core::Error),
+
+    #[error("failed decoding CBOR byte string for extensions: {0}")]
+    DecodingExtensions(cbor_core::SerdeError),
+
+    #[error("expected CBOR array for header: {0}")]
+    UnexpectedHeaderType(cbor_core::Error),
+
+    #[error("missing \"{0}\" field in header")]
+    MissingField(&'static str),
+
+    #[error("unexpected \"{0}\" field type for \"{0}\"")]
+    UnexpectedFieldType(cbor_core::Error, &'static str),
+
+    #[error("invalid verifying key: {0}")]
+    InvalidVerifyingKey(crate::identity::IdentityError),
+
+    #[error("invalid bytes length for \"{0}\", expected {1}, got {2} bytes")]
+    InvalidBytesLen(&'static str, usize, usize),
+
+    #[error("operation version {0} is not supported, needs to be <= {1}")]
+    UnsupportedVersion(Version, Version),
+
+    #[error("invalid signature")]
+    InvalidSignature,
+
+    #[error("unexpected excessive fields in header")]
+    ExcessiveFields,
+
+    #[error("didn't expect extensions but header contained excessive field")]
+    UnexpectedExtensions,
+
+    #[error("expected extensions but header didn't contain any")]
+    MissingExtensions,
+
+    #[error("failed encoding CBOR byte string for extensions: {0}")]
+    EncodingExtensions(cbor_core::SerdeError),
 }
 
 /// Body of a p2panda operation containing arbitrary bytes.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Body(pub(super) Vec<u8>);
 
 impl Body {
     /// Construct a body from a byte slice.
-    pub fn new(bytes: &[u8]) -> Self {
-        Self(bytes.to_vec())
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
+        Self(bytes.as_ref().to_vec())
     }
 
     /// Access the underlying body bytes.
@@ -411,21 +1123,25 @@ impl Body {
     }
 
     /// Size of body bytes.
-    pub fn size(&self) -> u32 {
-        self.0.len() as u32
+    pub fn size(&self) -> PayloadSize {
+        self.0.len() as PayloadSize
+    }
+
+    #[cfg(any(test, feature = "test_utils"))]
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.0)
     }
 }
 
-#[cfg(any(test, feature = "test_utils"))]
-impl Body {
-    pub fn to_hex(&self) -> String {
-        hex::encode(self.as_bytes())
+impl AsRef<[u8]> for Body {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
     }
 }
 
 impl From<&[u8]> for Body {
     fn from(value: &[u8]) -> Self {
-        Body::new(value)
+        Body::from_bytes(value)
     }
 }
 
@@ -477,30 +1193,27 @@ pub enum OperationError {
 ///
 /// This method validates that the following conditions are true:
 /// * Signature can be verified against the author public key and unsigned header bytes
-/// * Header version is supported (currently only version 1 is supported)
 /// * If `payload_hash` is set the `payload_size` is > `0` otherwise it is zero
 /// * If `backlink` is set then `seq_num` is > `0` otherwise it is zero
 /// * If provided the body bytes hash and size match those claimed in the header
-pub fn validate_operation<E>(operation: impl Borrow<Operation<E>>) -> Result<(), OperationError>
+pub fn validate_operation<T>(operation: &T) -> Result<(), OperationError>
 where
-    E: Extensions,
+    T: Provenance<VerifyingKey> + Chain<Hash> + Offchain<Hash>,
 {
-    let operation = operation.borrow();
-    validate_header(&operation.header)?;
+    validate_header::<T>(operation)?;
 
-    let claimed_payload_size = operation.header.payload_size;
+    let claimed_payload_size = operation.payload_size();
     let claimed_payload_hash: Option<Hash> = match claimed_payload_size {
         0 => None,
         _ => {
             let hash = operation
-                .header
-                .payload_hash
+                .payload_hash()
                 .ok_or(OperationError::MissingPayloadHash)?;
             Some(hash)
         }
     };
 
-    if let Some(body) = &operation.body
+    if let Some(body) = &operation.payload()
         && (claimed_payload_hash != Some(body.hash()) || claimed_payload_size != body.size())
     {
         return Err(OperationError::PayloadMismatch);
@@ -513,32 +1226,27 @@ where
 ///
 /// This method validates that the following conditions are true:
 /// * Signature can be verified against the author public key and unsigned header bytes
-/// * Header version is supported (currently only version 1 is supported)
 /// * If `payload_hash` is set the `payload_size` is > `0` otherwise it is zero
 /// * If `backlink` is set then `seq_num` is > `0` otherwise it is zero
-pub fn validate_header<E>(header: &Header<E>) -> Result<(), OperationError>
+pub fn validate_header<T>(header: &T) -> Result<(), OperationError>
 where
-    E: Extensions,
+    T: Provenance<VerifyingKey> + Chain<Hash> + Offchain<Hash>,
 {
     if !header.verify() {
         return Err(OperationError::SignatureMismatch);
     }
 
-    if header.version != 1 {
-        return Err(OperationError::UnsupportedVersion(header.version, 1));
-    }
-
-    if (header.payload_hash.is_some() && header.payload_size == 0)
-        || (header.payload_hash.is_none() && header.payload_size > 0)
+    if (header.payload_hash().is_some() && header.payload_size() == 0)
+        || (header.payload_hash().is_none() && header.payload_size() > 0)
     {
         return Err(OperationError::InconsistentPayloadInfo);
     }
 
-    if header.backlink.is_some() && header.seq_num == 0 {
+    if header.backlink().is_some() && header.seq_num() == 0 {
         return Err(OperationError::SeqNumMismatch);
     }
 
-    if header.backlink.is_none() && header.seq_num > 0 {
+    if header.backlink().is_none() && header.seq_num() > 0 {
         return Err(OperationError::BacklinkMissing);
     }
 
@@ -552,28 +1260,22 @@ where
 /// * Current and past headers contain the same public key
 /// * Current headers seq number increments from the past one by exactly `1`
 /// * Backlink hash contained in the current header matches the hash of the past header
-pub fn validate_backlink<E>(
-    past_header: impl Borrow<Header<E>>,
-    header: impl Borrow<Header<E>>,
-) -> Result<(), OperationError>
+pub fn validate_backlink<T>(past_header: &T, header: &T) -> Result<(), OperationError>
 where
-    E: Extensions,
+    T: Provenance<VerifyingKey> + Digest<Hash> + Chain<Hash>,
 {
-    let past_header = past_header.borrow();
-    let header = header.borrow();
-
-    if past_header.verifying_key != header.verifying_key {
+    if past_header.author() != header.author() {
         return Err(OperationError::TooManyAuthors);
     }
 
-    if past_header.seq_num + 1 != header.seq_num {
+    if past_header.seq_num() + 1 != header.seq_num() {
         return Err(OperationError::SeqNumNonIncremental(
-            past_header.seq_num + 1,
-            header.seq_num,
+            past_header.seq_num() + 1,
+            header.seq_num(),
         ));
     }
 
-    match header.backlink {
+    match header.backlink() {
         Some(backlink) => {
             if past_header.hash() != backlink {
                 return Err(OperationError::BacklinkMismatch);
@@ -591,47 +1293,61 @@ where
 mod tests {
     use serde::{Deserialize, Serialize};
 
-    use crate::{Extension, SigningKey};
+    use crate::identity::SigningKey;
 
     use super::*;
 
     #[test]
-    fn simple_extension_type_parameter() {
+    fn paths_leading_to_same_encoding() {
         let signing_key = SigningKey::generate();
-        let body = Body::new("Hello, Sloth!".as_bytes());
-        let mut header = Header {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
+
+        let header = Header::builder()
+            .body(b"test")
+            .chain(2, Hash::from([2; 32]))
+            .build(&signing_key, ());
+
+        let hacky_header = {
+            let body = Body::from_bytes(b"test");
+            let mut hacky_header = Header::<()> {
+                verifying_key: signing_key.verifying_key(),
+                payload_size: body.size(),
+                payload_hash: Some(body.hash()),
+                seq_num: 2,
+                backlink: Some(Hash::from([2; 32])),
+                ..Default::default()
+            };
+            hacky_header.sign(&signing_key);
+            hacky_header
         };
 
-        header.sign(&signing_key);
+        assert_eq!(header.encode(), hacky_header.encode());
+        assert_eq!(header.verify(), hacky_header.verify());
+        assert!(header.verify());
+        assert_eq!(header.hash(), hacky_header.hash());
+        assert_eq!(header.size(), hacky_header.size());
+
+        let any_header = AnyHeader::decode(&header.encode()).unwrap();
+
+        assert_eq!(header.encode(), any_header.encode());
+        assert_eq!(header.verify(), any_header.verify());
+        assert!(any_header.verify());
+        assert_eq!(header.hash(), any_header.hash());
+        assert_eq!(header.size(), any_header.size());
+
+        let header_again = Header::<()>::from_any(any_header.clone()).unwrap();
+        assert_eq!(header, header_again);
     }
 
     #[test]
     fn sign_and_verify() {
         let signing_key = SigningKey::generate();
-        let body = Body::new("Hello, Sloth!".as_bytes());
-        type CustomExtensions = ();
+        let body = Body::from_bytes("Hello, Sloth!".as_bytes());
 
-        let mut header = Header {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: None::<CustomExtensions>,
-        };
-        assert!(!header.verify());
+        type CustomExtensions = (u32, String);
 
-        header.sign(&signing_key);
+        let header = Header::<CustomExtensions>::builder()
+            .body(&body)
+            .build(&signing_key, (42, "penguin".to_string()));
         assert!(header.verify());
 
         let operation = Operation {
@@ -639,37 +1355,19 @@ mod tests {
             header,
             body: Some(body),
         };
-        assert!(validate_operation(&operation).is_ok());
+        assert!(validate_operation::<Operation<_>>(&operation).is_ok());
     }
 
     #[test]
     fn valid_backlink_header() {
         let signing_key = SigningKey::generate();
 
-        let mut header_0 = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header_0.sign(&signing_key);
+        let header_0 = Header::builder().build(&signing_key, ());
         assert!(validate_header(&header_0).is_ok());
 
-        let mut header_1 = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 1,
-            backlink: Some(header_0.hash()),
-            extensions: (),
-        };
-        header_1.sign(&signing_key);
+        let header_1 = Header::builder()
+            .chain(1, header_0.hash())
+            .build(&signing_key, ());
         assert!(validate_header(&header_1).is_ok());
 
         assert!(validate_backlink(&header_0, &header_1).is_ok());
@@ -678,27 +1376,14 @@ mod tests {
     #[test]
     fn invalid_operations() {
         let signing_key = SigningKey::generate();
-        let body: Body = Body::new("Hello, Sloth!".as_bytes());
+        let body: Body = Body::from_bytes("Hello, Sloth!".as_bytes());
 
         let header_base = Header::<()> {
-            version: 1,
             verifying_key: signing_key.verifying_key(),
-            signature: None,
             payload_size: body.size(),
             payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
+            ..Default::default()
         };
-
-        // Incompatible operation format
-        let mut header = header_base.clone();
-        header.version = 0;
-        header.sign(&signing_key);
-        assert!(matches!(
-            validate_header(&header),
-            Err(OperationError::UnsupportedVersion(0, 1))
-        ));
 
         // Signature doesn't match public key
         let mut header = header_base.clone();
@@ -755,66 +1440,6 @@ mod tests {
     }
 
     #[test]
-    fn extensions() {
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        struct LogId(Hash);
-
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        struct Expiry(u64);
-
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        struct CustomExtensions {
-            log_id: Option<LogId>,
-            expires: Expiry,
-        }
-
-        impl Extension<LogId> for CustomExtensions {
-            fn extract(header: &Header<Self>) -> Option<LogId> {
-                if header.seq_num == 0 {
-                    return Some(LogId(header.hash()));
-                };
-
-                header.extensions.log_id.clone()
-            }
-        }
-
-        impl Extension<Expiry> for CustomExtensions {
-            fn extract(header: &Header<Self>) -> Option<Expiry> {
-                Some(header.extensions.expires.clone())
-            }
-        }
-
-        let extensions = CustomExtensions {
-            log_id: None,
-            expires: Expiry(0123456),
-        };
-
-        let signing_key = SigningKey::generate();
-        let body: Body = Body::new("Hello, Sloth!".as_bytes());
-
-        let mut header = Header {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: extensions.clone(),
-        };
-
-        header.sign(&signing_key);
-
-        // Thanks to blanket implementation of Extension<T> on Header we can extract the extension
-        // value from the header itself.
-        let log_id: LogId = header.extension().unwrap();
-        let expiry: Expiry = header.extension().unwrap();
-
-        assert_eq!(header.hash(), log_id.0);
-        assert_eq!(extensions.expires.0, expiry.0);
-    }
-
-    #[test]
     fn zst_size_matches_mem_checks() {
         struct ZstExtensions;
         assert_eq!(std::mem::size_of::<ZstExtensions>(), 0);
@@ -824,5 +1449,205 @@ mod tests {
         struct NonZstExtensions(u32);
         assert_ne!(std::mem::size_of::<NonZstExtensions>(), 0);
         assert!(Header::<NonZstExtensions>::has_non_zero_sized_extensions());
+    }
+
+    #[test]
+    fn any_header_conversions() {
+        let signing_key = SigningKey::generate();
+
+        #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+        struct TestExtensions {
+            field_a: Vec<u8>,
+            field_b: bool,
+            field_c: u64,
+        }
+
+        let header = Header::builder().body(b"hello").build(
+            &signing_key,
+            TestExtensions {
+                field_a: vec![61, 112, 43],
+                field_b: true,
+                field_c: 54_938,
+            },
+        );
+
+        let hash = header.hash();
+        assert!(header.verify());
+
+        let any_header = AnyHeader::try_from(header.clone()).unwrap();
+        assert_eq!(any_header.hash(), hash);
+        assert_eq!(any_header.size(), header.encode().len() as u32);
+
+        let header_again: Header<TestExtensions> = any_header.try_into().unwrap();
+        assert_eq!(header, header_again);
+    }
+
+    #[test]
+    fn any_header_errors() {
+        let signing_key = SigningKey::generate();
+
+        // First check that this header is valid. The body is b"test".
+        let correct_header_bytes = r#"[
+            1,
+            h'6dec6975e5c280e9eadde785cf01df20690d02c8ab7a57efcd58150ab53a867f',
+            h'a4331f8d5742d3c40b7e8cfb93e487f4b3b8878e64f7ec9985169d6ed3a3fa3b7e9c9d4b69d6c62e6079dba734705a4b8fc2210f2793bf1ee8b2af5963ce9e0b',
+            4,
+            h'4878ca0425c739fa427f7eda20fe845f6b2e46ba5fe2a14df5b1e32f50603215',
+            0
+        ]"#
+        .parse::<cbor_core::Value>()
+        .unwrap()
+        .encode();
+        assert!(AnyHeader::decode(&correct_header_bytes).is_ok());
+
+        // Insufficient bytes for payload_hash.
+        let invalid_header_bytes = r#"[
+            1,
+            h'6dec6975e5c280e9eadde785cf01df20690d02c8ab7a57efcd58150ab53a867f',
+            h'a4331f8d5742d3c40b7e8cfb93e487f4b3b8878e64f7ec9985169d6ed3a3fa3b7e9c9d4b69d6c62e6079dba734705a4b8fc2210f2793bf1ee8b2af5963ce9e0b',
+            4,
+            h'4878',
+            0
+        ]"#
+        .parse::<cbor_core::Value>()
+        .unwrap()
+        .encode();
+
+        std::assert_matches!(
+            AnyHeader::decode(&invalid_header_bytes),
+            Err(AnyHeaderError::InvalidBytesLen("payload_hash", 32, 2))
+        );
+
+        // Invalid signature.
+        let mut header = Header::builder().build(&signing_key, ());
+        header.verifying_key = SigningKey::generate().verifying_key();
+
+        let result = AnyHeader::decode(&header.encode());
+        std::assert_matches!(result, Err(AnyHeaderError::InvalidSignature));
+
+        // payload_size given without payload_hash.
+        let mut header = Header::builder().build(&signing_key, ());
+        header.payload_size = 2829099;
+        header.sign(&signing_key);
+
+        let result = AnyHeader::decode(&header.encode());
+        std::assert_matches!(
+            result,
+            Err(AnyHeaderError::UnexpectedFieldType(
+                cbor_core::Error::IncompatibleType(cbor_core::DataType::Int),
+                "payload_hash"
+            ))
+        );
+
+        // payload_hash given without payload_size.
+        let mut header = Header::<()> {
+            verifying_key: signing_key.verifying_key(),
+            payload_size: 0,
+            payload_hash: Some(Hash::digest([0, 1, 2])),
+            extensions: (),
+            ..Default::default()
+        };
+        header.sign(&signing_key);
+
+        let result = AnyHeader::decode(&header.encode());
+        std::assert_matches!(
+            result,
+            Err(AnyHeaderError::UnexpectedFieldType(
+                cbor_core::Error::IncompatibleType(cbor_core::DataType::Bytes),
+                "seq_num"
+            ))
+        );
+
+        // backlink given with seq_num 0.
+        let mut header = Header::<()> {
+            verifying_key: signing_key.verifying_key(),
+            seq_num: 0,
+            backlink: Some(Hash::digest([0, 1, 2])),
+            ..Default::default()
+        };
+        header.sign(&signing_key);
+
+        // At this point we don't know that the backlink is _not_ an extension:
+        let result = AnyHeader::decode(&header.encode()).expect("this is fine ..");
+
+        // .. but latest here we'll find out!
+        let result = Header::<()>::try_from(result);
+        let result_2 = Header::<()>::decode(&header.encode());
+        assert!(result.is_err());
+        assert!(result_2.is_err());
+        std::assert_matches!(result, Err(AnyHeaderError::UnexpectedExtensions));
+
+        // backlink not given with seq_num > 0.
+        let mut header = Header::<()> {
+            verifying_key: signing_key.verifying_key(),
+            seq_num: 10,
+            backlink: None,
+            ..Default::default()
+        };
+        header.sign(&signing_key);
+
+        let result = AnyHeader::decode(&header.encode());
+        std::assert_matches!(result, Err(AnyHeaderError::MissingField("backlink")));
+    }
+
+    #[test]
+    fn forwards_compatible_checks() {
+        use crate::{PruneFlag, Timestamp};
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        struct LegacyExtensionsFormat {
+            timestamp: Timestamp,
+        }
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        struct FutureExtensionsFormat {
+            timestamp: Timestamp,
+            #[serde(default = "PruneFlag::default")]
+            prune_flag: PruneFlag,
+        }
+
+        let signing_key = SigningKey::generate();
+
+        let old_header = Header::builder().body(b"once upon a time").build(
+            &signing_key,
+            LegacyExtensionsFormat {
+                timestamp: 1780572316919.into(),
+            },
+        );
+        let old_header_bytes = old_header.encode();
+
+        let new_header = Header::builder()
+            .body(b"fitter, happier, more productive")
+            .build(
+                &signing_key,
+                FutureExtensionsFormat {
+                    timestamp: 1780572316919.into(),
+                    prune_flag: true.into(),
+                },
+            );
+        let new_header_bytes = new_header.encode();
+        let new_header_hash = new_header.hash();
+
+        // The old system can still parse headers with the new extensions format:
+        let any_header = AnyHeader::decode(&new_header_bytes).unwrap();
+
+        // The signature was checked during decoding already.
+        assert!(any_header.verify());
+
+        // .. and the hash digest matches with the original even though we don't know the new
+        // extension format:
+        assert_eq!(new_header_hash, any_header.hash());
+
+        // It can even parse the extensions, will omit the unknown prune_flag field.
+        let header = Header::<LegacyExtensionsFormat>::from_any(any_header).unwrap();
+        assert_eq!(header.extensions.timestamp, 1780572316919.into());
+        assert_eq!(new_header_hash, header.hash());
+        assert!(header.verify());
+
+        // The old system can still parse headers with the new extensions format, not too important
+        // for this test, but nice to show:
+        let header = Header::<FutureExtensionsFormat>::decode(&old_header_bytes).unwrap();
+        assert_eq!(header.extensions.timestamp, 1780572316919.into());
+        assert_eq!(header.extensions.prune_flag, false.into()); // set to default when not given
     }
 }

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -28,23 +28,13 @@
 //! ### Construct and sign a header
 //!
 //! ```
-//! use p2panda_core::{Body, Header, SigningKey};
+//! use p2panda_core::{Header, SigningKey};
 //!
 //! let signing_key = SigningKey::generate();
 //!
-//! let body = Body::new("Hello, Sloth!".as_bytes());
-//! let mut header = Header {
-//!     version: 1,
-//!     verifying_key: signing_key.verifying_key(),
-//!     signature: None,
-//!     payload_size: body.size(),
-//!     payload_hash: Some(body.hash()),
-//!     seq_num: 0,
-//!     backlink: None,
-//!     extensions: (),
-//! };
-//!
-//! header.sign(&signing_key);
+//! let header = Header::builder()
+//!     .body(b"Hello, Icebear!")
+//!     .build(&signing_key, ());
 //! ```
 //!
 //! ### Custom extensions
@@ -70,33 +60,25 @@
 //!     prune_flag: PruneFlag::new(true),
 //! };
 //!
-//! let body = Body::new("Prune from here please!".as_bytes());
-//! let mut header = Header {
-//!     version: 1,
-//!     verifying_key: signing_key.verifying_key(),
-//!     signature: None,
-//!     payload_size: body.size(),
-//!     payload_hash: Some(body.hash()),
-//!     seq_num: 0,
-//!     backlink: None,
-//!     extensions,
-//! };
-//!
-//! header.sign(&signing_key);
+//! let body = Body::from_bytes("Prune from here please!".as_bytes());
+//! let header = Header::builder()
+//!     .body(&body)
+//!     .build(&signing_key, extensions);
 //!
 //! let prune_flag: PruneFlag = header.extension().unwrap();
 //! assert!(prune_flag.is_set())
 //! ```
 use std::borrow::Borrow;
+use std::marker::PhantomData;
 
+use cbor_core::Value;
 use thiserror::Error;
 
-use crate::cbor::{DecodeError, decode_cbor, encode_cbor};
 use crate::extensions::{Extension, Extensions};
-use crate::hash::Hash;
-use crate::identity::{Signature, SigningKey, VerifyingKey};
+use crate::hash::{HASH_LEN, Hash};
+use crate::identity::{SIGNATURE_LEN, Signature, SigningKey, VERIFYING_KEY_LEN, VerifyingKey};
 use crate::logs::SeqNum;
-use crate::traits::{Digest, Provenance};
+use crate::traits::{Chain, Digest, Offchain, Provenance};
 
 /// Encoded bytes of an operation header and optional body.
 pub type RawOperation = (Vec<u8>, Option<Vec<u8>>);
@@ -113,14 +95,12 @@ impl<E> Operation<E>
 where
     E: Extensions,
 {
-    /// Get a reference to the operation header.
-    pub fn header(&self) -> &Header<E> {
-        &self.header
-    }
-
-    /// Get a reference to the operation body.
-    pub fn body(&self) -> Option<&Body> {
-        self.body.as_ref()
+    pub fn from_parts(header: Header<E>, body: Option<Body>) -> Self {
+        Self {
+            hash: header.hash(),
+            header,
+            body,
+        }
     }
 }
 
@@ -170,7 +150,233 @@ where
     }
 }
 
+impl<E> Chain<Hash> for Operation<E> {
+    fn backlink(&self) -> Option<Hash> {
+        self.header.backlink
+    }
+
+    fn seq_num(&self) -> SeqNum {
+        self.header.seq_num
+    }
+}
+
+impl<E> Offchain<Hash> for Operation<E> {
+    fn payload(&self) -> Option<&Body> {
+        self.body.as_ref()
+    }
+
+    fn payload_hash(&self) -> Option<Hash> {
+        self.header.payload_hash
+    }
+
+    fn payload_size(&self) -> PayloadSize {
+        self.header.payload_size
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AnyOperation {
+    pub hash: Hash,
+    pub header: AnyHeader,
+    pub body: Option<Body>,
+}
+
+impl Digest<Hash> for AnyOperation {
+    fn hash(&self) -> Hash {
+        self.hash
+    }
+}
+
+impl Provenance<VerifyingKey> for AnyOperation {
+    fn author(&self) -> VerifyingKey {
+        self.header.verifying_key
+    }
+
+    fn verify(&self) -> bool {
+        self.header.verify()
+    }
+}
+
+impl Chain<Hash> for AnyOperation {
+    fn backlink(&self) -> Option<Hash> {
+        self.header.backlink
+    }
+
+    fn seq_num(&self) -> SeqNum {
+        self.header.seq_num
+    }
+}
+
+impl Offchain<Hash> for AnyOperation {
+    fn payload(&self) -> Option<&Body> {
+        self.body.as_ref()
+    }
+
+    fn payload_hash(&self) -> Option<Hash> {
+        self.header.payload_hash
+    }
+
+    fn payload_size(&self) -> PayloadSize {
+        self.header.payload_size
+    }
+}
+
+impl TryFrom<RawOperation> for AnyOperation {
+    type Error = HeaderError;
+
+    fn try_from(bytes: RawOperation) -> Result<Self, Self::Error> {
+        let (header_bytes, body_bytes) = bytes;
+        let header: AnyHeader = AnyHeader::decode(&header_bytes)?;
+
+        Ok(AnyOperation {
+            hash: header.hash(),
+            header,
+            body: body_bytes.map(Body::from),
+        })
+    }
+}
+
+impl<E> TryFrom<AnyOperation> for Operation<E>
+where
+    E: Extensions,
+{
+    type Error = HeaderError;
+
+    fn try_from(any_operation: AnyOperation) -> Result<Self, Self::Error> {
+        let header: Header<E> = any_operation.header.try_into()?;
+        Ok(Operation {
+            header,
+            body: any_operation.body,
+            hash: any_operation.hash,
+        })
+    }
+}
+
 pub type Version = u16;
+
+pub type PayloadSize = u32;
+
+pub struct Builder<E> {
+    payload_size: PayloadSize,
+    payload_hash: Option<Hash>,
+    seq_num: SeqNum,
+    backlink: Option<Hash>,
+    _marker: PhantomData<E>,
+}
+
+impl<E> Default for Builder<E>
+where
+    E: Extensions,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E> Builder<E>
+where
+    E: Extensions,
+{
+    pub fn new() -> Self {
+        Self {
+            payload_size: 0,
+            payload_hash: None,
+            seq_num: 0,
+            backlink: None,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn body(mut self, bytes: impl AsRef<[u8]>) -> Self {
+        let bytes = bytes.as_ref();
+
+        self.payload_size = bytes.len() as PayloadSize;
+        self.payload_hash = if self.payload_size == 0 {
+            None
+        } else {
+            Some(Hash::digest(bytes))
+        };
+
+        self
+    }
+
+    pub fn chain(mut self, seq_num: SeqNum, backlink: Hash) -> Self {
+        self.seq_num = seq_num;
+
+        if self.seq_num > 0 {
+            self.backlink = Some(backlink);
+        } else {
+            // Ignore backlink if user tries to set one at seq_num = 0.
+            self.backlink = None;
+        }
+
+        self
+    }
+
+    pub fn seq_num(mut self, seq_num: SeqNum) -> Self {
+        self.seq_num = seq_num;
+        self
+    }
+
+    pub fn backlink(mut self, backlink: Option<Hash>) -> Self {
+        self.backlink = backlink;
+        self
+    }
+
+    pub fn build(self, signing_key: &SigningKey, extensions: E) -> Header<E> {
+        let version = 1;
+
+        let verifying_key = signing_key.verifying_key();
+
+        let extensions_cbor = if Header::<E>::has_non_zero_sized_extensions() {
+            let extensions_cbor = Value::serialized(&extensions).expect("serializable extensions");
+            Some(extensions_cbor)
+        } else {
+            None
+        };
+
+        let signing_bytes = encode_header(
+            version,
+            verifying_key,
+            None,
+            self.payload_size,
+            self.payload_hash,
+            self.seq_num,
+            self.backlink,
+            extensions_cbor.as_ref(),
+        );
+
+        let signature = signing_key.sign(&signing_bytes);
+
+        let bytes = encode_header(
+            version,
+            verifying_key,
+            Some(&signature),
+            self.payload_size,
+            self.payload_hash,
+            self.seq_num,
+            self.backlink,
+            extensions_cbor.as_ref(),
+        );
+
+        let digest = Hash::digest(&bytes);
+        let size = bytes.len() as u32;
+
+        Header {
+            version,
+            verifying_key,
+            signature,
+            payload_size: self.payload_size,
+            payload_hash: self.payload_hash,
+            seq_num: self.seq_num,
+            backlink: self.backlink,
+            extensions,
+            extensions_cbor,
+            digest,
+            size,
+        }
+    }
+}
 
 /// Header of a p2panda operation.
 ///
@@ -181,27 +387,16 @@ pub type Version = u16;
 /// ## Example
 ///
 /// ```
-/// use p2panda_core::{Body, Header, Operation, SigningKey};
+/// use p2panda_core::{Header, SigningKey};
 ///
 /// let signing_key = SigningKey::generate();
 ///
-/// let body = Body::new("Hello, Sloth!".as_bytes());
-/// let mut header = Header {
-///     version: 1,
-///     verifying_key: signing_key.verifying_key(),
-///     signature: None,
-///     payload_size: body.size(),
-///     payload_hash: Some(body.hash()),
-///     seq_num: 0,
-///     backlink: None,
-///     extensions: (),
-/// };
-///
-/// // Sign the header with the author's private key.
-/// header.sign(&signing_key);
+/// let header = Header::builder()
+///     .body(b"Hello, Icebear!")
+///      // Sign the header with the author's private key.
+///     .build(&signing_key, ());
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Header<E = ()> {
     /// Operation format version, allowing backwards compatibility when specification changes.
     pub version: Version,
@@ -210,10 +405,10 @@ pub struct Header<E = ()> {
     pub verifying_key: VerifyingKey,
 
     /// Signature by author over all fields in header, providing authenticity.
-    pub signature: Option<Signature>,
+    pub signature: Signature,
 
     /// Number of bytes of the body of this operation, must be zero if no body is given.
-    pub payload_size: u32,
+    pub payload_size: PayloadSize,
 
     /// Hash of the body of this operation, must be included if payload_size is non-zero and
     /// omitted otherwise.
@@ -241,19 +436,44 @@ pub struct Header<E = ()> {
     // An alternative would be to make this field an `Option` or introduce `E: Default` bounds to
     // allow initialisation in safe code which both are annoying to deal with.
     pub extensions: E,
+
+    /// Original extensions representation in CBOR AST.
+    ///
+    /// This allows us to correctly re-encode this header to bytes if necessary. If we would encode
+    /// the extensions from the Rust type `E` we might not be able to re-construct the original
+    /// bytes. A different system might have interpreted the extensions differently.
+    pub(crate) extensions_cbor: Option<cbor_core::Value<'static>>,
+
+    /// Size of header in encoded CBOR bytes.
+    pub(crate) size: u32,
+
+    /// BLAKE3 hash digest of header.
+    pub(crate) digest: Hash,
 }
 
-impl<E: Default> Default for Header<E> {
+#[cfg(any(test, feature = "test_utils"))]
+impl<E> Default for Header<E>
+where
+    E: Default,
+{
+    /// This is for hacky low-level access to this type, don't use this in production.
+    ///
+    /// Size and digest get re-computed whenever called in test environments. Note that we can't
+    /// re-encode `extensions_cbor` if `E` was changed in a test. Ideally you don't want to test
+    /// extensions-related code here anyway.
     fn default() -> Self {
         Self {
             version: 1,
             verifying_key: VerifyingKey::default(),
-            signature: None,
+            signature: Signature::from([0; SIGNATURE_LEN]),
             payload_size: 0,
             payload_hash: None,
             seq_num: 0,
             backlink: None,
             extensions: E::default(),
+            extensions_cbor: None,
+            size: 0,
+            digest: Hash::from([0; HASH_LEN]),
         }
     }
 }
@@ -262,46 +482,55 @@ impl<E> Header<E>
 where
     E: Extensions,
 {
-    /// Header encoded to bytes in CBOR format.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        encode_cbor(self)
-            // We can be sure that all values in this module are serializable and _if_ ciborium
-            // still fails then because of something really bad ..
-            .expect("CBOR encoder failed due to an critical IO error")
+    pub fn builder() -> Builder<E> {
+        Builder::new()
     }
 
-    /// Add a signature to the header using the provided `SigningKey`.
-    ///
-    /// This method signs the byte representation of a header with any existing signature removed
-    /// before adding back the newly generated signature.
-    pub fn sign(&mut self, signing_key: &SigningKey) {
-        // Make sure the signature is not already set before we encode
-        self.signature = None;
-
-        let bytes = self.to_bytes();
-        self.signature = Some(signing_key.sign(&bytes));
+    pub fn from_any(any_header: AnyHeader) -> Result<Self, HeaderError> {
+        Self::try_from(any_header)
     }
 
-    /// Verify that the signature contained in this `Header` was generated by the claimed
-    /// public key.
-    pub fn verify(&self) -> bool {
-        match self.signature {
-            Some(claimed_signature) => {
-                let mut unsigned_header = self.clone();
-                unsigned_header.signature = None;
-                let unsigned_bytes = unsigned_header.to_bytes();
-                self.verifying_key
-                    .verify(&unsigned_bytes, &claimed_signature)
-            }
-            None => false,
-        }
+    pub fn encode(&self) -> Vec<u8> {
+        encode_header(
+            self.version,
+            self.verifying_key,
+            Some(&self.signature),
+            self.payload_size,
+            self.payload_hash,
+            self.seq_num,
+            self.backlink,
+            self.extensions_cbor.as_ref(),
+        )
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, HeaderError> {
+        // Decode header.
+        let any_header = AnyHeader::decode(bytes)?;
+
+        // Decode extensions.
+        Self::from_any(any_header)
     }
 
     /// BLAKE3 hash of the header bytes.
     ///
     /// This hash is used as the unique identifier of an operation, aka the Operation Id.
     pub fn hash(&self) -> Hash {
-        Hash::digest(self.to_bytes())
+        // Re-calculate hash and size in test environments.
+        if cfg!(any(test, feature = "test_utils")) {
+            return Hash::digest(self.encode());
+        }
+
+        self.digest
+    }
+
+    /// Size of header when encoded as CBOR bytes.
+    pub fn size(&self) -> u32 {
+        // Re-calculate hash and size in test environments.
+        if cfg!(any(test, feature = "test_utils")) {
+            return self.encode().len() as u32;
+        }
+
+        self.size
     }
 
     /// Extract an extension value from the header.
@@ -327,32 +556,6 @@ impl<E> Header<E> {
         // no-op with no actual memory operations.
         unsafe { std::mem::zeroed() }
     }
-
-    /// Number of fields included in the header.
-    ///
-    /// Fields instantiated with `None` values are excluded from the count.
-    pub(crate) fn field_count(&self) -> usize {
-        // There will always be a minimum of 4 fields in an unsigned header.
-        let mut count = 4;
-
-        if self.signature.is_some() {
-            count += 1;
-        }
-
-        if self.payload_hash.is_some() {
-            count += 1;
-        }
-
-        if self.backlink.is_some() {
-            count += 1;
-        }
-
-        if Self::has_non_zero_sized_extensions() {
-            count += 1;
-        }
-
-        count
-    }
 }
 
 #[cfg(any(test, feature = "test_utils"))]
@@ -361,7 +564,70 @@ where
     E: Extensions,
 {
     pub fn to_hex(&self) -> String {
-        hex::encode(self.to_bytes())
+        hex::encode(self.encode())
+    }
+
+    fn encode_signing_bytes(&self) -> Vec<u8> {
+        encode_header(
+            self.version,
+            self.verifying_key,
+            None,
+            self.payload_size,
+            self.payload_hash,
+            self.seq_num,
+            self.backlink,
+            self.extensions_cbor.as_ref(),
+        )
+    }
+
+    pub fn sign(&mut self, signer: &SigningKey) {
+        let signing_bytes = self.encode_signing_bytes();
+        self.signature = signer.sign(&signing_bytes);
+    }
+
+    pub fn verify(&self) -> bool {
+        let signing_bytes = self.encode_signing_bytes();
+        self.verifying_key.verify(&signing_bytes, &self.signature)
+    }
+}
+
+impl<E> TryFrom<Header<E>> for AnyHeader
+where
+    E: Extensions,
+{
+    type Error = HeaderError;
+
+    fn try_from(value: Header<E>) -> Result<Self, Self::Error> {
+        let extensions = if Header::<E>::has_non_zero_sized_extensions() {
+            Some(
+                cbor_core::Value::serialized(&value.extensions)
+                    .map_err(HeaderError::EncodingExtensions)?,
+            )
+        } else {
+            None
+        };
+
+        Ok(AnyHeader {
+            version: value.version,
+            verifying_key: value.verifying_key,
+            signature: value.signature,
+            payload_size: value.payload_size,
+            payload_hash: value.payload_hash,
+            seq_num: value.seq_num,
+            backlink: value.backlink,
+            size: value.size,
+            digest: value.digest,
+            extensions,
+        })
+    }
+}
+
+impl<E> Digest<Hash> for Header<E>
+where
+    E: Extensions,
+{
+    fn hash(&self) -> Hash {
+        self.hash()
     }
 }
 
@@ -374,26 +640,488 @@ where
     }
 
     fn verify(&self) -> bool {
-        self.verify()
+        // Check signature in test environments as low-level access might have allowed users to
+        // tamper with the integrity.
+        if cfg!(any(test, feature = "test_utils")) {
+            return self.verify();
+        }
+
+        // Header was always created by us and has a valid signature.
+        true
     }
 }
 
-impl TryFrom<&[u8]> for Header {
-    type Error = DecodeError;
+impl<E> Chain<Hash> for Header<E>
+where
+    E: Extensions,
+{
+    fn backlink(&self) -> Option<Hash> {
+        self.backlink
+    }
+
+    fn seq_num(&self) -> SeqNum {
+        self.seq_num
+    }
+}
+
+impl<E> Offchain<Hash> for Header<E>
+where
+    E: Extensions,
+{
+    fn payload(&self) -> Option<&Body> {
+        None // We don't have the body here.
+    }
+
+    fn payload_hash(&self) -> Option<Hash> {
+        self.payload_hash
+    }
+
+    fn payload_size(&self) -> PayloadSize {
+        self.payload_size
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_header(
+    version: Version,
+    verifying_key: VerifyingKey,
+    signature: Option<&Signature>,
+    payload_size: PayloadSize,
+    payload_hash: Option<Hash>,
+    seq_num: SeqNum,
+    backlink: Option<Hash>,
+    extensions: Option<&Value<'static>>,
+) -> Vec<u8> {
+    let mut cbor = Value::array([Value::from(version), Value::from(verifying_key.as_bytes())]);
+
+    // Signature can be omitted to encode bytes for signing.
+    if let Some(signature) = &signature {
+        cbor.append(signature.to_bytes());
+    }
+
+    cbor.append(payload_size);
+
+    if let Some(payload_hash) = &payload_hash {
+        cbor.append(payload_hash.as_bytes());
+    }
+
+    cbor.append(seq_num);
+
+    if let Some(backlink) = &backlink {
+        cbor.append(backlink.as_bytes());
+    }
+
+    if let Some(extensions) = extensions {
+        cbor.append(extensions.to_owned());
+    }
+
+    cbor.encode()
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AnyHeader {
+    pub version: Version,
+    pub verifying_key: VerifyingKey,
+    pub signature: Signature,
+    pub payload_size: PayloadSize,
+    pub payload_hash: Option<Hash>,
+    pub seq_num: SeqNum,
+    pub backlink: Option<Hash>,
+    pub(crate) size: u32,
+    pub(crate) digest: Hash,
+    pub(crate) extensions: Option<cbor_core::Value<'static>>,
+}
+
+impl AnyHeader {
+    pub fn decode(bytes: &[u8]) -> Result<Self, HeaderError> {
+        // Attempt decoding bytes as CBOR.
+        //
+        // The bytes are decoded in a zero-copy manner, only reading from the given byte slice.
+        let cbor = {
+            let strict = cbor_core::DecodeOptions::new()
+                // Reduce strictness as we can't enforce it for all possible ways users will encode
+                // their extensions. On top we want to uphold the robustness principle:
+                // "be conservative in what you do, be liberal in what you accept from others"
+                .strictness(cbor_core::Strictness {
+                    // We're fine with non-canonical encodings.
+                    allow_non_shortest_integers: true,
+                    allow_non_shortest_floats: true,
+                    allow_oversized_bigints: true,
+                    allow_unsorted_map_keys: true,
+                    // Can lead to undefined behaviour and is simply wrong.
+                    allow_duplicate_map_keys: false,
+                    // Respect length limit right from the beginning.
+                    allow_indefinite_length: false,
+                })
+                // Still, we want to make sure some attacks are mitigated and set rather low
+                // / pessimistic thresholds.
+                .recursion_limit(64)
+                .length_limit(512) // 0.5kb
+                .oom_mitigation(64);
+
+            strict.decode(bytes).map_err(HeaderError::DecodingHeader)?
+        };
+
+        // Validate each field in header based on p2panda specification and extract Rust types.
+        //
+        // Every header is a tuple (CBOR array). We iterate over each field and check if the
+        // expected CBOR and Rust type is given.
+        //
+        // The types are converted into owned objects (leaving the zero-copy nature of this process)
+        // and kept to allow further validation (log integrity) or conversion into the more
+        // specialised Header<E> type (where the Extensions are known).
+        //
+        // We don't keep the CBOR representation or bytes around anymore in the end (except of the
+        // decoded extensions) to not waste memory with duplicate representations of the same data.
+        let mut seq = cbor
+            .into_array()
+            .map_err(HeaderError::UnexpectedHeaderType)?;
+        let mut iter = seq.iter();
+
+        let version = {
+            let next = iter.next().ok_or(HeaderError::MissingField("version"))?;
+
+            Version::try_from(next)
+                .map_err(|err| HeaderError::UnexpectedFieldType(err, "version"))?
+        };
+
+        if version != 1 {
+            return Err(HeaderError::UnsupportedVersion(version, 1));
+        }
+
+        let verifying_key = {
+            let next = iter
+                .next()
+                .ok_or(HeaderError::MissingField("verifying_key"))?;
+
+            let bytes = next
+                .as_bytes()
+                .map_err(|err| HeaderError::UnexpectedFieldType(err, "verifying_key"))?;
+
+            let bytes: [u8; VERIFYING_KEY_LEN] = bytes.try_into().map_err(|_| {
+                HeaderError::InvalidBytesLen("verifying_key", VERIFYING_KEY_LEN, bytes.len())
+            })?;
+
+            VerifyingKey::from_bytes(&bytes).map_err(HeaderError::InvalidVerifyingKey)?
+        };
+
+        let signature = {
+            let next = iter.next().ok_or(HeaderError::MissingField("signature"))?;
+
+            let bytes = next
+                .as_bytes()
+                .map_err(|err| HeaderError::UnexpectedFieldType(err, "signature"))?;
+
+            let bytes: [u8; SIGNATURE_LEN] = bytes.try_into().map_err(|_| {
+                HeaderError::InvalidBytesLen("signature", SIGNATURE_LEN, bytes.len())
+            })?;
+
+            Signature::from(&bytes)
+        };
+
+        let payload_size = {
+            let next = iter
+                .next()
+                .ok_or(HeaderError::MissingField("payload_size"))?;
+
+            PayloadSize::try_from(next)
+                .map_err(|err| HeaderError::UnexpectedFieldType(err, "payload_size"))?
+        };
+
+        let payload_hash = if payload_size > 0 {
+            let next = iter
+                .next()
+                .ok_or(HeaderError::MissingField("payload_hash"))?;
+
+            let bytes = next
+                .as_bytes()
+                .map_err(|err| HeaderError::UnexpectedFieldType(err, "payload_hash"))?;
+
+            let bytes: [u8; HASH_LEN] = bytes
+                .try_into()
+                .map_err(|_| HeaderError::InvalidBytesLen("payload_hash", HASH_LEN, bytes.len()))?;
+
+            Some(Hash::from(bytes))
+        } else {
+            None
+        };
+
+        let seq_num = {
+            let next = iter.next().ok_or(HeaderError::MissingField("seq_num"))?;
+
+            SeqNum::try_from(next)
+                .map_err(|err| HeaderError::UnexpectedFieldType(err, "seq_num"))?
+        };
+
+        let backlink = if seq_num > 0 {
+            let next = iter.next().ok_or(HeaderError::MissingField("backlink"))?;
+
+            let bytes = next
+                .as_bytes()
+                .map_err(|err| HeaderError::UnexpectedFieldType(err, "backlink"))?;
+
+            let bytes: [u8; HASH_LEN] = bytes
+                .try_into()
+                .map_err(|_| HeaderError::InvalidBytesLen("backlink", HASH_LEN, bytes.len()))?;
+
+            Some(Hash::from(bytes))
+        } else {
+            None
+        };
+
+        // Extract extensions and keep them for later, in case we need to deserialize them into
+        // Header<E> in the future.
+        //
+        // AnyHeader doesn't know the Rust type for E, only it's "raw" CBOR representation. To use
+        // extensions properly with Rust types we eventually want to convert into the concrete E
+        // type.
+        //
+        // Please note that at this stage we _don't know_ if this header is valid with the
+        // extensions set. We can only find out if this is correct if we know the concrete E type
+        // (if it's a ZST then there should not be an extensions field).
+        let extensions = iter.next().map(|value| value.to_owned());
+
+        // If anything came after all expected fields, something is wrong.
+        if iter.next().is_some() {
+            return Err(HeaderError::ExcessiveFields);
+        }
+
+        // Verify signature.
+        //
+        // Extract signature from field position 2. It'll be removed from the CBOR value, so we can
+        // encode the bytes without it.
+        //
+        //  [0]      [1]            [2]
+        // (version, verifying_key, signature, ..)
+        //                          =========
+        seq.remove(2);
+
+        let verify_bytes = cbor_core::Value::from(seq).encode();
+        if !verifying_key.verify(&verify_bytes, &signature) {
+            return Err(HeaderError::InvalidSignature);
+        }
+
+        // Calculate header size and generate hash digest.
+        //
+        // We keep these values around so if users of this object require the size or hash, it will
+        // not be re-computed again.
+        //
+        // Since we also have the bytes in our hands already we don't need to encode either.
+        let size = bytes.len() as u32;
+        let digest = Hash::digest(bytes);
+
+        Ok(Self {
+            version,
+            verifying_key,
+            signature,
+            payload_size,
+            payload_hash,
+            seq_num,
+            backlink,
+            size,
+            digest,
+            extensions,
+        })
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        encode_header(
+            self.version,
+            self.verifying_key,
+            Some(&self.signature),
+            self.payload_size,
+            self.payload_hash,
+            self.seq_num,
+            self.backlink,
+            self.extensions.as_ref(),
+        )
+    }
+
+    /// BLAKE3 hash of the header bytes.
+    ///
+    /// This hash is used as the unique identifier of an operation, aka the Operation Id.
+    pub fn hash(&self) -> Hash {
+        self.digest
+    }
+
+    /// Size of header when encoded as CBOR bytes.
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+}
+
+impl TryFrom<&[u8]> for AnyHeader {
+    type Error = HeaderError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        decode_cbor(value)
+        Self::decode(value)
     }
+}
+
+impl TryFrom<Vec<u8>> for AnyHeader {
+    type Error = HeaderError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::decode(&value)
+    }
+}
+
+impl<E> TryFrom<AnyHeader> for Header<E>
+where
+    E: Extensions,
+{
+    type Error = HeaderError;
+
+    fn try_from(value: AnyHeader) -> Result<Self, Self::Error> {
+        let extensions = match value.extensions {
+            Some(ref cbor) => {
+                // For ZST extension types we don't expect the extensions field in the header to be
+                // set. Since we now know E we can assure that this is the case.
+                if !Header::<E>::has_non_zero_sized_extensions() {
+                    return Err(HeaderError::UnexpectedExtensions);
+                }
+
+                // At this point we've already decoded the byte string into CBOR. Now we only need
+                // serde to iterate over these values to check if they match the given Rust type.
+                cbor.deserialized()
+                    .map_err(HeaderError::DecodingExtensions)?
+            }
+            None => {
+                if Header::<E>::has_non_zero_sized_extensions() {
+                    return Err(HeaderError::MissingExtensions);
+                } else {
+                    Header::<E>::zero_sized_extensions()
+                }
+            }
+        };
+
+        Ok(Header {
+            version: value.version,
+            verifying_key: value.verifying_key,
+            signature: value.signature,
+            payload_size: value.payload_size,
+            payload_hash: value.payload_hash,
+            seq_num: value.seq_num,
+            backlink: value.backlink,
+            extensions,
+            extensions_cbor: value.extensions,
+            size: value.size,
+            digest: value.digest,
+        })
+    }
+}
+
+impl<E> TryFrom<(AnyHeader, Option<Body>)> for Operation<E>
+where
+    E: Extensions,
+{
+    type Error = HeaderError;
+
+    fn try_from(value: (AnyHeader, Option<Body>)) -> Result<Self, Self::Error> {
+        let (any_header, body) = value;
+
+        // Take the already computed hash from AnyHeader to save some time.
+        let hash = any_header.hash();
+
+        // Most fields have already been decoded, at this stage we only need to take the already
+        // decoded CBOR values into a Rust type representation.
+        let header: Header<E> = any_header.try_into()?;
+
+        Ok(Operation { header, body, hash })
+    }
+}
+
+impl Digest<Hash> for AnyHeader {
+    fn hash(&self) -> Hash {
+        self.hash()
+    }
+}
+
+impl Provenance<VerifyingKey> for AnyHeader {
+    fn author(&self) -> VerifyingKey {
+        self.verifying_key
+    }
+
+    fn verify(&self) -> bool {
+        // Was checked during decoding.
+        true
+    }
+}
+
+impl Chain<Hash> for AnyHeader {
+    fn backlink(&self) -> Option<Hash> {
+        self.backlink
+    }
+
+    fn seq_num(&self) -> SeqNum {
+        self.seq_num
+    }
+}
+
+impl Offchain<Hash> for AnyHeader {
+    fn payload(&self) -> Option<&Body> {
+        None
+    }
+
+    fn payload_hash(&self) -> Option<Hash> {
+        self.payload_hash
+    }
+
+    fn payload_size(&self) -> PayloadSize {
+        self.payload_size
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum HeaderError {
+    #[error("failed decoding CBOR byte string for header: {0}")]
+    DecodingHeader(cbor_core::Error),
+
+    #[error("failed decoding CBOR byte string for extensions: {0}")]
+    DecodingExtensions(cbor_core::SerdeError),
+
+    #[error("expected CBOR array for header: {0}")]
+    UnexpectedHeaderType(cbor_core::Error),
+
+    #[error("missing \"{0}\" field in header")]
+    MissingField(&'static str),
+
+    #[error("unexpected \"{0}\" field type for \"{0}\"")]
+    UnexpectedFieldType(cbor_core::Error, &'static str),
+
+    #[error("invalid verifying key: {0}")]
+    InvalidVerifyingKey(crate::identity::IdentityError),
+
+    #[error("invalid bytes length for \"{0}\", expected {1}, got {2} bytes")]
+    InvalidBytesLen(&'static str, usize, usize),
+
+    #[error("operation version {0} is not supported, needs to be <= {1}")]
+    UnsupportedVersion(Version, Version),
+
+    #[error("invalid signature")]
+    InvalidSignature,
+
+    #[error("unexpected excessive fields in header")]
+    ExcessiveFields,
+
+    #[error("didn't expect extensions but header contained excessive field")]
+    UnexpectedExtensions,
+
+    #[error("expected extensions but header didn't contain any")]
+    MissingExtensions,
+
+    #[error("failed encoding CBOR byte string for extensions: {0}")]
+    EncodingExtensions(cbor_core::SerdeError),
 }
 
 /// Body of a p2panda operation containing arbitrary bytes.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Body(pub(super) Vec<u8>);
 
 impl Body {
     /// Construct a body from a byte slice.
-    pub fn new(bytes: &[u8]) -> Self {
-        Self(bytes.to_vec())
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
+        Self(bytes.as_ref().to_vec())
     }
 
     /// Access the underlying body bytes.
@@ -411,21 +1139,25 @@ impl Body {
     }
 
     /// Size of body bytes.
-    pub fn size(&self) -> u32 {
-        self.0.len() as u32
+    pub fn size(&self) -> PayloadSize {
+        self.0.len() as PayloadSize
+    }
+
+    #[cfg(any(test, feature = "test_utils"))]
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.0)
     }
 }
 
-#[cfg(any(test, feature = "test_utils"))]
-impl Body {
-    pub fn to_hex(&self) -> String {
-        hex::encode(self.as_bytes())
+impl AsRef<[u8]> for Body {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
     }
 }
 
 impl From<&[u8]> for Body {
     fn from(value: &[u8]) -> Self {
-        Body::new(value)
+        Body::from_bytes(value)
     }
 }
 
@@ -477,30 +1209,27 @@ pub enum OperationError {
 ///
 /// This method validates that the following conditions are true:
 /// * Signature can be verified against the author public key and unsigned header bytes
-/// * Header version is supported (currently only version 1 is supported)
 /// * If `payload_hash` is set the `payload_size` is > `0` otherwise it is zero
 /// * If `backlink` is set then `seq_num` is > `0` otherwise it is zero
 /// * If provided the body bytes hash and size match those claimed in the header
-pub fn validate_operation<E>(operation: impl Borrow<Operation<E>>) -> Result<(), OperationError>
+pub fn validate_operation<T>(operation: &T) -> Result<(), OperationError>
 where
-    E: Extensions,
+    T: Provenance<VerifyingKey> + Chain<Hash> + Offchain<Hash>,
 {
-    let operation = operation.borrow();
-    validate_header(&operation.header)?;
+    validate_header::<T>(operation)?;
 
-    let claimed_payload_size = operation.header.payload_size;
+    let claimed_payload_size = operation.payload_size();
     let claimed_payload_hash: Option<Hash> = match claimed_payload_size {
         0 => None,
         _ => {
             let hash = operation
-                .header
-                .payload_hash
+                .payload_hash()
                 .ok_or(OperationError::MissingPayloadHash)?;
             Some(hash)
         }
     };
 
-    if let Some(body) = &operation.body
+    if let Some(body) = &operation.payload()
         && (claimed_payload_hash != Some(body.hash()) || claimed_payload_size != body.size())
     {
         return Err(OperationError::PayloadMismatch);
@@ -513,32 +1242,27 @@ where
 ///
 /// This method validates that the following conditions are true:
 /// * Signature can be verified against the author public key and unsigned header bytes
-/// * Header version is supported (currently only version 1 is supported)
 /// * If `payload_hash` is set the `payload_size` is > `0` otherwise it is zero
 /// * If `backlink` is set then `seq_num` is > `0` otherwise it is zero
-pub fn validate_header<E>(header: &Header<E>) -> Result<(), OperationError>
+pub fn validate_header<T>(header: &T) -> Result<(), OperationError>
 where
-    E: Extensions,
+    T: Provenance<VerifyingKey> + Chain<Hash> + Offchain<Hash>,
 {
     if !header.verify() {
         return Err(OperationError::SignatureMismatch);
     }
 
-    if header.version != 1 {
-        return Err(OperationError::UnsupportedVersion(header.version, 1));
-    }
-
-    if (header.payload_hash.is_some() && header.payload_size == 0)
-        || (header.payload_hash.is_none() && header.payload_size > 0)
+    if (header.payload_hash().is_some() && header.payload_size() == 0)
+        || (header.payload_hash().is_none() && header.payload_size() > 0)
     {
         return Err(OperationError::InconsistentPayloadInfo);
     }
 
-    if header.backlink.is_some() && header.seq_num == 0 {
+    if header.backlink().is_some() && header.seq_num() == 0 {
         return Err(OperationError::SeqNumMismatch);
     }
 
-    if header.backlink.is_none() && header.seq_num > 0 {
+    if header.backlink().is_none() && header.seq_num() > 0 {
         return Err(OperationError::BacklinkMissing);
     }
 
@@ -552,28 +1276,22 @@ where
 /// * Current and past headers contain the same public key
 /// * Current headers seq number increments from the past one by exactly `1`
 /// * Backlink hash contained in the current header matches the hash of the past header
-pub fn validate_backlink<E>(
-    past_header: impl Borrow<Header<E>>,
-    header: impl Borrow<Header<E>>,
-) -> Result<(), OperationError>
+pub fn validate_backlink<T>(past_header: &T, header: &T) -> Result<(), OperationError>
 where
-    E: Extensions,
+    T: Provenance<VerifyingKey> + Digest<Hash> + Chain<Hash>,
 {
-    let past_header = past_header.borrow();
-    let header = header.borrow();
-
-    if past_header.verifying_key != header.verifying_key {
+    if past_header.author() != header.author() {
         return Err(OperationError::TooManyAuthors);
     }
 
-    if past_header.seq_num + 1 != header.seq_num {
+    if past_header.seq_num() + 1 != header.seq_num() {
         return Err(OperationError::SeqNumNonIncremental(
-            past_header.seq_num + 1,
-            header.seq_num,
+            past_header.seq_num() + 1,
+            header.seq_num(),
         ));
     }
 
-    match header.backlink {
+    match header.backlink() {
         Some(backlink) => {
             if past_header.hash() != backlink {
                 return Err(OperationError::BacklinkMismatch);
@@ -591,47 +1309,61 @@ where
 mod tests {
     use serde::{Deserialize, Serialize};
 
-    use crate::{Extension, SigningKey};
+    use crate::identity::SigningKey;
 
     use super::*;
 
     #[test]
-    fn simple_extension_type_parameter() {
+    fn paths_leading_to_same_encoding() {
         let signing_key = SigningKey::generate();
-        let body = Body::new("Hello, Sloth!".as_bytes());
-        let mut header = Header {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
+
+        let header = Header::builder()
+            .body(b"test")
+            .chain(2, Hash::from([2; 32]))
+            .build(&signing_key, ());
+
+        let hacky_header = {
+            let body = Body::from_bytes(b"test");
+            let mut hacky_header = Header::<()> {
+                verifying_key: signing_key.verifying_key(),
+                payload_size: body.size(),
+                payload_hash: Some(body.hash()),
+                seq_num: 2,
+                backlink: Some(Hash::from([2; 32])),
+                ..Default::default()
+            };
+            hacky_header.sign(&signing_key);
+            hacky_header
         };
 
-        header.sign(&signing_key);
+        assert_eq!(header.encode(), hacky_header.encode());
+        assert_eq!(header.verify(), hacky_header.verify());
+        assert!(header.verify());
+        assert_eq!(header.hash(), hacky_header.hash());
+        assert_eq!(header.size(), hacky_header.size());
+
+        let any_header = AnyHeader::decode(&header.encode()).unwrap();
+
+        assert_eq!(header.encode(), any_header.encode());
+        assert_eq!(header.verify(), any_header.verify());
+        assert!(any_header.verify());
+        assert_eq!(header.hash(), any_header.hash());
+        assert_eq!(header.size(), any_header.size());
+
+        let header_again = Header::<()>::from_any(any_header.clone()).unwrap();
+        assert_eq!(header, header_again);
     }
 
     #[test]
     fn sign_and_verify() {
         let signing_key = SigningKey::generate();
-        let body = Body::new("Hello, Sloth!".as_bytes());
-        type CustomExtensions = ();
+        let body = Body::from_bytes("Hello, Sloth!".as_bytes());
 
-        let mut header = Header {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: None::<CustomExtensions>,
-        };
-        assert!(!header.verify());
+        type CustomExtensions = (u32, String);
 
-        header.sign(&signing_key);
+        let header = Header::<CustomExtensions>::builder()
+            .body(&body)
+            .build(&signing_key, (42, "penguin".to_string()));
         assert!(header.verify());
 
         let operation = Operation {
@@ -639,37 +1371,19 @@ mod tests {
             header,
             body: Some(body),
         };
-        assert!(validate_operation(&operation).is_ok());
+        assert!(validate_operation::<Operation<_>>(&operation).is_ok());
     }
 
     #[test]
     fn valid_backlink_header() {
         let signing_key = SigningKey::generate();
 
-        let mut header_0 = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header_0.sign(&signing_key);
+        let header_0 = Header::builder().build(&signing_key, ());
         assert!(validate_header(&header_0).is_ok());
 
-        let mut header_1 = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 1,
-            backlink: Some(header_0.hash()),
-            extensions: (),
-        };
-        header_1.sign(&signing_key);
+        let header_1 = Header::builder()
+            .chain(1, header_0.hash())
+            .build(&signing_key, ());
         assert!(validate_header(&header_1).is_ok());
 
         assert!(validate_backlink(&header_0, &header_1).is_ok());
@@ -678,27 +1392,14 @@ mod tests {
     #[test]
     fn invalid_operations() {
         let signing_key = SigningKey::generate();
-        let body: Body = Body::new("Hello, Sloth!".as_bytes());
+        let body: Body = Body::from_bytes("Hello, Sloth!".as_bytes());
 
         let header_base = Header::<()> {
-            version: 1,
             verifying_key: signing_key.verifying_key(),
-            signature: None,
             payload_size: body.size(),
             payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
+            ..Default::default()
         };
-
-        // Incompatible operation format
-        let mut header = header_base.clone();
-        header.version = 0;
-        header.sign(&signing_key);
-        std::assert_matches!(
-            validate_header(&header),
-            Err(OperationError::UnsupportedVersion(0, 1))
-        );
 
         // Signature doesn't match public key
         let mut header = header_base.clone();
@@ -755,66 +1456,6 @@ mod tests {
     }
 
     #[test]
-    fn extensions() {
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        struct LogId(Hash);
-
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        struct Expiry(u64);
-
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        struct CustomExtensions {
-            log_id: Option<LogId>,
-            expires: Expiry,
-        }
-
-        impl Extension<LogId> for CustomExtensions {
-            fn extract(header: &Header<Self>) -> Option<LogId> {
-                if header.seq_num == 0 {
-                    return Some(LogId(header.hash()));
-                };
-
-                header.extensions.log_id.clone()
-            }
-        }
-
-        impl Extension<Expiry> for CustomExtensions {
-            fn extract(header: &Header<Self>) -> Option<Expiry> {
-                Some(header.extensions.expires.clone())
-            }
-        }
-
-        let extensions = CustomExtensions {
-            log_id: None,
-            expires: Expiry(0123456),
-        };
-
-        let signing_key = SigningKey::generate();
-        let body: Body = Body::new("Hello, Sloth!".as_bytes());
-
-        let mut header = Header {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: extensions.clone(),
-        };
-
-        header.sign(&signing_key);
-
-        // Thanks to blanket implementation of Extension<T> on Header we can extract the extension
-        // value from the header itself.
-        let log_id: LogId = header.extension().unwrap();
-        let expiry: Expiry = header.extension().unwrap();
-
-        assert_eq!(header.hash(), log_id.0);
-        assert_eq!(extensions.expires.0, expiry.0);
-    }
-
-    #[test]
     fn zst_size_matches_mem_checks() {
         struct ZstExtensions;
         assert_eq!(std::mem::size_of::<ZstExtensions>(), 0);
@@ -824,5 +1465,205 @@ mod tests {
         struct NonZstExtensions(u32);
         assert_ne!(std::mem::size_of::<NonZstExtensions>(), 0);
         assert!(Header::<NonZstExtensions>::has_non_zero_sized_extensions());
+    }
+
+    #[test]
+    fn any_header_conversions() {
+        let signing_key = SigningKey::generate();
+
+        #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+        struct TestExtensions {
+            field_a: Vec<u8>,
+            field_b: bool,
+            field_c: u64,
+        }
+
+        let header = Header::builder().body(b"hello").build(
+            &signing_key,
+            TestExtensions {
+                field_a: vec![61, 112, 43],
+                field_b: true,
+                field_c: 54_938,
+            },
+        );
+
+        let hash = header.hash();
+        assert!(header.verify());
+
+        let any_header = AnyHeader::try_from(header.clone()).unwrap();
+        assert_eq!(any_header.hash(), hash);
+        assert_eq!(any_header.size(), header.encode().len() as u32);
+
+        let header_again: Header<TestExtensions> = any_header.try_into().unwrap();
+        assert_eq!(header, header_again);
+    }
+
+    #[test]
+    fn any_header_errors() {
+        let signing_key = SigningKey::generate();
+
+        // First check that this header is valid. The body is b"test".
+        let correct_header_bytes = r#"[
+            1,
+            h'6dec6975e5c280e9eadde785cf01df20690d02c8ab7a57efcd58150ab53a867f',
+            h'a4331f8d5742d3c40b7e8cfb93e487f4b3b8878e64f7ec9985169d6ed3a3fa3b7e9c9d4b69d6c62e6079dba734705a4b8fc2210f2793bf1ee8b2af5963ce9e0b',
+            4,
+            h'4878ca0425c739fa427f7eda20fe845f6b2e46ba5fe2a14df5b1e32f50603215',
+            0
+        ]"#
+        .parse::<cbor_core::Value>()
+        .unwrap()
+        .encode();
+        assert!(AnyHeader::decode(&correct_header_bytes).is_ok());
+
+        // Insufficient bytes for payload_hash.
+        let invalid_header_bytes = r#"[
+            1,
+            h'6dec6975e5c280e9eadde785cf01df20690d02c8ab7a57efcd58150ab53a867f',
+            h'a4331f8d5742d3c40b7e8cfb93e487f4b3b8878e64f7ec9985169d6ed3a3fa3b7e9c9d4b69d6c62e6079dba734705a4b8fc2210f2793bf1ee8b2af5963ce9e0b',
+            4,
+            h'4878',
+            0
+        ]"#
+        .parse::<cbor_core::Value>()
+        .unwrap()
+        .encode();
+
+        std::assert_matches!(
+            AnyHeader::decode(&invalid_header_bytes),
+            Err(HeaderError::InvalidBytesLen("payload_hash", 32, 2))
+        );
+
+        // Invalid signature.
+        let mut header = Header::builder().build(&signing_key, ());
+        header.verifying_key = SigningKey::generate().verifying_key();
+
+        let result = AnyHeader::decode(&header.encode());
+        std::assert_matches!(result, Err(HeaderError::InvalidSignature));
+
+        // payload_size given without payload_hash.
+        let mut header = Header::builder().build(&signing_key, ());
+        header.payload_size = 2829099;
+        header.sign(&signing_key);
+
+        let result = AnyHeader::decode(&header.encode());
+        std::assert_matches!(
+            result,
+            Err(HeaderError::UnexpectedFieldType(
+                cbor_core::Error::IncompatibleType(cbor_core::DataType::Int),
+                "payload_hash"
+            ))
+        );
+
+        // payload_hash given without payload_size.
+        let mut header = Header::<()> {
+            verifying_key: signing_key.verifying_key(),
+            payload_size: 0,
+            payload_hash: Some(Hash::digest([0, 1, 2])),
+            extensions: (),
+            ..Default::default()
+        };
+        header.sign(&signing_key);
+
+        let result = AnyHeader::decode(&header.encode());
+        std::assert_matches!(
+            result,
+            Err(HeaderError::UnexpectedFieldType(
+                cbor_core::Error::IncompatibleType(cbor_core::DataType::Bytes),
+                "seq_num"
+            ))
+        );
+
+        // backlink given with seq_num 0.
+        let mut header = Header::<()> {
+            verifying_key: signing_key.verifying_key(),
+            seq_num: 0,
+            backlink: Some(Hash::digest([0, 1, 2])),
+            ..Default::default()
+        };
+        header.sign(&signing_key);
+
+        // At this point we don't know that the backlink is _not_ an extension:
+        let result = AnyHeader::decode(&header.encode()).expect("this is fine ..");
+
+        // .. but latest here we'll find out!
+        let result = Header::<()>::try_from(result);
+        let result_2 = Header::<()>::decode(&header.encode());
+        assert!(result.is_err());
+        assert!(result_2.is_err());
+        std::assert_matches!(result, Err(HeaderError::UnexpectedExtensions));
+
+        // backlink not given with seq_num > 0.
+        let mut header = Header::<()> {
+            verifying_key: signing_key.verifying_key(),
+            seq_num: 10,
+            backlink: None,
+            ..Default::default()
+        };
+        header.sign(&signing_key);
+
+        let result = AnyHeader::decode(&header.encode());
+        std::assert_matches!(result, Err(HeaderError::MissingField("backlink")));
+    }
+
+    #[test]
+    fn forwards_compatible_checks() {
+        use crate::{PruneFlag, Timestamp};
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        struct LegacyExtensionsFormat {
+            timestamp: Timestamp,
+        }
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        struct FutureExtensionsFormat {
+            timestamp: Timestamp,
+            #[serde(default = "PruneFlag::default")]
+            prune_flag: PruneFlag,
+        }
+
+        let signing_key = SigningKey::generate();
+
+        let old_header = Header::builder().body(b"once upon a time").build(
+            &signing_key,
+            LegacyExtensionsFormat {
+                timestamp: 1780572316919.into(),
+            },
+        );
+        let old_header_bytes = old_header.encode();
+
+        let new_header = Header::builder()
+            .body(b"fitter, happier, more productive")
+            .build(
+                &signing_key,
+                FutureExtensionsFormat {
+                    timestamp: 1780572316919.into(),
+                    prune_flag: true.into(),
+                },
+            );
+        let new_header_bytes = new_header.encode();
+        let new_header_hash = new_header.hash();
+
+        // The old system can still parse headers with the new extensions format:
+        let any_header = AnyHeader::decode(&new_header_bytes).unwrap();
+
+        // The signature was checked during decoding already.
+        assert!(any_header.verify());
+
+        // .. and the hash digest matches with the original even though we don't know the new
+        // extension format:
+        assert_eq!(new_header_hash, any_header.hash());
+
+        // It can even parse the extensions, will omit the unknown prune_flag field.
+        let header = Header::<LegacyExtensionsFormat>::from_any(any_header).unwrap();
+        assert_eq!(header.extensions.timestamp, 1780572316919.into());
+        assert_eq!(new_header_hash, header.hash());
+        assert!(header.verify());
+
+        // The old system can still parse headers with the new extensions format, not too important
+        // for this test, but nice to show:
+        let header = Header::<FutureExtensionsFormat>::decode(&old_header_bytes).unwrap();
+        assert_eq!(header.extensions.timestamp, 1780572316919.into());
+        assert_eq!(header.extensions.prune_flag, false.into()); // set to default when not given
     }
 }

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -328,7 +328,7 @@ where
 
         let verifying_key = signing_key.verifying_key();
 
-        let extensions_cbor = if Header::<E>::has_non_zero_sized_extensions() {
+        let extensions_cbor = if !Header::<E>::has_zero_sized_extensions() {
             let extensions_cbor = Value::serialized(&extensions).expect("serializable extensions");
             Some(extensions_cbor)
         } else {
@@ -567,12 +567,12 @@ where
 }
 
 impl<E> Header<E> {
-    pub(crate) const fn has_non_zero_sized_extensions() -> bool {
-        std::mem::size_of::<E>() > 0
+    pub(crate) const fn has_zero_sized_extensions() -> bool {
+        std::mem::size_of::<E>() == 0
     }
 
     pub(crate) fn zero_sized_extensions() -> E {
-        assert!(!Self::has_non_zero_sized_extensions());
+        assert!(Self::has_zero_sized_extensions());
 
         // SAFETY: The assertion guarantees E is a zero-sized type.
         //
@@ -628,7 +628,7 @@ where
     type Error = HeaderError;
 
     fn try_from(value: Header<E>) -> Result<Self, Self::Error> {
-        let extensions = if Header::<E>::has_non_zero_sized_extensions() {
+        let extensions = if !Header::<E>::has_zero_sized_extensions() {
             Some(
                 cbor_core::Value::serialized(&value.extensions)
                     .map_err(HeaderError::EncodingExtensions)?,
@@ -1007,7 +1007,7 @@ where
             Some(ref cbor) => {
                 // For ZST extension types we don't expect the extensions field in the header to be
                 // set. Since we now know E we can assure that this is the case.
-                if !Header::<E>::has_non_zero_sized_extensions() {
+                if Header::<E>::has_zero_sized_extensions() {
                     return Err(HeaderError::UnexpectedExtensions);
                 }
 
@@ -1017,7 +1017,7 @@ where
                     .map_err(HeaderError::DecodingExtensions)?
             }
             None => {
-                if Header::<E>::has_non_zero_sized_extensions() {
+                if !Header::<E>::has_zero_sized_extensions() {
                     return Err(HeaderError::MissingExtensions);
                 } else {
                     Header::<E>::zero_sized_extensions()
@@ -1489,12 +1489,12 @@ mod tests {
     fn zst_size_matches_mem_checks() {
         struct ZstExtensions;
         assert_eq!(std::mem::size_of::<ZstExtensions>(), 0);
-        assert!(!Header::<ZstExtensions>::has_non_zero_sized_extensions());
+        assert!(Header::<ZstExtensions>::has_zero_sized_extensions());
 
         #[allow(unused)]
         struct NonZstExtensions(u32);
         assert_ne!(std::mem::size_of::<NonZstExtensions>(), 0);
-        assert!(Header::<NonZstExtensions>::has_non_zero_sized_extensions());
+        assert!(!Header::<NonZstExtensions>::has_zero_sized_extensions());
     }
 
     #[test]

--- a/p2panda-core/src/operation.rs
+++ b/p2panda-core/src/operation.rs
@@ -451,6 +451,30 @@ pub struct Header<E = ()> {
     pub(crate) digest: Hash,
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, E> arbitrary::Arbitrary<'a> for Header<E>
+where
+    E: Default + Extensions,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let header = Header {
+            version: 1,
+            verifying_key: u.arbitrary()?,
+            signature: Signature::from_bytes(&[0; SIGNATURE_LEN]),
+            payload_size: u.arbitrary()?,
+            payload_hash: u.arbitrary()?,
+            seq_num: u.arbitrary()?,
+            backlink: u.arbitrary()?,
+            extensions: E::default(),
+            extensions_cbor: None,
+            size: 0,
+            digest: Hash::from_bytes([0; HASH_LEN]),
+        };
+
+        Ok(header)
+    }
+}
+
 #[cfg(any(test, feature = "test_utils"))]
 impl<E> Default for Header<E>
 where
@@ -583,11 +607,17 @@ where
     pub fn sign(&mut self, signer: &SigningKey) {
         let signing_bytes = self.encode_signing_bytes();
         self.signature = signer.sign(&signing_bytes);
+        self.update_size_and_digest();
     }
 
     pub fn verify(&self) -> bool {
         let signing_bytes = self.encode_signing_bytes();
         self.verifying_key.verify(&signing_bytes, &self.signature)
+    }
+
+    fn update_size_and_digest(&mut self) {
+        self.size = self.size();
+        self.digest = self.hash();
     }
 }
 

--- a/p2panda-core/src/prune.rs
+++ b/p2panda-core/src/prune.rs
@@ -15,7 +15,8 @@ use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{Extensions, Header, OperationError, validate_backlink};
+use crate::traits::{Chain, Digest, Provenance};
+use crate::{Hash, OperationError, VerifyingKey, validate_backlink};
 
 /// Flag indicating that all preceding operations in a log can be deleted.
 #[derive(Clone, Copy, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize)]
@@ -71,20 +72,20 @@ impl Deref for PruneFlag {
 /// otherwise we go on with validation as usual.
 ///
 /// Use this method instead of [`validate_backlink`] if you want to support prunable logs.
-pub fn validate_prunable_backlink<E>(
-    past_header: Option<&Header<E>>,
-    header: &Header<E>,
+pub fn validate_prunable_backlink<T>(
+    past_header: Option<&T>,
+    header: &T,
     prune_flag: bool,
 ) -> Result<(), OperationError>
 where
-    E: Extensions,
+    T: Provenance<VerifyingKey> + Digest<Hash> + Chain<Hash>,
 {
-    if header.seq_num > 0 {
+    if header.seq_num() > 0 {
         // If no pruning flag is set, we expect the log to have integrity with the previously given
         // operation.
         if !prune_flag {
             match past_header {
-                Some(past_header) => validate_backlink(past_header, header),
+                Some(past_header) => validate_backlink::<T>(past_header, header),
                 None => Err(OperationError::BacklinkMissing),
             }
         } else {
@@ -94,7 +95,7 @@ where
         // Operation is at the beginning of log but we've already progressed and assume a strictly
         // growing sequence.
         match past_header {
-            Some(past_header) => validate_backlink(past_header, header),
+            Some(past_header) => validate_backlink::<T>(past_header, header),
             None => Ok(()),
         }
     }

--- a/p2panda-core/src/serde.rs
+++ b/p2panda-core/src/serde.rs
@@ -11,8 +11,8 @@ use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};
 use crate::cursor::Cursor;
 use crate::hash::{Hash, HashError};
 use crate::identity::{Author, IdentityError, Signature, SigningKey, VerifyingKey};
-use crate::logs::{LogHeights, LogId, SeqNum};
-use crate::operation::{Body, Header, Version};
+use crate::logs::{LogHeights, LogId};
+use crate::operation::Body;
 use crate::topic::{Topic, TopicError};
 
 /// Helper method for `serde` to serialize bytes into a hex string when using a human readable
@@ -134,141 +134,6 @@ impl<'de> Deserialize<'de> for Signature {
     }
 }
 
-impl<E> Serialize for Header<E>
-where
-    E: Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut seq = serializer.serialize_seq(Some(self.field_count()))?;
-        seq.serialize_element(&self.version)?;
-        seq.serialize_element(&self.verifying_key)?;
-
-        if let Some(signature) = &self.signature {
-            seq.serialize_element(signature)?;
-        }
-
-        seq.serialize_element(&self.payload_size)?;
-        if let Some(hash) = &self.payload_hash {
-            seq.serialize_element(&hash)?;
-        }
-
-        seq.serialize_element(&self.seq_num)?;
-
-        if let Some(backlink) = &self.backlink {
-            seq.serialize_element(backlink)?;
-        }
-
-        if Self::has_non_zero_sized_extensions() {
-            seq.serialize_element(&self.extensions)?;
-        }
-
-        seq.end()
-    }
-}
-
-impl<'de, E> Deserialize<'de> for Header<E>
-where
-    E: Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct HeaderVisitor<E> {
-            _marker: PhantomData<E>,
-        }
-
-        impl<'de, E> Visitor<'de> for HeaderVisitor<E>
-        where
-            E: Deserialize<'de>,
-        {
-            type Value = Header<E>;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("Header encoded as a sequence")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
-                let version: Version = seq
-                    .next_element()?
-                    .ok_or(SerdeError::custom("version missing"))?;
-
-                let verifying_key: VerifyingKey = seq
-                    .next_element()?
-                    .ok_or(SerdeError::custom("public key missing"))?;
-
-                let signature: Signature = seq
-                    .next_element()?
-                    .ok_or(SerdeError::custom("signature missing"))?;
-
-                let payload_size: u32 = seq
-                    .next_element()?
-                    .ok_or(SerdeError::custom("payload size missing"))?;
-
-                let payload_hash: Option<Hash> = match payload_size {
-                    0 => None,
-                    _ => {
-                        let hash: Hash = seq
-                            .next_element()?
-                            .ok_or(SerdeError::custom("payload hash missing"))?;
-                        Some(hash)
-                    }
-                };
-
-                let seq_num: SeqNum = seq
-                    .next_element()?
-                    .ok_or(SerdeError::custom("sequence number missing"))?;
-
-                let backlink: Option<Hash> = match seq_num {
-                    0 => None,
-                    _ => {
-                        let hash: Hash = seq
-                            .next_element()?
-                            .ok_or(SerdeError::custom("backlink missing"))?;
-                        Some(hash)
-                    }
-                };
-
-                let extensions: E = if Header::<E>::has_non_zero_sized_extensions() {
-                    seq.next_element()?
-                        .ok_or(SerdeError::custom("extensions missing"))?
-                } else {
-                    Header::<E>::zero_sized_extensions()
-                };
-
-                if let Some(remainder) = seq.size_hint()
-                    && remainder > 0
-                {
-                    return Err(SerdeError::custom(format!(
-                        "unexpected {remainder} excessive field(s) in header"
-                    )));
-                }
-
-                Ok(Header {
-                    version,
-                    verifying_key,
-                    signature: Some(signature),
-                    payload_hash,
-                    payload_size,
-                    seq_num,
-                    backlink,
-                    extensions,
-                })
-            }
-        }
-
-        deserializer.deserialize_seq(HeaderVisitor::<E> {
-            _marker: PhantomData,
-        })
-    }
-}
-
 impl Serialize for Body {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -375,13 +240,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde::de::DeserializeOwned;
     use serde::{Deserialize, Serialize};
 
-    use crate::Body;
+    use crate::Extensions;
+    use crate::cbor::{decode_cbor, encode_cbor};
     use crate::hash::Hash;
     use crate::identity::{SigningKey, VerifyingKey};
-    use crate::operation::Header;
+    use crate::operation::{AnyHeader, Header};
 
     use super::{deserialize_hex, serialize_hex};
 
@@ -392,12 +257,11 @@ mod tests {
 
     #[test]
     fn serialize() {
-        let mut bytes: Vec<u8> = Vec::new();
         let test = Test(vec![1, 2, 3]);
 
         // For CBOR the bytes just get serialized straight away as it is not a human readable
-        // encoding
-        ciborium::ser::into_writer(&test, &mut bytes).unwrap();
+        // encoding.
+        let bytes = encode_cbor(&test).unwrap();
         assert_eq!(vec![67, 1, 2, 3], bytes);
     }
 
@@ -407,16 +271,15 @@ mod tests {
 
         // For CBOR the bytes just get deserialized straight away as an array as it is not a human
         // readable encoding
-        let test: Test = ciborium::de::from_reader(&bytes[..]).unwrap();
+        let test: Test = decode_cbor(&bytes[..]).unwrap();
         assert_eq!(test.0, vec![1, 2, 3]);
     }
 
     #[test]
     fn serialize_hash() {
         // Serialize CBOR (non human-readable byte encoding)
-        let mut bytes: Vec<u8> = Vec::new();
         let hash = Hash::digest([1, 2, 3]);
-        ciborium::ser::into_writer(&hash, &mut bytes).unwrap();
+        let bytes = encode_cbor(&hash).unwrap();
         assert_eq!(
             bytes,
             vec![
@@ -440,7 +303,7 @@ mod tests {
             88, 32, 177, 119, 236, 27, 242, 109, 251, 59, 112, 16, 212, 115, 230, 212, 71, 19, 178,
             155, 118, 91, 153, 198, 230, 14, 203, 250, 231, 66, 222, 73, 101, 67,
         ];
-        let hash: Hash = ciborium::de::from_reader(&bytes[..]).unwrap();
+        let hash: Hash = decode_cbor(&bytes[..]).unwrap();
         assert_eq!(hash, Hash::digest([1, 2, 3]));
 
         // Deserialize JSON (human-readable hex encoding)
@@ -452,13 +315,12 @@ mod tests {
     #[test]
     fn serialize_verifying_key() {
         // Serialize CBOR (non human-readable byte encoding)
-        let mut bytes: Vec<u8> = Vec::new();
         let verifying_key = VerifyingKey::from_bytes(&[
             215, 90, 152, 1, 130, 177, 10, 183, 213, 75, 254, 211, 201, 100, 7, 58, 14, 225, 114,
             243, 218, 166, 35, 37, 175, 2, 26, 104, 247, 7, 81, 26,
         ])
         .unwrap();
-        ciborium::ser::into_writer(&verifying_key, &mut bytes).unwrap();
+        let bytes = encode_cbor(&verifying_key).unwrap();
         assert_eq!(
             bytes,
             vec![
@@ -475,17 +337,14 @@ mod tests {
         );
     }
 
-    fn assert_serde_roundtrip<
-        E: Clone + std::fmt::Debug + PartialEq + Serialize + DeserializeOwned,
-    >(
-        mut header: Header<E>,
-        signing_key: &SigningKey,
-    ) {
-        header.sign(signing_key);
+    fn assert_serde_roundtrip<E>(header: Header<E>)
+    where
+        E: Extensions + PartialEq,
+    {
+        let bytes = header.encode();
+        let any_header = AnyHeader::decode(&bytes).expect("valid header");
+        let header_again: Header<E> = any_header.try_into().expect("valid extensions");
 
-        let mut bytes = Vec::new();
-        ciborium::ser::into_writer(&header, &mut bytes).unwrap();
-        let header_again: Header<E> = ciborium::de::from_reader(&bytes[..]).unwrap();
         assert_eq!(header, header_again);
     }
 
@@ -500,156 +359,24 @@ mod tests {
         let signing_key = SigningKey::generate();
 
         assert_serde_roundtrip(
-            Header::<CustomExtensions> {
-                version: 1,
-                verifying_key: signing_key.verifying_key(),
-                payload_size: 123,
-                payload_hash: Some(Hash::digest(vec![1, 2, 3])),
-                seq_num: 0,
-                backlink: None,
-                extensions: extensions.clone(),
-                signature: None,
-            },
-            &signing_key,
+            Header::builder()
+                .body(b"test")
+                .build(&signing_key, extensions),
         );
-
-        assert_serde_roundtrip(
-            Header::<CustomExtensions> {
-                version: 1,
-                verifying_key: signing_key.verifying_key(),
-                payload_size: 0,
-                payload_hash: None,
-                seq_num: 0,
-                backlink: None,
-                extensions: extensions,
-                signature: None,
-            },
-            &signing_key,
-        );
-    }
-
-    #[test]
-    fn expected_de_error() {
-        let signing_key = SigningKey::generate();
-
-        // payload size given without payload hash
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 2829099,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
-        assert!(result.is_err());
-
-        // payload hash given without payload size
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: Some(Hash::digest([0, 1, 2])),
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
-        assert!(result.is_err());
-
-        // backlink given with seq number 0
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: Some(Hash::digest([0, 1, 2])),
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
-        assert!(result.is_err());
-
-        // backlink not given with seq number > 0
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 10,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn serde_header_with_other_types() {
-        let signing_key = SigningKey::generate();
-
-        #[derive(Debug, PartialEq, Serialize, Deserialize)]
-        struct Message {
-            header: Header<()>,
-            body: Body,
-        }
-
-        let body = Body::new(b"hello");
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let message = Message { header, body };
-
-        let mut bytes = Vec::new();
-        ciborium::ser::into_writer(&message, &mut bytes).unwrap();
-
-        let message_again: Message = ciborium::de::from_reader(&bytes[..]).unwrap();
-        assert_eq!(message_again, message);
+        assert_serde_roundtrip(Header::builder().build(&signing_key, ()));
     }
 
     #[test]
     fn fixtures() {
-        let signing_key = SigningKey::from_bytes(&[
+        let signing_key = SigningKey::from([
             244, 123, 85, 215, 161, 204, 94, 227, 239, 253, 128, 164, 228, 160, 195, 49, 18, 49,
             125, 4, 50, 218, 157, 230, 174, 1, 154, 231, 231, 142, 22, 170,
         ]);
 
         // header at seq num 0
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
+        let header = Header::builder().build(&signing_key, ());
 
-        let bytes = [
+        let bytes = vec![
             133, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
             92, 42, 222, 249, 148, 139, 23, 91, 43, 92, 17, 225, 69, 17, 181, 22, 32, 88, 64, 17,
             129, 90, 32, 212, 224, 74, 141, 219, 82, 160, 35, 19, 205, 82, 55, 247, 204, 121, 153,
@@ -658,24 +385,18 @@ mod tests {
             127, 22, 118, 23, 102, 22, 2, 0, 0,
         ];
 
-        let header_again: Header<()> = ciborium::de::from_reader(&bytes[..]).unwrap();
+        assert_eq!(bytes, header.encode());
+
+        let any_header: AnyHeader = bytes.try_into().expect("valid header");
+        let header_again: Header<()> = any_header.try_into().expect("valid extensions");
         assert_eq!(header, header_again);
 
         // header at seq num 0 with body
-        let body = Body::new("Hello, Sloth!".as_bytes());
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
+        let header = Header::builder()
+            .body(b"Hello, Sloth!")
+            .build(&signing_key, ());
 
-        let bytes = [
+        let bytes = vec![
             134, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
             92, 42, 222, 249, 148, 139, 23, 91, 43, 92, 17, 225, 69, 17, 181, 22, 32, 88, 64, 187,
             89, 157, 165, 197, 22, 79, 145, 227, 116, 226, 203, 231, 213, 225, 253, 197, 253, 240,
@@ -686,23 +407,18 @@ mod tests {
             169, 5, 138, 160, 142, 0,
         ];
 
-        let header_again: Header<()> = ciborium::de::from_reader(&bytes[..]).unwrap();
+        assert_eq!(bytes, header.encode());
+
+        let any_header: AnyHeader = bytes.try_into().expect("valid header");
+        let header_again: Header<()> = any_header.try_into().expect("valid extensions");
         assert_eq!(header, header_again);
 
         // header at seq num 1 with backlink
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 1,
-            backlink: Some(header.hash()),
-            extensions: (),
-        };
-        header.sign(&signing_key);
+        let header = Header::builder()
+            .chain(1, header.hash())
+            .build(&signing_key, ());
 
-        let bytes = [
+        let bytes = vec![
             134, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
             92, 42, 222, 249, 148, 139, 23, 91, 43, 92, 17, 225, 69, 17, 181, 22, 32, 88, 64, 90,
             241, 219, 179, 113, 96, 207, 245, 193, 3, 115, 166, 84, 177, 236, 191, 194, 134, 34,
@@ -713,40 +429,21 @@ mod tests {
             104, 129, 60, 141, 161,
         ];
 
-        let header_again: Header<()> = ciborium::de::from_reader(&bytes[..]).unwrap();
+        let any_header: AnyHeader = bytes.try_into().expect("valid header");
+        let header_again: Header<()> = any_header.try_into().expect("valid extensions");
         assert_eq!(header, header_again);
     }
 
     #[test]
-    fn decode_non_map_extensions() {
-        let signing_key = SigningKey::generate();
-
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
-        assert!(result.is_ok());
-    }
-
-    #[test]
     fn unexpected_eof_when_incomplete() {
-        // ciborium should be able to detect an "Unexpected EOF" error if we're giving it an
+        // The CBOR decoder should be able to detect an "Unexpected EOF" error if we're giving it an
         // incomplete header.
         let incomplete = [
             137, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
         ];
 
-        let result: Result<Header<()>, _> = ciborium::de::from_reader(&incomplete[..]);
-        assert!(matches!(result, Err(ciborium::de::Error::Io(_))));
+        let result = AnyHeader::decode(&incomplete);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -762,25 +459,17 @@ mod tests {
         }
 
         let signing_key = SigningKey::generate();
-        let body = Body::new(b"look, no bytes!");
 
-        let mut header = Header::<ZeroSizedExtension> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: ZeroSizedExtension {
+        let header = Header::builder().body(b"look, no bytes!").build(
+            &signing_key,
+            ZeroSizedExtension {
                 field_a: [],
                 field_b: (),
                 field_c: Zilch,
             },
-        };
-        header.sign(&signing_key);
+        );
 
-        let bytes = header.to_bytes();
+        let bytes = header.encode();
 
         // Make sure we skip the extensions field which means we only need 6 fields for the header.
         //
@@ -789,7 +478,8 @@ mod tests {
         assert!(bytes[0] == 134);
 
         // We correctly deserialize to the ZST.
-        let result: Header<ZeroSizedExtension> = ciborium::de::from_reader(&bytes[..]).unwrap();
+        let any_header: AnyHeader = bytes.try_into().expect("valid header");
+        let result: Header<ZeroSizedExtension> = any_header.try_into().expect("valid extensions");
         assert_eq!(result.extensions.field_a.len(), 0);
         assert_eq!(result.extensions.field_b, ());
         assert_eq!(result.extensions.field_c, Zilch);

--- a/p2panda-core/src/serde.rs
+++ b/p2panda-core/src/serde.rs
@@ -11,8 +11,8 @@ use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};
 use crate::cursor::Cursor;
 use crate::hash::{Hash, HashError};
 use crate::identity::{Author, IdentityError, Signature, SigningKey, VerifyingKey};
-use crate::logs::{LogHeights, LogId, SeqNum};
-use crate::operation::{Body, Header, Version};
+use crate::logs::{LogHeights, LogId};
+use crate::operation::Body;
 use crate::topic::{Topic, TopicError};
 
 /// Helper method for `serde` to serialize bytes into a hex string when using a human readable
@@ -134,141 +134,6 @@ impl<'de> Deserialize<'de> for Signature {
     }
 }
 
-impl<E> Serialize for Header<E>
-where
-    E: Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut seq = serializer.serialize_seq(Some(self.field_count()))?;
-        seq.serialize_element(&self.version)?;
-        seq.serialize_element(&self.verifying_key)?;
-
-        if let Some(signature) = &self.signature {
-            seq.serialize_element(signature)?;
-        }
-
-        seq.serialize_element(&self.payload_size)?;
-        if let Some(hash) = &self.payload_hash {
-            seq.serialize_element(&hash)?;
-        }
-
-        seq.serialize_element(&self.seq_num)?;
-
-        if let Some(backlink) = &self.backlink {
-            seq.serialize_element(backlink)?;
-        }
-
-        if Self::has_non_zero_sized_extensions() {
-            seq.serialize_element(&self.extensions)?;
-        }
-
-        seq.end()
-    }
-}
-
-impl<'de, E> Deserialize<'de> for Header<E>
-where
-    E: Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct HeaderVisitor<E> {
-            _marker: PhantomData<E>,
-        }
-
-        impl<'de, E> Visitor<'de> for HeaderVisitor<E>
-        where
-            E: Deserialize<'de>,
-        {
-            type Value = Header<E>;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("Header encoded as a sequence")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
-                let version: Version = seq
-                    .next_element()?
-                    .ok_or(SerdeError::custom("version missing"))?;
-
-                let verifying_key: VerifyingKey = seq
-                    .next_element()?
-                    .ok_or(SerdeError::custom("public key missing"))?;
-
-                let signature: Signature = seq
-                    .next_element()?
-                    .ok_or(SerdeError::custom("signature missing"))?;
-
-                let payload_size: u32 = seq
-                    .next_element()?
-                    .ok_or(SerdeError::custom("payload size missing"))?;
-
-                let payload_hash: Option<Hash> = match payload_size {
-                    0 => None,
-                    _ => {
-                        let hash: Hash = seq
-                            .next_element()?
-                            .ok_or(SerdeError::custom("payload hash missing"))?;
-                        Some(hash)
-                    }
-                };
-
-                let seq_num: SeqNum = seq
-                    .next_element()?
-                    .ok_or(SerdeError::custom("sequence number missing"))?;
-
-                let backlink: Option<Hash> = match seq_num {
-                    0 => None,
-                    _ => {
-                        let hash: Hash = seq
-                            .next_element()?
-                            .ok_or(SerdeError::custom("backlink missing"))?;
-                        Some(hash)
-                    }
-                };
-
-                let extensions: E = if Header::<E>::has_non_zero_sized_extensions() {
-                    seq.next_element()?
-                        .ok_or(SerdeError::custom("extensions missing"))?
-                } else {
-                    Header::<E>::zero_sized_extensions()
-                };
-
-                if let Some(remainder) = seq.size_hint()
-                    && remainder > 0
-                {
-                    return Err(SerdeError::custom(format!(
-                        "unexpected {remainder} excessive field(s) in header"
-                    )));
-                }
-
-                Ok(Header {
-                    version,
-                    verifying_key,
-                    signature: Some(signature),
-                    payload_hash,
-                    payload_size,
-                    seq_num,
-                    backlink,
-                    extensions,
-                })
-            }
-        }
-
-        deserializer.deserialize_seq(HeaderVisitor::<E> {
-            _marker: PhantomData,
-        })
-    }
-}
-
 impl Serialize for Body {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -375,13 +240,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use serde::de::DeserializeOwned;
     use serde::{Deserialize, Serialize};
 
-    use crate::Body;
+    use crate::Extensions;
+    use crate::cbor::{decode_cbor, encode_cbor};
     use crate::hash::Hash;
     use crate::identity::{SigningKey, VerifyingKey};
-    use crate::operation::Header;
+    use crate::operation::{AnyHeader, Header};
 
     use super::{deserialize_hex, serialize_hex};
 
@@ -392,12 +257,11 @@ mod tests {
 
     #[test]
     fn serialize() {
-        let mut bytes: Vec<u8> = Vec::new();
         let test = Test(vec![1, 2, 3]);
 
         // For CBOR the bytes just get serialized straight away as it is not a human readable
-        // encoding
-        ciborium::ser::into_writer(&test, &mut bytes).unwrap();
+        // encoding.
+        let bytes = encode_cbor(&test).unwrap();
         assert_eq!(vec![67, 1, 2, 3], bytes);
     }
 
@@ -407,16 +271,15 @@ mod tests {
 
         // For CBOR the bytes just get deserialized straight away as an array as it is not a human
         // readable encoding
-        let test: Test = ciborium::de::from_reader(&bytes[..]).unwrap();
+        let test: Test = decode_cbor(&bytes[..]).unwrap();
         assert_eq!(test.0, vec![1, 2, 3]);
     }
 
     #[test]
     fn serialize_hash() {
         // Serialize CBOR (non human-readable byte encoding)
-        let mut bytes: Vec<u8> = Vec::new();
         let hash = Hash::digest([1, 2, 3]);
-        ciborium::ser::into_writer(&hash, &mut bytes).unwrap();
+        let bytes = encode_cbor(&hash).unwrap();
         assert_eq!(
             bytes,
             vec![
@@ -440,7 +303,7 @@ mod tests {
             88, 32, 177, 119, 236, 27, 242, 109, 251, 59, 112, 16, 212, 115, 230, 212, 71, 19, 178,
             155, 118, 91, 153, 198, 230, 14, 203, 250, 231, 66, 222, 73, 101, 67,
         ];
-        let hash: Hash = ciborium::de::from_reader(&bytes[..]).unwrap();
+        let hash: Hash = decode_cbor(&bytes[..]).unwrap();
         assert_eq!(hash, Hash::digest([1, 2, 3]));
 
         // Deserialize JSON (human-readable hex encoding)
@@ -452,13 +315,12 @@ mod tests {
     #[test]
     fn serialize_verifying_key() {
         // Serialize CBOR (non human-readable byte encoding)
-        let mut bytes: Vec<u8> = Vec::new();
         let verifying_key = VerifyingKey::from_bytes(&[
             215, 90, 152, 1, 130, 177, 10, 183, 213, 75, 254, 211, 201, 100, 7, 58, 14, 225, 114,
             243, 218, 166, 35, 37, 175, 2, 26, 104, 247, 7, 81, 26,
         ])
         .unwrap();
-        ciborium::ser::into_writer(&verifying_key, &mut bytes).unwrap();
+        let bytes = encode_cbor(&verifying_key).unwrap();
         assert_eq!(
             bytes,
             vec![
@@ -475,17 +337,14 @@ mod tests {
         );
     }
 
-    fn assert_serde_roundtrip<
-        E: Clone + std::fmt::Debug + PartialEq + Serialize + DeserializeOwned,
-    >(
-        mut header: Header<E>,
-        signing_key: &SigningKey,
-    ) {
-        header.sign(signing_key);
+    fn assert_serde_roundtrip<E>(header: Header<E>)
+    where
+        E: Extensions + PartialEq,
+    {
+        let bytes = header.encode();
+        let any_header = AnyHeader::decode(&bytes).expect("valid header");
+        let header_again: Header<E> = any_header.try_into().expect("valid extensions");
 
-        let mut bytes = Vec::new();
-        ciborium::ser::into_writer(&header, &mut bytes).unwrap();
-        let header_again: Header<E> = ciborium::de::from_reader(&bytes[..]).unwrap();
         assert_eq!(header, header_again);
     }
 
@@ -500,156 +359,24 @@ mod tests {
         let signing_key = SigningKey::generate();
 
         assert_serde_roundtrip(
-            Header::<CustomExtensions> {
-                version: 1,
-                verifying_key: signing_key.verifying_key(),
-                payload_size: 123,
-                payload_hash: Some(Hash::digest(vec![1, 2, 3])),
-                seq_num: 0,
-                backlink: None,
-                extensions: extensions.clone(),
-                signature: None,
-            },
-            &signing_key,
+            Header::builder()
+                .body(b"test")
+                .build(&signing_key, extensions),
         );
-
-        assert_serde_roundtrip(
-            Header::<CustomExtensions> {
-                version: 1,
-                verifying_key: signing_key.verifying_key(),
-                payload_size: 0,
-                payload_hash: None,
-                seq_num: 0,
-                backlink: None,
-                extensions: extensions,
-                signature: None,
-            },
-            &signing_key,
-        );
-    }
-
-    #[test]
-    fn expected_de_error() {
-        let signing_key = SigningKey::generate();
-
-        // payload size given without payload hash
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 2829099,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
-        assert!(result.is_err());
-
-        // payload hash given without payload size
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: Some(Hash::digest([0, 1, 2])),
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
-        assert!(result.is_err());
-
-        // backlink given with seq number 0
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: Some(Hash::digest([0, 1, 2])),
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
-        assert!(result.is_err());
-
-        // backlink not given with seq number > 0
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 10,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn serde_header_with_other_types() {
-        let signing_key = SigningKey::generate();
-
-        #[derive(Debug, PartialEq, Serialize, Deserialize)]
-        struct Message {
-            header: Header<()>,
-            body: Body,
-        }
-
-        let body = Body::new(b"hello");
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let message = Message { header, body };
-
-        let mut bytes = Vec::new();
-        ciborium::ser::into_writer(&message, &mut bytes).unwrap();
-
-        let message_again: Message = ciborium::de::from_reader(&bytes[..]).unwrap();
-        assert_eq!(message_again, message);
+        assert_serde_roundtrip(Header::builder().build(&signing_key, ()));
     }
 
     #[test]
     fn fixtures() {
-        let signing_key = SigningKey::from_bytes(&[
+        let signing_key = SigningKey::from([
             244, 123, 85, 215, 161, 204, 94, 227, 239, 253, 128, 164, 228, 160, 195, 49, 18, 49,
             125, 4, 50, 218, 157, 230, 174, 1, 154, 231, 231, 142, 22, 170,
         ]);
 
         // header at seq num 0
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
+        let header = Header::builder().build(&signing_key, ());
 
-        let bytes = [
+        let bytes = vec![
             133, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
             92, 42, 222, 249, 148, 139, 23, 91, 43, 92, 17, 225, 69, 17, 181, 22, 32, 88, 64, 17,
             129, 90, 32, 212, 224, 74, 141, 219, 82, 160, 35, 19, 205, 82, 55, 247, 204, 121, 153,
@@ -658,24 +385,18 @@ mod tests {
             127, 22, 118, 23, 102, 22, 2, 0, 0,
         ];
 
-        let header_again: Header<()> = ciborium::de::from_reader(&bytes[..]).unwrap();
+        assert_eq!(bytes, header.encode());
+
+        let any_header: AnyHeader = bytes.try_into().expect("valid header");
+        let header_again: Header<()> = any_header.try_into().expect("valid extensions");
         assert_eq!(header, header_again);
 
         // header at seq num 0 with body
-        let body = Body::new("Hello, Sloth!".as_bytes());
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
+        let header = Header::builder()
+            .body(b"Hello, Sloth!")
+            .build(&signing_key, ());
 
-        let bytes = [
+        let bytes = vec![
             134, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
             92, 42, 222, 249, 148, 139, 23, 91, 43, 92, 17, 225, 69, 17, 181, 22, 32, 88, 64, 187,
             89, 157, 165, 197, 22, 79, 145, 227, 116, 226, 203, 231, 213, 225, 253, 197, 253, 240,
@@ -686,23 +407,18 @@ mod tests {
             169, 5, 138, 160, 142, 0,
         ];
 
-        let header_again: Header<()> = ciborium::de::from_reader(&bytes[..]).unwrap();
+        assert_eq!(bytes, header.encode());
+
+        let any_header: AnyHeader = bytes.try_into().expect("valid header");
+        let header_again: Header<()> = any_header.try_into().expect("valid extensions");
         assert_eq!(header, header_again);
 
         // header at seq num 1 with backlink
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 1,
-            backlink: Some(header.hash()),
-            extensions: (),
-        };
-        header.sign(&signing_key);
+        let header = Header::builder()
+            .chain(1, header.hash())
+            .build(&signing_key, ());
 
-        let bytes = [
+        let bytes = vec![
             134, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
             92, 42, 222, 249, 148, 139, 23, 91, 43, 92, 17, 225, 69, 17, 181, 22, 32, 88, 64, 90,
             241, 219, 179, 113, 96, 207, 245, 193, 3, 115, 166, 84, 177, 236, 191, 194, 134, 34,
@@ -713,40 +429,21 @@ mod tests {
             104, 129, 60, 141, 161,
         ];
 
-        let header_again: Header<()> = ciborium::de::from_reader(&bytes[..]).unwrap();
+        let any_header: AnyHeader = bytes.try_into().expect("valid header");
+        let header_again: Header<()> = any_header.try_into().expect("valid extensions");
         assert_eq!(header, header_again);
     }
 
     #[test]
-    fn decode_non_map_extensions() {
-        let signing_key = SigningKey::generate();
-
-        let mut header = Header::<()> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let result = ciborium::de::from_reader::<Header<()>, _>(&header.to_bytes()[..]);
-        assert!(result.is_ok());
-    }
-
-    #[test]
     fn unexpected_eof_when_incomplete() {
-        // ciborium should be able to detect an "Unexpected EOF" error if we're giving it an
+        // The CBOR decoder should be able to detect an "Unexpected EOF" error if we're giving it an
         // incomplete header.
         let incomplete = [
             137, 1, 88, 32, 228, 21, 196, 25, 12, 199, 241, 100, 122, 89, 46, 191, 142, 95, 144,
         ];
 
-        let result: Result<Header<()>, _> = ciborium::de::from_reader(&incomplete[..]);
-        std::assert_matches!(result, Err(ciborium::de::Error::Io(_)));
+        let result = AnyHeader::decode(&incomplete);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -762,25 +459,17 @@ mod tests {
         }
 
         let signing_key = SigningKey::generate();
-        let body = Body::new(b"look, no bytes!");
 
-        let mut header = Header::<ZeroSizedExtension> {
-            version: 1,
-            verifying_key: signing_key.verifying_key(),
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: Some(body.hash()),
-            seq_num: 0,
-            backlink: None,
-            extensions: ZeroSizedExtension {
+        let header = Header::builder().body(b"look, no bytes!").build(
+            &signing_key,
+            ZeroSizedExtension {
                 field_a: [],
                 field_b: (),
                 field_c: Zilch,
             },
-        };
-        header.sign(&signing_key);
+        );
 
-        let bytes = header.to_bytes();
+        let bytes = header.encode();
 
         // Make sure we skip the extensions field which means we only need 6 fields for the header.
         //
@@ -789,7 +478,8 @@ mod tests {
         assert!(bytes[0] == 134);
 
         // We correctly deserialize to the ZST.
-        let result: Header<ZeroSizedExtension> = ciborium::de::from_reader(&bytes[..]).unwrap();
+        let any_header: AnyHeader = bytes.try_into().expect("valid header");
+        let result: Header<ZeroSizedExtension> = any_header.try_into().expect("valid extensions");
         assert_eq!(result.extensions.field_a.len(), 0);
         assert_eq!(result.extensions.field_b, ());
         assert_eq!(result.extensions.field_c, Zilch);

--- a/p2panda-core/src/serde.rs
+++ b/p2panda-core/src/serde.rs
@@ -270,7 +270,7 @@ mod tests {
         let bytes: Vec<u8> = vec![67, 1, 2, 3];
 
         // For CBOR the bytes just get deserialized straight away as an array as it is not a human
-        // readable encoding
+        // readable encoding.
         let test: Test = decode_cbor(&bytes[..]).unwrap();
         assert_eq!(test.0, vec![1, 2, 3]);
     }

--- a/p2panda-core/src/test_utils.rs
+++ b/p2panda-core/src/test_utils.rs
@@ -53,21 +53,13 @@ impl TestLog {
         let mut seq_num = self.seq_num.borrow_mut();
         let mut backlink = self.backlink.borrow_mut();
 
-        let mut header = Header::<E> {
-            verifying_key: self.signing_key.verifying_key(),
-            version: 1,
-            signature: None,
-            payload_size: body.size(),
-            payload_hash: if body.size() == 0 {
-                None
-            } else {
-                Some(body.hash())
-            },
-            seq_num: *seq_num,
-            backlink: *backlink,
-            extensions,
-        };
-        header.sign(&self.signing_key);
+        let mut header = Header::<E>::builder().body(&body);
+
+        if let Some(backlink) = *backlink {
+            header = header.chain(*seq_num, backlink);
+        }
+
+        let header = header.build(&self.signing_key, extensions);
 
         *backlink = Some(header.hash());
         *seq_num += 1;
@@ -82,16 +74,19 @@ impl TestLog {
 
 #[cfg(test)]
 mod tests {
-    use crate::Header;
-    use crate::cbor::{decode_cbor, encode_cbor};
-
-    use super::TestLog;
+    use crate::{AnyHeader, Header, SigningKey};
 
     #[test]
     fn zero_byte_body() {
-        let log = TestLog::new();
-        let operation = log.operation(&[], ());
-        let bytes = encode_cbor(operation.header()).unwrap();
-        assert!(decode_cbor::<Header, _>(&bytes[..]).is_ok());
+        let signing_key = SigningKey::generate();
+        let header = Header::builder().body(&[]).build(&signing_key, ());
+
+        // Assure that setting an _empty_ body is equals having no body at all.
+        assert_eq!(header.payload_size, 0);
+        assert!(header.payload_hash.is_none());
+
+        // Decoding works.
+        let bytes = header.encode();
+        assert!(AnyHeader::decode(&bytes).is_ok());
     }
 }

--- a/p2panda-core/src/traits.rs
+++ b/p2panda-core/src/traits.rs
@@ -3,6 +3,8 @@
 use std::hash::Hash as StdHash;
 
 use crate::identity::Author;
+use crate::operation::PayloadSize;
+use crate::{Body, SeqNum};
 
 /// Identifier of a single operation.
 pub trait OperationId: Copy + Clone + PartialEq + Eq + StdHash {}
@@ -23,4 +25,25 @@ where
     fn author(&self) -> A;
 
     fn verify(&self) -> bool;
+}
+
+/// Hash-chain structure with integrity guarantees and sequence numbers as a performance
+/// optimization.
+pub trait Chain<ID> {
+    /// Pointer at previous entry in log which gives us the integrity guarantee of the "hash chain".
+    /// The first entry in a log returns `None`.
+    fn backlink(&self) -> Option<ID>;
+
+    /// Sequence numbers are helpful to fastly detect forks and use the much faster and optimized
+    /// diffing strategy when the local log is not forked.
+    fn seq_num(&self) -> SeqNum;
+}
+
+/// Additional data which can be removed from the on-chain data-type.
+pub trait Offchain<ID> {
+    fn payload(&self) -> Option<&Body>;
+
+    fn payload_hash(&self) -> Option<ID>;
+
+    fn payload_size(&self) -> PayloadSize;
 }

--- a/p2panda-core/src/traits.rs
+++ b/p2panda-core/src/traits.rs
@@ -1,9 +1,11 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: MIT OR Apache-2.0tra
 
 use std::fmt::Debug;
 use std::hash::Hash as StdHash;
 
 use crate::identity::Author;
+use crate::operation::PayloadSize;
+use crate::{Body, SeqNum};
 
 /// Identifier of a single operation.
 pub trait OperationId: Copy + Clone + Debug + PartialEq + Eq + Ord + StdHash {}
@@ -29,4 +31,25 @@ where
     fn author(&self) -> A;
 
     fn verify(&self) -> bool;
+}
+
+/// Hash-chain structure with integrity guarantees and sequence numbers as a performance
+/// optimization.
+pub trait Chain<ID> {
+    /// Pointer at previous entry in log which gives us the integrity guarantee of the "hash chain".
+    /// The first entry in a log returns `None`.
+    fn backlink(&self) -> Option<ID>;
+
+    /// Sequence numbers are helpful to fastly detect forks and use the much faster and optimized
+    /// diffing strategy when the local log is not forked.
+    fn seq_num(&self) -> SeqNum;
+}
+
+/// Additional data which can be removed from the on-chain data-type.
+pub trait Offchain<ID> {
+    fn payload(&self) -> Option<&Body>;
+
+    fn payload_hash(&self) -> Option<ID>;
+
+    fn payload_size(&self) -> PayloadSize;
 }

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -310,7 +310,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Sign and encode each line of text input and broadcast it on the chat topic.
     tokio::task::spawn(async move {
         while let Some(text) = line_rx.recv().await {
-            let body = Body::new(text.as_bytes());
+            let body = Body::from_bytes(text.as_bytes());
             let (hash, operation) = create_operation(&signing_key, &body, seq_num, backlink);
             let permit = store.begin().await.unwrap();
             store

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -34,7 +34,7 @@ use futures_util::StreamExt;
 use iroh::EndpointAddr;
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
 use p2panda_core::test_utils::setup_logging;
-use p2panda_core::{Body, Hash, Header, Operation, SeqNum, SigningKey, Topic, VerifyingKey};
+use p2panda_core::{Body, Hash, Header, Operation, SigningKey, Topic, VerifyingKey};
 use p2panda_net::addrs::NodeInfo;
 use p2panda_net::iroh_mdns::MdnsDiscoveryMode;
 use p2panda_net::utils::{ShortFormat, from_verifying_key};
@@ -310,8 +310,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Sign and encode each line of text input and broadcast it on the chat topic.
     tokio::task::spawn(async move {
         while let Some(text) = line_rx.recv().await {
-            let body = Body::new(text.as_bytes());
-            let (hash, operation) = create_operation(&signing_key, &body, seq_num, backlink);
+            let body = Body::from_bytes(text.as_bytes());
+
+            let header = Header::builder()
+                .seq_num(seq_num)
+                .backlink(backlink)
+                .body(&body)
+                .build(&signing_key, ());
+
+            let operation = Operation::from_parts(header, Some(body));
+            let hash = operation.hash;
+
             let permit = store.begin().await.unwrap();
             store
                 .insert_operation(&hash, &operation, &LOG_ID)
@@ -358,33 +367,4 @@ fn input_loop(line_tx: mpsc::Sender<String>) -> Result<(), std::io::Error> {
             .map_err(|err| std::io::Error::other(err))?;
         buffer.clear();
     }
-}
-
-fn create_operation(
-    signing_key: &SigningKey,
-    body: &Body,
-    seq_num: SeqNum,
-    backlink: Option<Hash>,
-) -> (Hash, Operation) {
-    let mut header = Header {
-        version: 1,
-        verifying_key: signing_key.verifying_key(),
-        signature: None,
-        payload_size: body.size(),
-        payload_hash: Some(body.hash()),
-        seq_num,
-        backlink,
-        extensions: (),
-    };
-
-    header.sign(signing_key);
-    let hash = header.hash();
-
-    let operation = Operation {
-        hash,
-        header: header.clone(),
-        body: Some(body.to_owned()),
-    };
-
-    (hash, operation)
 }

--- a/p2panda-net/src/codec.rs
+++ b/p2panda-net/src/codec.rs
@@ -160,7 +160,6 @@ pub enum CodecError {
 mod tests {
     use futures_util::{FutureExt, SinkExt, StreamExt};
     use p2panda_core::test_utils::TestLog;
-    use p2panda_core::{Body, Header};
     use tokio::io::AsyncWriteExt;
     use tokio_util::codec::{FramedRead, FramedWrite};
 
@@ -261,7 +260,7 @@ mod tests {
 
     #[tokio::test]
     async fn operations_stream() {
-        type Payload = (Header<u32>, Option<Body>);
+        type Payload = (Vec<u8>, Option<Vec<u8>>);
 
         // Give stream a large enough buffer size since we're creating all messages up-front before
         // consuming them.
@@ -274,7 +273,12 @@ mod tests {
         let log = TestLog::new();
         for _ in 0..100 {
             let operation = log.operation(b"boom boom boom", 32);
-            tx.send((operation.header, operation.body)).await.unwrap();
+            tx.send((
+                operation.header.encode(),
+                operation.body.map(|body| body.to_bytes()),
+            ))
+            .await
+            .unwrap();
         }
 
         // Receiver writes bytes into buffer, attempts decoding and returns header/body tuple 100

--- a/p2panda-net/src/test_utils.rs
+++ b/p2panda-net/src/test_utils.rs
@@ -336,7 +336,7 @@ pub fn create_operation(
     seq_num: SeqNum,
     backlink: Option<Hash>,
 ) -> (Header<TestExtensions>, Vec<u8>, Body) {
-    let body = Body::new(body);
+    let body = Body::from_bytes(body);
 
     let mut header = Header::<()> {
         version: 1,
@@ -350,7 +350,7 @@ pub fn create_operation(
     };
 
     header.sign(signing_key);
-    let header_bytes = header.to_bytes();
+    let header_bytes = header.encode();
 
     (header, header_bytes, body)
 }

--- a/p2panda-net/src/test_utils.rs
+++ b/p2panda-net/src/test_utils.rs
@@ -274,16 +274,11 @@ impl TestClient {
     ) -> (Header<()>, Vec<u8>, Body) {
         let (header, header_bytes, body) = self.create_operation_no_insert(body, log_id).await;
 
-        let id = header.hash();
-        let operation = Operation {
-            hash: header.hash(),
-            header: header.clone(),
-            body: Some(body.to_owned()),
-        };
+        let operation = Operation::from_parts(header.clone(), Some(body.to_owned()));
 
         tx_unwrap!(&self.store, {
             self.store
-                .insert_operation(&id, &operation, &log_id)
+                .insert_operation(&operation.hash, &operation, &log_id)
                 .await
                 .unwrap();
         });
@@ -336,21 +331,15 @@ pub fn create_operation(
     seq_num: SeqNum,
     backlink: Option<Hash>,
 ) -> (Header<TestExtensions>, Vec<u8>, Body) {
-    let body = Body::new(body);
+    let body = Body::from_bytes(body);
 
-    let mut header = Header::<()> {
-        version: 1,
-        verifying_key: signing_key.verifying_key(),
-        signature: None,
-        payload_size: body.size(),
-        payload_hash: Some(body.hash()),
-        seq_num,
-        backlink,
-        extensions: (),
-    };
+    let header = Header::builder()
+        .seq_num(seq_num)
+        .backlink(backlink)
+        .body(&body)
+        .build(signing_key, ());
 
-    header.sign(signing_key);
-    let header_bytes = header.to_bytes();
+    let header_bytes = header.encode();
 
     (header, header_bytes, body)
 }

--- a/p2panda-net/tests/e2e.rs
+++ b/p2panda-net/tests/e2e.rs
@@ -91,5 +91,5 @@ async fn gossip_and_sync_with_same_topic() {
     assert_eq!(message, Some(b"Hello, Panda!".to_vec()));
 
     let operation = panda_sync_task.await.unwrap().unwrap();
-    assert_eq!(operation.body, Some(Body::new(b"Hello, again, Panda!")));
+    assert_eq!(operation.body, Some(Body::from_bytes(b"Hello, again, Panda!")));
 }

--- a/p2panda-net/tests/e2e.rs
+++ b/p2panda-net/tests/e2e.rs
@@ -91,5 +91,8 @@ async fn gossip_and_sync_with_same_topic() {
     assert_eq!(message, Some(b"Hello, Panda!".to_vec()));
 
     let operation = panda_sync_task.await.unwrap().unwrap();
-    assert_eq!(operation.body, Some(Body::new(b"Hello, again, Panda!")));
+    assert_eq!(
+        operation.body,
+        Some(Body::from_bytes(b"Hello, again, Panda!"))
+    );
 }

--- a/p2panda-spaces/src/test_utils/forge.rs
+++ b/p2panda-spaces/src/test_utils/forge.rs
@@ -52,28 +52,15 @@ impl Forge<TestConditions> for TestForge {
             .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
             .unwrap_or((0, None));
 
-            let mut header = Header {
-                version: 1,
-                verifying_key: self.signing_key.verifying_key(),
-                signature: None,
-                payload_size: 0,
-                payload_hash: None,
-                seq_num,
-                backlink,
-                extensions: args,
-            };
+            let header = Header::builder()
+                .seq_num(seq_num)
+                .backlink(backlink)
+                .build(&self.signing_key, args);
 
-            header.sign(&self.signing_key);
-            let hash = header.hash();
-
-            let operation = TestOperation {
-                hash,
-                header,
-                body: None,
-            };
+            let operation = TestOperation::from_parts(header, None);
 
             self.store
-                .insert_operation(&hash, &operation, &DEFAULT_LOG_ID)
+                .insert_operation(&operation.hash, &operation, &DEFAULT_LOG_ID)
                 .await?;
 
             operation

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -58,7 +58,7 @@
 //! # let log_id = 2;
 //! # let topic = Topic::random();
 //! # let signing_key = SigningKey::generate();
-//! # let body = Body::new(b"Transaction! Yay!");
+//! # let body = Body::from_bytes(b"Transaction! Yay!");
 //! #
 //! // Acquire a lock on the store for the duration of the read to write cycle.
 //! //
@@ -81,25 +81,11 @@
 //!     .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
 //!     .unwrap_or((0, None));
 //!
-//!     let mut header = Header {
-//!         version: 1,
-//!         verifying_key: signing_key.verifying_key(),
-//!         signature: None,
-//!         payload_size: body.size(),
-//!         payload_hash: Some(body.hash()),
-//!         seq_num,
-//!         backlink,
-//!         extensions: (),
-//!     };
-//!
-//!     header.sign(&signing_key);
-//!     let hash = header.hash();
-//!
-//!     let operation = Operation {
-//!         hash,
-//!         header: header.clone(),
-//!         body: Some(body),
-//!     };
+//!     let header = Header::builder()
+//!         .seq_num(seq_num)
+//!         .backlink(backlink)
+//!         .body(&body)
+//!         .build(&signing_key, ());
 //!
 //!     <SqliteStore as TopicStore<Topic, VerifyingKey, u64>>::associate(
 //!         &store,
@@ -109,8 +95,10 @@
 //!     )
 //!     .await?;
 //!
+//!     let operation = Operation::from_parts(header, Some(body));
+//!
 //!     store
-//!         .insert_operation(&hash, &operation, &log_id)
+//!         .insert_operation(&operation.hash, &operation, &log_id)
 //!         .await?;
 //!
 //!     operation

--- a/p2panda-store/src/logs/sqlite/tests.rs
+++ b/p2panda-store/src/logs/sqlite/tests.rs
@@ -153,9 +153,9 @@ async fn get_log_size() {
 
     assert_eq!(operations_num, 2);
 
-    let expected_size = operation_1.header.to_bytes().len() as u32
+    let expected_size = operation_1.header.encode().len() as u32
         + operation_1.header.payload_size
-        + operation_2.header.to_bytes().len() as u32
+        + operation_2.header.encode().len() as u32
         + operation_2.header.payload_size;
     assert_eq!(size, expected_size);
 }

--- a/p2panda-store/src/logs/sqlite/tests.rs
+++ b/p2panda-store/src/logs/sqlite/tests.rs
@@ -138,9 +138,9 @@ async fn get_log_size() {
 
     assert_eq!(operations_num, 2);
 
-    let expected_size = operation_1.header.to_bytes().len() as u32
+    let expected_size = operation_1.header.size() as u32
         + operation_1.header.payload_size
-        + operation_2.header.to_bytes().len() as u32
+        + operation_2.header.size() as u32
         + operation_2.header.payload_size;
     assert_eq!(size, expected_size);
 }

--- a/p2panda-store/src/operations/sqlite.rs
+++ b/p2panda-store/src/operations/sqlite.rs
@@ -81,7 +81,7 @@ where
                     encode_cbor(&operation.header)
                         .map_err(|err| SqliteError::Encode("header".to_string(), err))?,
                 )
-                .bind(operation.header.to_bytes().len().to_string())
+                .bind(operation.header.encode().len().to_string())
                 .bind(operation.body().map(|body| body.to_bytes()))
                 .execute(&mut **tx)
                 .await

--- a/p2panda-store/src/operations/sqlite.rs
+++ b/p2panda-store/src/operations/sqlite.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use p2panda_core::cbor::{decode_cbor, encode_cbor};
+use p2panda_core::cbor::encode_cbor;
 use p2panda_core::hash::{Hash, HashError};
-use p2panda_core::{Extensions, LogId, Operation};
+use p2panda_core::{Extensions, Header, LogId, Operation};
 use sqlx::{FromRow, query, query_as};
 
 use crate::operations::OperationStore;
@@ -71,18 +71,15 @@ where
                     encode_cbor(&log_id)
                         .map_err(|err| SqliteError::Encode("log id".to_string(), err))?,
                 )
-                .bind(operation.header.version.to_string())
+                .bind(operation.header.version)
                 .bind(operation.header.verifying_key.to_hex())
-                .bind(operation.header.signature.map(|sig| sig.to_hex()))
-                .bind(operation.header.payload_size.to_string())
+                .bind(operation.header.signature.to_hex())
+                .bind(operation.header.payload_size)
                 .bind(operation.header.payload_hash.map(|hash| hash.to_hex()))
                 .bind(operation.header.seq_num.to_string())
-                .bind(
-                    encode_cbor(&operation.header)
-                        .map_err(|err| SqliteError::Encode("header".to_string(), err))?,
-                )
-                .bind(operation.header.to_bytes().len().to_string())
-                .bind(operation.body().map(|body| body.to_bytes()))
+                .bind(operation.header.encode())
+                .bind(operation.header.size())
+                .bind(operation.body.as_ref().map(|body| body.as_bytes()))
                 .execute(&mut **tx)
                 .await
                 .map_err(SqliteError::Sqlite)
@@ -218,7 +215,7 @@ where
                 .hash
                 .parse()
                 .map_err(|err: HashError| SqliteError::Decode("hash".to_string(), err.into()))?,
-            header: decode_cbor(&row.header[..])
+            header: Header::<E>::decode(&row.header)
                 .map_err(|err| SqliteError::Decode("header".into(), err.into()))?,
             body: row.body.map(|body| body.into()),
         })

--- a/p2panda-store/src/spaces/sqlite.rs
+++ b/p2panda-store/src/spaces/sqlite.rs
@@ -52,10 +52,10 @@ where
             .await?
         {
             Some(operation) => {
-                let args = operation.header().extensions.borrow().clone();
+                let args = operation.header.extensions.borrow().clone();
                 let message = SpacesMessage {
                     id: operation.hash,
-                    author: operation.header().verifying_key,
+                    author: operation.header.verifying_key,
                     args,
                 };
                 Ok(Some(message))

--- a/p2panda-store/src/sqlite.rs
+++ b/p2panda-store/src/sqlite.rs
@@ -464,7 +464,10 @@ pub enum SqliteError {
 #[derive(Debug, Error)]
 pub enum DecodeError {
     #[error(transparent)]
-    DecodeCbor(#[from] p2panda_core::cbor::DecodeError),
+    Cbor(#[from] p2panda_core::cbor::DecodeError),
+
+    #[error(transparent)]
+    Header(#[from] p2panda_core::operation::HeaderError),
 
     #[error(transparent)]
     Hash(#[from] p2panda_core::hash::HashError),

--- a/p2panda-stream/src/ingest/operation.rs
+++ b/p2panda-stream/src/ingest/operation.rs
@@ -70,11 +70,10 @@ where
     validate_prunable_backlink(past_header.as_ref(), &operation.header, prune_flag)?;
 
     // Insert operation into store and associate its log with the given topic.
-    let id = operation.hash;
     let verifying_key = operation.header.verifying_key;
 
     store
-        .insert_operation(&id, operation, log_id)
+        .insert_operation(&operation.hash, operation, log_id)
         .await
         .map_err(|err| IngestError::StoreError(err.to_string()))?;
 
@@ -225,25 +224,14 @@ mod tests {
 
         // Create an operation which has already advanced in the log (it has a backlink and higher
         // sequence number).
-        let mut header = Header {
-            verifying_key: signing_key.verifying_key(),
-            version: 1,
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 12, // we'll be missing 11 operations between the first and this one
-            backlink: Some(Hash::digest(b"mock operation")),
-            extensions: (),
-        };
-        header.sign(&signing_key);
+        let header = Header::builder()
+            // we'll be missing 11 operations between the first and this one
+            .chain(12, Hash::digest(b"mock operation"))
+            .build(&signing_key, ());
 
-        let operation = Operation {
-            hash: header.hash(),
-            header,
-            body: None,
-        };
-
+        let operation = Operation::from_parts(header, None);
         let result = ingest_operation(&store, &operation, &1, &1, false).await;
+
         assert!(result.is_err());
     }
 
@@ -254,46 +242,18 @@ mod tests {
 
         // 1. Create an advanced operation in a log which assumes that all previous operations have
         //    been pruned.
-        let mut header = Header {
-            verifying_key: signing_key.verifying_key(),
-            version: 1,
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 1,
-            backlink: Some(Hash::digest(b"mock operation")),
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let operation = Operation {
-            hash: header.hash(),
-            header,
-            body: None,
-        };
+        let header = Header::builder()
+            .chain(1, Hash::digest(b"mock operation"))
+            .build(&signing_key, ());
+        let operation = Operation::from_parts(header, None);
 
         let prune_flag = true; // Ingest does not do any pruning, but the flag affects validation.
         let result = ingest_operation(&store, &operation, &1, &1, prune_flag).await;
         assert!(result.is_ok());
 
         // 2. Create an operation which is from an "outdated" seq from before the log was pruned.
-        let mut header = Header {
-            verifying_key: signing_key.verifying_key(),
-            version: 1,
-            signature: None,
-            payload_size: 0,
-            payload_hash: None,
-            seq_num: 0,
-            backlink: None,
-            extensions: (),
-        };
-        header.sign(&signing_key);
-
-        let operation = Operation {
-            hash: header.hash(),
-            header,
-            body: None,
-        };
+        let header = Header::builder().build(&signing_key, ());
+        let operation = Operation::from_parts(header, None);
 
         let result = ingest_operation(&store, &operation, &1, &1, false).await;
         assert!(result.is_err());

--- a/p2panda-stream/src/orderer/processor.rs
+++ b/p2panda-stream/src/orderer/processor.rs
@@ -155,50 +155,30 @@ mod tests {
         // Icebear's.
         let operation_panda = {
             let signing_key = SigningKey::generate();
-            let verifying_key = signing_key.verifying_key();
-
             let body: Body = b"Hi, Icebear".to_vec().into();
 
-            let mut header = Header {
-                verifying_key,
-                payload_size: body.size(),
-                payload_hash: Some(body.hash()),
-                extensions: TestExtension {
+            let header = Header::builder().body(&body).build(
+                &signing_key,
+                TestExtension {
                     dependencies: vec![],
                 },
-                ..Default::default()
-            };
-            header.sign(&signing_key);
+            );
 
-            Operation {
-                hash: header.hash(),
-                header,
-                body: Some(body),
-            }
+            Operation::from_parts(header, Some(body))
         };
 
         let operation_icebear = {
             let signing_key = SigningKey::generate();
-            let verifying_key = signing_key.verifying_key();
-
             let body: Body = b"Hello, Pandasan!".to_vec().into();
 
-            let mut header = Header {
-                verifying_key,
-                payload_size: body.size(),
-                payload_hash: Some(body.hash()),
-                extensions: TestExtension {
+            let header = Header::builder().body(&body).build(
+                &signing_key,
+                TestExtension {
                     dependencies: vec![operation_panda.hash],
                 },
-                ..Default::default()
-            };
-            header.sign(&signing_key);
+            );
 
-            Operation {
-                hash: header.hash(),
-                header,
-                body: Some(body),
-            }
+            Operation::from_parts(header, Some(body))
         };
 
         let local = task::LocalSet::new();

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -269,7 +269,7 @@ mod tests {
 
         // Setup Peer A
         let mut peer_a = Peer::new(0).await;
-        let body = Body::new("Hello from Peer A".as_bytes());
+        let body = Body::from_bytes("Hello from Peer A".as_bytes());
         let _ = peer_a.create_operation(&body, LOG_ID).await;
         let logs = BTreeMap::from([(peer_a.id(), vec![LOG_ID])]);
         peer_a.associate(&topic, &logs).await;
@@ -277,7 +277,7 @@ mod tests {
 
         // Setup Peer B
         let mut peer_b = Peer::new(1).await;
-        let body = Body::new("Hello from Peer B".as_bytes());
+        let body = Body::from_bytes("Hello from Peer B".as_bytes());
         let _ = peer_b.create_operation(&body, LOG_ID).await;
         let logs = BTreeMap::from([(peer_b.id(), vec![LOG_ID])]);
         peer_b.associate(&topic, &logs).await;
@@ -428,19 +428,19 @@ mod tests {
 
         // Peer A
         let mut peer_a = Peer::new(0).await;
-        let body_a = Body::new("Hello from A".as_bytes());
+        let body_a = Body::from_bytes("Hello from A".as_bytes());
         let (peer_a_header_0, _) = peer_a.create_operation(&body_a, LOG_ID).await;
         let mut manager_a = TestTopicSyncManager::new(peer_a.store.clone());
 
         // Peer B
         let mut peer_b = Peer::new(1).await;
-        let body_b = Body::new("Hello from B".as_bytes());
+        let body_b = Body::from_bytes("Hello from B".as_bytes());
         let (peer_b_header_0, _) = peer_b.create_operation(&body_b, LOG_ID).await;
         let mut manager_b = TestTopicSyncManager::new(peer_b.store.clone());
 
         // Peer C
         let mut peer_c = Peer::new(2).await;
-        let body_c = Body::new("Hello from C".as_bytes());
+        let body_c = Body::from_bytes("Hello from C".as_bytes());
         let (peer_c_header_0, _) = peer_c.create_operation(&body_c, LOG_ID).await;
         let mut manager_c = TestTopicSyncManager::new(peer_c.store.clone());
 
@@ -522,9 +522,9 @@ mod tests {
         let mut handle_ba = manager_b.session_handle(SESSION_BA).await.unwrap();
         let mut handle_ca = manager_c.session_handle(SESSION_CA).await.unwrap();
 
-        let body_a = Body::new("Hello again from A".as_bytes());
-        let body_b = Body::new("Hello again from B".as_bytes());
-        let body_c = Body::new("Hello again from C".as_bytes());
+        let body_a = Body::from_bytes("Hello again from A".as_bytes());
+        let body_b = Body::from_bytes("Hello again from B".as_bytes());
+        let body_c = Body::from_bytes("Hello again from C".as_bytes());
         let (peer_a_header_1, _) = peer_a.create_operation(&body_a, LOG_ID).await;
         let (peer_b_header_1, _) = peer_b.create_operation(&body_b, LOG_ID).await;
         let (peer_c_header_1, _) = peer_c.create_operation(&body_c, LOG_ID).await;
@@ -606,7 +606,7 @@ mod tests {
 
         // Setup Peer A
         let mut peer_a = Peer::new(0).await;
-        let body = Body::new("Hello from Peer A".as_bytes());
+        let body = Body::from_bytes("Hello from Peer A".as_bytes());
         let _ = peer_a.create_operation(&body, LOG_ID).await;
         let logs = BTreeMap::from([(peer_a.id(), vec![LOG_ID])]);
         peer_a.associate(&topic, &logs).await;
@@ -622,7 +622,7 @@ mod tests {
 
         // Setup Peer B
         let mut peer_b = Peer::new(1).await;
-        let body = Body::new("Hello from Peer B".as_bytes());
+        let body = Body::from_bytes("Hello from Peer B".as_bytes());
         let _ = peer_b.create_operation(&body, LOG_ID).await;
         let logs = BTreeMap::from([(peer_b.id(), vec![LOG_ID])]);
         peer_b.associate(&topic, &logs).await;

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -268,7 +268,7 @@ mod tests {
 
         // Setup Peer A
         let mut peer_a = Peer::new(0).await;
-        let body = Body::new("Hello from Peer A".as_bytes());
+        let body = Body::from_bytes(b"Hello from Peer A");
         let _ = peer_a.create_operation(&body, LOG_ID).await;
         let logs = BTreeMap::from([(peer_a.id(), vec![LOG_ID])]);
         peer_a.associate(&topic, &logs).await;
@@ -276,7 +276,7 @@ mod tests {
 
         // Setup Peer B
         let mut peer_b = Peer::new(1).await;
-        let body = Body::new("Hello from Peer B".as_bytes());
+        let body = Body::from_bytes(b"Hello from Peer B");
         let _ = peer_b.create_operation(&body, LOG_ID).await;
         let logs = BTreeMap::from([(peer_b.id(), vec![LOG_ID])]);
         peer_b.associate(&topic, &logs).await;
@@ -427,19 +427,19 @@ mod tests {
 
         // Peer A
         let mut peer_a = Peer::new(0).await;
-        let body_a = Body::new("Hello from A".as_bytes());
+        let body_a = Body::from_bytes("Hello from A".as_bytes());
         let (peer_a_header_0, _) = peer_a.create_operation(&body_a, LOG_ID).await;
         let mut manager_a = TestTopicSyncManager::new(peer_a.store.clone());
 
         // Peer B
         let mut peer_b = Peer::new(1).await;
-        let body_b = Body::new("Hello from B".as_bytes());
+        let body_b = Body::from_bytes("Hello from B".as_bytes());
         let (peer_b_header_0, _) = peer_b.create_operation(&body_b, LOG_ID).await;
         let mut manager_b = TestTopicSyncManager::new(peer_b.store.clone());
 
         // Peer C
         let mut peer_c = Peer::new(2).await;
-        let body_c = Body::new("Hello from C".as_bytes());
+        let body_c = Body::from_bytes("Hello from C".as_bytes());
         let (peer_c_header_0, _) = peer_c.create_operation(&body_c, LOG_ID).await;
         let mut manager_c = TestTopicSyncManager::new(peer_c.store.clone());
 
@@ -521,9 +521,9 @@ mod tests {
         let mut handle_ba = manager_b.session_handle(SESSION_BA).await.unwrap();
         let mut handle_ca = manager_c.session_handle(SESSION_CA).await.unwrap();
 
-        let body_a = Body::new("Hello again from A".as_bytes());
-        let body_b = Body::new("Hello again from B".as_bytes());
-        let body_c = Body::new("Hello again from C".as_bytes());
+        let body_a = Body::from_bytes("Hello again from A".as_bytes());
+        let body_b = Body::from_bytes("Hello again from B".as_bytes());
+        let body_c = Body::from_bytes("Hello again from C".as_bytes());
         let (peer_a_header_1, _) = peer_a.create_operation(&body_a, LOG_ID).await;
         let (peer_b_header_1, _) = peer_b.create_operation(&body_b, LOG_ID).await;
         let (peer_c_header_1, _) = peer_c.create_operation(&body_c, LOG_ID).await;
@@ -561,17 +561,17 @@ mod tests {
                 tokio::select! {
                     Some(event) = event_stream_a.next() => {
                         if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
-                            operations_a.push(operation.header().clone());
+                            operations_a.push(operation.header.clone());
                         }
                     }
                     Some(event) = event_stream_b.next() => {
                         if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
-                            operations_b.push(operation.header().clone());
+                            operations_b.push(operation.header.clone());
                         }
                     }
                     Some(event) = event_stream_c.next() => {
                         if let TopicLogSyncEvent::OperationReceived { operation, .. } = event.event() {
-                            operations_c.push(operation.header().clone());
+                            operations_c.push(operation.header.clone());
                         }
                     }
                     else => tokio::time::sleep(Duration::from_millis(20)).await
@@ -605,7 +605,7 @@ mod tests {
 
         // Setup Peer A
         let mut peer_a = Peer::new(0).await;
-        let body = Body::new("Hello from Peer A".as_bytes());
+        let body = Body::from_bytes("Hello from Peer A".as_bytes());
         let _ = peer_a.create_operation(&body, LOG_ID).await;
         let logs = BTreeMap::from([(peer_a.id(), vec![LOG_ID])]);
         peer_a.associate(&topic, &logs).await;
@@ -621,7 +621,7 @@ mod tests {
 
         // Setup Peer B
         let mut peer_b = Peer::new(1).await;
-        let body = Body::new("Hello from Peer B".as_bytes());
+        let body = Body::from_bytes(b"Hello from Peer B");
         let _ = peer_b.create_operation(&body, LOG_ID).await;
         let logs = BTreeMap::from([(peer_b.id(), vec![LOG_ID])]);
         peer_b.associate(&topic, &logs).await;

--- a/p2panda-sync/src/protocols/log_sync.rs
+++ b/p2panda-sync/src/protocols/log_sync.rs
@@ -256,7 +256,7 @@ where
                                         metrics.received_operations += 1;
 
                                         let header: Header<E> = decode_cbor(&header[..])?;
-                                        let body = body.map(|ref bytes| Body::new(bytes));
+                                        let body = body.map(|ref bytes| Body::from_bytes(bytes));
 
                                         // Insert message hash into deduplication buffer.
                                         if !dedup.insert(header.hash()) {
@@ -568,7 +568,7 @@ mod tests {
         let mut peer = Peer::new(0).await;
         let log_id = 0;
 
-        let body = Body::new("Hello, Sloth!".as_bytes());
+        let body = Body::from_bytes("Hello, Sloth!".as_bytes());
         let (header_0, header_bytes_0) = peer.create_operation(&body, log_id).await;
         let (header_1, header_bytes_1) = peer.create_operation(&body, log_id).await;
         let (header_2, header_bytes_2) = peer.create_operation(&body, log_id).await;
@@ -631,21 +631,21 @@ mod tests {
             TestLogSyncMessage::Operation(header, Some(body)) => (header.clone(), body.clone())
         );
         assert_eq!(header, header_bytes_0);
-        assert_eq!(Body::new(&body_inner), body);
+        assert_eq!(Body::from_bytes(&body_inner), body);
 
         let (header, body_inner) = assert_matches!(
             &messages[3],
             TestLogSyncMessage::Operation(header, Some(body)) => (header.clone(), body.clone())
         );
         assert_eq!(header, header_bytes_1);
-        assert_eq!(Body::new(&body_inner), body);
+        assert_eq!(Body::from_bytes(&body_inner), body);
 
         let (header, body_inner) = assert_matches!(
             &messages[4],
             TestLogSyncMessage::Operation(header, Some(body)) => (header.clone(), body.clone())
         );
         assert_eq!(header, header_bytes_2);
-        assert_eq!(Body::new(&body_inner), body);
+        assert_eq!(Body::from_bytes(&body_inner), body);
 
         assert_eq!(messages[5], TestLogSyncMessage::Done);
     }
@@ -659,8 +659,8 @@ mod tests {
         let mut peer_a = Peer::new(0).await;
         let mut peer_b = Peer::new(1).await;
 
-        let body_a = Body::new("From Alice".as_bytes());
-        let body_b = Body::new("From Bob".as_bytes());
+        let body_a = Body::from_bytes("From Alice".as_bytes());
+        let body_b = Body::from_bytes("From Bob".as_bytes());
 
         let (header_a0, _) = peer_a.create_operation(&body_a, LOG_ID).await;
         let (header_a1, _) = peer_a.create_operation(&body_a, LOG_ID).await;
@@ -750,7 +750,7 @@ mod tests {
         let mut peer = Peer::new(0).await;
         const LOG_ID: TestLogId = 1;
 
-        let body = Body::new(b"unexpected op before presend");
+        let body = Body::from_bytes(b"unexpected op before presend");
         let (_, header_bytes) = peer.create_operation(&body, LOG_ID).await;
 
         let mut logs = Logs::default();
@@ -778,7 +778,7 @@ mod tests {
         let mut peer = Peer::new(0).await;
         const LOG_ID: TestLogId = 1;
 
-        let body = Body::new(b"two presends");
+        let body = Body::from_bytes(b"two presends");
         peer.create_operation(&body, LOG_ID).await;
 
         let mut logs = Logs::default();
@@ -822,7 +822,7 @@ mod tests {
         let mut peer = Peer::new(0).await;
         const LOG_ID: TestLogId = 1;
 
-        let body = Body::new(b"bad have order");
+        let body = Body::from_bytes(b"bad have order");
         peer.create_operation(&body, LOG_ID).await;
 
         let mut logs = Logs::default();
@@ -856,7 +856,7 @@ mod tests {
         let mut peer_b = Peer::new(1).await;
         let mut peer_c = Peer::new(2).await;
 
-        let body = Body::new(&[0; 1000]);
+        let body = Body::from_bytes(&[0; 1000]);
 
         for _ in 0..100 {
             let _ = peer_a.create_operation(&body, 0).await;

--- a/p2panda-sync/src/protocols/log_sync.rs
+++ b/p2panda-sync/src/protocols/log_sync.rs
@@ -6,7 +6,6 @@ use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 
 use futures_util::{Sink, SinkExt, Stream, StreamExt, stream};
-use p2panda_core::cbor::{DecodeError, decode_cbor};
 use p2panda_core::logs::{LogHeights, LogRanges, compare};
 use p2panda_core::{Body, Extensions, Hash, Header, LogId, Operation, SeqNum, VerifyingKey};
 use p2panda_store::logs::LogStore;
@@ -311,12 +310,17 @@ where
                                         } as u32;
                                         metrics.received_operations += 1;
 
-                                        let header: Header<E> = decode_cbor(&header[..])?;
-                                        let body = body.map(|ref bytes| Body::new(bytes));
+                                        let header = Header::<E>::decode(&header)?;
+                                        let body = body.map(|ref bytes| Body::from_bytes(bytes));
 
                                         // Insert message hash into deduplication buffer.
                                         if !dedup.insert(header.hash()) {
-                                            trace!(parent: &span, operation_id = ?header.hash().fmt_short(), "ignore duplicate operation sent from remote");
+                                            trace!(
+                                                parent: &span,
+                                                operation_id = %header.hash().fmt_short(),
+                                                "ignore duplicate operation sent from remote"
+                                            );
+
                                             continue;
                                         }
 
@@ -531,8 +535,8 @@ pub struct LogSyncMetrics {
 /// Protocol error types.
 #[derive(Debug, Error)]
 pub enum LogSyncError {
-    #[error(transparent)]
-    Decode(#[from] DecodeError),
+    #[error("failed decoding incoming header bytes: {0}")]
+    DecodeHeader(#[from] p2panda_core::operation::HeaderError),
 
     #[error("log store error: {0}")]
     LogStore(String),
@@ -637,7 +641,7 @@ mod tests {
         let mut peer = Peer::new(0).await;
         let log_id = 0;
 
-        let body = Body::new("Hello, Sloth!".as_bytes());
+        let body = Body::from_bytes(b"Hello, Sloth!");
         let (header_0, header_bytes_0) = peer.create_operation(&body, log_id).await;
         let (header_1, header_bytes_1) = peer.create_operation(&body, log_id).await;
         let (header_2, header_bytes_2) = peer.create_operation(&body, log_id).await;
@@ -700,21 +704,21 @@ mod tests {
         };
         let (header, body_inner) = (header.clone(), body_inner.clone());
         assert_eq!(header, header_bytes_0);
-        assert_eq!(Body::new(&body_inner), body);
+        assert_eq!(Body::from_bytes(&body_inner), body);
 
         let TestLogSyncMessage::Operation(header, Some(body_inner)) = &messages[3] else {
             panic!("Not a TestLogSyncMessage::Operation: {:?}", &messages[3]);
         };
         let (header, body_inner) = (header.clone(), body_inner.clone());
         assert_eq!(header, header_bytes_1);
-        assert_eq!(Body::new(&body_inner), body);
+        assert_eq!(Body::from_bytes(&body_inner), body);
 
         let TestLogSyncMessage::Operation(header, Some(body_inner)) = &messages[4] else {
             panic!("Not a TestLogSyncMessage::Operation: {:?}", &messages[4]);
         };
         let (header, body_inner) = (header.clone(), body_inner.clone());
         assert_eq!(header, header_bytes_2);
-        assert_eq!(Body::new(&body_inner), body);
+        assert_eq!(Body::from_bytes(&body_inner), body);
 
         assert_eq!(messages[5], TestLogSyncMessage::Done);
     }
@@ -729,8 +733,8 @@ mod tests {
         let mut peer_a = Peer::new(0).await;
         let mut peer_b = Peer::new(1).await;
 
-        let body_a = Body::new("From Alice".as_bytes());
-        let body_b = Body::new("From Bob".as_bytes());
+        let body_a = Body::from_bytes("From Alice".as_bytes());
+        let body_b = Body::from_bytes("From Bob".as_bytes());
 
         let (header_a0, _) = peer_a.create_operation(&body_a, LOG_ID).await;
         let (header_a1, _) = peer_a.create_operation(&body_a, LOG_ID).await;
@@ -829,7 +833,7 @@ mod tests {
         let mut peer = Peer::new(0).await;
         const LOG_ID: TestLogId = 1;
 
-        let body = Body::new(b"unexpected op before presend");
+        let body = Body::from_bytes(b"unexpected op before presend");
         let (_, header_bytes) = peer.create_operation(&body, LOG_ID).await;
 
         let mut logs = Logs::default();
@@ -858,7 +862,7 @@ mod tests {
         let mut peer = Peer::new(0).await;
         const LOG_ID: TestLogId = 1;
 
-        let body = Body::new(b"two presends");
+        let body = Body::from_bytes(b"two presends");
         peer.create_operation(&body, LOG_ID).await;
 
         let mut logs = Logs::default();
@@ -904,7 +908,7 @@ mod tests {
         let mut peer = Peer::new(0).await;
         const LOG_ID: TestLogId = 1;
 
-        let body = Body::new(b"bad have order");
+        let body = Body::from_bytes(b"bad have order");
         peer.create_operation(&body, LOG_ID).await;
 
         let mut logs = Logs::default();
@@ -939,7 +943,7 @@ mod tests {
         let mut peer_b = Peer::new(1).await;
         let mut peer_c = Peer::new(2).await;
 
-        let body = Body::new(&[0; 1000]);
+        let body = Body::from_bytes(&[0; 1000]);
 
         for _ in 0..100 {
             let _ = peer_a.create_operation(&body, 0).await;

--- a/p2panda-sync/src/protocols/topic_log_sync.rs
+++ b/p2panda-sync/src/protocols/topic_log_sync.rs
@@ -211,7 +211,7 @@ where
                                     }
 
                                     metrics.sent_live_bytes +=
-                                        operation.header.to_bytes().len() as u32 + operation.header.payload_size;
+                                        operation.header.encode().len() as u32 + operation.header.payload_size;
                                     metrics.sent_live_operations += 1;
 
                                     trace!(
@@ -284,7 +284,7 @@ where
                                         continue;
                                     }
 
-                                    metrics.received_live_bytes += header.to_bytes().len() as u32 + header.payload_size;
+                                    metrics.received_live_bytes += header.encode().len() as u32 + header.payload_size;
                                     metrics.received_live_operations += 1;
 
                                     trace!(
@@ -675,7 +675,7 @@ pub mod tests {
         let topic = Topic::random();
         let mut peer = Peer::new(0).await;
 
-        let body = Body::new("Hello, Sloth!".as_bytes());
+        let body = Body::from_bytes("Hello, Sloth!".as_bytes());
         let (header_0, header_bytes_0) = peer.create_operation(&body, log_id).await;
         let (header_1, header_bytes_1) = peer.create_operation(&body, log_id).await;
         let (header_2, header_bytes_2) = peer.create_operation(&body, log_id).await;
@@ -741,7 +741,7 @@ pub mod tests {
                         Some(body),
                     )) => (header, body));
                     assert_eq!(header, header_bytes_0);
-                    assert_eq!(Body::new(&body_inner), body)
+                    assert_eq!(Body::from_bytes(&body_inner), body)
                 }
                 3 => {
                     let (header, body_inner) = assert_matches!(message, TestTopicSyncMessage::Sync(LogSyncMessage::Operation(
@@ -749,7 +749,7 @@ pub mod tests {
                         Some(body),
                     )) => (header, body));
                     assert_eq!(header, header_bytes_1);
-                    assert_eq!(Body::new(&body_inner), body)
+                    assert_eq!(Body::from_bytes(&body_inner), body)
                 }
                 4 => {
                     let (header, body_inner) = assert_matches!(message, TestTopicSyncMessage::Sync(LogSyncMessage::Operation(
@@ -757,7 +757,7 @@ pub mod tests {
                         Some(body),
                     )) => (header, body));
                     assert_eq!(header, header_bytes_2);
-                    assert_eq!(Body::new(&body_inner), body)
+                    assert_eq!(Body::from_bytes(&body_inner), body)
                 }
                 5 => {
                     assert_eq!(message, TestTopicSyncMessage::Sync(LogSyncMessage::Done));
@@ -777,7 +777,7 @@ pub mod tests {
         let mut peer_a = Peer::new(0).await;
         let mut peer_b = Peer::new(1).await;
 
-        let body = Body::new("Hello, Sloth!".as_bytes());
+        let body = Body::from_bytes("Hello, Sloth!".as_bytes());
         let (header_0, _) = peer_a.create_operation(&body, 0).await;
         let (header_1, _) = peer_a.create_operation(&body, 0).await;
         let (header_2, _) = peer_a.create_operation(&body, 0).await;
@@ -856,7 +856,7 @@ pub mod tests {
         let mut peer_a = Peer::new(0).await;
         let mut peer_b = Peer::new(1).await;
 
-        let body = Body::new("Hello, Sloth!".as_bytes());
+        let body = Body::from_bytes("Hello, Sloth!".as_bytes());
         let (header_0, header_bytes_0) = peer_b.create_operation(&body, log_id).await;
 
         let logs = BTreeMap::from([(peer_a.id(), vec![log_id])]);
@@ -867,11 +867,11 @@ pub mod tests {
 
         let (header_1, _) = peer_b.create_operation_no_insert(&body, log_id).await;
         let expected_bytes_received = header_0.payload_size
-            + header_0.to_bytes().len() as u32
+            + header_0.encode().len() as u32
             + header_1.payload_size
-            + header_1.to_bytes().len() as u32;
+            + header_1.encode().len() as u32;
         let (header_2, _) = peer_a.create_operation_no_insert(&body, log_id).await;
-        let expected_bytes_sent = header_2.payload_size + header_2.to_bytes().len() as u32;
+        let expected_bytes_sent = header_2.payload_size + header_2.encode().len() as u32;
 
         let (protocol, mut events_rx, mut live_mode_tx) =
             peer_a.topic_sync_protocol(topic.clone(), true);
@@ -967,7 +967,7 @@ pub mod tests {
         let mut peer_a = Peer::new(0).await;
         let mut peer_b = Peer::new(1).await;
 
-        let body = Body::new("Hello, Sloth!".as_bytes());
+        let body = Body::from_bytes("Hello, Sloth!".as_bytes());
         let (header_0, header_bytes_0) = peer_b.create_operation(&body, log_id).await;
 
         let logs = BTreeMap::from([(peer_a.id(), vec![log_id])]);
@@ -978,11 +978,11 @@ pub mod tests {
 
         let (header_1, _) = peer_b.create_operation_no_insert(&body, log_id).await;
         let expected_bytes_received = header_0.payload_size
-            + header_0.to_bytes().len() as u32
+            + header_0.encode().len() as u32
             + header_1.payload_size
-            + header_1.to_bytes().len() as u32;
+            + header_1.encode().len() as u32;
         let (header_2, _) = peer_a.create_operation_no_insert(&body, log_id).await;
-        let expected_bytes_sent = header_2.payload_size + header_2.to_bytes().len() as u32;
+        let expected_bytes_sent = header_2.payload_size + header_2.encode().len() as u32;
 
         let (protocol, mut events_rx, mut live_mode_tx) =
             peer_a.topic_sync_protocol(topic.clone(), true);

--- a/p2panda-sync/src/protocols/topic_log_sync.rs
+++ b/p2panda-sync/src/protocols/topic_log_sync.rs
@@ -109,7 +109,7 @@ where
     E: Extensions + Send + 'static,
 {
     type Error = TopicLogSyncError;
-    type Message = TopicLogSyncMessage<L, E>;
+    type Message = TopicLogSyncMessage<L>;
     type Output = ();
 
     async fn run(
@@ -206,26 +206,29 @@ where
                             match message {
                                 ToSync::Payload(operation) => {
                                     if !dedup.insert(operation.hash) {
-                                        trace!(id = ?operation.hash.fmt_short(), "ignore duplicate operation sent on live-mode channel");
+                                        trace!(
+                                            id = %operation.hash.fmt_short(),
+                                            "ignore duplicate operation sent on live-mode channel"
+                                        );
                                         continue;
                                     }
 
                                     metrics.sent_live_bytes +=
-                                        operation.header.to_bytes().len() as u32 + operation.header.payload_size;
+                                        operation.header.size() + operation.header.payload_size;
                                     metrics.sent_live_operations += 1;
 
                                     trace!(
                                         phase = "live",
-                                        id = ?operation.hash.fmt_short(),
-                                        sent_ops = ?metrics.sent_live_operations,
-                                        sent_bytes = ?metrics.sent_live_bytes,
+                                        id = %operation.hash.fmt_short(),
+                                        sent_ops = %metrics.sent_live_operations,
+                                        sent_bytes = %metrics.sent_live_bytes,
                                         "sent operation"
                                     );
 
                                     let result = sink
                                         .send(TopicLogSyncMessage::Live(
-                                            operation.header,
-                                            operation.body,
+                                            operation.header.encode(),
+                                            operation.body.map(|body| body.to_bytes()),
                                         ))
                                         .await
                                         .map_err(|err| TopicLogSyncChannelError::MessageSink(format!("{err:?}")).into());
@@ -274,39 +277,51 @@ where
                                         ));
                                     };
 
+                                    let header = Header::<E>::decode(&header)?;
+                                    let body = body.map(Body::from_bytes);
+
                                     // TODO: check that this message is a part of our topic T set.
 
                                     // Insert operation hash into deduplication buffer and if it was
                                     // previously present do not forward the operation to the application
                                     // layer.
                                     if !dedup.insert(header.hash()) {
-                                        trace!(phase = "live", operation_id = ?header.hash().fmt_short(), "ignore duplicate operation sent from remote");
+                                        trace!(
+                                            phase = "live",
+                                            operation_id = %header.hash().fmt_short(),
+                                            "ignore duplicate operation sent from remote"
+                                        );
+
                                         continue;
                                     }
 
-                                    metrics.received_live_bytes += header.to_bytes().len() as u32 + header.payload_size;
+                                    metrics.received_live_bytes += header.size() + header.payload_size;
                                     metrics.received_live_operations += 1;
 
                                     trace!(
                                         phase = "live",
-                                        operation_id = ?header.hash().fmt_short(),
+                                        operation_id = %header.hash().fmt_short(),
                                         received_ops = %metrics.received_live_operations,
                                         received_bytes = %metrics.received_live_bytes,
                                         "received operation"
                                     );
 
                                     self.event_tx
-                                        .send(TopicLogSyncEvent::OperationReceived{operation: Box::new(Operation {
-                                            hash: header.hash(),
-                                            header,
-                                            body,
-                                        }), metrics: metrics.clone()})
+                                        .send(TopicLogSyncEvent::OperationReceived {
+                                            operation: Box::new(Operation {
+                                                hash: header.hash(),
+                                                header,
+                                                body,
+                                            }),
+                                            metrics: metrics.clone(),
+                                        })
                                         .map_err(|_| TopicLogSyncChannelError::EventSend)?;
                                 }
                                 Err(err) => {
                                     if close_sent {
                                         break Ok(());
                                     }
+
                                     break Err(TopicLogSyncError::DecodeMessage(format!("{err:?}")));
                                 }
                             }
@@ -349,16 +364,15 @@ where
 
 /// Map raw message sink and stream into log sync protocol specific channels.
 #[allow(clippy::complexity)]
-fn sync_channels<'a, L, E>(
-    sink: &mut (impl Sink<TopicLogSyncMessage<L, E>, Error = impl Debug> + Unpin),
-    stream: &mut (impl Stream<Item = Result<TopicLogSyncMessage<L, E>, impl Debug>> + Unpin),
+fn sync_channels<'a, L>(
+    sink: &mut (impl Sink<TopicLogSyncMessage<L>, Error = impl Debug> + Unpin),
+    stream: &mut (impl Stream<Item = Result<TopicLogSyncMessage<L>, impl Debug>> + Unpin),
 ) -> (
     impl Sink<LogSyncMessage<L>, Error = TopicLogSyncChannelError> + Unpin,
     impl Stream<Item = Result<LogSyncMessage<L>, TopicLogSyncChannelError>> + Unpin,
 )
 where
     L: LogId,
-    E: Extensions,
 {
     let log_sync_sink = LogSyncSink::new(sink);
 
@@ -389,6 +403,9 @@ pub enum TopicLogSyncChannelError {
 /// Error type occurring in topic log sync protocol.
 #[derive(Debug, Error)]
 pub enum TopicLogSyncError {
+    #[error(transparent)]
+    DecodeHeader(#[from] p2panda_core::operation::HeaderError),
+
     #[error(transparent)]
     Sync(#[from] LogSyncError),
 
@@ -521,20 +538,18 @@ impl<E> From<LogSyncEvent<E>> for TopicLogSyncEvent<E> {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(bound(deserialize = "L: LogId"))]
 #[allow(clippy::large_enum_variant)]
-pub enum TopicLogSyncMessage<L, E>
+pub enum TopicLogSyncMessage<L>
 where
     L: LogId,
-    E: Extensions,
 {
     Sync(LogSyncMessage<L>),
-    Live(Header<E>, Option<Body>),
+    Live(Vec<u8>, Option<Vec<u8>>),
     Close,
 }
 
-impl<L, E> std::fmt::Display for TopicLogSyncMessage<L, E>
+impl<L> std::fmt::Display for TopicLogSyncMessage<L>
 where
     L: LogId,
-    E: Extensions,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = match self {
@@ -548,14 +563,14 @@ where
 
 pin_project! {
     /// Sink wrapper which converts messages and errors into the expected types.
-    pub struct LogSyncSink<S, L, E> {
+    pub struct LogSyncSink<S, L> {
         #[pin]
         inner: S,
-        _phantom: std::marker::PhantomData<(L, E)>,
+        _phantom: std::marker::PhantomData<L>,
     }
 }
 
-impl<S, L, E> LogSyncSink<S, L, E> {
+impl<S, L> LogSyncSink<S, L> {
     pub fn new(inner: S) -> Self {
         Self {
             inner,
@@ -564,12 +579,11 @@ impl<S, L, E> LogSyncSink<S, L, E> {
     }
 }
 
-impl<S, L, E> Sink<LogSyncMessage<L>> for LogSyncSink<S, L, E>
+impl<S, L> Sink<LogSyncMessage<L>> for LogSyncSink<S, L>
 where
     L: LogId,
-    S: Sink<TopicLogSyncMessage<L, E>>,
+    S: Sink<TopicLogSyncMessage<L>>,
     S::Error: Debug,
-    E: Extensions,
 {
     type Error = TopicLogSyncChannelError;
 
@@ -674,7 +688,7 @@ pub mod tests {
         let topic = Topic::random();
         let mut peer = Peer::new(0).await;
 
-        let body = Body::new("Hello, Sloth!".as_bytes());
+        let body = Body::from_bytes(b"Hello, Sloth!");
         let (header_0, header_bytes_0) = peer.create_operation(&body, log_id).await;
         let (header_1, header_bytes_1) = peer.create_operation(&body, log_id).await;
         let (header_2, header_bytes_2) = peer.create_operation(&body, log_id).await;
@@ -743,7 +757,7 @@ pub mod tests {
                         panic!("Not a TestTopicSyncMessage::Sync: {message:?}");
                     };
                     assert_eq!(header, header_bytes_0);
-                    assert_eq!(Body::new(&body_inner), body)
+                    assert_eq!(Body::from_bytes(&body_inner), body)
                 }
                 3 => {
                     let TestTopicSyncMessage::Sync(LogSyncMessage::Operation(
@@ -754,7 +768,7 @@ pub mod tests {
                         panic!("Not a TestTopicSyncMessage::Sync: {message:?}");
                     };
                     assert_eq!(header, header_bytes_1);
-                    assert_eq!(Body::new(&body_inner), body)
+                    assert_eq!(Body::from_bytes(&body_inner), body)
                 }
                 4 => {
                     let TestTopicSyncMessage::Sync(LogSyncMessage::Operation(
@@ -765,7 +779,7 @@ pub mod tests {
                         panic!("Not a TestTopicSyncMessage::Sync: {message:?}");
                     };
                     assert_eq!(header, header_bytes_2);
-                    assert_eq!(Body::new(&body_inner), body)
+                    assert_eq!(Body::from_bytes(&body_inner), body)
                 }
                 5 => {
                     assert_eq!(message, TestTopicSyncMessage::Sync(LogSyncMessage::Done));
@@ -785,7 +799,7 @@ pub mod tests {
         let mut peer_a = Peer::new(0).await;
         let mut peer_b = Peer::new(1).await;
 
-        let body = Body::new("Hello, Sloth!".as_bytes());
+        let body = Body::from_bytes(b"Hello, Sloth!");
         let (header_0, _) = peer_a.create_operation(&body, 0).await;
         let (header_1, _) = peer_a.create_operation(&body, 0).await;
         let (header_2, _) = peer_a.create_operation(&body, 0).await;
@@ -870,7 +884,7 @@ pub mod tests {
         let mut peer_a = Peer::new(0).await;
         let mut peer_b = Peer::new(1).await;
 
-        let body = Body::new("Hello, Sloth!".as_bytes());
+        let body = Body::from_bytes(b"Hello, Sloth!");
         let (header_0, header_bytes_0) = peer_b.create_operation(&body, log_id).await;
 
         let logs = BTreeMap::from([(peer_a.id(), vec![log_id])]);
@@ -880,12 +894,10 @@ pub mod tests {
         peer_a.associate(&topic, &logs).await;
 
         let (header_1, _) = peer_b.create_operation_no_insert(&body, log_id).await;
-        let expected_bytes_received = header_0.payload_size
-            + header_0.to_bytes().len() as u32
-            + header_1.payload_size
-            + header_1.to_bytes().len() as u32;
+        let expected_bytes_received =
+            header_0.payload_size + header_0.size() + header_1.payload_size + header_1.size();
         let (header_2, _) = peer_a.create_operation_no_insert(&body, log_id).await;
-        let expected_bytes_sent = header_2.payload_size + header_2.to_bytes().len() as u32;
+        let expected_bytes_sent = header_2.payload_size + header_2.size();
 
         let (protocol, mut events_rx, mut live_mode_tx) =
             peer_a.topic_sync_protocol(topic.clone(), true);
@@ -914,7 +926,7 @@ pub mod tests {
                     Some(body.to_bytes()),
                 )),
                 TestTopicSyncMessage::Sync(LogSyncMessage::Done),
-                TestTopicSyncMessage::Live(header_1.clone(), Some(body.clone())),
+                TestTopicSyncMessage::Live(header_1.encode(), Some(body.to_bytes())),
                 TestTopicSyncMessage::Close,
             ],
         )
@@ -965,8 +977,8 @@ pub mod tests {
                     let TestTopicSyncMessage::Live(header, Some(body_inner)) = message else {
                         panic!("Not a TestTopicSyncMessage::Live");
                     };
-                    assert_eq!(header, header_2);
-                    assert_eq!(body_inner, body);
+                    assert_eq!(header, header_2.encode());
+                    assert_eq!(body_inner, body.to_bytes());
                 }
                 3 => {
                     std::assert_matches!(message, TestTopicSyncMessage::Close)
@@ -983,7 +995,7 @@ pub mod tests {
         let mut peer_a = Peer::new(0).await;
         let mut peer_b = Peer::new(1).await;
 
-        let body = Body::new("Hello, Sloth!".as_bytes());
+        let body = Body::from_bytes(b"Hello, Sloth!");
         let (header_0, header_bytes_0) = peer_b.create_operation(&body, log_id).await;
 
         let logs = BTreeMap::from([(peer_a.id(), vec![log_id])]);
@@ -993,12 +1005,10 @@ pub mod tests {
         peer_a.associate(&topic, &logs).await;
 
         let (header_1, _) = peer_b.create_operation_no_insert(&body, log_id).await;
-        let expected_bytes_received = header_0.payload_size
-            + header_0.to_bytes().len() as u32
-            + header_1.payload_size
-            + header_1.to_bytes().len() as u32;
+        let expected_bytes_received =
+            header_0.payload_size + header_0.size() + header_1.payload_size + header_1.size();
         let (header_2, _) = peer_a.create_operation_no_insert(&body, log_id).await;
-        let expected_bytes_sent = header_2.payload_size + header_2.to_bytes().len() as u32;
+        let expected_bytes_sent = header_2.payload_size + header_2.size();
 
         let (protocol, mut events_rx, mut live_mode_tx) =
             peer_a.topic_sync_protocol(topic.clone(), true);
@@ -1038,11 +1048,11 @@ pub mod tests {
                     Some(body.to_bytes()),
                 )),
                 TestTopicSyncMessage::Sync(LogSyncMessage::Done),
-                TestTopicSyncMessage::Live(header_1.clone(), Some(body.clone())),
+                TestTopicSyncMessage::Live(header_1.encode(), Some(body.to_bytes())),
                 // Duplicate of message sent during sync.
-                TestTopicSyncMessage::Live(header_0.clone(), Some(body.clone())),
+                TestTopicSyncMessage::Live(header_0.encode(), Some(body.to_bytes())),
                 // Duplicate of message sent earlier in live-mode.
-                TestTopicSyncMessage::Live(header_1.clone(), Some(body.clone())),
+                TestTopicSyncMessage::Live(header_1.encode(), Some(body.to_bytes())),
                 TestTopicSyncMessage::Close,
             ],
         )
@@ -1094,8 +1104,8 @@ pub mod tests {
                     let TestTopicSyncMessage::Live(header, Some(body_inner)) = message else {
                         unreachable!();
                     };
-                    assert_eq!(header, header_2);
-                    assert_eq!(body_inner, body);
+                    assert_eq!(header, header_2.encode());
+                    assert_eq!(body_inner, body.to_bytes());
                 }
                 3 => {
                     std::assert_matches!(message, TestTopicSyncMessage::Close)

--- a/p2panda-sync/src/test_utils.rs
+++ b/p2panda-sync/src/test_utils.rs
@@ -231,6 +231,6 @@ pub fn create_operation(
         extensions: log_id,
     };
     header.sign(signing_key);
-    let header_bytes = header.to_bytes();
+    let header_bytes = header.encode();
     (header, header_bytes)
 }

--- a/p2panda-sync/src/test_utils.rs
+++ b/p2panda-sync/src/test_utils.rs
@@ -33,7 +33,7 @@ pub type TestLogSync = LogSync<TestLogId, TestExtensions, SqliteStore, TestLogSy
 pub type TestLogSyncError = LogSyncError;
 
 // Types used in topic log sync protocol tests.
-pub type TestTopicSyncMessage = TopicLogSyncMessage<TestLogId, TestExtensions>;
+pub type TestTopicSyncMessage = TopicLogSyncMessage<TestLogId>;
 pub type TestTopicSyncEvent = TopicLogSyncEvent<TestExtensions>;
 pub type TestTopicSync = TopicLogSync<Topic, SqliteStore, TestLogId, TestExtensions>;
 pub type TestTopicSyncError = TopicLogSyncError;
@@ -220,17 +220,11 @@ pub fn create_operation(
     backlink: Option<Hash>,
     log_id: TestLogId,
 ) -> (Header<TestExtensions>, Vec<u8>) {
-    let mut header = Header::<TestExtensions> {
-        version: 1,
-        verifying_key: signing_key.verifying_key(),
-        signature: None,
-        payload_size: body.size(),
-        payload_hash: Some(body.hash()),
-        seq_num,
-        backlink,
-        extensions: log_id,
-    };
-    header.sign(signing_key);
-    let header_bytes = header.to_bytes();
+    let header = Header::builder()
+        .body(body)
+        .seq_num(seq_num)
+        .backlink(backlink)
+        .build(signing_key, log_id);
+    let header_bytes = header.encode();
     (header, header_bytes)
 }

--- a/p2panda/src/forge.rs
+++ b/p2panda/src/forge.rs
@@ -79,10 +79,7 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
         body: Option<Vec<u8>>,
         extensions: Extensions,
     ) -> Result<Operation, Self::Error> {
-        // Perform prerequisite computations outside of the locked transaction.
-        let payload_size = body.as_ref().map(|bytes| bytes.len()).unwrap_or(0) as u32;
         let body: Option<Body> = body.map(|bytes| bytes.into());
-        let payload_hash = body.as_ref().map(|body| body.hash());
 
         // Acquire a lock on the store for the duration of the read to write cycle.
         //
@@ -105,24 +102,14 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
             .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
             .unwrap_or((0, None));
 
-            let mut header = Header {
-                version: 1,
-                verifying_key: self.signing_key.verifying_key(),
-                signature: None,
-                payload_size,
-                payload_hash,
-                seq_num,
-                backlink,
-                extensions,
-            };
+            let header = {
+                let mut builder = Header::builder().seq_num(seq_num).backlink(backlink);
 
-            header.sign(&self.signing_key);
-            let hash = header.hash();
+                if let Some(ref body) = body {
+                    builder = builder.body(body);
+                }
 
-            let operation = Operation {
-                hash,
-                header: header.clone(),
-                body,
+                builder.build(&self.signing_key, extensions)
             };
 
             <SqliteStore as TopicStore<Topic, VerifyingKey, LogId>>::associate(
@@ -133,8 +120,10 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
             )
             .await?;
 
+            let operation = Operation::from_parts(header, body);
+
             self.store
-                .insert_operation(&hash, &operation, &log_id)
+                .insert_operation(&operation.hash, &operation, &log_id)
                 .await?;
 
             operation

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -476,21 +476,9 @@ async fn import_external_stream() {
     assert!(start_received);
     assert!(end_received);
     assert_eq!(imported.len(), 3);
-    assert!(
-        imported
-            .iter()
-            .any(|event| event.id() == operation_1.header().hash())
-    );
-    assert!(
-        imported
-            .iter()
-            .any(|event| event.id() == operation_2.header().hash())
-    );
-    assert!(
-        imported
-            .iter()
-            .any(|event| event.id() == operation_3.header().hash())
-    );
+    assert!(imported.iter().any(|event| event.id() == operation_1.hash));
+    assert!(imported.iter().any(|event| event.id() == operation_2.hash));
+    assert!(imported.iter().any(|event| event.id() == operation_3.hash));
     assert!(end_received);
 }
 


### PR DESCRIPTION
### Background

`Header::<E>` has been slightly too simple for what we need. It was used to create operations, validate them, encode and decode them all at once. That was really easy to use, but also ignored some important implementation details as we revealed now and in hindsight also makes dealing with operations actually harder .. and slower.

The main issue is: We can't rely only on `serde` to encode headers as this is one abstraction level too high (Rust type level), see related issue here: https://github.com/p2panda/p2panda/issues/1201. We want to be on CBOR level instead (with the help of an AST representation).

### New type to decode operations: `AnyHeader` and `AnyOperation`

This PR introduces an `AnyHeader` type. It doesn't know about an explicit extensions type `E` anymore (less generics, yay) and is designed to decode headers as efficiently as possible using `cbor_core`. It keeps the extension's CBOR AST around to always correctly encode it back into it's original shape while ensuring correct hash digest, size and signature check.

There's no serde support for encoding and decoding headers anymore, instead one needs to call `AnyHeader::decode(bytes)` or `AnyHeader::encode()` etc.

We can do already a lot of validation here and I focused on optimizing for reducing redundant, repetitive work and memory usage. Now we're computing the digest and check the header format AND the signature in one go with as little memory allocations (zero copy) and encodings as possible.

The hash digest and header size is stored inside AnyHeader so any call on it like `header.hash()` etc. returns an already computed result, no need to encode anything again.

Things like this were not possible before since `Header::<E>` didn't have any proper constructors, we always assembled it from using the fields directly, so that's a nice side-effect from this refactor.

Obviously there's an `AnyOperation` type as well now, converting between all of them is really easy and almost doesn't cost much.

For converting between `AnyHeader` -> `Header::<E>` or `AnyOperation` -> `Operation::<E>` we also have a lot in our hands already, the computed hash, mostly all fields of the header. The only thing left is to decode the extensions, now that we know the concrete Rust type `E`.

There's not really a need anymore for `Header::<E>` to check the signature or compute a hash or size, this type is now mostly representing an immutable version of a header. `Signature` is not an `Option` anymore and the pre-computed hash and size lives inside of it as well.

To decode bytes to headers the flow looks like this now:

```
Vec<u8> -> AnyHeader::decode(bytes)? -> Header::<E>::from_any(any_header)?

.. or

Vec<u8> -> Header::<E>::decode(bytes)?
```

### New traits to describe data-type guarantees

To check the log integrity we need to update our `validate_operation`, `validate_backlink` and `validate_header` methods to work with these new types.

Instead of asking for a concrete type here this PR introduces trait bounds. Here are the traits (naming etc. heavily WIP):

```rust
/// Identifier of a single operation.
pub trait OperationId: Copy + Clone + PartialEq + Eq + StdHash {}

/// Returns (unique) hash digest, which can be used as identifier of this published data type.
pub trait Digest<ID>
where
    ID: OperationId,
{
    fn hash(&self) -> ID;
}

/// Returns the author of this published data type and a method to verify the authenticity of it.
pub trait Provenance<A>
where
    A: Author,
{
    fn author(&self) -> A;

    fn verify(&self) -> bool;
}

/// Hash-chain structure with integrity guarantees and sequence numbers as a performance
/// optimization.
pub trait Chain<ID> {
    /// Pointer at previous entry in log which gives us the integrity guarantee of the "hash chain".
    /// The first entry in a log returns `None`.
    fn backlink(&self) -> Option<ID>;

    /// Sequence numbers are helpful to fastly detect forks and use the much faster and optimized
    /// diffing strategy when the local log is not forked.
    fn seq_num(&self) -> SeqNum;
}

/// Additional data which can be removed from the on-chain data-type.
pub trait Offchain<ID> {
    fn payload(&self) -> Option<&Body>;

    fn payload_hash(&self) -> Option<ID>;

    fn payload_size(&self) -> PayloadSize;
}
```

### New builder type to create & sign headers

Lastly we need a way now to create operations. Since we can't use `Header<E>` for that anymore we need .. a new builder struct!

Here is an example:

```rust
let header = Header::builder()
    .body(b"test")
    .build(&signing_key, extensions);
```

.. or:

```rust
let header = Header::builder()
    .chain(1, previous_header.hash())
    .build(&signing_key, extensions);
```

The encoding of everything doesn't use serde internally but `cbor_core` directly to skip the `Signature: None` workaround and also because we don't really have any serializer implemented for such a struct anymore.

Again it's optimized for encoding only twice (once for signature calculation and once for digest) and these things, plus header size are then moved straight into `Header<E>`, so we don't need to compute it ever again.

This gives us the path to publish operations as such:

```
Header::<E>::builder() -> Header::<E>::encode() -> Vec<u8>
```

Since `Header<E>` can only be created ever by ourselves (and never came from bytes) we know that the signature and operation format is always checked and correct.

### Use of `cbor_core` instead of `ciborium`

This PR replaced `ciborium` with [`cbor_core`](https://docs.rs/cbor-core/latest/cbor_core/). The reason is that `ciborium` doesn't have a Value and AST as powerful as `cbor_core` to work with for low-level messing with CBOR types. It only offers a fairly abstract serde API.

Closes https://github.com/p2panda/p2panda/issues/1201

## Todo

- [x] Rework flow to create, encode and decode operations
- [x] Allow low-level (dangerous!) access to manipulating headers in test environments

## Further work

- Remove `E` from all `p2panda-store` methods, we work with AnyHeader and AnyOperation now
- Remove `E` from all `p2panda-sync` code
- Decode into `Header::<E>` in `p2panda`

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
