### PR TITLE
Replace `SpacesMessage` trait with `Borrow<SpacesArgs>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Highlights are marked with a pancake 🥞
 - spaces: Don't sync all spaces when group membership changes
   [#1216](https://github.com/p2panda/p2panda/pull/1216)
 - spaces: Adjust all "command" methods to not persist state locally [#1216](https://github.com/p2panda/p2panda/pull/1216)
+- spaces: Replace SpacesMessage trait with Borrow<SpacesArgs> [#1217](https://github.com/p2panda/p2panda/pull/1217)
 
 ## [0.6.1] - 22/05/2026
 

--- a/p2panda-spaces/src/auth/message.rs
+++ b/p2panda-spaces/src/auth/message.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::borrow::Borrow;
 use std::fmt::Debug;
 
 use p2panda_auth::group::GroupAction;
 use p2panda_auth::traits::{Conditions, Operation as AuthOperation};
 
 use crate::message::SpacesArgs;
-use crate::traits::{AuthoredMessage, SpaceId, SpacesMessage};
+use crate::traits::{AuthoredMessage, SpaceId};
 use crate::types::{ActorId, OperationId};
 
 #[derive(Clone, Debug)]
@@ -25,13 +26,13 @@ where
     pub(crate) fn from_forged<ID, M>(message: &M) -> Self
     where
         ID: SpaceId,
-        M: AuthoredMessage + SpacesMessage<ID, C>,
+        M: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
     {
         let SpacesArgs::Auth {
             group_id,
             group_action,
             auth_dependencies,
-        } = message.args()
+        } = message.borrow()
         else {
             panic!("unexpected message type")
         };

--- a/p2panda-spaces/src/encryption/message.rs
+++ b/p2panda-spaces/src/encryption/message.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::borrow::Borrow;
+
 use p2panda_auth::traits::{Conditions, Operation};
 use p2panda_encryption::crypto::xchacha20::XAeadNonce;
 use p2panda_encryption::data_scheme::GroupSecretId;
@@ -8,7 +10,7 @@ use p2panda_encryption::traits::{GroupMessage as EncryptionOperation, GroupMessa
 use crate::auth::message::AuthMessage;
 use crate::encryption::dgm::EncryptionGroupMembership;
 use crate::message::SpacesArgs;
-use crate::traits::{AuthoredMessage, SpaceId, SpacesMessage};
+use crate::traits::{AuthoredMessage, SpaceId};
 use crate::types::{
     ActorId, AuthGroupAction, EncryptionControlMessage, EncryptionDirectMessage, OperationId,
 };
@@ -47,7 +49,7 @@ impl EncryptionMessage {
     pub(crate) fn from_application<ID, M, C>(space_message: &M) -> Self
     where
         ID: SpaceId,
-        M: AuthoredMessage + SpacesMessage<ID, C>,
+        M: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
         C: Conditions,
     {
         let SpacesArgs::Application {
@@ -56,7 +58,7 @@ impl EncryptionMessage {
             nonce,
             ciphertext,
             ..
-        } = space_message.args()
+        } = space_message.borrow()
         else {
             panic!("unexpected message type")
         };
@@ -94,7 +96,7 @@ impl EncryptionMessage {
     ) -> Self
     where
         ID: SpaceId,
-        M: AuthoredMessage + SpacesMessage<ID, C>,
+        M: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
         C: Conditions,
     {
         let SpacesArgs::SpaceMembership {
@@ -102,7 +104,7 @@ impl EncryptionMessage {
             auth_message_id,
             direct_messages,
             ..
-        } = space_message.args()
+        } = space_message.borrow()
         else {
             panic!("unexpected message type");
         };

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::borrow::Borrow;
+
 use serde::{Deserialize, Serialize};
 
 use p2panda_auth::Access;
@@ -10,7 +12,7 @@ use p2panda_encryption::data_scheme::GroupOutput;
 use crate::ActorId;
 use crate::auth::message::AuthMessage;
 use crate::message::SpacesArgs;
-use crate::traits::{AuthoredMessage, SpaceId, SpacesMessage};
+use crate::traits::{AuthoredMessage, SpaceId};
 use crate::types::{AuthGroupAction, AuthGroupState, EncryptionGroupOutput};
 use crate::utils::{added_members, removed_members, sort_members};
 
@@ -264,9 +266,9 @@ pub(crate) fn space_message_to_space_event<ID, C, M>(
 where
     ID: SpaceId,
     C: Conditions,
-    M: AuthoredMessage + SpacesMessage<ID, C>,
+    M: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
 {
-    let SpacesArgs::SpaceMembership { space_id, .. } = space_message.args() else {
+    let SpacesArgs::SpaceMembership { space_id, .. } = space_message.borrow() else {
         panic!("unexpected message type");
     };
     let space_id = *space_id;

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -3,6 +3,7 @@
 //! API for managing members of a group in the shared auth context.
 //!
 //! Group membership changes also effect all spaces and groups for which the altered group is itself a member.
+use std::borrow::Borrow;
 use std::fmt::Debug;
 
 use p2panda_auth::Access;
@@ -19,8 +20,7 @@ use crate::manager::Manager;
 use crate::message::SpacesArgs;
 use crate::traits::SpaceId;
 use crate::traits::{
-    AuthStore, AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore, MessageStore,
-    SpacesMessage, SpacesStore,
+    AuthStore, AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore, MessageStore, SpacesStore,
 };
 use crate::types::{
     ActorId, AuthGroup, AuthGroupAction, AuthGroupError, AuthGroupState, AuthResolver,
@@ -58,7 +58,7 @@ where
     S: SpacesStore<ID, M, C> + AuthStore<C> + MessageStore<M> + Debug,
     K: KeyRegistryStore + KeySecretStore + Debug,
     F: Forge<ID, M, C> + Debug,
-    M: AuthoredMessage + SpacesMessage<ID, C> + Debug,
+    M: AuthoredMessage + Borrow<SpacesArgs<ID, C>> + Debug,
     C: Conditions,
     RS: AuthResolver<C> + Debug,
 {

--- a/p2panda-spaces/src/identity.rs
+++ b/p2panda-spaces/src/identity.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! API for managing members and their key bundles.
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -16,7 +17,7 @@ use crate::event::Event;
 use crate::member::Member;
 use crate::message::SpacesArgs;
 use crate::traits::SpaceId;
-use crate::traits::{AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore, SpacesMessage};
+use crate::traits::{AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore};
 use crate::types::ActorId;
 use crate::{Config, Credentials};
 
@@ -45,7 +46,7 @@ where
     ID: SpaceId,
     K: KeySecretStore + KeyRegistryStore + Debug,
     F: Forge<ID, M, C> + Debug,
-    M: AuthoredMessage + SpacesMessage<ID, C>,
+    M: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
     C: Conditions,
 {
     pub async fn new(
@@ -255,6 +256,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Borrow;
     use std::time::Duration;
 
     use p2panda_encryption::Rng;
@@ -264,7 +266,7 @@ mod tests {
 
     use crate::message::SpacesArgs;
     use crate::test_utils::{TestForge, TestKeyStore, TestStore};
-    use crate::traits::{AuthoredMessage, SpacesMessage};
+    use crate::traits::AuthoredMessage;
     use crate::{ActorId, Config, Credentials};
 
     use super::IdentityManager;
@@ -313,7 +315,7 @@ mod tests {
 
         let actor_id: ActorId = credentials.signing_key().verifying_key().into();
         assert_eq!(msg.author(), actor_id);
-        match msg.args() {
+        match msg.borrow() {
             SpacesArgs::KeyBundle { key_bundle } => {
                 assert!(key_bundle.verify().is_ok());
             }

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! High-level API for managing spaces, groups and member keys.
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -21,7 +22,7 @@ use crate::message::SpacesArgs;
 use crate::space::{Space, SpaceError, SpaceState};
 use crate::traits::{
     AuthStore, AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore, MessageStore, SpaceId,
-    SpacesMessage, SpacesStore,
+    SpacesStore,
 };
 use crate::types::{ActorId, AuthGroupState, AuthResolver, OperationId};
 use crate::{Config, Credentials};
@@ -73,7 +74,7 @@ where
     S: SpacesStore<ID, M, C> + AuthStore<C> + MessageStore<M> + Debug,
     K: KeyRegistryStore + KeySecretStore + Debug,
     F: Forge<ID, M, C> + Debug,
-    M: AuthoredMessage + SpacesMessage<ID, C> + Debug,
+    M: AuthoredMessage + Borrow<SpacesArgs<ID, C>> + Debug,
     C: Conditions,
     RS: AuthResolver<C> + Debug,
 {
@@ -271,7 +272,7 @@ where
         message: &M,
     ) -> Result<Vec<Event<ID, C>>, ManagerError<ID, S, K, F, M, C, RS>> {
         // Route message to the regarding member-, group- or space processor.
-        let events = match message.args() {
+        let events = match message.borrow() {
             // Received key bundle from a member.
             SpacesArgs::KeyBundle { key_bundle } => {
                 let mut manager = self.inner.write().await;
@@ -480,7 +481,7 @@ where
             space_id,
             auth_message_id,
             ..
-        } = message.args()
+        } = message.borrow()
         else {
             panic!("unexpected message type");
         };
@@ -500,7 +501,7 @@ where
                 ));
             };
 
-            match message.args() {
+            match message.borrow() {
                 SpacesArgs::Auth { .. } => AuthMessage::from_forged(&message),
                 _ => {
                     return Err(ManagerError::IncorrectMessageVariant(*auth_message_id));

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! API for managing members of a space and sending/receiving messages.
+use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::convert::Infallible;
 use std::fmt::Debug;
@@ -24,7 +25,7 @@ use crate::manager::Manager;
 use crate::message::SpacesArgs;
 use crate::traits::{
     AuthStore, AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore, MessageStore, SpaceId,
-    SpacesMessage, SpacesStore,
+    SpacesStore,
 };
 use crate::types::{
     ActorId, AuthGroup, AuthGroupAction, AuthGroupError, AuthGroupState, AuthResolver,
@@ -66,7 +67,7 @@ where
     S: SpacesStore<ID, M, C> + AuthStore<C> + MessageStore<M> + Debug,
     K: KeyRegistryStore + KeySecretStore + Debug,
     F: Forge<ID, M, C> + Debug,
-    M: AuthoredMessage + SpacesMessage<ID, C> + Debug,
+    M: AuthoredMessage + Borrow<SpacesArgs<ID, C>> + Debug,
     C: Conditions,
     RS: Debug + AuthResolver<C>,
 {
@@ -266,7 +267,7 @@ where
         space_message: &M,
         auth_message: Option<&AuthMessage<C>>,
     ) -> Result<Vec<Event<ID, C>>, SpaceError<ID, S, K, F, M, C, RS>> {
-        let events = match space_message.args() {
+        let events = match space_message.borrow() {
             SpacesArgs::SpaceMembership { space_id, .. } => {
                 assert_eq!(space_id, &self.id); // Sanity check.
                 let auth_message =
@@ -345,7 +346,7 @@ where
             group_id,
             space_dependencies,
             ..
-        } = space_message.args()
+        } = space_message.borrow()
         else {
             panic!("unexpected message type");
         };
@@ -520,7 +521,7 @@ where
     ) -> Result<Vec<Event<ID, C>>, SpaceError<ID, S, K, F, M, C, RS>> {
         let SpacesArgs::Application {
             space_dependencies, ..
-        } = message.args()
+        } = message.borrow()
         else {
             panic!("unexpected message type")
         };

--- a/p2panda-spaces/src/test_utils/message.rs
+++ b/p2panda-spaces/src/test_utils/message.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::borrow::Borrow;
+
 use p2panda_core::{Hash, VerifyingKey};
 
 use crate::message::SpacesArgs;
 use crate::test_utils::{TestConditions, TestSpaceId};
-use crate::traits::{AuthoredMessage, SpacesMessage};
+use crate::traits::AuthoredMessage;
 use crate::{ActorId, OperationId};
 
 pub type SeqNum = u64;
@@ -28,8 +30,8 @@ impl AuthoredMessage for TestMessage {
     }
 }
 
-impl SpacesMessage<TestSpaceId, TestConditions> for TestMessage {
-    fn args(&self) -> &SpacesArgs<TestSpaceId, TestConditions> {
+impl Borrow<SpacesArgs<TestSpaceId, TestConditions>> for TestMessage {
+    fn borrow(&self) -> &SpacesArgs<TestSpaceId, TestConditions> {
         &self.spaces_args
     }
 }

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -17,7 +18,7 @@ use crate::member::Member;
 use crate::message::SpacesArgs;
 use crate::space::Space;
 use crate::test_utils::{TestPeer, TestSpaceError};
-use crate::traits::{AuthStore, AuthoredMessage, SpacesMessage, SpacesStore};
+use crate::traits::{AuthStore, AuthoredMessage, SpacesStore};
 use crate::types::AuthGroupAction;
 
 #[tokio::test]
@@ -53,7 +54,7 @@ async fn create_space() {
         group_id: auth_group_id,
         group_action,
         auth_dependencies,
-    } = message_01.args()
+    } = message_01.borrow()
     else {
         panic!("expected auth message");
     };
@@ -64,7 +65,7 @@ async fn create_space() {
         space_dependencies,
         auth_message_id,
         direct_messages,
-    } = message_02.args()
+    } = message_02.borrow()
     else {
         panic!("expected system message");
     };
@@ -212,7 +213,7 @@ async fn add_member_to_space() {
         group_id: auth_group_id,
         group_action,
         auth_dependencies,
-    } = message_03.args()
+    } = message_03.borrow()
     else {
         panic!("expected auth message");
     };
@@ -223,7 +224,7 @@ async fn add_member_to_space() {
         space_dependencies,
         direct_messages,
         ..
-    } = message_04.args()
+    } = message_04.borrow()
     else {
         panic!("expected system message");
     };
@@ -392,7 +393,7 @@ async fn add_pull_member_to_space() {
         group_id: auth_group_id,
         group_action,
         auth_dependencies,
-    } = message_03.args()
+    } = message_03.borrow()
     else {
         panic!("expected auth message");
     };
@@ -403,7 +404,7 @@ async fn add_pull_member_to_space() {
         space_dependencies,
         auth_message_id,
         direct_messages,
-    } = message_04.args()
+    } = message_04.borrow()
     else {
         panic!("expected system message");
     };
@@ -621,13 +622,13 @@ async fn remove_member() {
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
     let (message_03, message_04) = space.remove_persisted(bob_id).await.unwrap();
 
-    let SpacesArgs::Auth { group_action, .. } = message_03.args() else {
+    let SpacesArgs::Auth { group_action, .. } = message_03.borrow() else {
         panic!("expected auth message");
     };
 
     let SpacesArgs::SpaceMembership {
         direct_messages, ..
-    } = message_04.args()
+    } = message_04.borrow()
     else {
         panic!("expected system message");
     };
@@ -740,13 +741,13 @@ async fn concurrent_removal_conflict() {
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
     let (message_05, message_06) = space.add_persisted(dave_id, Access::read()).await.unwrap();
 
-    let SpacesArgs::Auth { group_action, .. } = message_05.args() else {
+    let SpacesArgs::Auth { group_action, .. } = message_05.borrow() else {
         panic!("expected auth message");
     };
 
     let SpacesArgs::SpaceMembership {
         direct_messages, ..
-    } = message_06.args()
+    } = message_06.borrow()
     else {
         panic!("expected system message");
     };
@@ -825,7 +826,7 @@ async fn space_from_existing_auth_state() {
     let message_03 = messages[1].clone();
     let message_04 = messages[2].clone();
 
-    let SpacesArgs::Auth { group_action, .. } = message_02.args() else {
+    let SpacesArgs::Auth { group_action, .. } = message_02.borrow() else {
         panic!("expected auth message");
     };
 
@@ -844,7 +845,7 @@ async fn space_from_existing_auth_state() {
         direct_messages,
         auth_message_id,
         ..
-    } = message_03.args()
+    } = message_03.borrow()
     else {
         panic!("expected system message");
     };
@@ -859,7 +860,7 @@ async fn space_from_existing_auth_state() {
         direct_messages,
         auth_message_id,
         ..
-    } = message_04.args()
+    } = message_04.borrow()
     else {
         panic!("expected system message");
     };
@@ -922,7 +923,7 @@ async fn create_group() {
         group_id,
         group_action,
         ..
-    } = message_01.args()
+    } = message_01.borrow()
     else {
         panic!("expected auth message");
     };
@@ -984,7 +985,7 @@ async fn add_member_to_group() {
         group_id,
         group_action,
         auth_dependencies,
-    } = message_02.args()
+    } = message_02.borrow()
     else {
         panic!("expected auth message");
     };
@@ -1036,7 +1037,7 @@ async fn remove_member_from_group() {
         group_id,
         group_action,
         auth_dependencies,
-    } = message_02.args()
+    } = message_02.borrow()
     else {
         panic!("expected auth message");
     };

--- a/p2panda-spaces/src/traits/message.rs
+++ b/p2panda-spaces/src/traits/message.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Trait interfaces expressing signed space messages.
-use crate::message::SpacesArgs;
 use crate::{ActorId, OperationId};
 
 // @TODO: Use traits from p2panda-core when ready:
@@ -12,9 +11,4 @@ pub trait AuthoredMessage {
     fn id(&self) -> OperationId;
 
     fn author(&self) -> ActorId;
-}
-
-/// Interface to be implemented on messages containing spaces args.
-pub trait SpacesMessage<ID, C> {
-    fn args(&self) -> &SpacesArgs<ID, C>;
 }

--- a/p2panda-spaces/src/traits/mod.rs
+++ b/p2panda-spaces/src/traits/mod.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 pub use forge::Forge;
-pub use message::{AuthoredMessage, SpacesMessage};
+pub use message::AuthoredMessage;
 pub use store::{AuthStore, KeyRegistryStore, KeySecretStore, MessageStore, SpacesStore};
 
 /// Trait representing the identifier of a space.


### PR DESCRIPTION
Replace `SpacesMessage` trait with `Borrow<SpacesArgs>` in spaces API.

## 📋 Checklist

- [x] ~Add tests that cover your changes~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
