### PR TITLE
Introduce spaces processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Highlights are marked with a pancake 🥞
 - spaces: Replace SpacesMessage trait with Borrow<SpacesArgs> [#1217](https://github.com/p2panda/p2panda/pull/1217)
 - spaces: Move top-level M generic to Manager::process<M>(..) [#1229](https://github.com/p2panda/p2panda/pull/1229)
 - spaces: Fix generics in MessageStore and MemoryStore [#1229](https://github.com/p2panda/p2panda/pull/1229)
+- stream: Introduce spaces processor [#1218](https://github.com/p2panda/p2panda/pull/1218)
 
 ## [0.6.1] - 22/05/2026
 

--- a/p2panda-spaces/src/lib.rs
+++ b/p2panda-spaces/src/lib.rs
@@ -24,5 +24,5 @@ mod utils;
 pub use config::Config;
 pub use credentials::Credentials;
 pub use event::Event;
-pub use message::SpacesArgs;
-pub use types::{ActorId, OperationId};
+pub use message::{SpacesArgs, SpacesMessage};
+pub use types::{ActorId, OperationId, StrongRemoveResolver};

--- a/p2panda-spaces/src/traits/message.rs
+++ b/p2panda-spaces/src/traits/message.rs
@@ -3,6 +3,7 @@
 //! Trait interfaces expressing signed space messages.
 use crate::{ActorId, OperationId};
 
+// @TODO: Remove these; we'll use the `Borrow` method instead and define a concrete type.
 // @TODO: Use traits from p2panda-core when ready:
 // https://github.com/p2panda/p2panda/blob/a6762e9831ccc8b6c008caf655468d6e75cff408/p2panda-core/src/traits.rs
 /// Interface to be implemented on custom message types which have a unique operation id and were

--- a/p2panda-stream/Cargo.toml
+++ b/p2panda-stream/Cargo.toml
@@ -27,6 +27,7 @@ default = [
   "ingest",
   "log_prune",
   "orderer",
+  "spaces",
 ]
 groups = [
   "p2panda-auth/serde",
@@ -35,11 +36,15 @@ groups = [
 ingest = []
 log_prune = []
 orderer = []
+spaces = [
+  "p2panda-spaces"
+]
 
 [dependencies]
 futures-core = { version = "0.3.31", default-features = false, features = ["alloc"] }
 p2panda-auth = { workspace = true, optional = true }
 p2panda-core = { workspace = true, default-features = true }
+p2panda-spaces = { workspace = true, default-features = true, optional = true }
 p2panda-store = { workspace = true, default-features = true }
 pin-project = "1.1.10"
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/p2panda-stream/src/lib.rs
+++ b/p2panda-stream/src/lib.rs
@@ -34,6 +34,8 @@ pub mod log_prune;
 #[cfg(feature = "orderer")]
 pub mod orderer;
 mod processors;
+#[cfg(feature = "spaces")]
+pub mod spaces;
 #[cfg(test)]
 mod test_utils;
 

--- a/p2panda-stream/src/spaces/args.rs
+++ b/p2panda-stream/src/spaces/args.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use p2panda_spaces::SpacesMessage;
+
+#[derive(Clone, Debug, Default)]
+#[allow(clippy::large_enum_variant)]
+pub enum SpacesArgs<ID, C> {
+    Process {
+        msg: SpacesMessage<ID, C>,
+    },
+    #[default]
+    Ignore,
+}

--- a/p2panda-stream/src/spaces/mod.rs
+++ b/p2panda-stream/src/spaces/mod.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Types and methods for processing spaces messages for group encryption.
+mod args;
+mod processor;
+
+pub use args::SpacesArgs;
+pub use processor::{Spaces, SpacesManager, SpacesManagerError, SpacesResult};

--- a/p2panda-stream/src/spaces/processor.rs
+++ b/p2panda-stream/src/spaces/processor.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::borrow::Borrow;
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::fmt::Debug;
+
+use p2panda_auth::traits::Conditions;
+use p2panda_spaces::manager::{Manager, ManagerError};
+use p2panda_spaces::traits::{
+    AuthStore, AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore, MessageStore, SpaceId,
+    SpacesStore,
+};
+use p2panda_spaces::{Event, SpacesArgs as SpacesMessageArgs, StrongRemoveResolver};
+use tokio::sync::Notify;
+use tracing::trace;
+
+use crate::Processor;
+use crate::spaces::SpacesArgs;
+
+pub type SpacesManager<ID, S, K, F, C> = Manager<ID, S, K, F, C, StrongRemoveResolver<C>>;
+pub type SpacesManagerError<ID, S, K, F, C> = ManagerError<ID, S, K, F, C, StrongRemoveResolver<C>>;
+
+#[derive(Clone)]
+pub enum SpacesResult<ID, C> {
+    Processed { events: Vec<Event<ID, C>> },
+    Ignored,
+}
+
+impl<ID, C> SpacesResult<ID, C> {
+    pub fn was_processed(self) -> bool {
+        match self {
+            Self::Processed { .. } => true,
+            Self::Ignored => false,
+        }
+    }
+}
+
+/// Processor for spaces operations.
+pub struct Spaces<T, ID, S, K, F, C> {
+    manager: SpacesManager<ID, S, K, F, C>,
+    notify: Notify,
+    queue: RefCell<VecDeque<(T, SpacesResult<ID, C>)>>,
+}
+
+impl<T, ID, S, K, F, C> Spaces<T, ID, S, K, F, C> {
+    pub fn new(manager: SpacesManager<ID, S, K, F, C>) -> Self {
+        Self {
+            manager,
+            notify: Notify::new(),
+            queue: RefCell::new(VecDeque::new()),
+        }
+    }
+}
+
+impl<T, ID, S, K, F, C> Processor<T> for Spaces<T, ID, S, K, F, C>
+where
+    T: Borrow<SpacesArgs<ID, C>>,
+    ID: SpaceId,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<F::Message> + Debug,
+    K: KeyRegistryStore + KeySecretStore + Debug,
+    F: Forge<ID, C> + Debug,
+    F::Message: AuthoredMessage + Borrow<SpacesMessageArgs<ID, C>>,
+    C: Conditions,
+{
+    type Output = (T, SpacesResult<ID, C>);
+
+    type Error = (T, SpacesManagerError<ID, S, K, F, C>);
+
+    async fn process(&self, input: T) -> Result<(), Self::Error> {
+        let input_args: &SpacesArgs<ID, C> = input.borrow();
+
+        let result = if let SpacesArgs::Process { msg } = input_args {
+            let events = match self.manager.process(msg).await {
+                Ok(events) => events,
+                Err(err) => return Err((input, err)),
+            };
+
+            (input, SpacesResult::Processed { events })
+        } else {
+            trace!("ignore non-spaces operation");
+            (input, SpacesResult::Ignored)
+        };
+
+        self.queue.borrow_mut().push_back(result);
+        self.notify.notify_one();
+
+        Ok(())
+    }
+
+    async fn next(&self) -> Result<Self::Output, Self::Error> {
+        loop {
+            if let Some(item) = self.queue.borrow_mut().pop_front() {
+                return Ok(item);
+            }
+
+            self.notify.notified().await;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new `Spaces` type which acts as a processor for
spaces operations. It holds a spaces `Manager` internally which is used
to process the received input. Input is expected in the form of a
`SpacesMessage` which implements `Borrow` in order to be able to extract
the required `SpacesArgs`. Events emitted by the processing of the
spaces operation are returned as part of the result.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
