### PR TITLE
Adjust spaces API to suit "command issuing" and "processing" separation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Highlights are marked with a pancake 🥞
 - Use framed postcard codec instead of CBOR for wire protocols [#1198](https://github.com/p2panda/p2panda/pull/1198)
 - Future-proof extensions format in Node API [#1155](https://github.com/p2panda/p2panda/pull/1155)
 - spaces: Only return events when calling Manager::process [#1216](https://github.com/p2panda/p2panda/pull/1216)
+- spaces: Don't sync all spaces when group membership changes
+  [#1216](https://github.com/p2panda/p2panda/pull/1216)
 
 ## [0.6.1] - 22/05/2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Highlights are marked with a pancake 🥞
 - spaces: Only return events when calling Manager::process [#1216](https://github.com/p2panda/p2panda/pull/1216)
 - spaces: Don't sync all spaces when group membership changes
   [#1216](https://github.com/p2panda/p2panda/pull/1216)
+- spaces: Adjust all "command" methods to not persist state locally [#1216](https://github.com/p2panda/p2panda/pull/1216)
 
 ## [0.6.1] - 22/05/2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Highlights are marked with a pancake 🥞
     - Fix header encoding for ZST extensions [#1196](https://github.com/p2panda/p2panda/pull/1196)
 - Use framed postcard codec instead of CBOR for wire protocols [#1198](https://github.com/p2panda/p2panda/pull/1198)
 - Future-proof extensions format in Node API [#1155](https://github.com/p2panda/p2panda/pull/1155)
+- spaces: Only return events when calling Manager::process [#1216](https://github.com/p2panda/p2panda/pull/1216)
 
 ## [0.6.1] - 22/05/2026
 

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -81,7 +81,7 @@ where
     pub(crate) async fn create(
         manager_ref: Manager<ID, S, K, F, M, C, RS>,
         initial_members: Vec<(ActorId, Access<C>)>,
-    ) -> Result<(Self, Vec<M>, Event<ID, C>), GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(Self, Vec<M>), GroupError<ID, S, K, F, M, C, RS>> {
         // Generate random group id.
         let group_id: ActorId = {
             let manager = manager_ref.inner.read().await;
@@ -103,14 +103,9 @@ where
             initial_members: initial_members.clone(),
         };
 
-        let (messages, mut events) =
+        let messages =
             Self::process_local_control(manager_ref.clone(), group_id, auth_dependencies, action)
                 .await?;
-
-        // Sanity check: there should only one event as this group was only just
-        // created and cannot be associated with any space yet.
-        assert_eq!(events.len(), 1);
-        let event = events.remove(0);
 
         Ok((
             Self {
@@ -118,7 +113,6 @@ where
                 manager: manager_ref,
             },
             messages,
-            event,
         ))
     }
 
@@ -130,7 +124,7 @@ where
         &self,
         member: ActorId,
         access: Access<C>,
-    ) -> Result<(Vec<M>, Vec<Event<ID, C>>), GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<M>, GroupError<ID, S, K, F, M, C, RS>> {
         let (group_id, auth_dependencies, action) = {
             let manager = self.manager.inner.read().await;
             let auth_y = manager.store.auth().await.map_err(GroupError::AuthStore)?;
@@ -142,11 +136,11 @@ where
             )
         };
 
-        let (messages, events) =
+        let messages =
             Self::process_local_control(self.manager.clone(), group_id, auth_dependencies, action)
                 .await?;
 
-        Ok((messages, events))
+        Ok(messages)
     }
 
     /// Remove member from group.
@@ -156,7 +150,7 @@ where
     pub async fn remove(
         &self,
         member: ActorId,
-    ) -> Result<(Vec<M>, Vec<Event<ID, C>>), GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<M>, GroupError<ID, S, K, F, M, C, RS>> {
         let (group_id, auth_dependencies, action) = {
             let manager = self.manager.inner.read().await;
             let auth_y = manager.store.auth().await.map_err(GroupError::AuthStore)?;
@@ -168,11 +162,11 @@ where
             )
         };
 
-        let (messages, events) =
+        let messages =
             Self::process_local_control(self.manager.clone(), group_id, auth_dependencies, action)
                 .await?;
 
-        Ok((messages, events))
+        Ok(messages)
     }
 
     /// Process a remote message.
@@ -211,7 +205,7 @@ where
         group_id: ActorId,
         auth_dependencies: Vec<OperationId>,
         group_action: GroupAction<ActorId, C>,
-    ) -> Result<(Vec<M>, Vec<Event<ID, C>>), GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<M>, GroupError<ID, S, K, F, M, C, RS>> {
         let mut auth_y = {
             let manager = manager_ref.inner.read().await;
             manager.store.auth().await.map_err(GroupError::AuthStore)?
@@ -239,18 +233,15 @@ where
                 .map_err(GroupError::AuthStore)?;
         }
 
-        let auth_event = auth_message_to_group_event(&auth_y, &auth_message);
-        let (space_messages, space_events) = manager_ref
+        let space_messages = manager_ref
             .apply_group_change_to_spaces(&message)
             .await
             .map_err(|err| GroupError::SyncSpaces(auth_message.id(), format!("{err:?}")))?;
 
         let mut messages = vec![message];
-        let mut events = vec![auth_event];
         messages.extend(space_messages);
-        events.extend(space_events);
 
-        Ok((messages, events))
+        Ok(messages)
     }
 
     /// Get the global auth state.

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -76,12 +76,11 @@ where
     /// without manager rights. If this is done then after creation no further change of the group
     /// membership would be possible by the local actor.
     ///
-    /// Returns messages for replication to other instances and events which inform users of any
-    /// state changes which occurred.
+    /// Returns message for replication to other instances.
     pub(crate) async fn create(
         manager_ref: Manager<ID, S, K, F, M, C, RS>,
         initial_members: Vec<(ActorId, Access<C>)>,
-    ) -> Result<(Self, Vec<M>), GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(Self, M), GroupError<ID, S, K, F, M, C, RS>> {
         // Generate random group id.
         let group_id: ActorId = {
             let manager = manager_ref.inner.read().await;
@@ -103,7 +102,7 @@ where
             initial_members: initial_members.clone(),
         };
 
-        let messages =
+        let message =
             Self::process_local_control(manager_ref.clone(), group_id, auth_dependencies, action)
                 .await?;
 
@@ -112,7 +111,7 @@ where
                 id: group_id,
                 manager: manager_ref,
             },
-            messages,
+            message,
         ))
     }
 
@@ -124,7 +123,7 @@ where
         &self,
         member: ActorId,
         access: Access<C>,
-    ) -> Result<Vec<M>, GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<M, GroupError<ID, S, K, F, M, C, RS>> {
         let (group_id, auth_dependencies, action) = {
             let manager = self.manager.inner.read().await;
             let auth_y = manager.store.auth().await.map_err(GroupError::AuthStore)?;
@@ -136,11 +135,7 @@ where
             )
         };
 
-        let messages =
-            Self::process_local_control(self.manager.clone(), group_id, auth_dependencies, action)
-                .await?;
-
-        Ok(messages)
+        Self::process_local_control(self.manager.clone(), group_id, auth_dependencies, action).await
     }
 
     /// Remove member from group.
@@ -150,7 +145,7 @@ where
     pub async fn remove(
         &self,
         member: ActorId,
-    ) -> Result<Vec<M>, GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<M, GroupError<ID, S, K, F, M, C, RS>> {
         let (group_id, auth_dependencies, action) = {
             let manager = self.manager.inner.read().await;
             let auth_y = manager.store.auth().await.map_err(GroupError::AuthStore)?;
@@ -162,11 +157,7 @@ where
             )
         };
 
-        let messages =
-            Self::process_local_control(self.manager.clone(), group_id, auth_dependencies, action)
-                .await?;
-
-        Ok(messages)
+        Self::process_local_control(self.manager.clone(), group_id, auth_dependencies, action).await
     }
 
     /// Process a remote message.
@@ -205,7 +196,7 @@ where
         group_id: ActorId,
         auth_dependencies: Vec<OperationId>,
         group_action: GroupAction<ActorId, C>,
-    ) -> Result<Vec<M>, GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<M, GroupError<ID, S, K, F, M, C, RS>> {
         let mut auth_y = {
             let manager = manager_ref.inner.read().await;
             manager.store.auth().await.map_err(GroupError::AuthStore)?
@@ -233,15 +224,7 @@ where
                 .map_err(GroupError::AuthStore)?;
         }
 
-        let space_messages = manager_ref
-            .apply_group_change_to_spaces(&message)
-            .await
-            .map_err(|err| GroupError::SyncSpaces(auth_message.id(), format!("{err:?}")))?;
-
-        let mut messages = vec![message];
-        messages.extend(space_messages);
-
-        Ok(messages)
+        Ok(message)
     }
 
     /// Get the global auth state.

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -8,7 +8,6 @@ use std::fmt::Debug;
 use p2panda_auth::Access;
 use p2panda_auth::group::GroupAction;
 use p2panda_auth::traits::{Conditions, Operation};
-use p2panda_core::SigningKey;
 use p2panda_encryption::RngError;
 use thiserror::Error;
 
@@ -76,88 +75,98 @@ where
     /// without manager rights. If this is done then after creation no further change of the group
     /// membership would be possible by the local actor.
     ///
-    /// Returns message for replication to other instances.
+    /// Returns resulting state and message for processing.
     pub(crate) async fn create(
         manager_ref: Manager<ID, S, K, F, M, C, RS>,
+        y: AuthGroupState<C>,
+        group_id: ActorId,
         initial_members: Vec<(ActorId, Access<C>)>,
-    ) -> Result<(Self, M), GroupError<ID, S, K, F, M, C, RS>> {
-        // Generate random group id.
-        let group_id: ActorId = {
-            let manager = manager_ref.inner.read().await;
-            let signing_key = SigningKey::from_bytes(&manager.rng.random_array()?);
-            signing_key.verifying_key().into()
-        };
+    ) -> Result<(AuthGroupState<C>, M), GroupError<ID, S, K, F, M, C, RS>> {
+        let initial_members = typed_members(&y, initial_members);
 
-        let initial_members = typed_members(manager_ref.clone(), initial_members)
-            .await
-            .map_err(GroupError::AuthStore)?;
-
-        let auth_dependencies = {
-            let manager = manager_ref.inner.read().await;
-            let auth_y = manager.store.auth().await.map_err(GroupError::AuthStore)?;
-            auth_y.inner.heads().into_iter().collect()
-        };
-
+        let auth_dependencies = y.inner.heads().into_iter().collect();
         let action = AuthGroupAction::Create {
             initial_members: initial_members.clone(),
         };
 
-        let message =
-            Self::process_local_control(manager_ref.clone(), group_id, auth_dependencies, action)
-                .await?;
+        let (y, message) = Self::process_local_control(
+            manager_ref.clone(),
+            y,
+            group_id,
+            auth_dependencies,
+            action,
+        )
+        .await?;
 
-        Ok((
-            Self {
-                id: group_id,
-                manager: manager_ref,
-            },
-            message,
-        ))
+        Ok((y, message))
     }
 
     /// Add member to group with specified access level.
     ///
-    /// Returns messages for replication to other instances and events which inform users of any
-    /// state changes which occurred.
-    pub async fn add(
+    /// Persists resulting state and returns forged message.
+    #[cfg(any(test, feature = "test_utils"))]
+    pub async fn add_persisted(
         &self,
         member: ActorId,
         access: Access<C>,
     ) -> Result<M, GroupError<ID, S, K, F, M, C, RS>> {
-        let (group_id, auth_dependencies, action) = {
-            let manager = self.manager.inner.read().await;
-            let auth_y = manager.store.auth().await.map_err(GroupError::AuthStore)?;
-            let member = typed_member(&auth_y, member);
-            (
-                self.id,
-                auth_y.inner.heads().into_iter().collect(),
-                AuthGroupAction::Add { member, access },
-            )
-        };
+        let (y, message) = self.add(member, access).await?;
+        self.manager
+            .set_auth(&y)
+            .await
+            .map_err(GroupError::AuthStore)?;
 
-        Self::process_local_control(self.manager.clone(), group_id, auth_dependencies, action).await
+        Ok(message)
+    }
+
+    /// Add member to group with specified access level.
+    ///
+    /// Returns resulting state and message for processing.
+    pub async fn add(
+        &self,
+        member: ActorId,
+        access: Access<C>,
+    ) -> Result<(AuthGroupState<C>, M), GroupError<ID, S, K, F, M, C, RS>> {
+        let y = self.manager.auth().await.map_err(GroupError::AuthStore)?;
+
+        let member = typed_member(&y, member);
+        let dependencies = y.inner.heads().into_iter().collect();
+        let action = AuthGroupAction::Add { member, access };
+
+        Self::process_local_control(self.manager.clone(), y, self.id, dependencies, action).await
     }
 
     /// Remove member from group.
     ///
-    /// Returns messages for replication to other instances and events which inform users of any
-    /// state changes which occurred.
-    pub async fn remove(
+    /// Persists resulting state and returns forged message.
+    #[cfg(any(test, feature = "test_utils"))]
+    pub async fn remove_persisted(
         &self,
         member: ActorId,
     ) -> Result<M, GroupError<ID, S, K, F, M, C, RS>> {
-        let (group_id, auth_dependencies, action) = {
-            let manager = self.manager.inner.read().await;
-            let auth_y = manager.store.auth().await.map_err(GroupError::AuthStore)?;
-            let member = typed_member(&auth_y, member);
-            (
-                self.id,
-                auth_y.inner.heads().into_iter().collect(),
-                AuthGroupAction::Remove { member },
-            )
-        };
+        let (y, message) = self.remove(member).await?;
+        self.manager
+            .set_auth(&y)
+            .await
+            .map_err(GroupError::AuthStore)?;
 
-        Self::process_local_control(self.manager.clone(), group_id, auth_dependencies, action).await
+        Ok(message)
+    }
+
+    /// Remove member from group.
+    ///
+    /// Returns resulting state and message for processing.
+    pub async fn remove(
+        &self,
+        member: ActorId,
+    ) -> Result<(AuthGroupState<C>, M), GroupError<ID, S, K, F, M, C, RS>> {
+        let y = self.manager.auth().await.map_err(GroupError::AuthStore)?;
+
+        let member = typed_member(&y, member);
+        let dependencies = y.inner.heads().into_iter().collect();
+        let action = AuthGroupAction::Remove { member };
+
+        Self::process_local_control(self.manager.clone(), y, self.id, dependencies, action).await
     }
 
     /// Process a remote message.
@@ -191,17 +200,13 @@ where
     }
 
     /// Process a local control message.
-    async fn process_local_control(
+    pub async fn process_local_control(
         manager_ref: Manager<ID, S, K, F, M, C, RS>,
+        y: AuthGroupState<C>,
         group_id: ActorId,
         auth_dependencies: Vec<OperationId>,
         group_action: GroupAction<ActorId, C>,
-    ) -> Result<M, GroupError<ID, S, K, F, M, C, RS>> {
-        let mut auth_y = {
-            let manager = manager_ref.inner.read().await;
-            manager.store.auth().await.map_err(GroupError::AuthStore)?
-        };
-
+    ) -> Result<(AuthGroupState<C>, M), GroupError<ID, S, K, F, M, C, RS>> {
         let args = SpacesArgs::Auth {
             group_id,
             auth_dependencies,
@@ -212,26 +217,11 @@ where
             let mut manager = manager_ref.inner.write().await;
             manager.identity.forge(args).await?
         };
+
         let auth_message = AuthMessage::from_forged(&message);
+        let y = AuthGroup::process(y, &auth_message).map_err(GroupError::AuthGroup)?;
 
-        {
-            let manager = manager_ref.inner.write().await;
-            auth_y = AuthGroup::process(auth_y, &auth_message).map_err(GroupError::AuthGroup)?;
-            manager
-                .store
-                .set_auth(&auth_y)
-                .await
-                .map_err(GroupError::AuthStore)?;
-        }
-
-        Ok(message)
-    }
-
-    /// Get the global auth state.
-    async fn state(&self) -> Result<AuthGroupState<C>, GroupError<ID, S, K, F, M, C, RS>> {
-        let manager = self.manager.inner.read().await;
-        let auth_y = manager.store.auth().await.map_err(GroupError::AuthStore)?;
-        Ok(auth_y)
+        Ok((y, message))
     }
 
     /// Id of this group.
@@ -243,7 +233,7 @@ where
     pub async fn members(
         &self,
     ) -> Result<Vec<(ActorId, Access<C>)>, GroupError<ID, S, K, F, M, C, RS>> {
-        let y = self.state().await?;
+        let y = self.manager.auth().await.map_err(GroupError::AuthStore)?;
         let mut group_members = y.members(self.id);
         sort_members(&mut group_members);
         Ok(group_members)

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 
 use p2panda_auth::Access;
 use p2panda_auth::traits::{Conditions, Operation};
-use p2panda_encryption::Rng;
+use p2panda_core::SigningKey;
+use p2panda_encryption::{Rng, RngError};
 use thiserror::Error;
 use tokio::sync::RwLock;
 
@@ -17,12 +18,12 @@ use crate::group::{Group, GroupError};
 use crate::identity::{IdentityError, IdentityManager};
 use crate::member::Member;
 use crate::message::SpacesArgs;
-use crate::space::{Space, SpaceError};
+use crate::space::{Space, SpaceError, SpaceState};
 use crate::traits::{
     AuthStore, AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore, MessageStore, SpaceId,
     SpacesMessage, SpacesStore,
 };
-use crate::types::{ActorId, AuthResolver, OperationId};
+use crate::types::{ActorId, AuthGroupState, AuthResolver, OperationId};
 use crate::{Config, Credentials};
 
 /// API for creating and managing groups and spaces.
@@ -170,18 +171,66 @@ where
     /// If not already included, then the local actor (creator of this space) will be added to the
     /// initial members and given manage access level.
     ///
-    /// Returns messages for replication to other instances and events which inform users of any
-    /// state changes which occurred.
-    pub async fn create_space(
+    /// Persists resulting state, returns space instance and forged message.
+    #[cfg(any(test, feature = "test_utils"))]
+    pub async fn create_space_persisted(
         &self,
         id: ID,
         initial_members: &[(ActorId, Access<C>)],
     ) -> Result<(Space<ID, S, K, F, M, C, RS>, Vec<M>), ManagerError<ID, S, K, F, M, C, RS>> {
-        let (space, messages) = Space::create(self.clone(), id, initial_members.to_owned())
-            .await
-            .map_err(ManagerError::Space)?;
+        let (auth_y, space_y, messages) = self.create_space(id, initial_members).await?;
+        let space_id = space_y.space_id;
 
+        self.set_auth(&auth_y)
+            .await
+            .map_err(ManagerError::AuthStore)?;
+        let manager = self.inner.write().await;
+        manager
+            .store
+            .set_space(&space_id, space_y)
+            .await
+            .map_err(SpaceError::SpacesStore)?;
+
+        let space = Space::new(self.clone(), space_id);
         Ok((space, messages))
+    }
+
+    /// Create a new space containing initial members and access levels.
+    ///
+    /// If not already included, then the local actor (creator of this space) will be added to the
+    /// initial members and given manage access level.
+    ///
+    /// Returns resulting auth and space state and messages for processing.
+    pub async fn create_space(
+        &self,
+        id: ID,
+        initial_members: &[(ActorId, Access<C>)],
+    ) -> Result<
+        (AuthGroupState<C>, SpaceState<ID, M, C>, Vec<M>),
+        ManagerError<ID, S, K, F, M, C, RS>,
+    > {
+        let (auth_y, space_y, messages) =
+            Space::create(self.clone(), id, initial_members.to_owned())
+                .await
+                .map_err(ManagerError::Space)?;
+
+        Ok((auth_y, space_y, messages))
+    }
+
+    /// Create a new group containing initial members with associated access levels.
+    ///
+    /// Persists resulting state, returns group instance and forged message.
+    #[cfg(any(test, feature = "test_utils"))]
+    pub async fn create_group_persisted(
+        &self,
+        initial_members: &[(ActorId, Access<C>)],
+    ) -> Result<(Group<ID, S, K, F, M, C, RS>, M), ManagerError<ID, S, K, F, M, C, RS>> {
+        let (auth_y, group_id, message) = self.create_group(initial_members).await?;
+        self.set_auth(&auth_y)
+            .await
+            .map_err(ManagerError::AuthStore)?;
+        let group = Group::new(self.clone(), group_id);
+        Ok((group, message))
     }
 
     /// Create a new group containing initial members with associated access levels.
@@ -190,16 +239,26 @@ where
     /// without manager rights. If this is done then after creation no further change of the group
     /// membership would be possible.
     ///
-    /// Returns message for replication to other instances.
+    /// Returns resulting auth state, group id and message for processing.
     pub async fn create_group(
         &self,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<(Group<ID, S, K, F, M, C, RS>, M), ManagerError<ID, S, K, F, M, C, RS>> {
-        let (group, message) = Group::create(self.clone(), initial_members.to_owned())
-            .await
-            .map_err(ManagerError::Group)?;
+    ) -> Result<(AuthGroupState<C>, ActorId, M), ManagerError<ID, S, K, F, M, C, RS>> {
+        let auth_y = self.auth().await.map_err(ManagerError::AuthStore)?;
 
-        Ok((group, message))
+        // Generate random group id.
+        let group_id: ActorId = {
+            let manager = self.inner.read().await;
+            let signing_key = SigningKey::from_bytes(&manager.rng.random_array()?);
+            signing_key.verifying_key().into()
+        };
+
+        let (auth_y, message) =
+            Group::create(self.clone(), auth_y, group_id, initial_members.to_owned())
+                .await
+                .map_err(ManagerError::Group)?;
+
+        Ok((auth_y, group_id, message))
     }
 
     /// Process a spaces message.
@@ -306,6 +365,18 @@ where
             .key_bundle_message()
             .await
             .map_err(ManagerError::IdentityManager)
+    }
+
+    /// Get the global auth state.
+    pub async fn auth(&self) -> Result<AuthGroupState<C>, <S as AuthStore<C>>::Error> {
+        let manager = self.inner.read().await;
+        manager.store.auth().await
+    }
+
+    /// Set the global auth state.
+    pub async fn set_auth(&self, y: &AuthGroupState<C>) -> Result<(), <S as AuthStore<C>>::Error> {
+        let manager = self.inner.write().await;
+        manager.store.set_auth(y).await
     }
 
     /// Returns a list of all spaces which are "out-of-sync" with the global shared auth state.
@@ -529,4 +600,7 @@ where
 
     #[error("unexpected message variant, expected auth {0}")]
     IncorrectMessageVariant(OperationId),
+
+    #[error(transparent)]
+    Rng(#[from] RngError),
 }

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use p2panda_auth::Access;
 use p2panda_auth::traits::{Conditions, Operation};
 use p2panda_encryption::Rng;
-use petgraph::algo::toposort;
 use thiserror::Error;
 use tokio::sync::RwLock;
 
@@ -191,17 +190,16 @@ where
     /// without manager rights. If this is done then after creation no further change of the group
     /// membership would be possible.
     ///
-    /// Returns messages for replication to other instances and events which inform users of any
-    /// state changes which occurred.
+    /// Returns message for replication to other instances.
     pub async fn create_group(
         &self,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<(Group<ID, S, K, F, M, C, RS>, Vec<M>), ManagerError<ID, S, K, F, M, C, RS>> {
-        let (group, messages) = Group::create(self.clone(), initial_members.to_owned())
+    ) -> Result<(Group<ID, S, K, F, M, C, RS>, M), ManagerError<ID, S, K, F, M, C, RS>> {
+        let (group, message) = Group::create(self.clone(), initial_members.to_owned())
             .await
             .map_err(ManagerError::Group)?;
 
-        Ok((group, messages))
+        Ok((group, message))
     }
 
     /// Process a spaces message.
@@ -389,84 +387,18 @@ where
         &self,
         space_ids: &Vec<ID>,
     ) -> Result<Vec<M>, ManagerError<ID, S, K, F, M, C, RS>> {
-        let auth_y = {
-            let manager = self.inner.read().await;
-            manager
-                .store
-                .auth()
-                .await
-                .map_err(ManagerError::AuthStore)?
-        };
-        let operation_ids =
-            toposort(&auth_y.inner.graph, None).expect("auth graph does not contain cycles");
-
         let mut messages = vec![];
-        // @TODO: we can optimize here by calculating the diff between the current space auth
-        // graph tips and the global auth graph tips. Then we could apply only the missing
-        // operations rather than applying all operations as we do here.
-        for id in operation_ids {
-            let message = {
-                let manager = self.inner.read().await;
-                manager
-                    .store
-                    .message(&id)
-                    .await
-                    .map_err(ManagerError::MessageStore)?
-                    .expect("message present in store")
-            };
-            for id in space_ids {
-                let message = self.apply_group_change_to_space(&message, *id).await?;
-                if let Some(message) = message {
-                    messages.push(message);
-                }
-            }
-        }
 
-        Ok(messages)
-    }
-
-    /// Apply an auth message from the shared auth state to each space we know about locally.
-    ///
-    /// This is required so that all spaces stay "in sync" with the shared auth state and produce
-    /// any required encryption direct messages in order to correctly update a spaces' encryption
-    /// state.
-    pub(crate) async fn apply_group_change_to_spaces(
-        &self,
-        auth_message: &M,
-    ) -> Result<Vec<M>, ManagerError<ID, S, K, F, M, C, RS>> {
-        let space_ids = {
-            let manager = self.inner.read().await;
-            manager
-                .store
-                .spaces_ids()
-                .await
-                .map_err(ManagerError::SpacesStore)?
-        };
-
-        let mut messages = vec![];
         for id in space_ids {
-            let message = self.apply_group_change_to_space(auth_message, id).await?;
-            if let Some(message) = message {
-                messages.push(message);
-            }
+            let Some(space) = self.space(*id).await? else {
+                continue;
+            };
+
+            let msgs = space.repair().await.map_err(ManagerError::Space)?;
+            messages.extend(msgs);
         }
 
         Ok(messages)
-    }
-
-    /// Apply a message from the shared auth state to a single space.
-    pub(crate) async fn apply_group_change_to_space(
-        &self,
-        auth_message: &M,
-        space_id: ID,
-    ) -> Result<Option<M>, ManagerError<ID, S, K, F, M, C, RS>> {
-        let Some(space) = self.space(space_id).await? else {
-            panic!("expect space to exist");
-        };
-        space
-            .handle_auth_group_change(auth_message)
-            .await
-            .map_err(ManagerError::Space)
     }
 
     async fn handle_space_membership_message(

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -177,15 +177,12 @@ where
         &self,
         id: ID,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<
-        (Space<ID, S, K, F, M, C, RS>, Vec<M>, Vec<Event<ID, C>>),
-        ManagerError<ID, S, K, F, M, C, RS>,
-    > {
-        let (space, messages, events) = Space::create(self.clone(), id, initial_members.to_owned())
+    ) -> Result<(Space<ID, S, K, F, M, C, RS>, Vec<M>), ManagerError<ID, S, K, F, M, C, RS>> {
+        let (space, messages) = Space::create(self.clone(), id, initial_members.to_owned())
             .await
             .map_err(ManagerError::Space)?;
 
-        Ok((space, messages, events))
+        Ok((space, messages))
     }
 
     /// Create a new group containing initial members with associated access levels.
@@ -199,15 +196,12 @@ where
     pub async fn create_group(
         &self,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<
-        (Group<ID, S, K, F, M, C, RS>, Vec<M>, Event<ID, C>),
-        ManagerError<ID, S, K, F, M, C, RS>,
-    > {
-        let (group, messages, event) = Group::create(self.clone(), initial_members.to_owned())
+    ) -> Result<(Group<ID, S, K, F, M, C, RS>, Vec<M>), ManagerError<ID, S, K, F, M, C, RS>> {
+        let (group, messages) = Group::create(self.clone(), initial_members.to_owned())
             .await
             .map_err(ManagerError::Group)?;
 
-        Ok((group, messages, event))
+        Ok((group, messages))
     }
 
     /// Process a spaces message.
@@ -394,7 +388,7 @@ where
     pub async fn repair_spaces(
         &self,
         space_ids: &Vec<ID>,
-    ) -> Result<(Vec<M>, Vec<Event<ID, C>>), ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<M>, ManagerError<ID, S, K, F, M, C, RS>> {
         let auth_y = {
             let manager = self.inner.read().await;
             manager
@@ -407,7 +401,6 @@ where
             toposort(&auth_y.inner.graph, None).expect("auth graph does not contain cycles");
 
         let mut messages = vec![];
-        let mut events = vec![];
         // @TODO: we can optimize here by calculating the diff between the current space auth
         // graph tips and the global auth graph tips. Then we could apply only the missing
         // operations rather than applying all operations as we do here.
@@ -422,17 +415,14 @@ where
                     .expect("message present in store")
             };
             for id in space_ids {
-                let (message, event) = self.apply_group_change_to_space(&message, *id).await?;
+                let message = self.apply_group_change_to_space(&message, *id).await?;
                 if let Some(message) = message {
                     messages.push(message);
-                }
-                if let Some(event) = event {
-                    events.push(event)
                 }
             }
         }
 
-        Ok((messages, events))
+        Ok(messages)
     }
 
     /// Apply an auth message from the shared auth state to each space we know about locally.
@@ -443,7 +433,7 @@ where
     pub(crate) async fn apply_group_change_to_spaces(
         &self,
         auth_message: &M,
-    ) -> Result<(Vec<M>, Vec<Event<ID, C>>), ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<M>, ManagerError<ID, S, K, F, M, C, RS>> {
         let space_ids = {
             let manager = self.inner.read().await;
             manager
@@ -454,18 +444,14 @@ where
         };
 
         let mut messages = vec![];
-        let mut events = vec![];
         for id in space_ids {
-            let (message, event) = self.apply_group_change_to_space(auth_message, id).await?;
+            let message = self.apply_group_change_to_space(auth_message, id).await?;
             if let Some(message) = message {
                 messages.push(message);
             }
-            if let Some(event) = event {
-                events.push(event)
-            }
         }
 
-        Ok((messages, events))
+        Ok(messages)
     }
 
     /// Apply a message from the shared auth state to a single space.
@@ -473,7 +459,7 @@ where
         &self,
         auth_message: &M,
         space_id: ID,
-    ) -> Result<(Option<M>, Option<Event<ID, C>>), ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Option<M>, ManagerError<ID, S, K, F, M, C, RS>> {
         let Some(space) = self.space(space_id).await? else {
             panic!("expect space to exist");
         };

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -7,6 +7,7 @@ use std::fmt::Debug;
 
 use p2panda_auth::Access;
 use p2panda_auth::traits::{Conditions, Operation};
+use p2panda_core::SigningKey;
 use p2panda_encryption::traits::GroupMessage;
 use p2panda_encryption::{Rng, RngError};
 use petgraph::algo::toposort;
@@ -81,94 +82,133 @@ where
     /// If not already included, then the local actor (creator of this space) will be added to the
     /// initial members and given manage access level.
     ///
-    /// Returns messages for replication to other instances and events which inform users of any
-    /// state changes which occurred.
+    /// Returns resulting auth and space state and messages for processing.
     pub(crate) async fn create(
         manager_ref: Manager<ID, S, K, F, M, C, RS>,
         space_id: ID,
         mut initial_members: Vec<(ActorId, Access<C>)>,
-    ) -> Result<(Self, Vec<M>), SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, SpaceState<ID, M, C>, Vec<M>), SpaceError<ID, S, K, F, M, C, RS>>
+    {
         let my_id = manager_ref.id();
-
-        // Get the global auth state. We use this state in a following step to initialise the
-        // space state and we don't want it to contain the group for the space itself.
-        let initial_auth_y = {
-            let manager = manager_ref.inner.read().await;
-            manager.store.auth().await.map_err(SpaceError::AuthStore)?
-        };
 
         // Automatically add ourselves with "manage" level without any conditions as default.
         if !initial_members.iter().any(|(member, _)| *member == my_id) {
             initial_members.push((my_id, Access::manage()));
         }
 
-        // Create new group for the space.
-        let (group, create_group) = Group::create(manager_ref.clone(), initial_members)
-            .await
-            .map_err(SpaceError::Group)?;
+        // Generate random group id.
+        let group_id: ActorId = {
+            let manager = manager_ref.inner.read().await;
+            let signing_key = SigningKey::from_bytes(&manager.rng.random_array()?);
+            signing_key.verifying_key().into()
+        };
 
         // Instantiate new space state from existing global auth state.
-        let (space, space_history) =
-            Self::from_group(manager_ref.clone(), initial_auth_y, space_id, group.id()).await?;
+        let (space_y, space_history) =
+            Self::from_group(manager_ref.clone(), space_id, group_id).await?;
+
+        // Create the space group.
+        let auth_y = manager_ref.auth().await.map_err(SpaceError::AuthStore)?;
+        let (auth_y, create_group) =
+            Group::create(manager_ref.clone(), auth_y, group_id, initial_members)
+                .await
+                .map_err(SpaceError::Group)?;
 
         // Apply the "create" auth message to the space state.
-        let create_space = space.process_auth_message(&create_group).await?;
+        let (space_y, create_space) =
+            Space::process_auth_message(manager_ref.clone(), space_y, &create_group).await?;
 
         let mut messages = vec![create_group];
         messages.extend(space_history);
         messages.extend([create_space]);
 
-        Ok((
-            Self {
-                id: space_id,
-                manager: manager_ref,
-            },
-            messages,
-        ))
+        Ok((auth_y, space_y, messages))
     }
 
     /// Add a member to the space with assigned access level.
     ///
-    /// Returns messages for replication to other instances and events which inform users of any
-    /// state changes which occurred.
-    pub async fn add(
+    /// Persists resulting state and returns forged message.
+    #[cfg(any(test, feature = "test_utils"))]
+    pub async fn add_persisted(
         &self,
         member: ActorId,
         access: Access<C>,
     ) -> Result<(M, M), SpaceError<ID, S, K, F, M, C, RS>> {
-        // If the space exists we can assume the associated group exists.
-        let group_id = self.group_id().await?;
-        let group = Group::new(self.manager.clone(), group_id);
-        let auth_message = group.add(member, access).await.map_err(SpaceError::Group)?;
-        let space_message = self.process_auth_message(&auth_message).await?;
+        let (auth_y, space_y, auth_message, space_message) = self.add(member, access).await?;
+
+        self.manager
+            .set_auth(&auth_y)
+            .await
+            .map_err(SpaceError::AuthStore)?;
+        Self::set_state(self.manager.clone(), self.id(), space_y).await?;
+
+        Ok((auth_message, space_message))
+    }
+
+    /// Add a member to the space with assigned access level.
+    ///
+    /// Returns resulting auth and space state and messages for processing.
+    pub async fn add(
+        &self,
+        member: ActorId,
+        access: Access<C>,
+    ) -> Result<(AuthGroupState<C>, SpaceState<ID, M, C>, M, M), SpaceError<ID, S, K, F, M, C, RS>>
+    {
+        let space_y = self.state().await?;
+        let group = Group::new(self.manager.clone(), space_y.group_id);
+        let (auth_y, auth_message) = group.add(member, access).await.map_err(SpaceError::Group)?;
+
+        let (space_y, space_message) =
+            Space::process_auth_message(self.manager.clone(), space_y, &auth_message).await?;
+
+        Ok((auth_y, space_y, auth_message, space_message))
+    }
+
+    /// Remove a member from the space.
+    ///
+    /// Persists resulting state and returns forged message.
+    #[cfg(any(test, feature = "test_utils"))]
+    pub async fn remove_persisted(
+        &self,
+        member: ActorId,
+    ) -> Result<(M, M), SpaceError<ID, S, K, F, M, C, RS>> {
+        let (auth_y, space_y, auth_message, space_message) = self.remove(member).await?;
+
+        self.manager
+            .set_auth(&auth_y)
+            .await
+            .map_err(SpaceError::AuthStore)?;
+        Self::set_state(self.manager.clone(), self.id(), space_y).await?;
+
         Ok((auth_message, space_message))
     }
 
     /// Remove a member from the space.
     ///
-    /// Returns messages for replication to other instances and events which inform users of any
-    /// state changes which occurred.
+    /// Returns resulting auth and space state and messages for processing.
     pub async fn remove(
         &self,
         member: ActorId,
-    ) -> Result<(M, M), SpaceError<ID, S, K, F, M, C, RS>> {
-        // If the space exists we can assume the associated group exists.
-        let group_id = self.group_id().await?;
-        let group = Group::new(self.manager.clone(), group_id);
-        let auth_message = group.remove(member).await.map_err(SpaceError::Group)?;
-        let space_message = self.process_auth_message(&auth_message).await?;
-        Ok((auth_message, space_message))
+    ) -> Result<(AuthGroupState<C>, SpaceState<ID, M, C>, M, M), SpaceError<ID, S, K, F, M, C, RS>>
+    {
+        let space_y = self.state().await?;
+        let group = Group::new(self.manager.clone(), space_y.group_id);
+        let (auth_y, auth_message) = group.remove(member).await.map_err(SpaceError::Group)?;
+
+        let (space_y, space_message) =
+            Space::process_auth_message(self.manager.clone(), space_y, &auth_message).await?;
+
+        Ok((auth_y, space_y, auth_message, space_message))
     }
 
     /// Forge a "pointer" space message from an already existing auth message and apply any
     /// resulting group membership changes. Any resulting encryption direct messages are included
     /// in the space message alongside a reference to the auth message.
     pub(crate) async fn process_auth_message(
-        &self,
+        manager_ref: Manager<ID, S, K, F, M, C, RS>,
+        mut y: SpaceState<ID, M, C>,
         auth_message: &M,
-    ) -> Result<M, SpaceError<ID, S, K, F, M, C, RS>> {
-        let mut y = self.state().await?;
-
+    ) -> Result<(SpaceState<ID, M, C>, M), SpaceError<ID, S, K, F, M, C, RS>> {
         // Get current space members.
         let current_members = secret_members(y.auth_y.members(y.group_id));
 
@@ -181,7 +221,7 @@ where
 
         // Process the change of membership on encryption the context.
         let (encryption_y, direct_messages) = if current_members != next_members {
-            let manager = self.manager.inner.read().await;
+            let manager = manager_ref.inner.read().await;
             Self::apply_secret_member_change(
                 y.encryption_y,
                 &auth_message,
@@ -206,26 +246,16 @@ where
                 direct_messages,
             };
 
-            let mut manager = self.manager.inner.write().await;
+            let mut manager = manager_ref.inner.write().await;
+            // Forge and persist the message.
             manager.identity.forge(args).await?
         };
 
-        // Update space state and persist it.
-        {
-            let manager = self.manager.inner.write().await;
-            y.encryption_y
-                .orderer
-                .add_dependency(space_message.id(), &dependencies);
+        y.encryption_y
+            .orderer
+            .add_dependency(space_message.id(), &dependencies);
 
-            let space_id = y.space_id;
-            manager
-                .store
-                .set_space(&space_id, y)
-                .await
-                .map_err(SpaceError::SpacesStore)?;
-        }
-
-        Ok(space_message)
+        Ok((y, space_message))
     }
 
     /// Process a space message along with it's relevant auth message (if required).
@@ -262,10 +292,9 @@ where
     /// published before the space existed.
     async fn from_group(
         manager_ref: Manager<ID, S, K, F, M, C, RS>,
-        auth_y: AuthGroupState<C>,
         space_id: ID,
         group_id: ActorId,
-    ) -> Result<(Self, Vec<M>), SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(SpaceState<ID, M, C>, Vec<M>), SpaceError<ID, S, K, F, M, C, RS>> {
         // Instantiate empty space state.
         let mut y = { Self::get_or_init_state(space_id, group_id, manager_ref.clone()).await? };
         let mut messages = vec![];
@@ -275,6 +304,7 @@ where
         //
         // These won't contain any encryption messages as they were published _before_ the space
         // was created.
+        let auth_y = manager_ref.auth().await.map_err(SpaceError::AuthStore)?;
         let mut manager = manager_ref.inner.write().await;
         let mut space_dependencies = vec![];
         let operations =
@@ -300,17 +330,7 @@ where
         }
         y.auth_y = auth_y;
 
-        manager
-            .store
-            .set_space(&space_id, y)
-            .await
-            .map_err(SpaceError::SpacesStore)?;
-
-        let space = Space {
-            id: space_id,
-            manager: manager_ref.clone(),
-        };
-        Ok((space, messages))
+        Ok((y, messages))
     }
 
     /// Handle messages which effect the space membership. Each of these messages contained a
@@ -565,7 +585,9 @@ where
                     .expect("message present in store")
             };
 
-            let space_message = self.process_auth_message(&message).await?;
+            let (y, space_message) =
+                Space::process_auth_message(self.manager.clone(), y, &message).await?;
+            Space::set_state(self.manager.clone(), self.id(), y).await?;
 
             messages.push(space_message);
         }
@@ -649,6 +671,19 @@ where
         // Sanity check.
         assert_eq!(space_y.group_id, group_id);
         Ok(space_y)
+    }
+
+    async fn set_state(
+        manager_ref: Manager<ID, S, K, F, M, C, RS>,
+        space_id: ID,
+        y: SpaceState<ID, M, C>,
+    ) -> Result<(), SpaceError<ID, S, K, F, M, C, RS>> {
+        let manager = manager_ref.inner.write().await;
+        manager
+            .store
+            .set_space(&space_id, y)
+            .await
+            .map_err(SpaceError::SpacesStore)
     }
 
     /// Id of this space.

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -87,7 +87,7 @@ where
         manager_ref: Manager<ID, S, K, F, M, C, RS>,
         space_id: ID,
         mut initial_members: Vec<(ActorId, Access<C>)>,
-    ) -> Result<(Self, Vec<M>, Vec<Event<ID, C>>), SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(Self, Vec<M>), SpaceError<ID, S, K, F, M, C, RS>> {
         let my_id = manager_ref.id();
 
         // Get the global auth state. We use this state in a following step to initialise the
@@ -103,7 +103,7 @@ where
         }
 
         // Create new group for the space.
-        let (group, mut messages, auth_event) = Group::create(manager_ref.clone(), initial_members)
+        let (group, mut messages) = Group::create(manager_ref.clone(), initial_members)
             .await
             .map_err(SpaceError::Group)?;
 
@@ -120,11 +120,10 @@ where
         // Apply the "create" auth message to the space state.
         //
         // We know the first message is the auth message.
-        let (space_message, space_event) =
+        let space_message =
             Self::process_auth_message(manager_ref.clone(), y, &messages[0]).await?;
 
         messages.push(space_message.expect("creating space results in message"));
-        let space_event = space_event.expect("creating space results in event");
 
         Ok((
             Self {
@@ -132,7 +131,6 @@ where
                 manager: manager_ref,
             },
             messages,
-            vec![auth_event, space_event],
         ))
     }
 
@@ -144,7 +142,7 @@ where
         &self,
         member: ActorId,
         access: Access<C>,
-    ) -> Result<(Vec<M>, Vec<Event<ID, C>>), SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<M>, SpaceError<ID, S, K, F, M, C, RS>> {
         let y = self.state().await?;
 
         // If the space exists we can assume the associated group exists.
@@ -159,7 +157,7 @@ where
     pub async fn remove(
         &self,
         member: ActorId,
-    ) -> Result<(Vec<M>, Vec<Event<ID, C>>), SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<M>, SpaceError<ID, S, K, F, M, C, RS>> {
         let y = self.state().await?;
         // If the space exists we can assume the associated group exists.
         let group = Group::new(self.manager.clone(), y.group_id);
@@ -173,9 +171,9 @@ where
         manager_ref: Manager<ID, S, K, F, M, C, RS>,
         mut y: SpaceState<ID, M, C>,
         auth_message: &M,
-    ) -> Result<(Option<M>, Option<Event<ID, C>>), SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Option<M>, SpaceError<ID, S, K, F, M, C, RS>> {
         if y.auth_y.inner.operations.contains_key(&auth_message.id()) {
-            return Ok((None, None));
+            return Ok(None);
         }
 
         // Get current space members.
@@ -234,23 +232,7 @@ where
                 .map_err(SpaceError::SpacesStore)?;
         }
 
-        // If current and next member sets are equal it indicates that the space is not affected
-        // by this auth change. This can be because the space wasn't created yet, or the auth
-        // change simply does not effect the members of this space. In either case we don't want
-        // to emit any membership change event.
-        if current_members == next_members {
-            return Ok((Some(space_message), None));
-        };
-
-        // Construct space membership event.
-        let space_event = space_message_to_space_event(
-            &space_message,
-            &auth_message,
-            current_members,
-            next_members,
-        );
-
-        Ok((Some(space_message), Some(space_event)))
+        Ok(Some(space_message))
     }
 
     /// Process a space message along with it's relevant auth message (if required).
@@ -551,11 +533,11 @@ where
     pub(crate) async fn handle_auth_group_change(
         &self,
         auth_message: &M,
-    ) -> Result<(Option<M>, Option<Event<ID, C>>), SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Option<M>, SpaceError<ID, S, K, F, M, C, RS>> {
         // If this space already processed this auth message then skip it.
         let y = self.state().await?;
         if y.auth_y.inner.operations.contains_key(&auth_message.id()) {
-            return Ok((None, None));
+            return Ok(None);
         }
 
         let my_id = self.manager.id();
@@ -569,7 +551,7 @@ where
             return Space::process_auth_message(self.manager.clone(), y, auth_message).await;
         }
 
-        Ok((None, None))
+        Ok(None)
     }
 
     /// Get the space state.

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -92,7 +92,7 @@ where
 
         // Get the global auth state. We use this state in a following step to initialise the
         // space state and we don't want it to contain the group for the space itself.
-        let auth_y = {
+        let initial_auth_y = {
             let manager = manager_ref.inner.read().await;
             manager.store.auth().await.map_err(SpaceError::AuthStore)?
         };
@@ -103,27 +103,20 @@ where
         }
 
         // Create new group for the space.
-        let (group, mut messages) = Group::create(manager_ref.clone(), initial_members)
+        let (group, create_group) = Group::create(manager_ref.clone(), initial_members)
             .await
             .map_err(SpaceError::Group)?;
 
         // Instantiate new space state from existing global auth state.
-        let y = Self::state_from_auth(
-            manager_ref.clone(),
-            auth_y,
-            space_id,
-            group.id(),
-            &mut messages,
-        )
-        .await?;
+        let (space, space_history) =
+            Self::from_group(manager_ref.clone(), initial_auth_y, space_id, group.id()).await?;
 
         // Apply the "create" auth message to the space state.
-        //
-        // We know the first message is the auth message.
-        let space_message =
-            Self::process_auth_message(manager_ref.clone(), y, &messages[0]).await?;
+        let create_space = space.process_auth_message(&create_group).await?;
 
-        messages.push(space_message.expect("creating space results in message"));
+        let mut messages = vec![create_group];
+        messages.extend(space_history);
+        messages.extend([create_space]);
 
         Ok((
             Self {
@@ -142,12 +135,13 @@ where
         &self,
         member: ActorId,
         access: Access<C>,
-    ) -> Result<Vec<M>, SpaceError<ID, S, K, F, M, C, RS>> {
-        let y = self.state().await?;
-
+    ) -> Result<(M, M), SpaceError<ID, S, K, F, M, C, RS>> {
         // If the space exists we can assume the associated group exists.
-        let group = Group::new(self.manager.clone(), y.group_id);
-        group.add(member, access).await.map_err(SpaceError::Group)
+        let group_id = self.group_id().await?;
+        let group = Group::new(self.manager.clone(), group_id);
+        let auth_message = group.add(member, access).await.map_err(SpaceError::Group)?;
+        let space_message = self.process_auth_message(&auth_message).await?;
+        Ok((auth_message, space_message))
     }
 
     /// Remove a member from the space.
@@ -157,24 +151,23 @@ where
     pub async fn remove(
         &self,
         member: ActorId,
-    ) -> Result<Vec<M>, SpaceError<ID, S, K, F, M, C, RS>> {
-        let y = self.state().await?;
+    ) -> Result<(M, M), SpaceError<ID, S, K, F, M, C, RS>> {
         // If the space exists we can assume the associated group exists.
-        let group = Group::new(self.manager.clone(), y.group_id);
-        group.remove(member).await.map_err(SpaceError::Group)
+        let group_id = self.group_id().await?;
+        let group = Group::new(self.manager.clone(), group_id);
+        let auth_message = group.remove(member).await.map_err(SpaceError::Group)?;
+        let space_message = self.process_auth_message(&auth_message).await?;
+        Ok((auth_message, space_message))
     }
 
     /// Forge a "pointer" space message from an already existing auth message and apply any
     /// resulting group membership changes. Any resulting encryption direct messages are included
     /// in the space message alongside a reference to the auth message.
     pub(crate) async fn process_auth_message(
-        manager_ref: Manager<ID, S, K, F, M, C, RS>,
-        mut y: SpaceState<ID, M, C>,
+        &self,
         auth_message: &M,
-    ) -> Result<Option<M>, SpaceError<ID, S, K, F, M, C, RS>> {
-        if y.auth_y.inner.operations.contains_key(&auth_message.id()) {
-            return Ok(None);
-        }
+    ) -> Result<M, SpaceError<ID, S, K, F, M, C, RS>> {
+        let mut y = self.state().await?;
 
         // Get current space members.
         let current_members = secret_members(y.auth_y.members(y.group_id));
@@ -188,7 +181,7 @@ where
 
         // Process the change of membership on encryption the context.
         let (encryption_y, direct_messages) = if current_members != next_members {
-            let manager = manager_ref.inner.read().await;
+            let manager = self.manager.inner.read().await;
             Self::apply_secret_member_change(
                 y.encryption_y,
                 &auth_message,
@@ -213,13 +206,13 @@ where
                 direct_messages,
             };
 
-            let mut manager = manager_ref.inner.write().await;
+            let mut manager = self.manager.inner.write().await;
             manager.identity.forge(args).await?
         };
 
         // Update space state and persist it.
         {
-            let manager = manager_ref.inner.write().await;
+            let manager = self.manager.inner.write().await;
             y.encryption_y
                 .orderer
                 .add_dependency(space_message.id(), &dependencies);
@@ -232,7 +225,7 @@ where
                 .map_err(SpaceError::SpacesStore)?;
         }
 
-        Ok(Some(space_message))
+        Ok(space_message)
     }
 
     /// Process a space message along with it's relevant auth message (if required).
@@ -267,15 +260,15 @@ where
     /// method iterates through all existing auth messages and publishes these pointers to the
     /// space. None of the messages will contain encryption control messages as they were
     /// published before the space existed.
-    async fn state_from_auth(
+    async fn from_group(
         manager_ref: Manager<ID, S, K, F, M, C, RS>,
         auth_y: AuthGroupState<C>,
         space_id: ID,
         group_id: ActorId,
-        messages: &mut Vec<M>,
-    ) -> Result<SpaceState<ID, M, C>, SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(Self, Vec<M>), SpaceError<ID, S, K, F, M, C, RS>> {
         // Instantiate empty space state.
         let mut y = { Self::get_or_init_state(space_id, group_id, manager_ref.clone()).await? };
+        let mut messages = vec![];
 
         // Publish pointers for all operations in the global auth graph. We topologically sort the
         // operations and publish them in this linear order.
@@ -306,7 +299,18 @@ where
             messages.push(message);
         }
         y.auth_y = auth_y;
-        Ok(y)
+
+        manager
+            .store
+            .set_space(&space_id, y)
+            .await
+            .map_err(SpaceError::SpacesStore)?;
+
+        let space = Space {
+            id: space_id,
+            manager: manager_ref.clone(),
+        };
+        Ok((space, messages))
     }
 
     /// Handle messages which effect the space membership. Each of these messages contained a
@@ -529,29 +533,44 @@ where
         Ok(events)
     }
 
-    /// Sync a shared auth state change with this space.
-    pub(crate) async fn handle_auth_group_change(
-        &self,
-        auth_message: &M,
-    ) -> Result<Option<M>, SpaceError<ID, S, K, F, M, C, RS>> {
-        // If this space already processed this auth message then skip it.
-        let y = self.state().await?;
-        if y.auth_y.inner.operations.contains_key(&auth_message.id()) {
-            return Ok(None);
+    pub async fn repair(&self) -> Result<Vec<M>, SpaceError<ID, S, K, F, M, C, RS>> {
+        let global_auth_y = {
+            let manager = self.manager.inner.read().await;
+            manager.store.auth().await.map_err(SpaceError::AuthStore)?
+        };
+
+        // @TODO: here we need to account for the new Groups::heads_filtered(..) approach to
+        // calculating dependencies and only include the ones strictly necessary for this space.
+        let operation_ids =
+            toposort(&global_auth_y.inner.graph, None).expect("auth graph does not contain cycles");
+
+        let mut messages = vec![];
+        // @TODO: we can optimize here by calculating the diff between the current space auth
+        // graph tips and the global auth graph tips. Then we could apply only the missing
+        // operations rather than applying all operations as we do here.
+        for id in operation_ids {
+            // This auth message has already been processed by the space.
+            let y = self.state().await?;
+            if y.auth_y.inner.operations.contains_key(&id) {
+                continue;
+            };
+
+            let message = {
+                let manager = self.manager.inner.read().await;
+                manager
+                    .store
+                    .message(&id)
+                    .await
+                    .map_err(SpaceError::MessageStore)?
+                    .expect("message present in store")
+            };
+
+            let space_message = self.process_auth_message(&message).await?;
+
+            messages.push(space_message);
         }
 
-        let my_id = self.manager.id();
-        let is_reader = self
-            .members()
-            .await?
-            .iter()
-            .any(|(member, access)| *member == my_id && access > &Access::pull());
-
-        if is_reader {
-            return Space::process_auth_message(self.manager.clone(), y, auth_message).await;
-        }
-
-        Ok(None)
+        Ok(messages)
     }
 
     /// Get the space state.

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -15,6 +15,7 @@ use p2panda_encryption::key_bundle::{Lifetime, LongTermKeyBundle, PreKey};
 use crate::event::{Event, GroupActor, GroupContext, GroupEvent, SpaceContext, SpaceEvent};
 use crate::member::Member;
 use crate::message::SpacesArgs;
+use crate::space::Space;
 use crate::test_utils::{TestPeer, TestSpaceError};
 use crate::traits::{AuthStore, AuthoredMessage, SpacesMessage, SpacesStore};
 use crate::types::AuthGroupAction;
@@ -35,7 +36,7 @@ async fn create_space() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages) = manager.create_space(space_id, &[]).await.unwrap();
+    let (space, messages) = manager.create_space_persisted(space_id, &[]).await.unwrap();
 
     // We've added ourselves automatically with manage access.
     assert_eq!(
@@ -119,7 +120,7 @@ async fn send_and_receive() {
     let space_id = 0;
     let (alice_space, alice_messages) = alice
         .manager
-        .create_space(space_id, &[(bob.manager.id(), Access::write())])
+        .create_space_persisted(space_id, &[(bob.manager.id(), Access::write())])
         .await
         .unwrap();
 
@@ -187,7 +188,7 @@ async fn add_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages) = manager.create_space(space_id, &[]).await.unwrap();
+    let (space, messages) = manager.create_space_persisted(space_id, &[]).await.unwrap();
 
     // There are two messages (one auth, and one space)
     assert_eq!(messages.len(), 2);
@@ -200,7 +201,10 @@ async fn add_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space = manager.space(space_id).await.unwrap().unwrap();
-    let (message_03 , message_04) = space.add(bob.manager.id(), Access::read()).await.unwrap();
+    let (message_03, message_04) = space
+        .add_persisted(bob.manager.id(), Access::read())
+        .await
+        .unwrap();
     let members = space.members().await.unwrap();
     drop(space);
 
@@ -275,7 +279,7 @@ async fn register_key_bundles_after_space_creation() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, _) = manager.create_space(space_id, &[]).await.unwrap();
+    let (space, _) = manager.create_space_persisted(space_id, &[]).await.unwrap();
     drop(space);
 
     // Register key bundles _after_ the space was already created
@@ -290,7 +294,7 @@ async fn register_key_bundles_after_space_creation() {
     // Add new member to Space
     // ~~~~~~~~~~~~
     let space = manager.space(space_id).await.unwrap().unwrap();
-    let result = space.add(bob.manager.id(), Access::read()).await;
+    let result = space.add_persisted(bob.manager.id(), Access::read()).await;
 
     assert!(result.is_ok());
 }
@@ -318,10 +322,17 @@ async fn send_and_receive_after_add() {
     // Alice creates a space, adds Bob in a following step and then sends a message.
 
     let space_id = 0;
-    let (alice_space, messages) = alice.manager.create_space(space_id, &[]).await.unwrap();
+    let (alice_space, messages) = alice
+        .manager
+        .create_space_persisted(space_id, &[])
+        .await
+        .unwrap();
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
-    let (message_03, message_04) = alice_space.add(bob_id, Access::read()).await.unwrap();
+    let (message_03, message_04) = alice_space
+        .add_persisted(bob_id, Access::read())
+        .await
+        .unwrap();
     let message_05 = alice_space.publish(b"Hello bob").await.unwrap();
 
     // Bob processes all of Alice's messages.
@@ -361,7 +372,7 @@ async fn add_pull_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages) = manager.create_space(space_id, &[]).await.unwrap();
+    let (space, messages) = manager.create_space_persisted(space_id, &[]).await.unwrap();
     assert_eq!(messages.len(), 2);
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
@@ -371,7 +382,10 @@ async fn add_pull_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space = manager.space(space_id).await.unwrap().unwrap();
-    let (message_03, message_04) = space.add(bob.manager.id(), Access::pull()).await.unwrap();
+    let (message_03, message_04) = space
+        .add_persisted(bob.manager.id(), Access::pull())
+        .await
+        .unwrap();
     let members = space.members().await.unwrap();
 
     let SpacesArgs::Auth {
@@ -459,7 +473,10 @@ async fn receive_control_messages() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages) = alice_manager.create_space(space_id, &[]).await.unwrap();
+    let (space, messages) = alice_manager
+        .create_space_persisted(space_id, &[])
+        .await
+        .unwrap();
     let group_id = space.group_id().await.unwrap();
     drop(space);
 
@@ -509,7 +526,10 @@ async fn receive_control_messages() {
     // Alice: Add new member to Space
     // ~~~~~~~~~~~~
 
-    let (message_04, message_05) = space.add(bob.manager.id(), Access::read()).await.unwrap();
+    let (message_04, message_05) = space
+        .add_persisted(bob.manager.id(), Access::read())
+        .await
+        .unwrap();
     drop(space);
 
     // Bob: Receive Message 03, 04 and 05
@@ -575,7 +595,7 @@ async fn remove_member() {
 
     let space_id = 0;
     let (space, messages) = alice_manager
-        .create_space(space_id, &[(bob_id, Access::read())])
+        .create_space_persisted(space_id, &[(bob_id, Access::read())])
         .await
         .unwrap();
     drop(space);
@@ -599,7 +619,7 @@ async fn remove_member() {
     // ~~~~~~~~~~~~
 
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
-    let (message_03, message_04) = space.remove(bob_id).await.unwrap();
+    let (message_03, message_04) = space.remove_persisted(bob_id).await.unwrap();
 
     let SpacesArgs::Auth { group_action, .. } = message_03.args() else {
         panic!("expected auth message");
@@ -671,7 +691,7 @@ async fn concurrent_removal_conflict() {
 
     let space_id = 0;
     let (space, messages) = alice_manager
-        .create_space(space_id, &[(bob_id, Access::manage())])
+        .create_space_persisted(space_id, &[(bob_id, Access::manage())])
         .await
         .unwrap();
     drop(space);
@@ -693,14 +713,17 @@ async fn concurrent_removal_conflict() {
     // ~~~~~~~~~~~~
 
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
-    let _ = space.remove(bob_id).await.unwrap();
+    let _ = space.remove_persisted(bob_id).await.unwrap();
     drop(space);
 
     // Bob: Adds claire (concurrently)
     // ~~~~~~~~~~~~
 
     let space = bob_manager.space(space_id).await.unwrap().unwrap();
-    let (message_03, message_04) = space.add(claire_id, Access::read()).await.unwrap();
+    let (message_03, message_04) = space
+        .add_persisted(claire_id, Access::read())
+        .await
+        .unwrap();
     drop(space);
 
     // Alice: process bobs' message
@@ -715,7 +738,7 @@ async fn concurrent_removal_conflict() {
     // ~~~~~~~~~~~~
 
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
-    let (message_05, message_06) = space.add(dave_id, Access::read()).await.unwrap();
+    let (message_05, message_06) = space.add_persisted(dave_id, Access::read()).await.unwrap();
 
     let SpacesArgs::Auth { group_action, .. } = message_05.args() else {
         panic!("expected auth message");
@@ -779,7 +802,7 @@ async fn space_from_existing_auth_state() {
     // ~~~~~~~~~~~~
 
     let (group, message_01) = alice_manager
-        .create_group(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
+        .create_group_persisted(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
         .await
         .unwrap();
     let member_group_id = group.id();
@@ -789,7 +812,7 @@ async fn space_from_existing_auth_state() {
 
     let space_id = 0;
     let (space, messages) = alice_manager
-        .create_space(space_id, &[(member_group_id, Access::read())])
+        .create_space_persisted(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
 
@@ -884,7 +907,7 @@ async fn create_group() {
     // ~~~~~~~~~~~~
 
     let (group, message_01) = manager
-        .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
+        .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
 
@@ -937,11 +960,14 @@ async fn add_member_to_group() {
     // ~~~~~~~~~~~~
 
     let (group, message_01) = manager
-        .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
+        .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
 
-    let message_02 = group.add(claire_id, Access::read()).await.unwrap();
+    let message_02 = group
+        .add_persisted(claire_id, Access::read())
+        .await
+        .unwrap();
 
     let members = group.members().await.unwrap();
     assert_eq!(
@@ -993,14 +1019,14 @@ async fn remove_member_from_group() {
     // ~~~~~~~~~~~~
 
     let (group, message_01) = manager
-        .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
+        .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
 
     // Remove bob from group
     // ~~~~~~~~~~~~
 
-    let message_02 = group.remove(bob_id).await.unwrap();
+    let message_02 = group.remove_persisted(bob_id).await.unwrap();
 
     let members = group.members().await.unwrap();
     assert_eq!(members, vec![(alice_id, Access::manage()),]);
@@ -1048,7 +1074,7 @@ async fn receive_auth_messages() {
     // ~~~~~~~~~~~~
 
     let (group, message_01) = alice_manager
-        .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
+        .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
     let group_id = group.id();
@@ -1056,7 +1082,10 @@ async fn receive_auth_messages() {
     // Add claire
     // ~~~~~~~~~~~~
 
-    let message_02 = group.add(claire_id, Access::read()).await.unwrap();
+    let message_02 = group
+        .add_persisted(claire_id, Access::read())
+        .await
+        .unwrap();
     drop(group);
 
     // Bob receives message 01 & 02
@@ -1114,7 +1143,7 @@ async fn shared_auth_state() {
 
     let space_id = 0;
     let (space_0, messages) = manager
-        .create_space(space_id, &[(alice_id, Access::manage())])
+        .create_space_persisted(space_id, &[(alice_id, Access::manage())])
         .await
         .unwrap();
 
@@ -1126,7 +1155,7 @@ async fn shared_auth_state() {
 
     let space_id = 1;
     let (space_1, messages) = manager
-        .create_space(space_id, &[(alice_id, Access::manage())])
+        .create_space_persisted(space_id, &[(alice_id, Access::manage())])
         .await
         .unwrap();
 
@@ -1141,7 +1170,7 @@ async fn shared_auth_state() {
     // ~~~~~~~~~~~~
 
     let (group, _) = manager
-        .create_group(&[(alice_id, Access::manage()), (bob_id, Access::read())])
+        .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::read())])
         .await
         .unwrap();
 
@@ -1154,7 +1183,10 @@ async fn shared_auth_state() {
     // Add group A to space 0
     // ~~~~~~~~~~~~
 
-    let _ = space_0.add(group.id(), Access::read()).await.unwrap();
+    let _ = space_0
+        .add_persisted(group.id(), Access::read())
+        .await
+        .unwrap();
 
     // Make Space 1 aware of this change.
     let messages = space_1.repair().await.unwrap();
@@ -1163,7 +1195,10 @@ async fn shared_auth_state() {
     // Add group A to space 1
     // ~~~~~~~~~~~~
 
-    let _ = space_1.add(group.id(), Access::read()).await.unwrap();
+    let _ = space_1
+        .add_persisted(group.id(), Access::read())
+        .await
+        .unwrap();
 
     // Make Space 0 aware of this change.
     let messages = space_0.repair().await.unwrap();
@@ -1172,7 +1207,10 @@ async fn shared_auth_state() {
     // Add claire to the group
     // ~~~~~~~~~~~~
 
-    let _ = group.add(claire_id, Access::read()).await.unwrap();
+    let _ = group
+        .add_persisted(claire_id, Access::read())
+        .await
+        .unwrap();
 
     // Both Space 0 and Space 1 need to be made aware of this change.
     let messages = space_0.repair().await.unwrap();
@@ -1227,7 +1265,7 @@ async fn events() {
 
     // Create Group with bob and claire as managers.
     let (group, auth_message) = alice_manager
-        .create_group(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
+        .create_group_persisted(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
         .await
         .unwrap();
     let member_group_id = group.id();
@@ -1236,7 +1274,7 @@ async fn events() {
     // Create Space with group as member
     let space_id = 0;
     let (space, messages) = alice_manager
-        .create_space(space_id, &[(member_group_id, Access::read())])
+        .create_space_persisted(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
     let space_group_id = space.group_id().await.unwrap();
@@ -1244,19 +1282,19 @@ async fn events() {
     alice_messages.extend(messages);
 
     // Add dave to space with read access
-    let (auth_message, space_message) = space.add(dave_id, Access::read()).await.unwrap();
+    let (auth_message, space_message) = space.add_persisted(dave_id, Access::read()).await.unwrap();
     alice_messages.extend([auth_message, space_message]);
 
     // Remove dave from space
-    let (auth_message, space_message) = space.remove(dave_id).await.unwrap();
+    let (auth_message, space_message) = space.remove_persisted(dave_id).await.unwrap();
     alice_messages.extend([auth_message, space_message]);
 
     // Add dave back into space with pull access
-    let (auth_message, space_message) = space.add(dave_id, Access::pull()).await.unwrap();
+    let (auth_message, space_message) = space.add_persisted(dave_id, Access::pull()).await.unwrap();
     alice_messages.extend([auth_message, space_message]);
 
     // Remove member group from space
-    let (auth_message, space_message) = space.remove(group.id()).await.unwrap();
+    let (auth_message, space_message) = space.remove_persisted(group.id()).await.unwrap();
     alice_messages.extend([auth_message, space_message]);
 
     // Test basic expected event types.
@@ -1367,7 +1405,10 @@ async fn idempotent_api() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (_, messages) = alice_manager.create_space(space_id, &[]).await.unwrap();
+    let (_, messages) = alice_manager
+        .create_space_persisted(space_id, &[])
+        .await
+        .unwrap();
 
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
@@ -1443,7 +1484,7 @@ async fn repair_space() {
     // ~~~~~~~~~~~~
 
     let (group, message_01) = alice_manager
-        .create_group(&[(bob_id, Access::manage())])
+        .create_group_persisted(&[(bob_id, Access::manage())])
         .await
         .unwrap();
     let member_group_id = group.id();
@@ -1453,7 +1494,7 @@ async fn repair_space() {
 
     let space_id = 0;
     let (space, messages) = alice_manager
-        .create_space(space_id, &[(member_group_id, Access::read())])
+        .create_space_persisted(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
     drop(space);
@@ -1468,7 +1509,10 @@ async fn repair_space() {
     bob_manager.persist_message(&message_01).await.unwrap();
     bob_manager.process(&message_01).await.unwrap();
     let group = bob_manager.group(member_group_id).await.unwrap().unwrap();
-    let bob_message_01 = group.add(claire_id, Access::read()).await.unwrap();
+    let bob_message_01 = group
+        .add_persisted(claire_id, Access::read())
+        .await
+        .unwrap();
     drop(group);
 
     // Alice: Process Bob's message (published concurrently to the space creation).
@@ -1559,7 +1603,7 @@ async fn duplicate_auth_state_references() {
     // ~~~~~~~~~~~~
 
     let (group, message_01) = alice_manager
-        .create_group(&[(bob_id, Access::manage())])
+        .create_group_persisted(&[(bob_id, Access::manage())])
         .await
         .unwrap();
     let member_group_id = group.id();
@@ -1569,7 +1613,7 @@ async fn duplicate_auth_state_references() {
 
     let space_id = 0;
     let (space, messages) = alice_manager
-        .create_space(space_id, &[(member_group_id, Access::read())])
+        .create_space_persisted(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
     drop(space);
@@ -1584,7 +1628,10 @@ async fn duplicate_auth_state_references() {
     bob_manager.persist_message(&message_01).await.unwrap();
     bob_manager.process(&message_01).await.unwrap();
     let group = bob_manager.group(member_group_id).await.unwrap().unwrap();
-    let bob_message_01 = group.add(claire_id, Access::read()).await.unwrap();
+    let bob_message_01 = group
+        .add_persisted(claire_id, Access::read())
+        .await
+        .unwrap();
     drop(group);
 
     // Alice: Process Bob's message (published concurrently to the space creation).
@@ -1703,7 +1750,7 @@ async fn add_expired_member_to_group() {
     assert!(
         alice
             .manager
-            .create_space(0, &[(expired_bob.id(), Access::write())])
+            .create_space_persisted(0, &[(expired_bob.id(), Access::write())])
             .await
             .is_err()
     );
@@ -1752,7 +1799,7 @@ async fn process_operation_from_expired_member() {
     // Alice creates a space with Bob.
     let (_space, messages) = alice
         .manager
-        .create_space(0, &[(expired_bob.id(), Access::write())])
+        .create_space_persisted(0, &[(expired_bob.id(), Access::write())])
         .await
         .unwrap();
 
@@ -1764,4 +1811,49 @@ async fn process_operation_from_expired_member() {
     // Bob processes Alice's "create space", but unfortunately Bob's key bundle expired and they
     // can't decrypt the initial key agreement (X3DH) in the direct message anymore.
     assert!(bob.manager.process(&messages[1]).await.is_err());
+}
+
+#[tokio::test]
+async fn publish_process_separation() {
+    let alice = <TestPeer>::new(0).await;
+    let manager = alice.manager.clone();
+    let alice_id = manager.id();
+
+    let space_id = 0;
+
+    // Node API: create a space, forging required operations, but not persisting any other state.
+    // ~~~~~~~~~~~~
+
+    // We drop the returned states as we are only interested in the forged operations.
+    let (_auth_y, space_y, messages) = Space::create(manager.clone(), space_id, vec![])
+        .await
+        .unwrap();
+    let group_id = space_y.group_id;
+
+    assert_eq!(messages.len(), 2);
+    let auth_message = &messages[0];
+    let space_message = &messages[1];
+
+    // Both global auth state and spaces state have NOT been mutated in the store.
+    let auth = manager.auth().await.unwrap();
+    let members = auth.members(group_id);
+    assert_eq!(members, vec![]);
+
+    assert!(manager.space(space_id).await.unwrap().is_none());
+
+    // Spaces Processor: process the create group and create space operations.
+    // ~~~~~~~~~~~~
+
+    let _ = manager.process(auth_message).await.unwrap();
+    let _ = manager.process(space_message).await.unwrap();
+
+    // Both global auth state and spaces state have now been updated and persisted properly.
+    let auth = manager.auth().await.unwrap();
+    let space = manager.space(space_id).await.unwrap().unwrap();
+
+    let members = auth.members(space.group_id().await.unwrap());
+    assert_eq!(members, vec![(alice_id, Access::manage())]);
+
+    let members = space.members().await.unwrap();
+    assert_eq!(members, vec![(alice_id, Access::manage())]);
 }

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -200,14 +200,9 @@ async fn add_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space = manager.space(space_id).await.unwrap().unwrap();
-    let messages = space.add(bob.manager.id(), Access::read()).await.unwrap();
+    let (message_03 , message_04) = space.add(bob.manager.id(), Access::read()).await.unwrap();
     let members = space.members().await.unwrap();
     drop(space);
-
-    // There are two messages (one auth, and one space)
-    assert_eq!(messages.len(), 2);
-    let message_03 = messages[0].clone();
-    let message_04 = messages[1].clone();
 
     let SpacesArgs::Auth {
         group_id: auth_group_id,
@@ -326,9 +321,7 @@ async fn send_and_receive_after_add() {
     let (alice_space, messages) = alice.manager.create_space(space_id, &[]).await.unwrap();
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
-    let messages = alice_space.add(bob_id, Access::read()).await.unwrap();
-    let message_03 = messages[0].clone();
-    let message_04 = messages[1].clone();
+    let (message_03, message_04) = alice_space.add(bob_id, Access::read()).await.unwrap();
     let message_05 = alice_space.publish(b"Hello bob").await.unwrap();
 
     // Bob processes all of Alice's messages.
@@ -378,13 +371,8 @@ async fn add_pull_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space = manager.space(space_id).await.unwrap().unwrap();
-    let messages = space.add(bob.manager.id(), Access::pull()).await.unwrap();
+    let (message_03, message_04) = space.add(bob.manager.id(), Access::pull()).await.unwrap();
     let members = space.members().await.unwrap();
-
-    // There are two messages (one auth, one space)
-    assert_eq!(messages.len(), 2);
-    let message_03 = messages[0].clone();
-    let message_04 = messages[1].clone();
 
     let SpacesArgs::Auth {
         group_id: auth_group_id,
@@ -521,10 +509,7 @@ async fn receive_control_messages() {
     // Alice: Add new member to Space
     // ~~~~~~~~~~~~
 
-    let messages = space.add(bob.manager.id(), Access::read()).await.unwrap();
-    let message_04 = messages[0].clone();
-    let message_05 = messages[1].clone();
-
+    let (message_04, message_05) = space.add(bob.manager.id(), Access::read()).await.unwrap();
     drop(space);
 
     // Bob: Receive Message 03, 04 and 05
@@ -614,12 +599,7 @@ async fn remove_member() {
     // ~~~~~~~~~~~~
 
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
-    let messages = space.remove(bob_id).await.unwrap();
-
-    // There are two messages (one auth, and one space)
-    assert_eq!(messages.len(), 2);
-    let message_03 = messages[0].clone();
-    let message_04 = messages[1].clone();
+    let (message_03, message_04) = space.remove(bob_id).await.unwrap();
 
     let SpacesArgs::Auth { group_action, .. } = message_03.args() else {
         panic!("expected auth message");
@@ -720,13 +700,8 @@ async fn concurrent_removal_conflict() {
     // ~~~~~~~~~~~~
 
     let space = bob_manager.space(space_id).await.unwrap().unwrap();
-    let messages = space.add(claire_id, Access::read()).await.unwrap();
+    let (message_03, message_04) = space.add(claire_id, Access::read()).await.unwrap();
     drop(space);
-
-    // There are two messages (one auth, and one space)
-    assert_eq!(messages.len(), 2);
-    let message_03 = messages[0].clone();
-    let message_04 = messages[1].clone();
 
     // Alice: process bobs' message
     // ~~~~~~~~~~~~
@@ -740,11 +715,7 @@ async fn concurrent_removal_conflict() {
     // ~~~~~~~~~~~~
 
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
-    let messages = space.add(dave_id, Access::read()).await.unwrap();
-
-    assert_eq!(messages.len(), 2);
-    let message_05 = messages[0].clone();
-    let message_06 = messages[1].clone();
+    let (message_05, message_06) = space.add(dave_id, Access::read()).await.unwrap();
 
     let SpacesArgs::Auth { group_action, .. } = message_05.args() else {
         panic!("expected auth message");
@@ -807,14 +778,11 @@ async fn space_from_existing_auth_state() {
     // Create Group with bob and claire as managers.
     // ~~~~~~~~~~~~
 
-    let (group, messages) = alice_manager
+    let (group, message_01) = alice_manager
         .create_group(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
         .await
         .unwrap();
     let member_group_id = group.id();
-
-    assert_eq!(messages.len(), 1);
-    let message_01 = messages[0].clone();
 
     // Create Space with group as member
     // ~~~~~~~~~~~~
@@ -915,13 +883,10 @@ async fn create_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, messages) = manager
+    let (group, message_01) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
-
-    assert_eq!(messages.len(), 1);
-    let message_01 = messages[0].clone();
 
     let members = group.members().await.unwrap();
     assert_eq!(
@@ -971,17 +936,12 @@ async fn add_member_to_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, messages) = manager
+    let (group, message_01) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
 
-    assert_eq!(messages.len(), 1);
-    let message_01 = messages[0].clone();
-
-    let messages = group.add(claire_id, Access::read()).await.unwrap();
-    assert_eq!(messages.len(), 1);
-    let message_02 = messages[0].clone();
+    let message_02 = group.add(claire_id, Access::read()).await.unwrap();
 
     let members = group.members().await.unwrap();
     assert_eq!(
@@ -1032,19 +992,15 @@ async fn remove_member_from_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, messages) = manager
+    let (group, message_01) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
-    assert_eq!(messages.len(), 1);
-    let message_01 = messages[0].clone();
 
     // Remove bob from group
     // ~~~~~~~~~~~~
 
-    let messages = group.remove(bob_id).await.unwrap();
-    assert_eq!(messages.len(), 1);
-    let message_02 = messages[0].clone();
+    let message_02 = group.remove(bob_id).await.unwrap();
 
     let members = group.members().await.unwrap();
     assert_eq!(members, vec![(alice_id, Access::manage()),]);
@@ -1091,20 +1047,16 @@ async fn receive_auth_messages() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, messages) = alice_manager
+    let (group, message_01) = alice_manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
     let group_id = group.id();
-    assert_eq!(messages.len(), 1);
-    let message_01 = messages[0].clone();
 
     // Add claire
     // ~~~~~~~~~~~~
 
-    let messages = group.add(claire_id, Access::read()).await.unwrap();
-    assert_eq!(messages.len(), 1);
-    let message_02 = messages[0].clone();
+    let message_02 = group.add(claire_id, Access::read()).await.unwrap();
     drop(group);
 
     // Bob receives message 01 & 02
@@ -1166,6 +1118,7 @@ async fn shared_auth_state() {
         .await
         .unwrap();
 
+    // One auth message, one space message.
     assert_eq!(messages.len(), 2);
 
     // Create Space 1
@@ -1176,40 +1129,56 @@ async fn shared_auth_state() {
         .create_space(space_id, &[(alice_id, Access::manage())])
         .await
         .unwrap();
-    // There are four messages (one auth, and three space)
-    assert_eq!(messages.len(), 4);
 
-    // Create group
+    // One auth message, two space messages (one for history, one for the Space 1 create).
+    assert_eq!(messages.len(), 3);
+
+    // Make Space 0 aware of this change.
+    let messages = space_0.repair().await.unwrap();
+    assert_eq!(messages.len(), 1);
+
+    // Create group A
     // ~~~~~~~~~~~~
 
-    let (group, messages) = manager
+    let (group, _) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::read())])
         .await
         .unwrap();
 
-    // There are three messages (one auth, and two space)
-    assert_eq!(messages.len(), 3);
+    // Make Space 0 and Space 1 aware of this change.
+    let messages = space_0.repair().await.unwrap();
+    assert_eq!(messages.len(), 1);
+    let messages = space_1.repair().await.unwrap();
+    assert_eq!(messages.len(), 1);
 
-    // Add group to space 0
+    // Add group A to space 0
     // ~~~~~~~~~~~~
 
-    let messages = space_0.add(group.id(), Access::read()).await.unwrap();
-    // There are three messages (one auth, and two space)
-    assert_eq!(messages.len(), 3);
+    let _ = space_0.add(group.id(), Access::read()).await.unwrap();
 
-    // Add group to space 1
+    // Make Space 1 aware of this change.
+    let messages = space_1.repair().await.unwrap();
+    assert_eq!(messages.len(), 1);
+
+    // Add group A to space 1
     // ~~~~~~~~~~~~
 
-    let messages = space_1.add(group.id(), Access::read()).await.unwrap();
-    // There are three messages (one auth, and two space)
-    assert_eq!(messages.len(), 3);
+    let _ = space_1.add(group.id(), Access::read()).await.unwrap();
+
+    // Make Space 0 aware of this change.
+    let messages = space_0.repair().await.unwrap();
+    assert_eq!(messages.len(), 1);
 
     // Add claire to the group
     // ~~~~~~~~~~~~
 
-    let messages = group.add(claire_id, Access::read()).await.unwrap();
-    // There are three messages (one auth, and two space)
-    assert_eq!(messages.len(), 3);
+    let _ = group.add(claire_id, Access::read()).await.unwrap();
+
+    // Both Space 0 and Space 1 need to be made aware of this change.
+    let messages = space_0.repair().await.unwrap();
+    assert_eq!(messages.len(), 1);
+    let messages = space_1.repair().await.unwrap();
+    assert_eq!(messages.len(), 1);
 
     // Both space 0 and space 1 should now include claire.
     let expected_members = vec![
@@ -1257,14 +1226,12 @@ async fn events() {
     let mut alice_messages = vec![];
 
     // Create Group with bob and claire as managers.
-    let (group, messages) = alice_manager
+    let (group, auth_message) = alice_manager
         .create_group(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
         .await
         .unwrap();
     let member_group_id = group.id();
-
-    assert_eq!(messages.len(), 1);
-    alice_messages.extend(messages);
+    alice_messages.push(auth_message);
 
     // Create Space with group as member
     let space_id = 0;
@@ -1277,24 +1244,20 @@ async fn events() {
     alice_messages.extend(messages);
 
     // Add dave to space with read access
-    let messages = space.add(dave_id, Access::read()).await.unwrap();
-    assert_eq!(messages.len(), 2);
-    alice_messages.extend(messages);
+    let (auth_message, space_message) = space.add(dave_id, Access::read()).await.unwrap();
+    alice_messages.extend([auth_message, space_message]);
 
     // Remove dave from space
-    let messages = space.remove(dave_id).await.unwrap();
-    assert_eq!(messages.len(), 2);
-    alice_messages.extend(messages);
+    let (auth_message, space_message) = space.remove(dave_id).await.unwrap();
+    alice_messages.extend([auth_message, space_message]);
 
     // Add dave back into space with pull access
-    let messages = space.add(dave_id, Access::pull()).await.unwrap();
-    assert_eq!(messages.len(), 2);
-    alice_messages.extend(messages);
+    let (auth_message, space_message) = space.add(dave_id, Access::pull()).await.unwrap();
+    alice_messages.extend([auth_message, space_message]);
 
     // Remove member group from space
-    let messages = space.remove(group.id()).await.unwrap();
-    assert_eq!(messages.len(), 2);
-    alice_messages.extend(messages);
+    let (auth_message, space_message) = space.remove(group.id()).await.unwrap();
+    alice_messages.extend([auth_message, space_message]);
 
     // Test basic expected event types.
     let mut all_bob_events = vec![];
@@ -1479,14 +1442,11 @@ async fn repair_space() {
     // Alice: Create Group with Bob as a manager.
     // ~~~~~~~~~~~~
 
-    let (group, messages) = alice_manager
+    let (group, message_01) = alice_manager
         .create_group(&[(bob_id, Access::manage())])
         .await
         .unwrap();
     let member_group_id = group.id();
-
-    assert_eq!(messages.len(), 1);
-    let message_01 = messages[0].clone();
 
     // Alice: Create Space with group as member.
     // ~~~~~~~~~~~~
@@ -1508,8 +1468,7 @@ async fn repair_space() {
     bob_manager.persist_message(&message_01).await.unwrap();
     bob_manager.process(&message_01).await.unwrap();
     let group = bob_manager.group(member_group_id).await.unwrap().unwrap();
-    let messages = group.add(claire_id, Access::read()).await.unwrap();
-    let bob_message_01 = messages[0].clone();
+    let bob_message_01 = group.add(claire_id, Access::read()).await.unwrap();
     drop(group);
 
     // Alice: Process Bob's message (published concurrently to the space creation).
@@ -1599,14 +1558,11 @@ async fn duplicate_auth_state_references() {
     // Alice: Create Group with Bob as a manager.
     // ~~~~~~~~~~~~
 
-    let (group, messages) = alice_manager
+    let (group, message_01) = alice_manager
         .create_group(&[(bob_id, Access::manage())])
         .await
         .unwrap();
     let member_group_id = group.id();
-
-    assert_eq!(messages.len(), 1);
-    let message_01 = messages[0].clone();
 
     // Alice: Create Space with group as member.
     // ~~~~~~~~~~~~
@@ -1628,8 +1584,7 @@ async fn duplicate_auth_state_references() {
     bob_manager.persist_message(&message_01).await.unwrap();
     bob_manager.process(&message_01).await.unwrap();
     let group = bob_manager.group(member_group_id).await.unwrap().unwrap();
-    let messages = group.add(claire_id, Access::read()).await.unwrap();
-    let bob_message_01 = messages[0].clone();
+    let bob_message_01 = group.add(claire_id, Access::read()).await.unwrap();
     drop(group);
 
     // Alice: Process Bob's message (published concurrently to the space creation).

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -12,21 +12,12 @@ use p2panda_encryption::crypto::x25519::SecretKey;
 use p2panda_encryption::data_scheme::DirectMessage;
 use p2panda_encryption::key_bundle::{Lifetime, LongTermKeyBundle, PreKey};
 
-use crate::ActorId;
 use crate::event::{Event, GroupActor, GroupContext, GroupEvent, SpaceContext, SpaceEvent};
 use crate::member::Member;
 use crate::message::SpacesArgs;
-use crate::test_utils::{TestConditions, TestPeer, TestSpaceError};
+use crate::test_utils::{TestPeer, TestSpaceError};
 use crate::traits::{AuthStore, AuthoredMessage, SpacesMessage, SpacesStore};
 use crate::types::AuthGroupAction;
-
-fn sort_group_actors(members: &mut Vec<(GroupActor, Access<TestConditions>)>) {
-    members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.id().cmp(&actor_b.id()));
-}
-
-fn sort_members(members: &mut Vec<(ActorId, Access<TestConditions>)>) {
-    members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(&actor_b));
-}
 
 #[tokio::test]
 async fn create_space() {
@@ -44,16 +35,13 @@ async fn create_space() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages, events) = manager.create_space(space_id, &[]).await.unwrap();
+    let (space, messages) = manager.create_space(space_id, &[]).await.unwrap();
 
     // We've added ourselves automatically with manage access.
     assert_eq!(
         space.members().await.unwrap(),
         vec![(alice_id, Access::manage())]
     );
-
-    // There are two events
-    assert_eq!(events.len(), 2);
 
     // There are two messages (one auth, one space)
     assert_eq!(messages.len(), 2);
@@ -129,7 +117,7 @@ async fn send_and_receive() {
     // Alice creates a space with Bob.
 
     let space_id = 0;
-    let (alice_space, alice_messages, _) = alice
+    let (alice_space, alice_messages) = alice
         .manager
         .create_space(space_id, &[(bob.manager.id(), Access::write())])
         .await
@@ -199,7 +187,7 @@ async fn add_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages, _) = manager.create_space(space_id, &[]).await.unwrap();
+    let (space, messages) = manager.create_space(space_id, &[]).await.unwrap();
 
     // There are two messages (one auth, and one space)
     assert_eq!(messages.len(), 2);
@@ -212,7 +200,7 @@ async fn add_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space = manager.space(space_id).await.unwrap().unwrap();
-    let (messages, _) = space.add(bob.manager.id(), Access::read()).await.unwrap();
+    let messages = space.add(bob.manager.id(), Access::read()).await.unwrap();
     let members = space.members().await.unwrap();
     drop(space);
 
@@ -292,7 +280,7 @@ async fn register_key_bundles_after_space_creation() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, _, _) = manager.create_space(space_id, &[]).await.unwrap();
+    let (space, _) = manager.create_space(space_id, &[]).await.unwrap();
     drop(space);
 
     // Register key bundles _after_ the space was already created
@@ -335,10 +323,10 @@ async fn send_and_receive_after_add() {
     // Alice creates a space, adds Bob in a following step and then sends a message.
 
     let space_id = 0;
-    let (alice_space, messages, _) = alice.manager.create_space(space_id, &[]).await.unwrap();
+    let (alice_space, messages) = alice.manager.create_space(space_id, &[]).await.unwrap();
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
-    let (messages, _) = alice_space.add(bob_id, Access::read()).await.unwrap();
+    let messages = alice_space.add(bob_id, Access::read()).await.unwrap();
     let message_03 = messages[0].clone();
     let message_04 = messages[1].clone();
     let message_05 = alice_space.publish(b"Hello bob").await.unwrap();
@@ -380,7 +368,7 @@ async fn add_pull_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages, _) = manager.create_space(space_id, &[]).await.unwrap();
+    let (space, messages) = manager.create_space(space_id, &[]).await.unwrap();
     assert_eq!(messages.len(), 2);
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
@@ -390,7 +378,7 @@ async fn add_pull_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space = manager.space(space_id).await.unwrap().unwrap();
-    let (messages, _) = space.add(bob.manager.id(), Access::pull()).await.unwrap();
+    let messages = space.add(bob.manager.id(), Access::pull()).await.unwrap();
     let members = space.members().await.unwrap();
 
     // There are two messages (one auth, one space)
@@ -483,7 +471,7 @@ async fn receive_control_messages() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages, _) = alice_manager.create_space(space_id, &[]).await.unwrap();
+    let (space, messages) = alice_manager.create_space(space_id, &[]).await.unwrap();
     let group_id = space.group_id().await.unwrap();
     drop(space);
 
@@ -533,7 +521,7 @@ async fn receive_control_messages() {
     // Alice: Add new member to Space
     // ~~~~~~~~~~~~
 
-    let (messages, _) = space.add(bob.manager.id(), Access::read()).await.unwrap();
+    let messages = space.add(bob.manager.id(), Access::read()).await.unwrap();
     let message_04 = messages[0].clone();
     let message_05 = messages[1].clone();
 
@@ -601,7 +589,7 @@ async fn remove_member() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages, _) = alice_manager
+    let (space, messages) = alice_manager
         .create_space(space_id, &[(bob_id, Access::read())])
         .await
         .unwrap();
@@ -626,7 +614,7 @@ async fn remove_member() {
     // ~~~~~~~~~~~~
 
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
-    let (messages, _) = space.remove(bob_id).await.unwrap();
+    let messages = space.remove(bob_id).await.unwrap();
 
     // There are two messages (one auth, and one space)
     assert_eq!(messages.len(), 2);
@@ -702,7 +690,7 @@ async fn concurrent_removal_conflict() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages, _) = alice_manager
+    let (space, messages) = alice_manager
         .create_space(space_id, &[(bob_id, Access::manage())])
         .await
         .unwrap();
@@ -732,7 +720,7 @@ async fn concurrent_removal_conflict() {
     // ~~~~~~~~~~~~
 
     let space = bob_manager.space(space_id).await.unwrap().unwrap();
-    let (messages, _) = space.add(claire_id, Access::read()).await.unwrap();
+    let messages = space.add(claire_id, Access::read()).await.unwrap();
     drop(space);
 
     // There are two messages (one auth, and one space)
@@ -752,7 +740,7 @@ async fn concurrent_removal_conflict() {
     // ~~~~~~~~~~~~
 
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
-    let (messages, _) = space.add(dave_id, Access::read()).await.unwrap();
+    let messages = space.add(dave_id, Access::read()).await.unwrap();
 
     assert_eq!(messages.len(), 2);
     let message_05 = messages[0].clone();
@@ -819,7 +807,7 @@ async fn space_from_existing_auth_state() {
     // Create Group with bob and claire as managers.
     // ~~~~~~~~~~~~
 
-    let (group, messages, _) = alice_manager
+    let (group, messages) = alice_manager
         .create_group(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
         .await
         .unwrap();
@@ -832,7 +820,7 @@ async fn space_from_existing_auth_state() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages, _) = alice_manager
+    let (space, messages) = alice_manager
         .create_space(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
@@ -927,7 +915,7 @@ async fn create_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, messages, _) = manager
+    let (group, messages) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
@@ -983,7 +971,7 @@ async fn add_member_to_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, messages, _) = manager
+    let (group, messages) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
@@ -991,7 +979,7 @@ async fn add_member_to_group() {
     assert_eq!(messages.len(), 1);
     let message_01 = messages[0].clone();
 
-    let (messages, _) = group.add(claire_id, Access::read()).await.unwrap();
+    let messages = group.add(claire_id, Access::read()).await.unwrap();
     assert_eq!(messages.len(), 1);
     let message_02 = messages[0].clone();
 
@@ -1044,7 +1032,7 @@ async fn remove_member_from_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, messages, _) = manager
+    let (group, messages) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
@@ -1054,7 +1042,7 @@ async fn remove_member_from_group() {
     // Remove bob from group
     // ~~~~~~~~~~~~
 
-    let (messages, _) = group.remove(bob_id).await.unwrap();
+    let messages = group.remove(bob_id).await.unwrap();
     assert_eq!(messages.len(), 1);
     let message_02 = messages[0].clone();
 
@@ -1103,7 +1091,7 @@ async fn receive_auth_messages() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, messages, _) = alice_manager
+    let (group, messages) = alice_manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
@@ -1114,7 +1102,7 @@ async fn receive_auth_messages() {
     // Add claire
     // ~~~~~~~~~~~~
 
-    let (messages, _) = group.add(claire_id, Access::read()).await.unwrap();
+    let messages = group.add(claire_id, Access::read()).await.unwrap();
     assert_eq!(messages.len(), 1);
     let message_02 = messages[0].clone();
     drop(group);
@@ -1173,7 +1161,7 @@ async fn shared_auth_state() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space_0, messages, _) = manager
+    let (space_0, messages) = manager
         .create_space(space_id, &[(alice_id, Access::manage())])
         .await
         .unwrap();
@@ -1184,7 +1172,7 @@ async fn shared_auth_state() {
     // ~~~~~~~~~~~~
 
     let space_id = 1;
-    let (space_1, messages, _) = manager
+    let (space_1, messages) = manager
         .create_space(space_id, &[(alice_id, Access::manage())])
         .await
         .unwrap();
@@ -1194,7 +1182,7 @@ async fn shared_auth_state() {
     // Create group
     // ~~~~~~~~~~~~
 
-    let (group, messages, _) = manager
+    let (group, messages) = manager
         .create_group(&[(alice_id, Access::manage()), (bob_id, Access::read())])
         .await
         .unwrap();
@@ -1205,21 +1193,21 @@ async fn shared_auth_state() {
     // Add group to space 0
     // ~~~~~~~~~~~~
 
-    let (messages, _) = space_0.add(group.id(), Access::read()).await.unwrap();
+    let messages = space_0.add(group.id(), Access::read()).await.unwrap();
     // There are three messages (one auth, and two space)
     assert_eq!(messages.len(), 3);
 
     // Add group to space 1
     // ~~~~~~~~~~~~
 
-    let (messages, _) = space_1.add(group.id(), Access::read()).await.unwrap();
+    let messages = space_1.add(group.id(), Access::read()).await.unwrap();
     // There are three messages (one auth, and two space)
     assert_eq!(messages.len(), 3);
 
     // Add claire to the group
     // ~~~~~~~~~~~~
 
-    let (messages, _) = group.add(claire_id, Access::read()).await.unwrap();
+    let messages = group.add(claire_id, Access::read()).await.unwrap();
     // There are three messages (one auth, and two space)
     assert_eq!(messages.len(), 3);
 
@@ -1267,10 +1255,9 @@ async fn events() {
     }
 
     let mut alice_messages = vec![];
-    let mut alice_events = vec![];
 
     // Create Group with bob and claire as managers.
-    let (group, messages, event) = alice_manager
+    let (group, messages) = alice_manager
         .create_group(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
         .await
         .unwrap();
@@ -1278,49 +1265,36 @@ async fn events() {
 
     assert_eq!(messages.len(), 1);
     alice_messages.extend(messages);
-    alice_events.push(event);
 
     // Create Space with group as member
     let space_id = 0;
-    let (space, messages, events) = alice_manager
+    let (space, messages) = alice_manager
         .create_space(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
     let space_group_id = space.group_id().await.unwrap();
     assert_eq!(messages.len(), 3);
     alice_messages.extend(messages);
-    assert_eq!(events.len(), 2);
-    alice_events.extend(events);
 
     // Add dave to space with read access
-    let (messages, events) = space.add(dave_id, Access::read()).await.unwrap();
+    let messages = space.add(dave_id, Access::read()).await.unwrap();
     assert_eq!(messages.len(), 2);
     alice_messages.extend(messages);
-    assert_eq!(events.len(), 2);
-    alice_events.extend(events);
 
     // Remove dave from space
-    let (messages, events) = space.remove(dave_id).await.unwrap();
+    let messages = space.remove(dave_id).await.unwrap();
     assert_eq!(messages.len(), 2);
     alice_messages.extend(messages);
-    assert_eq!(events.len(), 2);
-    alice_events.extend(events);
 
     // Add dave back into space with pull access
-    let (messages, events) = space.add(dave_id, Access::pull()).await.unwrap();
+    let messages = space.add(dave_id, Access::pull()).await.unwrap();
     assert_eq!(messages.len(), 2);
     alice_messages.extend(messages);
-    // Only one event as new member only has Pull access so no space membership change occurred
-    // and therefore no space event was emitted.
-    assert_eq!(events.len(), 1);
-    alice_events.extend(events);
 
     // Remove member group from space
-    let (messages, events) = space.remove(group.id()).await.unwrap();
+    let messages = space.remove(group.id()).await.unwrap();
     assert_eq!(messages.len(), 2);
     alice_messages.extend(messages);
-    assert_eq!(events.len(), 2);
-    alice_events.extend(events);
 
     // Test basic expected event types.
     let mut all_bob_events = vec![];
@@ -1398,251 +1372,7 @@ async fn events() {
         }
     }
 
-    assert_eq!(alice_events.len(), 10);
-    // Bob has one more event as he got the "ejected" event when being removed from the space.
     assert_eq!(all_bob_events.len(), 11);
-    all_bob_events.pop();
-
-    for (id, bob_event) in all_bob_events.iter().enumerate() {
-        assert_eq!(&alice_events[id], bob_event)
-    }
-
-    // Test expected members.
-    for (idx, event) in alice_events.iter().enumerate() {
-        match idx {
-            // Member auth group created.
-            0 => {
-                let Event::Group(GroupEvent::Created {
-                    context:
-                        GroupContext {
-                            group_actors,
-                            members,
-                            ..
-                        },
-                    ..
-                }) = event.clone()
-                else {
-                    panic!()
-                };
-
-                let expected_group_actors = vec![
-                    (GroupActor::individual(bob_id), Access::manage()),
-                    (GroupActor::individual(claire_id), Access::manage()),
-                ];
-
-                let expected_members =
-                    vec![(bob_id, Access::manage()), (claire_id, Access::manage())];
-
-                assert_eq!(group_actors, expected_group_actors);
-                assert_eq!(members, expected_members);
-            }
-            // Space auth group created.
-            1 => {
-                let Event::Group(GroupEvent::Created {
-                    context:
-                        GroupContext {
-                            group_actors,
-                            members,
-                            ..
-                        },
-                    ..
-                }) = event.clone()
-                else {
-                    panic!()
-                };
-
-                let mut expected_group_actors = vec![
-                    (GroupActor::individual(alice_id), Access::manage()),
-                    (GroupActor::group(group.id()), Access::read()),
-                ];
-                let expected_members = vec![
-                    (alice_id, Access::manage()),
-                    (bob_id, Access::read()),
-                    (claire_id, Access::read()),
-                ];
-
-                sort_group_actors(&mut expected_group_actors);
-                assert_eq!(group_actors, expected_group_actors);
-                assert_eq!(members, expected_members);
-            }
-            // Both previous auth messages published to newly created space, initial members added
-            // to encryption context.
-            2 => {
-                let Event::Space(SpaceEvent::Created {
-                    context: SpaceContext { members, .. },
-                    ..
-                }) = event.clone()
-                else {
-                    panic!()
-                };
-
-                let expected_members = vec![alice_id, bob_id, claire_id];
-                assert_eq!(members, expected_members);
-            }
-            // Dave added to space auth group and encryption context.
-            3 => {
-                let Event::Group(GroupEvent::Added {
-                    context:
-                        GroupContext {
-                            group_actors,
-                            members,
-                            ..
-                        },
-                    ..
-                }) = event.clone()
-                else {
-                    panic!()
-                };
-
-                let mut expected_group_actors = vec![
-                    (GroupActor::individual(alice_id), Access::manage()),
-                    (GroupActor::individual(dave_id), Access::read()),
-                    (GroupActor::group(group.id()), Access::read()),
-                ];
-                let mut expected_members = vec![
-                    (alice_id, Access::manage()),
-                    (bob_id, Access::read()),
-                    (claire_id, Access::read()),
-                    (dave_id, Access::read()),
-                ];
-
-                sort_group_actors(&mut expected_group_actors);
-                sort_members(&mut expected_members);
-                assert_eq!(group_actors, expected_group_actors);
-                assert_eq!(members, expected_members);
-            }
-            4 => {
-                let Event::Space(SpaceEvent::Added {
-                    context: SpaceContext { members, .. },
-                    ..
-                }) = event.clone()
-                else {
-                    panic!()
-                };
-
-                let mut expected_members = vec![alice_id, bob_id, claire_id, dave_id];
-                expected_members.sort();
-                assert_eq!(members, expected_members);
-            }
-            // Dave removed from space auth group and encryption context.
-            5 => {
-                let Event::Group(GroupEvent::Removed {
-                    context:
-                        GroupContext {
-                            group_actors,
-                            members,
-                            ..
-                        },
-                    ..
-                }) = event.clone()
-                else {
-                    panic!()
-                };
-
-                let mut expected_group_actors = vec![
-                    (GroupActor::individual(alice_id), Access::manage()),
-                    (GroupActor::group(group.id()), Access::read()),
-                ];
-                let mut expected_members = vec![
-                    (alice_id, Access::manage()),
-                    (bob_id, Access::read()),
-                    (claire_id, Access::read()),
-                ];
-
-                sort_group_actors(&mut expected_group_actors);
-                sort_members(&mut expected_members);
-                assert_eq!(group_actors, expected_group_actors);
-                assert_eq!(members, expected_members);
-            }
-            6 => {
-                let Event::Space(SpaceEvent::Removed {
-                    context: SpaceContext { members, .. },
-                    ..
-                }) = event.clone()
-                else {
-                    panic!()
-                };
-
-                let mut expected_members = vec![alice_id, bob_id, claire_id];
-                expected_members.sort();
-                assert_eq!(members, expected_members);
-            }
-            // Dave added to auth group with pull access and no resulting encryption context change.
-            7 => {
-                let Event::Group(GroupEvent::Added {
-                    context:
-                        GroupContext {
-                            group_actors,
-                            members,
-                            ..
-                        },
-                    ..
-                }) = event.clone()
-                else {
-                    panic!()
-                };
-
-                let mut expected_group_actors = vec![
-                    (GroupActor::individual(alice_id), Access::manage()),
-                    (GroupActor::individual(dave_id), Access::pull()),
-                    (GroupActor::group(group.id()), Access::read()),
-                ];
-                let mut expected_members = vec![
-                    (alice_id, Access::manage()),
-                    (bob_id, Access::read()),
-                    (claire_id, Access::read()),
-                    (dave_id, Access::pull()),
-                ];
-
-                sort_group_actors(&mut expected_group_actors);
-                sort_members(&mut expected_members);
-                assert_eq!(group_actors, expected_group_actors);
-                assert_eq!(members, expected_members);
-            }
-            // Remove member group from space auth group, both bob and claire removed from space
-            // encryption context.
-            8 => {
-                let Event::Group(GroupEvent::Removed {
-                    context:
-                        GroupContext {
-                            group_actors,
-                            members,
-                            ..
-                        },
-                    ..
-                }) = event.clone()
-                else {
-                    panic!()
-                };
-
-                let mut expected_group_actors = vec![
-                    (GroupActor::individual(alice_id), Access::manage()),
-                    (GroupActor::individual(dave_id), Access::pull()),
-                ];
-                let mut expected_members =
-                    vec![(alice_id, Access::manage()), (dave_id, Access::pull())];
-
-                sort_group_actors(&mut expected_group_actors);
-                sort_members(&mut expected_members);
-                assert_eq!(group_actors, expected_group_actors);
-                assert_eq!(members, expected_members);
-            }
-            9 => {
-                let Event::Space(SpaceEvent::Removed {
-                    context: SpaceContext { members, .. },
-                    ..
-                }) = event.clone()
-                else {
-                    panic!()
-                };
-
-                let mut expected_members = vec![alice_id];
-                expected_members.sort();
-                assert_eq!(members, expected_members);
-            }
-            _ => panic!(),
-        }
-    }
 }
 
 #[tokio::test]
@@ -1674,7 +1404,7 @@ async fn idempotent_api() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (_, messages, _) = alice_manager.create_space(space_id, &[]).await.unwrap();
+    let (_, messages) = alice_manager.create_space(space_id, &[]).await.unwrap();
 
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
@@ -1749,7 +1479,7 @@ async fn repair_space() {
     // Alice: Create Group with Bob as a manager.
     // ~~~~~~~~~~~~
 
-    let (group, messages, _) = alice_manager
+    let (group, messages) = alice_manager
         .create_group(&[(bob_id, Access::manage())])
         .await
         .unwrap();
@@ -1762,7 +1492,7 @@ async fn repair_space() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages, _) = alice_manager
+    let (space, messages) = alice_manager
         .create_space(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
@@ -1778,7 +1508,7 @@ async fn repair_space() {
     bob_manager.persist_message(&message_01).await.unwrap();
     bob_manager.process(&message_01).await.unwrap();
     let group = bob_manager.group(member_group_id).await.unwrap().unwrap();
-    let (messages, _) = group.add(claire_id, Access::read()).await.unwrap();
+    let messages = group.add(claire_id, Access::read()).await.unwrap();
     let bob_message_01 = messages[0].clone();
     drop(group);
 
@@ -1796,7 +1526,7 @@ async fn repair_space() {
     assert_eq!(vec![space_id], repair_required);
 
     // Trigger repair of the space.
-    let (messages, _events) = alice_manager.repair_spaces(&repair_required).await.unwrap();
+    let messages = alice_manager.repair_spaces(&repair_required).await.unwrap();
     let message_05 = messages[0].clone();
     // @TODO: assert the correct events are present once we return events for messages we created ourselves.
 
@@ -1869,7 +1599,7 @@ async fn duplicate_auth_state_references() {
     // Alice: Create Group with Bob as a manager.
     // ~~~~~~~~~~~~
 
-    let (group, messages, _) = alice_manager
+    let (group, messages) = alice_manager
         .create_group(&[(bob_id, Access::manage())])
         .await
         .unwrap();
@@ -1882,7 +1612,7 @@ async fn duplicate_auth_state_references() {
     // ~~~~~~~~~~~~
 
     let space_id = 0;
-    let (space, messages, _) = alice_manager
+    let (space, messages) = alice_manager
         .create_space(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
@@ -1898,7 +1628,7 @@ async fn duplicate_auth_state_references() {
     bob_manager.persist_message(&message_01).await.unwrap();
     bob_manager.process(&message_01).await.unwrap();
     let group = bob_manager.group(member_group_id).await.unwrap().unwrap();
-    let (messages, _) = group.add(claire_id, Access::read()).await.unwrap();
+    let messages = group.add(claire_id, Access::read()).await.unwrap();
     let bob_message_01 = messages[0].clone();
     drop(group);
 
@@ -1916,7 +1646,7 @@ async fn duplicate_auth_state_references() {
     assert_eq!(vec![space_id], repair_required);
 
     // Trigger repair of the space.
-    let (messages, _) = alice_manager.repair_spaces(&repair_required).await.unwrap();
+    let messages = alice_manager.repair_spaces(&repair_required).await.unwrap();
     let message_05 = messages[0].clone();
     // @TODO: assert the correct events are present once we return events for messages we created ourselves.
 
@@ -1947,7 +1677,7 @@ async fn duplicate_auth_state_references() {
     assert_eq!(vec![space_id], repair_required);
 
     // Trigger repair of the space.
-    let (messages, _) = bob_manager.repair_spaces(&repair_required).await.unwrap();
+    let messages = bob_manager.repair_spaces(&repair_required).await.unwrap();
     let _ = messages[0].clone();
 
     // Bob: processes Alice's (duplicate) auth state pointer.
@@ -2065,7 +1795,7 @@ async fn process_operation_from_expired_member() {
     bob.manager.register_member(&expired_bob).await.unwrap();
 
     // Alice creates a space with Bob.
-    let (_space, messages, _events) = alice
+    let (_space, messages) = alice
         .manager
         .create_space(0, &[(expired_bob.id(), Access::write())])
         .await

--- a/p2panda-spaces/src/utils.rs
+++ b/p2panda-spaces/src/utils.rs
@@ -5,17 +5,15 @@ use p2panda_auth::group::GroupMember;
 use p2panda_auth::traits::Conditions;
 
 use crate::ActorId;
-use crate::manager::Manager;
-use crate::traits::AuthStore;
 use crate::types::AuthGroupState;
 
 /// Assign a GroupMember type to passed actor based on looking up if the actor is a group in the
 /// auth state.
 pub(crate) fn typed_member<C: Conditions>(
-    auth_y: &AuthGroupState<C>,
+    y: &AuthGroupState<C>,
     member: ActorId,
 ) -> GroupMember<ActorId> {
-    if auth_y.members(member).is_empty() {
+    if y.members(member).is_empty() {
         GroupMember::Individual(member)
     } else {
         GroupMember::Group(member)
@@ -24,20 +22,14 @@ pub(crate) fn typed_member<C: Conditions>(
 
 /// Assign GroupMember type to every actor based on looking up if the actor is a group in the auth
 /// state.
-pub(crate) async fn typed_members<ID, S, K, F, M, C, RS>(
-    manager_ref: Manager<ID, S, K, F, M, C, RS>,
+pub(crate) fn typed_members<C: Conditions>(
+    y: &AuthGroupState<C>,
     members: Vec<(ActorId, Access<C>)>,
-) -> Result<Vec<(GroupMember<ActorId>, Access<C>)>, <S as AuthStore<C>>::Error>
-where
-    S: AuthStore<C>,
-    C: Conditions,
-{
-    let manager = manager_ref.inner.read().await;
-    let auth_y = manager.store.auth().await?;
-    Ok(members
+) -> Vec<(GroupMember<ActorId>, Access<C>)> {
+    members
         .into_iter()
-        .map(|(member, access)| (typed_member(&auth_y, member), access))
-        .collect())
+        .map(|(member, access)| (typed_member(y, member), access))
+        .collect()
 }
 
 pub(crate) fn sort_members<ID: Ord, C>(members: &mut [(ID, Access<C>)]) {


### PR DESCRIPTION
Several API changes required for integrating `p2panda-spaces` into the Node API.

- only emit events on Manager::process calls
- don't automatically sync groups state changes with all spaces (now this should be done by the user)
- don't persist state in public "command" issuing API (Manager::create_space, Space::add etc...)

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
