### PR TITLE
spaces: Move top-level `M` generic to `Manager::process<M>(..)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Highlights are marked with a pancake 🥞
 - spaces: Adjust all "command" methods to not persist state locally [#1216](https://github.com/p2panda/p2panda/pull/1216)
 - spaces: Replace SpacesMessage trait with Borrow<SpacesArgs> [#1217](https://github.com/p2panda/p2panda/pull/1217)
 - spaces: Move top-level M generic to Manager::process<M>(..) [#1229](https://github.com/p2panda/p2panda/pull/1229)
+- spaces: Fix generics in MessageStore and MemoryStore [#1229](https://github.com/p2panda/p2panda/pull/1229)
 
 ## [0.6.1] - 22/05/2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Highlights are marked with a pancake 🥞
   [#1216](https://github.com/p2panda/p2panda/pull/1216)
 - spaces: Adjust all "command" methods to not persist state locally [#1216](https://github.com/p2panda/p2panda/pull/1216)
 - spaces: Replace SpacesMessage trait with Borrow<SpacesArgs> [#1217](https://github.com/p2panda/p2panda/pull/1217)
+- spaces: Move top-level M generic to Manager::process<M>(..) [#1229](https://github.com/p2panda/p2panda/pull/1229)
 
 ## [0.6.1] - 22/05/2026
 

--- a/p2panda-spaces/src/auth/message.rs
+++ b/p2panda-spaces/src/auth/message.rs
@@ -1,49 +1,19 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::borrow::Borrow;
 use std::fmt::Debug;
 
 use p2panda_auth::group::GroupAction;
 use p2panda_auth::traits::{Conditions, Operation as AuthOperation};
 
-use crate::message::SpacesArgs;
-use crate::traits::{AuthoredMessage, SpaceId};
 use crate::types::{ActorId, OperationId};
 
 #[derive(Clone, Debug)]
 pub struct AuthMessage<C> {
-    operation_id: OperationId,
-    author: ActorId,
-    dependencies: Vec<OperationId>,
-    group_id: ActorId,
-    action: GroupAction<ActorId, C>,
-}
-
-impl<C> AuthMessage<C>
-where
-    C: Conditions,
-{
-    pub(crate) fn from_forged<ID, M>(message: &M) -> Self
-    where
-        ID: SpaceId,
-        M: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
-    {
-        let SpacesArgs::Auth {
-            group_id,
-            group_action,
-            auth_dependencies,
-        } = message.borrow()
-        else {
-            panic!("unexpected message type")
-        };
-        AuthMessage {
-            operation_id: message.id(),
-            author: message.author(),
-            dependencies: auth_dependencies.to_owned(),
-            group_id: *group_id,
-            action: group_action.to_owned(),
-        }
-    }
+    pub(crate) operation_id: OperationId,
+    pub(crate) author: ActorId,
+    pub(crate) dependencies: Vec<OperationId>,
+    pub(crate) group_id: ActorId,
+    pub(crate) action: GroupAction<ActorId, C>,
 }
 
 impl<C> AuthOperation<ActorId, OperationId, C> for AuthMessage<C>

--- a/p2panda-spaces/src/encryption/message.rs
+++ b/p2panda-spaces/src/encryption/message.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::borrow::Borrow;
-
 use p2panda_auth::traits::{Conditions, Operation};
 use p2panda_encryption::crypto::xchacha20::XAeadNonce;
 use p2panda_encryption::data_scheme::GroupSecretId;
@@ -9,8 +7,7 @@ use p2panda_encryption::traits::{GroupMessage as EncryptionOperation, GroupMessa
 
 use crate::auth::message::AuthMessage;
 use crate::encryption::dgm::EncryptionGroupMembership;
-use crate::message::SpacesArgs;
-use crate::traits::{AuthoredMessage, SpaceId};
+use crate::message::{ApplicationMessage, SpaceMembershipMessage};
 use crate::types::{
     ActorId, AuthGroupAction, EncryptionControlMessage, EncryptionDirectMessage, OperationId,
 };
@@ -46,22 +43,16 @@ pub enum EncryptionMessage {
 
 impl EncryptionMessage {
     /// Construct an encryption message from a space application message.
-    pub(crate) fn from_application<ID, M, C>(space_message: &M) -> Self
-    where
-        ID: SpaceId,
-        M: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
-        C: Conditions,
-    {
-        let SpacesArgs::Application {
+    pub(crate) fn from_application(space_message: &ApplicationMessage) -> Self {
+        let ApplicationMessage {
+            id,
+            author,
             space_dependencies,
             group_secret_id,
             nonce,
             ciphertext,
             ..
-        } = space_message.borrow()
-        else {
-            panic!("unexpected message type")
-        };
+        } = space_message;
 
         let encryption_args = EncryptionArgs::Application {
             dependencies: space_dependencies.clone(),
@@ -71,8 +62,8 @@ impl EncryptionMessage {
         };
 
         EncryptionMessage::Forged {
-            author: space_message.author(),
-            operation_id: space_message.id(),
+            author: *author,
+            operation_id: *id,
             args: encryption_args,
         }
     }
@@ -87,27 +78,24 @@ impl EncryptionMessage {
     /// manually replaced with the latest membership state provided by p2panda-auth. The only case
     /// where it does matter is if we ourselves were added or removed from the group; here we
     /// should make sure that the control message contains our own actor id.
-    pub(crate) fn from_membership<ID, M, C>(
-        space_message: &M,
+    pub(crate) fn from_membership<C>(
+        space_message: &SpaceMembershipMessage,
         my_id: ActorId,
         auth_message: &AuthMessage<C>,
         current_members: &Vec<ActorId>,
         next_members: &Vec<ActorId>,
     ) -> Self
     where
-        ID: SpaceId,
-        M: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
         C: Conditions,
     {
-        let SpacesArgs::SpaceMembership {
+        let SpaceMembershipMessage {
+            id,
+            author,
             space_dependencies,
             auth_message_id,
             direct_messages,
             ..
-        } = space_message.borrow()
-        else {
-            panic!("unexpected message type");
-        };
+        } = space_message;
 
         // Sanity check.
         assert_eq!(auth_message.id(), *auth_message_id);
@@ -169,8 +157,8 @@ impl EncryptionMessage {
         };
 
         EncryptionMessage::Forged {
-            author: space_message.author(),
-            operation_id: space_message.id(),
+            author: *author,
+            operation_id: *id,
             args: encryption_args,
         }
     }

--- a/p2panda-spaces/src/encryption/orderer.rs
+++ b/p2panda-spaces/src/encryption/orderer.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::convert::Infallible;
-use std::marker::PhantomData;
 
 use p2panda_encryption::crypto::xchacha20::XAeadNonce;
 use p2panda_encryption::data_scheme::GroupSecretId;
@@ -19,21 +18,17 @@ use crate::types::{ActorId, EncryptionControlMessage, EncryptionDirectMessage, O
 /// care of ordering of control and application messages; p2panda-spaces expects messages to be
 /// orderer before being processed.
 #[derive(Clone, Debug)]
-pub struct EncryptionOrderer<M> {
-    _marker: PhantomData<M>,
-}
+pub struct EncryptionOrderer {}
 
-impl<M> Default for EncryptionOrderer<M> {
+impl Default for EncryptionOrderer {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<M> EncryptionOrderer<M> {
+impl EncryptionOrderer {
     pub fn new() -> Self {
-        Self {
-            _marker: PhantomData,
-        }
+        Self {}
     }
 }
 
@@ -116,8 +111,8 @@ impl EncryptionOrdererState {
     }
 }
 
-impl<M> p2panda_encryption::traits::Ordering<ActorId, OperationId, EncryptionGroupMembership>
-    for EncryptionOrderer<M>
+impl p2panda_encryption::traits::Ordering<ActorId, OperationId, EncryptionGroupMembership>
+    for EncryptionOrderer
 {
     type State = EncryptionOrdererState;
 

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::borrow::Borrow;
-
 use serde::{Deserialize, Serialize};
 
 use p2panda_auth::Access;
@@ -11,8 +9,8 @@ use p2panda_encryption::data_scheme::GroupOutput;
 
 use crate::ActorId;
 use crate::auth::message::AuthMessage;
-use crate::message::SpacesArgs;
-use crate::traits::{AuthoredMessage, SpaceId};
+use crate::message::SpaceMembershipMessage;
+use crate::traits::SpaceId;
 use crate::types::{AuthGroupAction, AuthGroupState, EncryptionGroupOutput};
 use crate::utils::{added_members, removed_members, sort_members};
 
@@ -182,9 +180,9 @@ pub enum SpaceEvent<ID> {
     },
 }
 
-pub(crate) fn encryption_output_to_space_events<ID, M, C>(
+pub(crate) fn encryption_output_to_space_events<ID, C>(
     space_id: &ID,
-    encryption_output: Vec<EncryptionGroupOutput<M>>,
+    encryption_output: Vec<EncryptionGroupOutput>,
 ) -> Vec<Event<ID, C>>
 where
     ID: SpaceId,
@@ -257,8 +255,9 @@ where
     Event::Group(group_event)
 }
 
-pub(crate) fn space_message_to_space_event<ID, C, M>(
-    space_message: &M,
+pub(crate) fn space_message_to_space_event<ID, C>(
+    space_id: ID,
+    space_message: &SpaceMembershipMessage,
     auth_message: &AuthMessage<C>,
     current_members: Vec<ActorId>,
     next_members: Vec<ActorId>,
@@ -266,17 +265,12 @@ pub(crate) fn space_message_to_space_event<ID, C, M>(
 where
     ID: SpaceId,
     C: Conditions,
-    M: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
 {
-    let SpacesArgs::SpaceMembership { space_id, .. } = space_message.borrow() else {
-        panic!("unexpected message type");
-    };
-    let space_id = *space_id;
     let group_id = auth_message.group_id();
 
     let context = SpaceContext {
         auth_author: auth_message.author(),
-        spaces_author: space_message.author(),
+        spaces_author: space_message.author,
         group_id,
         members: next_members.clone(),
     };

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -55,7 +55,7 @@ pub struct Group<ID, S, K, F, C, RS> {
 impl<ID, S, K, F, C, RS> Group<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
-    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C> + Debug,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<F::Message> + Debug,
     K: KeyRegistryStore + KeySecretStore + Debug,
     F: Forge<ID, C> + Debug,
     F::Message: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
@@ -243,7 +243,7 @@ where
 pub enum GroupError<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
-    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C>,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<F::Message>,
     K: KeyRegistryStore + KeySecretStore,
     F: Forge<ID, C>,
     C: Conditions,
@@ -265,7 +265,7 @@ where
     AuthStore(<S as AuthStore<C>>::Error),
 
     #[error("{0}")]
-    MessageStore(<S as MessageStore<ID, C>>::Error),
+    MessageStore(<S as MessageStore<F::Message>>::Error),
 
     // @TODO: We lose the concrete error type which caused sync of spaces to fail, ideal we would
     // retain this type information.

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -17,11 +17,11 @@ use crate::auth::message::AuthMessage;
 use crate::event::{Event, auth_message_to_group_event};
 use crate::identity::IdentityError;
 use crate::manager::Manager;
-use crate::message::SpacesArgs;
-use crate::traits::SpaceId;
+use crate::message::{SpacesArgs, SpacesMessage};
 use crate::traits::{
-    AuthStore, AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore, MessageStore, SpacesStore,
+    AuthStore, Forge, KeyRegistryStore, KeySecretStore, MessageStore, SpacesStore,
 };
+use crate::traits::{AuthoredMessage, SpaceId};
 use crate::types::{
     ActorId, AuthGroup, AuthGroupAction, AuthGroupError, AuthGroupState, AuthResolver,
     EncryptionGroupError,
@@ -39,12 +39,12 @@ use crate::utils::{sort_members, typed_member, typed_members};
 ///
 /// Only members with Manage access level are allowed to manage the groups members.
 #[derive(Debug)]
-pub struct Group<ID, S, K, F, M, C, RS> {
+pub struct Group<ID, S, K, F, C, RS> {
     /// Reference to the manager.
     ///
     /// This allows us to build an API where users can treat "group" instances independently from the
     /// manager API, even though internally it has a reference to it.
-    manager: Manager<ID, S, K, F, M, C, RS>,
+    manager: Manager<ID, S, K, F, C, RS>,
 
     /// Id of the group.
     ///
@@ -52,17 +52,17 @@ pub struct Group<ID, S, K, F, M, C, RS> {
     id: ActorId,
 }
 
-impl<ID, S, K, F, M, C, RS> Group<ID, S, K, F, M, C, RS>
+impl<ID, S, K, F, C, RS> Group<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
-    S: SpacesStore<ID, M, C> + AuthStore<C> + MessageStore<M> + Debug,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C> + Debug,
     K: KeyRegistryStore + KeySecretStore + Debug,
-    F: Forge<ID, M, C> + Debug,
-    M: AuthoredMessage + Borrow<SpacesArgs<ID, C>> + Debug,
+    F: Forge<ID, C> + Debug,
+    F::Message: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
     C: Conditions,
     RS: AuthResolver<C> + Debug,
 {
-    pub(crate) fn new(manager_ref: Manager<ID, S, K, F, M, C, RS>, id: ActorId) -> Self {
+    pub(crate) fn new(manager_ref: Manager<ID, S, K, F, C, RS>, id: ActorId) -> Self {
         Self {
             manager: manager_ref,
             id,
@@ -77,11 +77,11 @@ where
     ///
     /// Returns resulting state and message for processing.
     pub(crate) async fn create(
-        manager_ref: Manager<ID, S, K, F, M, C, RS>,
+        manager_ref: Manager<ID, S, K, F, C, RS>,
         y: AuthGroupState<C>,
         group_id: ActorId,
         initial_members: Vec<(ActorId, Access<C>)>,
-    ) -> Result<(AuthGroupState<C>, M), GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, F::Message), GroupError<ID, S, K, F, C, RS>> {
         let initial_members = typed_members(&y, initial_members);
 
         let auth_dependencies = y.inner.heads().into_iter().collect();
@@ -109,7 +109,7 @@ where
         &self,
         member: ActorId,
         access: Access<C>,
-    ) -> Result<M, GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<F::Message, GroupError<ID, S, K, F, C, RS>> {
         let (y, message) = self.add(member, access).await?;
         self.manager
             .set_auth(&y)
@@ -126,7 +126,7 @@ where
         &self,
         member: ActorId,
         access: Access<C>,
-    ) -> Result<(AuthGroupState<C>, M), GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, F::Message), GroupError<ID, S, K, F, C, RS>> {
         let y = self.manager.auth().await.map_err(GroupError::AuthStore)?;
 
         let member = typed_member(&y, member);
@@ -143,7 +143,7 @@ where
     pub async fn remove_persisted(
         &self,
         member: ActorId,
-    ) -> Result<M, GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<F::Message, GroupError<ID, S, K, F, C, RS>> {
         let (y, message) = self.remove(member).await?;
         self.manager
             .set_auth(&y)
@@ -159,7 +159,7 @@ where
     pub async fn remove(
         &self,
         member: ActorId,
-    ) -> Result<(AuthGroupState<C>, M), GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, F::Message), GroupError<ID, S, K, F, C, RS>> {
         let y = self.manager.auth().await.map_err(GroupError::AuthStore)?;
 
         let member = typed_member(&y, member);
@@ -173,11 +173,9 @@ where
     ///
     /// Returns events which inform users of any state changes which occurred.
     pub(crate) async fn process(
-        manager_ref: Manager<ID, S, K, F, M, C, RS>,
-        message: &M,
-    ) -> Result<Option<Event<ID, C>>, GroupError<ID, S, K, F, M, C, RS>> {
-        let auth_message = AuthMessage::from_forged(message);
-
+        manager_ref: Manager<ID, S, K, F, C, RS>,
+        auth_message: &AuthMessage<C>,
+    ) -> Result<Option<Event<ID, C>>, GroupError<ID, S, K, F, C, RS>> {
         let mut auth_y = {
             let manager = manager_ref.inner.read().await;
             manager.store.auth().await.map_err(GroupError::AuthStore)?
@@ -189,24 +187,24 @@ where
         }
 
         let manager = manager_ref.inner.write().await;
-        auth_y = AuthGroup::process(auth_y, &auth_message).map_err(GroupError::AuthGroup)?;
+        auth_y = AuthGroup::process(auth_y, auth_message).map_err(GroupError::AuthGroup)?;
         manager
             .store
             .set_auth(&auth_y)
             .await
             .map_err(GroupError::AuthStore)?;
 
-        Ok(Some(auth_message_to_group_event(&auth_y, &auth_message)))
+        Ok(Some(auth_message_to_group_event(&auth_y, auth_message)))
     }
 
     /// Process a local control message.
     pub async fn process_local_control(
-        manager_ref: Manager<ID, S, K, F, M, C, RS>,
+        manager_ref: Manager<ID, S, K, F, C, RS>,
         y: AuthGroupState<C>,
         group_id: ActorId,
         auth_dependencies: Vec<OperationId>,
         group_action: GroupAction<ActorId, C>,
-    ) -> Result<(AuthGroupState<C>, M), GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, F::Message), GroupError<ID, S, K, F, C, RS>> {
         let args = SpacesArgs::Auth {
             group_id,
             auth_dependencies,
@@ -218,8 +216,8 @@ where
             manager.identity.forge(args).await?
         };
 
-        let auth_message = AuthMessage::from_forged(&message);
-        let y = AuthGroup::process(y, &auth_message).map_err(GroupError::AuthGroup)?;
+        let y =
+            AuthGroup::process(y, &SpacesMessage::auth(&message)).map_err(GroupError::AuthGroup)?;
 
         Ok((y, message))
     }
@@ -232,7 +230,7 @@ where
     /// Current group members and access levels.
     pub async fn members(
         &self,
-    ) -> Result<Vec<(ActorId, Access<C>)>, GroupError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<(ActorId, Access<C>)>, GroupError<ID, S, K, F, C, RS>> {
         let y = self.manager.auth().await.map_err(GroupError::AuthStore)?;
         let mut group_members = y.members(self.id);
         sort_members(&mut group_members);
@@ -242,12 +240,12 @@ where
 
 /// Group error type.
 #[derive(Debug, Error)]
-pub enum GroupError<ID, S, K, F, M, C, RS>
+pub enum GroupError<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
-    S: SpacesStore<ID, M, C> + AuthStore<C> + MessageStore<M>,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C>,
     K: KeyRegistryStore + KeySecretStore,
-    F: Forge<ID, M, C>,
+    F: Forge<ID, C>,
     C: Conditions,
     RS: AuthResolver<C> + Debug,
 {
@@ -258,16 +256,16 @@ where
     AuthGroup(AuthGroupError<C, RS>),
 
     #[error("{0}")]
-    EncryptionGroup(EncryptionGroupError<M>),
+    EncryptionGroup(EncryptionGroupError),
 
     #[error(transparent)]
-    IdentityManager(#[from] IdentityError<ID, K, F, M, C>),
+    IdentityManager(#[from] IdentityError<ID, K, F, C>),
 
     #[error("{0}")]
     AuthStore(<S as AuthStore<C>>::Error),
 
     #[error("{0}")]
-    MessageStore(<S as MessageStore<M>>::Error),
+    MessageStore(<S as MessageStore<ID, C>>::Error),
 
     // @TODO: We lose the concrete error type which caused sync of spaces to fail, ideal we would
     // retain this type information.

--- a/p2panda-spaces/src/identity.rs
+++ b/p2panda-spaces/src/identity.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! API for managing members and their key bundles.
-use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -17,7 +16,7 @@ use crate::event::Event;
 use crate::member::Member;
 use crate::message::SpacesArgs;
 use crate::traits::SpaceId;
-use crate::traits::{AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore};
+use crate::traits::{Forge, KeyRegistryStore, KeySecretStore};
 use crate::types::ActorId;
 use crate::{Config, Credentials};
 
@@ -32,21 +31,20 @@ use crate::{Config, Credentials};
 /// undefined behavior. Rotating both keys is possible but will result in the loss of access to
 /// existing spaces.
 #[derive(Debug)]
-pub struct IdentityManager<ID, K, F, M, C> {
+pub struct IdentityManager<ID, K, F, C> {
     key_store: K,
     forge: F,
     credentials: Credentials,
     config: Config,
     rng: Rng,
-    _marker: PhantomData<(ID, F, M, C)>,
+    _marker: PhantomData<(ID, F, C)>,
 }
 
-impl<ID, K, F, M, C> IdentityManager<ID, K, F, M, C>
+impl<ID, K, F, C> IdentityManager<ID, K, F, C>
 where
     ID: SpaceId,
     K: KeySecretStore + KeyRegistryStore + Debug,
-    F: Forge<ID, M, C> + Debug,
-    M: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
+    F: Forge<ID, C> + Debug,
     C: Conditions,
 {
     pub async fn new(
@@ -55,7 +53,7 @@ where
         credentials: Credentials,
         config: &Config,
         rng: &Rng,
-    ) -> Result<Self, IdentityError<ID, K, F, M, C>> {
+    ) -> Result<Self, IdentityError<ID, K, F, C>> {
         Ok(Self {
             key_store,
             forge,
@@ -74,14 +72,14 @@ where
     /// The local actor id and their long-term key bundle.
     ///
     /// Note: Key bundle will be rotated if the latest is reaching it's configured expiry date.
-    pub(crate) async fn me(&mut self) -> Result<Member, IdentityError<ID, K, F, M, C>> {
+    pub(crate) async fn me(&mut self) -> Result<Member, IdentityError<ID, K, F, C>> {
         Ok(Member::new(self.id(), self.key_bundle().await?))
     }
 
     /// Returns "latest", publishable key bundle of us or automatically generates a new one if
     /// either nothing was generated yet, if previous bundles expired or are about to be expired
     /// (given an additional "pessimistic" rotation window).
-    async fn key_bundle(&mut self) -> Result<LongTermKeyBundle, IdentityError<ID, K, F, M, C>> {
+    async fn key_bundle(&mut self) -> Result<LongTermKeyBundle, IdentityError<ID, K, F, C>> {
         let key_manager_y = self.key_manager().await?;
 
         let valid_bundle = match KeyManager::prekey_bundle(&key_manager_y) {
@@ -129,7 +127,7 @@ where
     }
 
     /// Returns `true` if my latest key bundle has expired or is about to expire.
-    pub async fn key_bundle_expired(&self) -> Result<bool, IdentityError<ID, K, F, M, C>> {
+    pub async fn key_bundle_expired(&self) -> Result<bool, IdentityError<ID, K, F, C>> {
         let key_manager_y = self.key_manager().await?;
         match KeyManager::prekey_bundle(&key_manager_y) {
             Ok(bundle) => Ok(bundle
@@ -144,7 +142,7 @@ where
     /// Forge a key bundle message containing my latest key bundle.
     ///
     /// Note: Key bundle will be rotated if the latest is reaching it's configured expiry date.
-    pub async fn key_bundle_message(&mut self) -> Result<M, IdentityError<ID, K, F, M, C>> {
+    pub async fn key_bundle_message(&mut self) -> Result<F::Message, IdentityError<ID, K, F, C>> {
         let args = SpacesArgs::KeyBundle {
             key_bundle: self.key_bundle().await?,
         };
@@ -163,7 +161,7 @@ where
     pub async fn register_member(
         &mut self,
         member: &Member,
-    ) -> Result<(), IdentityError<ID, K, F, M, C>> {
+    ) -> Result<(), IdentityError<ID, K, F, C>> {
         let pki = {
             let y = self.key_registry().await?;
             KeyRegistry::add_longterm_bundle(y, member.id(), member.key_bundle().clone())?
@@ -182,7 +180,7 @@ where
         &mut self,
         author: ActorId,
         key_bundle: &LongTermKeyBundle,
-    ) -> Result<Event<ID, C>, IdentityError<ID, K, F, M, C>> {
+    ) -> Result<Event<ID, C>, IdentityError<ID, K, F, C>> {
         key_bundle.verify()?;
         let member = Member::new(author, key_bundle.clone());
         self.register_member(&member).await?;
@@ -192,12 +190,12 @@ where
     pub async fn forge(
         &mut self,
         args: SpacesArgs<ID, C>,
-    ) -> Result<M, IdentityError<ID, K, F, M, C>> {
+    ) -> Result<F::Message, IdentityError<ID, K, F, C>> {
         self.forge.forge(args).await.map_err(IdentityError::Forge)
     }
 
     /// Assemble and return key manager state from persisted pre-key bundles and identity secret.
-    pub async fn key_manager(&self) -> Result<KeyManagerState, IdentityError<ID, K, F, M, C>> {
+    pub async fn key_manager(&self) -> Result<KeyManagerState, IdentityError<ID, K, F, C>> {
         let prekeys = self
             .key_store
             .prekey_secrets()
@@ -212,7 +210,7 @@ where
 
     pub async fn key_registry(
         &self,
-    ) -> Result<KeyRegistryState<ActorId>, IdentityError<ID, K, F, M, C>> {
+    ) -> Result<KeyRegistryState<ActorId>, IdentityError<ID, K, F, C>> {
         self.key_store
             .key_registry()
             .await
@@ -222,11 +220,11 @@ where
 
 #[derive(Debug, Error)]
 #[allow(clippy::large_enum_variant)]
-pub enum IdentityError<ID, K, F, M, C>
+pub enum IdentityError<ID, K, F, C>
 where
     ID: SpaceId,
     K: KeySecretStore + KeyRegistryStore,
-    F: Forge<ID, M, C>,
+    F: Forge<ID, C>,
     C: Conditions,
 {
     #[error("{0}")]

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -13,12 +13,11 @@ use p2panda_encryption::{Rng, RngError};
 use thiserror::Error;
 use tokio::sync::RwLock;
 
-use crate::auth::message::AuthMessage;
 use crate::event::Event;
 use crate::group::{Group, GroupError};
 use crate::identity::{IdentityError, IdentityManager};
 use crate::member::Member;
-use crate::message::SpacesArgs;
+use crate::message::{SpaceMembershipMessage, SpacesArgs, SpacesMessage};
 use crate::space::{Space, SpaceError, SpaceState};
 use crate::traits::{
     AuthStore, AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore, MessageStore, SpaceId,
@@ -51,30 +50,30 @@ use crate::{Config, Credentials};
 /// on the manager. All messages created within p2panda-spaces express their dependencies; these
 /// should be used to perform partial ordering of all incoming messages.
 #[derive(Debug)]
-pub struct Manager<ID, S, K, F, M, C, RS> {
+pub struct Manager<ID, S, K, F, C, RS> {
     pub(crate) actor_id: ActorId,
     #[allow(clippy::type_complexity)]
-    pub(crate) inner: Arc<RwLock<ManagerInner<ID, S, K, F, M, C, RS>>>,
+    pub(crate) inner: Arc<RwLock<ManagerInner<ID, S, K, F, C, RS>>>,
 }
 
 #[derive(Debug)]
-pub(crate) struct ManagerInner<ID, S, K, F, M, C, RS> {
+pub(crate) struct ManagerInner<ID, S, K, F, C, RS> {
     pub(crate) store: S,
-    pub(crate) identity: IdentityManager<ID, K, F, M, C>,
+    pub(crate) identity: IdentityManager<ID, K, F, C>,
     pub(crate) rng: Rng,
     _marker: PhantomData<(F, RS)>,
 }
 
-impl<ID, S, K, F, M, C, RS> Manager<ID, S, K, F, M, C, RS>
+impl<ID, S, K, F, C, RS> Manager<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
     // @TODO: the Debug bound is required as we are string formatting the manager error in
     // groups.rs due to challenges handling cyclical errors. If that issue is solved in a more
     // satisfactory way then this bound can be removed.
-    S: SpacesStore<ID, M, C> + AuthStore<C> + MessageStore<M> + Debug,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C> + Debug,
     K: KeyRegistryStore + KeySecretStore + Debug,
-    F: Forge<ID, M, C> + Debug,
-    M: AuthoredMessage + Borrow<SpacesArgs<ID, C>> + Debug,
+    F: Forge<ID, C> + Debug,
+    F::Message: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
     C: Conditions,
     RS: AuthResolver<C> + Debug,
 {
@@ -86,7 +85,7 @@ where
         forge: F,
         credentials: Credentials,
         rng: Rng,
-    ) -> Result<Self, ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Self, ManagerError<ID, S, K, F, C, RS>> {
         Self::new_with_config(
             store,
             key_store,
@@ -107,7 +106,7 @@ where
         credentials: Credentials,
         config: &Config,
         rng: Rng,
-    ) -> Result<Self, ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Self, ManagerError<ID, S, K, F, C, RS>> {
         let actor_id: ActorId = credentials.verifying_key().into();
         let identity = IdentityManager::new(key_store, forge, credentials, config, &rng).await?;
         let inner = ManagerInner {
@@ -129,7 +128,7 @@ where
     pub async fn space(
         &self,
         id: ID,
-    ) -> Result<Option<Space<ID, S, K, F, M, C, RS>>, ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Option<Space<ID, S, K, F, C, RS>>, ManagerError<ID, S, K, F, C, RS>> {
         let has_space = {
             let inner = self.inner.read().await;
             inner
@@ -153,7 +152,7 @@ where
     pub async fn group(
         &self,
         id: ActorId,
-    ) -> Result<Option<Group<ID, S, K, F, M, C, RS>>, ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Option<Group<ID, S, K, F, C, RS>>, ManagerError<ID, S, K, F, C, RS>> {
         let auth_y = {
             let manager = self.inner.read().await;
             manager.store.auth().await.map_err(GroupError::AuthStore)?
@@ -178,7 +177,8 @@ where
         &self,
         id: ID,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<(Space<ID, S, K, F, M, C, RS>, Vec<M>), ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(Space<ID, S, K, F, C, RS>, Vec<F::Message>), ManagerError<ID, S, K, F, C, RS>>
+    {
         let (auth_y, space_y, messages) = self.create_space(id, initial_members).await?;
         let space_id = space_y.space_id;
 
@@ -207,8 +207,8 @@ where
         id: ID,
         initial_members: &[(ActorId, Access<C>)],
     ) -> Result<
-        (AuthGroupState<C>, SpaceState<ID, M, C>, Vec<M>),
-        ManagerError<ID, S, K, F, M, C, RS>,
+        (AuthGroupState<C>, SpaceState<ID, C>, Vec<F::Message>),
+        ManagerError<ID, S, K, F, C, RS>,
     > {
         let (auth_y, space_y, messages) =
             Space::create(self.clone(), id, initial_members.to_owned())
@@ -225,7 +225,7 @@ where
     pub async fn create_group_persisted(
         &self,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<(Group<ID, S, K, F, M, C, RS>, M), ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(Group<ID, S, K, F, C, RS>, F::Message), ManagerError<ID, S, K, F, C, RS>> {
         let (auth_y, group_id, message) = self.create_group(initial_members).await?;
         self.set_auth(&auth_y)
             .await
@@ -244,7 +244,7 @@ where
     pub async fn create_group(
         &self,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<(AuthGroupState<C>, ActorId, M), ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, ActorId, F::Message), ManagerError<ID, S, K, F, C, RS>> {
         let auth_y = self.auth().await.map_err(ManagerError::AuthStore)?;
 
         // Generate random group id.
@@ -267,12 +267,15 @@ where
     /// We expect messages to be signature-checked, dependency-checked & partially ordered.
     ///
     /// Returns events which inform users of any state changes which occurred.
-    pub async fn process(
+    pub async fn process<M>(
         &self,
         message: &M,
-    ) -> Result<Vec<Event<ID, C>>, ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<Event<ID, C>>, ManagerError<ID, S, K, F, C, RS>>
+    where
+        M: AuthoredMessage + Borrow<SpacesArgs<ID, C>> + Debug,
+    {
         // Route message to the regarding member-, group- or space processor.
-        let events = match message.borrow() {
+        let events = match &message.borrow() {
             // Received key bundle from a member.
             SpacesArgs::KeyBundle { key_bundle } => {
                 let mut manager = self.inner.write().await;
@@ -285,7 +288,7 @@ where
                 vec![event]
             }
             SpacesArgs::Auth { .. } => {
-                let event = Group::process(self.clone(), message)
+                let event = Group::process(self.clone(), &SpacesMessage::auth(message))
                     .await
                     .map_err(ManagerError::Group)?;
 
@@ -296,8 +299,12 @@ where
                 }
             }
             // Received control message related to a space.
-            SpacesArgs::SpaceMembership { .. } => {
-                self.handle_space_membership_message(message).await?
+            SpacesArgs::SpaceMembership { space_id, .. } => {
+                self.handle_space_membership_message(
+                    *space_id,
+                    &SpacesMessage::space_membership(message),
+                )
+                .await?
             }
             SpacesArgs::SpaceUpdate { .. } => unimplemented!(),
             // Received encrypted application data for a space.
@@ -307,7 +314,7 @@ where
                 };
 
                 space
-                    .process(message, None)
+                    .handle_application_message(&SpacesMessage::application(message))
                     .await
                     .map_err(ManagerError::Space)?
             }
@@ -324,7 +331,7 @@ where
     /// The local actor id and their long-term key bundle.
     ///
     /// Note: Key bundle will be rotated if the latest is reaching it's configured expiry date.
-    pub async fn me(&self) -> Result<Member, ManagerError<ID, S, K, F, M, C, RS>> {
+    pub async fn me(&self) -> Result<Member, ManagerError<ID, S, K, F, C, RS>> {
         let mut manager = self.inner.write().await;
         manager
             .identity
@@ -338,7 +345,7 @@ where
     pub async fn register_member(
         &self,
         member: &Member,
-    ) -> Result<(), ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(), ManagerError<ID, S, K, F, C, RS>> {
         let mut manager = self.inner.write().await;
         manager
             .identity
@@ -351,7 +358,7 @@ where
     ///
     /// If `true` then users should rotate their pre-key and generate a new bundle message (which
     /// should then be published) by calling `key_bundle_message`.
-    pub async fn key_bundle_expired(&self) -> Result<bool, ManagerError<ID, S, K, F, M, C, RS>> {
+    pub async fn key_bundle_expired(&self) -> Result<bool, ManagerError<ID, S, K, F, C, RS>> {
         let manager = self.inner.read().await;
         Ok(manager.identity.key_bundle_expired().await?)
     }
@@ -359,7 +366,7 @@ where
     /// Forge a key bundle message containing my latest key bundle.
     ///
     /// Note: Key bundle will be rotated if the latest is reaching it's configured expiry date.
-    pub async fn key_bundle_message(&self) -> Result<M, ManagerError<ID, S, K, F, M, C, RS>> {
+    pub async fn key_bundle_message(&self) -> Result<F::Message, ManagerError<ID, S, K, F, C, RS>> {
         let mut manager = self.inner.write().await;
         manager
             .identity
@@ -383,7 +390,7 @@ where
     /// Returns a list of all spaces which are "out-of-sync" with the global shared auth state.
     pub async fn spaces_repair_required(
         &self,
-    ) -> Result<Vec<ID>, ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<ID>, ManagerError<ID, S, K, F, C, RS>> {
         let manager = self.inner.read().await;
 
         let auth_y = manager
@@ -458,7 +465,7 @@ where
     pub async fn repair_spaces(
         &self,
         space_ids: &Vec<ID>,
-    ) -> Result<Vec<M>, ManagerError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<F::Message>, ManagerError<ID, S, K, F, C, RS>> {
         let mut messages = vec![];
 
         for id in space_ids {
@@ -475,59 +482,52 @@ where
 
     async fn handle_space_membership_message(
         &self,
-        message: &M,
-    ) -> Result<Vec<Event<ID, C>>, ManagerError<ID, S, K, F, M, C, RS>> {
-        let SpacesArgs::SpaceMembership {
-            space_id,
-            auth_message_id,
-            ..
-        } = message.borrow()
-        else {
-            panic!("unexpected message type");
-        };
-
+        space_id: ID,
+        message: &SpaceMembershipMessage,
+    ) -> Result<Vec<Event<ID, C>>, ManagerError<ID, S, K, F, C, RS>> {
         // Get auth message.
         let auth_message = {
             let inner = self.inner.read().await;
+            let auth_message_id = message.auth_message_id;
             let Some(message) = inner
                 .store
-                .message(auth_message_id)
+                .message(&auth_message_id)
                 .await
                 .map_err(ManagerError::MessageStore)?
             else {
                 return Err(ManagerError::MissingAuthMessage(
-                    message.id(),
-                    *auth_message_id,
+                    message.id,
+                    auth_message_id,
                 ));
             };
 
             match message.borrow() {
-                SpacesArgs::Auth { .. } => AuthMessage::from_forged(&message),
+                SpacesArgs::Auth { .. } => SpacesMessage::auth(&message),
                 _ => {
-                    return Err(ManagerError::IncorrectMessageVariant(*auth_message_id));
+                    return Err(ManagerError::IncorrectMessageVariant(auth_message_id));
                 }
             }
         };
 
-        let space = match self.space(*space_id).await? {
+        let space = match self.space(space_id).await? {
             Some(space) => space,
             None => {
                 if !auth_message.action().is_create() {
                     // If this is not a "create" message we should have learned about the space
                     // before. This can be either a faulty message or a problem with the message
                     // orderer.
-                    return Err(ManagerError::UnexpectedMessage(message.id()));
+                    return Err(ManagerError::UnexpectedMessage(message.id));
                 }
 
                 // @TODO: This is a bit strange. What are the API guarantees here over
                 // "inexistant" spaces. We should tell from the outside that a new one is
                 // initialised instead of pointing at an existing one.
-                Space::new(self.clone(), *space_id)
+                Space::new(self.clone(), space_id)
             }
         };
 
         space
-            .process(message, Some(&auth_message))
+            .handle_membership_message(message, &auth_message)
             .await
             .map_err(ManagerError::Space)
     }
@@ -539,8 +539,8 @@ where
     #[cfg(test)]
     pub async fn persist_message(
         &self,
-        message: &M,
-    ) -> Result<(), ManagerError<ID, S, K, F, M, C, RS>> {
+        message: &SpacesMessage<ID, C>,
+    ) -> Result<(), ManagerError<ID, S, K, F, C, RS>> {
         let manager = self.inner.write().await;
         manager
             .store
@@ -553,7 +553,7 @@ where
 
 // Deriving clone on Manager will enforce generics to also impl Clone even though we are wrapping
 // them in an Arc. Related: https://stackoverflow.com/questions/72150623
-impl<ID, S, K, F, M, C, RS> Clone for Manager<ID, S, K, F, M, C, RS> {
+impl<ID, S, K, F, C, RS> Clone for Manager<ID, S, K, F, C, RS> {
     fn clone(&self) -> Self {
         Self {
             actor_id: self.actor_id,
@@ -564,32 +564,32 @@ impl<ID, S, K, F, M, C, RS> Clone for Manager<ID, S, K, F, M, C, RS> {
 
 #[derive(Debug, Error)]
 #[allow(clippy::large_enum_variant)]
-pub enum ManagerError<ID, S, K, F, M, C, RS>
+pub enum ManagerError<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
-    S: SpacesStore<ID, M, C> + AuthStore<C> + MessageStore<M>,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C>,
     K: KeyRegistryStore + KeySecretStore + Debug,
-    F: Forge<ID, M, C> + Debug,
+    F: Forge<ID, C> + Debug,
     C: Conditions,
     RS: AuthResolver<C> + Debug,
 {
     #[error(transparent)]
-    Space(#[from] SpaceError<ID, S, K, F, M, C, RS>),
+    Space(#[from] SpaceError<ID, S, K, F, C, RS>),
 
     #[error(transparent)]
-    Group(#[from] GroupError<ID, S, K, F, M, C, RS>),
+    Group(#[from] GroupError<ID, S, K, F, C, RS>),
 
     #[error(transparent)]
-    IdentityManager(#[from] IdentityError<ID, K, F, M, C>),
+    IdentityManager(#[from] IdentityError<ID, K, F, C>),
 
     #[error("{0}")]
-    SpacesStore(<S as SpacesStore<ID, M, C>>::Error),
+    SpacesStore(<S as SpacesStore<ID, C>>::Error),
 
     #[error("{0}")]
     AuthStore(<S as AuthStore<C>>::Error),
 
     #[error("{0}")]
-    MessageStore(<S as MessageStore<M>>::Error),
+    MessageStore(<S as MessageStore<ID, C>>::Error),
 
     #[error("received unexpected message with id {0}, maybe it arrived out-of-order")]
     UnexpectedMessage(OperationId),

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -70,7 +70,7 @@ where
     // @TODO: the Debug bound is required as we are string formatting the manager error in
     // groups.rs due to challenges handling cyclical errors. If that issue is solved in a more
     // satisfactory way then this bound can be removed.
-    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C> + Debug,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<F::Message> + Debug,
     K: KeyRegistryStore + KeySecretStore + Debug,
     F: Forge<ID, C> + Debug,
     F::Message: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
@@ -539,7 +539,7 @@ where
     #[cfg(test)]
     pub async fn persist_message(
         &self,
-        message: &SpacesMessage<ID, C>,
+        message: &F::Message,
     ) -> Result<(), ManagerError<ID, S, K, F, C, RS>> {
         let manager = self.inner.write().await;
         manager
@@ -567,7 +567,7 @@ impl<ID, S, K, F, C, RS> Clone for Manager<ID, S, K, F, C, RS> {
 pub enum ManagerError<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
-    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C>,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<F::Message>,
     K: KeyRegistryStore + KeySecretStore + Debug,
     F: Forge<ID, C> + Debug,
     C: Conditions,
@@ -589,7 +589,7 @@ where
     AuthStore(<S as AuthStore<C>>::Error),
 
     #[error("{0}")]
-    MessageStore(<S as MessageStore<ID, C>>::Error),
+    MessageStore(<S as MessageStore<F::Message>>::Error),
 
     #[error("received unexpected message with id {0}, maybe it arrived out-of-order")]
     UnexpectedMessage(OperationId),

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -1,13 +1,141 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::borrow::Borrow;
 use std::fmt::Debug;
 
 use p2panda_auth::group::GroupAction;
+use p2panda_auth::traits::Conditions;
 use p2panda_encryption::data_scheme::GroupSecretId;
 use p2panda_encryption::{crypto::xchacha20::XAeadNonce, key_bundle::LongTermKeyBundle};
 use serde::{Deserialize, Serialize};
 
+use crate::auth::message::AuthMessage;
+use crate::traits::{AuthoredMessage, SpaceId};
 use crate::types::{ActorId, EncryptionDirectMessage, OperationId};
+
+/// Spaces message type.
+///
+/// Although the spaces API is generic over concrete data type both when messages are forged
+/// (output) and processed (input) this type is used internally where generic types are not
+/// required and also exposes an API for converting into specific message variants where these are
+/// needed.
+#[derive(Clone, Debug)]
+pub struct SpacesMessage<SID, C> {
+    pub id: OperationId,
+    pub author: ActorId,
+    pub args: SpacesArgs<SID, C>,
+}
+
+impl<SID, C> Borrow<SpacesArgs<SID, C>> for SpacesMessage<SID, C> {
+    fn borrow(&self) -> &SpacesArgs<SID, C> {
+        &self.args
+    }
+}
+
+impl<SID, C> AuthoredMessage for SpacesMessage<SID, C> {
+    fn id(&self) -> OperationId {
+        self.id
+    }
+
+    fn author(&self) -> ActorId {
+        self.author
+    }
+}
+
+/// Message type representing a group membership change on a space.
+pub(crate) struct SpaceMembershipMessage {
+    pub id: OperationId,
+    pub author: ActorId,
+    pub group_id: ActorId,
+    pub space_dependencies: Vec<OperationId>,
+    pub auth_message_id: OperationId,
+    pub direct_messages: Vec<EncryptionDirectMessage>,
+}
+
+/// Message type representing application messages.
+pub(crate) struct ApplicationMessage {
+    pub id: OperationId,
+    pub author: ActorId,
+    pub space_dependencies: Vec<OperationId>,
+    pub group_secret_id: GroupSecretId,
+    pub nonce: XAeadNonce,
+    pub ciphertext: Vec<u8>,
+}
+
+impl<SID, C> SpacesMessage<SID, C>
+where
+    SID: SpaceId,
+    C: Conditions,
+{
+    pub(crate) fn space_membership<M>(message: &M) -> SpaceMembershipMessage
+    where
+        M: AuthoredMessage + Borrow<SpacesArgs<SID, C>>,
+    {
+        let SpacesArgs::SpaceMembership {
+            group_id,
+            space_dependencies,
+            auth_message_id,
+            direct_messages,
+            ..
+        } = message.borrow().clone()
+        else {
+            panic!("unexpected message type")
+        };
+        SpaceMembershipMessage {
+            id: message.id(),
+            author: message.author(),
+            group_id,
+            space_dependencies,
+            auth_message_id,
+            direct_messages,
+        }
+    }
+
+    pub(crate) fn auth<M>(message: &M) -> AuthMessage<C>
+    where
+        M: AuthoredMessage + Borrow<SpacesArgs<SID, C>>,
+    {
+        let SpacesArgs::Auth {
+            group_id,
+            group_action,
+            auth_dependencies,
+        } = &message.borrow()
+        else {
+            panic!("unexpected message type")
+        };
+        AuthMessage {
+            operation_id: message.id(),
+            author: message.author(),
+            dependencies: auth_dependencies.to_owned(),
+            group_id: *group_id,
+            action: group_action.to_owned(),
+        }
+    }
+
+    pub(crate) fn application<M>(message: &M) -> ApplicationMessage
+    where
+        M: AuthoredMessage + Borrow<SpacesArgs<SID, C>>,
+    {
+        let SpacesArgs::Application {
+            space_dependencies,
+            group_secret_id,
+            nonce,
+            ciphertext,
+            ..
+        } = message.borrow().to_owned()
+        else {
+            panic!("unexpected message type")
+        };
+        ApplicationMessage {
+            id: message.id(),
+            author: message.author(),
+            space_dependencies,
+            group_secret_id,
+            nonce,
+            ciphertext,
+        }
+    }
+}
 
 /// Enum representing all possible message types.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -64,7 +64,7 @@ pub struct Space<ID, S, K, F, C, RS> {
 impl<ID, S, K, F, C, RS> Space<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
-    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C> + Debug,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<F::Message> + Debug,
     K: KeyRegistryStore + KeySecretStore + Debug,
     F: Forge<ID, C> + Debug,
     F::Message: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
@@ -794,7 +794,7 @@ where
 pub enum SpaceError<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
-    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C>,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<F::Message>,
     K: KeyRegistryStore + KeySecretStore + Debug,
     F: Forge<ID, C> + Debug,
     C: Conditions,
@@ -819,7 +819,7 @@ where
     AuthStore(<S as AuthStore<C>>::Error),
 
     #[error("{0}")]
-    MessageStore(<S as MessageStore<ID, C>>::Error),
+    MessageStore(<S as MessageStore<F::Message>>::Error),
 
     #[error("{0}")]
     SpacesStore(<S as SpacesStore<ID, C>>::Error),

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -22,7 +22,7 @@ use crate::event::{Event, encryption_output_to_space_events, space_message_to_sp
 use crate::group::{Group, GroupError};
 use crate::identity::IdentityError;
 use crate::manager::Manager;
-use crate::message::SpacesArgs;
+use crate::message::{ApplicationMessage, SpaceMembershipMessage, SpacesArgs, SpacesMessage};
 use crate::traits::{
     AuthStore, AuthoredMessage, Forge, KeyRegistryStore, KeySecretStore, MessageStore, SpaceId,
     SpacesStore,
@@ -48,12 +48,12 @@ use crate::utils::{added_members, removed_members, secret_members, sort_members}
 /// Members with only Pull access are not included in the encryption context and won't receive any
 /// group secrets. Only members with Manage access level are allowed to manage the groups members.
 #[derive(Debug)]
-pub struct Space<ID, S, K, F, M, C, RS> {
+pub struct Space<ID, S, K, F, C, RS> {
     /// Reference to the manager.
     ///
     /// This allows us build an API where users can treat "space" instances independently from the
     /// manager API, even though internally it has a reference to it.
-    manager: Manager<ID, S, K, F, M, C, RS>,
+    manager: Manager<ID, S, K, F, C, RS>,
 
     /// Id of the space.
     ///
@@ -61,17 +61,17 @@ pub struct Space<ID, S, K, F, M, C, RS> {
     id: ID,
 }
 
-impl<ID, S, K, F, M, C, RS> Space<ID, S, K, F, M, C, RS>
+impl<ID, S, K, F, C, RS> Space<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
-    S: SpacesStore<ID, M, C> + AuthStore<C> + MessageStore<M> + Debug,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C> + Debug,
     K: KeyRegistryStore + KeySecretStore + Debug,
-    F: Forge<ID, M, C> + Debug,
-    M: AuthoredMessage + Borrow<SpacesArgs<ID, C>> + Debug,
+    F: Forge<ID, C> + Debug,
+    F::Message: AuthoredMessage + Borrow<SpacesArgs<ID, C>>,
     C: Conditions,
     RS: Debug + AuthResolver<C>,
 {
-    pub(crate) fn new(manager_ref: Manager<ID, S, K, F, M, C, RS>, id: ID) -> Self {
+    pub(crate) fn new(manager_ref: Manager<ID, S, K, F, C, RS>, id: ID) -> Self {
         Self {
             manager: manager_ref,
             id,
@@ -85,11 +85,13 @@ where
     ///
     /// Returns resulting auth and space state and messages for processing.
     pub(crate) async fn create(
-        manager_ref: Manager<ID, S, K, F, M, C, RS>,
+        manager_ref: Manager<ID, S, K, F, C, RS>,
         space_id: ID,
         mut initial_members: Vec<(ActorId, Access<C>)>,
-    ) -> Result<(AuthGroupState<C>, SpaceState<ID, M, C>, Vec<M>), SpaceError<ID, S, K, F, M, C, RS>>
-    {
+    ) -> Result<
+        (AuthGroupState<C>, SpaceState<ID, C>, Vec<F::Message>),
+        SpaceError<ID, S, K, F, C, RS>,
+    > {
         let my_id = manager_ref.id();
 
         // Automatically add ourselves with "manage" level without any conditions as default.
@@ -116,8 +118,12 @@ where
                 .map_err(SpaceError::Group)?;
 
         // Apply the "create" auth message to the space state.
-        let (space_y, create_space) =
-            Space::process_auth_message(manager_ref.clone(), space_y, &create_group).await?;
+        let (space_y, create_space) = Space::process_auth_message(
+            manager_ref.clone(),
+            space_y,
+            &SpacesMessage::auth(&create_group),
+        )
+        .await?;
 
         let mut messages = vec![create_group];
         messages.extend(space_history);
@@ -134,7 +140,7 @@ where
         &self,
         member: ActorId,
         access: Access<C>,
-    ) -> Result<(M, M), SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(F::Message, F::Message), SpaceError<ID, S, K, F, C, RS>> {
         let (auth_y, space_y, auth_message, space_message) = self.add(member, access).await?;
 
         self.manager
@@ -153,14 +159,20 @@ where
         &self,
         member: ActorId,
         access: Access<C>,
-    ) -> Result<(AuthGroupState<C>, SpaceState<ID, M, C>, M, M), SpaceError<ID, S, K, F, M, C, RS>>
-    {
+    ) -> Result<
+        (AuthGroupState<C>, SpaceState<ID, C>, F::Message, F::Message),
+        SpaceError<ID, S, K, F, C, RS>,
+    > {
         let space_y = self.state().await?;
         let group = Group::new(self.manager.clone(), space_y.group_id);
         let (auth_y, auth_message) = group.add(member, access).await.map_err(SpaceError::Group)?;
 
-        let (space_y, space_message) =
-            Space::process_auth_message(self.manager.clone(), space_y, &auth_message).await?;
+        let (space_y, space_message) = Space::process_auth_message(
+            self.manager.clone(),
+            space_y,
+            &SpacesMessage::auth(&auth_message),
+        )
+        .await?;
 
         Ok((auth_y, space_y, auth_message, space_message))
     }
@@ -172,7 +184,7 @@ where
     pub async fn remove_persisted(
         &self,
         member: ActorId,
-    ) -> Result<(M, M), SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(F::Message, F::Message), SpaceError<ID, S, K, F, C, RS>> {
         let (auth_y, space_y, auth_message, space_message) = self.remove(member).await?;
 
         self.manager
@@ -190,14 +202,20 @@ where
     pub async fn remove(
         &self,
         member: ActorId,
-    ) -> Result<(AuthGroupState<C>, SpaceState<ID, M, C>, M, M), SpaceError<ID, S, K, F, M, C, RS>>
-    {
+    ) -> Result<
+        (AuthGroupState<C>, SpaceState<ID, C>, F::Message, F::Message),
+        SpaceError<ID, S, K, F, C, RS>,
+    > {
         let space_y = self.state().await?;
         let group = Group::new(self.manager.clone(), space_y.group_id);
         let (auth_y, auth_message) = group.remove(member).await.map_err(SpaceError::Group)?;
 
-        let (space_y, space_message) =
-            Space::process_auth_message(self.manager.clone(), space_y, &auth_message).await?;
+        let (space_y, space_message) = Space::process_auth_message(
+            self.manager.clone(),
+            space_y,
+            &SpacesMessage::auth(&auth_message),
+        )
+        .await?;
 
         Ok((auth_y, space_y, auth_message, space_message))
     }
@@ -206,16 +224,15 @@ where
     /// resulting group membership changes. Any resulting encryption direct messages are included
     /// in the space message alongside a reference to the auth message.
     pub(crate) async fn process_auth_message(
-        manager_ref: Manager<ID, S, K, F, M, C, RS>,
-        mut y: SpaceState<ID, M, C>,
-        auth_message: &M,
-    ) -> Result<(SpaceState<ID, M, C>, M), SpaceError<ID, S, K, F, M, C, RS>> {
+        manager_ref: Manager<ID, S, K, F, C, RS>,
+        mut y: SpaceState<ID, C>,
+        auth_message: &AuthMessage<C>,
+    ) -> Result<(SpaceState<ID, C>, F::Message), SpaceError<ID, S, K, F, C, RS>> {
         // Get current space members.
         let current_members = secret_members(y.auth_y.members(y.group_id));
 
         // Process auth message on local auth state.
-        let auth_message = AuthMessage::from_forged(auth_message);
-        y.auth_y = AuthGroup::process(y.auth_y, &auth_message).map_err(SpaceError::AuthGroup)?;
+        y.auth_y = AuthGroup::process(y.auth_y, auth_message).map_err(SpaceError::AuthGroup)?;
 
         // Get next space members.
         let next_members = secret_members(y.auth_y.members(y.group_id));
@@ -225,7 +242,7 @@ where
             let manager = manager_ref.inner.read().await;
             Self::apply_secret_member_change(
                 y.encryption_y,
-                &auth_message,
+                auth_message,
                 current_members.clone(),
                 next_members.clone(),
                 &manager.rng,
@@ -259,32 +276,6 @@ where
         Ok((y, space_message))
     }
 
-    /// Process a space message along with it's relevant auth message (if required).
-    ///
-    /// Returns events which inform users of any state changes which occurred.
-    pub(crate) async fn process(
-        &self,
-        space_message: &M,
-        auth_message: Option<&AuthMessage<C>>,
-    ) -> Result<Vec<Event<ID, C>>, SpaceError<ID, S, K, F, M, C, RS>> {
-        let events = match space_message.borrow() {
-            SpacesArgs::SpaceMembership { space_id, .. } => {
-                assert_eq!(space_id, &self.id); // Sanity check.
-                let auth_message =
-                    auth_message.expect("all space membership messages have auth message");
-                self.handle_membership_message(space_message, auth_message)
-                    .await?
-            }
-            SpacesArgs::Application { space_id, .. } => {
-                assert_eq!(space_id, &self.id); // Sanity check.
-                self.handle_application_message(space_message).await?
-            }
-            _ => panic!("unexpected message"),
-        };
-
-        Ok(events)
-    }
-
     /// Instantiate space state from existing global auth state.
     ///
     /// Every space contains pointers to all messages published to the global auth state. This
@@ -292,10 +283,10 @@ where
     /// space. None of the messages will contain encryption control messages as they were
     /// published before the space existed.
     async fn from_group(
-        manager_ref: Manager<ID, S, K, F, M, C, RS>,
+        manager_ref: Manager<ID, S, K, F, C, RS>,
         space_id: ID,
         group_id: ActorId,
-    ) -> Result<(SpaceState<ID, M, C>, Vec<M>), SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<(SpaceState<ID, C>, Vec<F::Message>), SpaceError<ID, S, K, F, C, RS>> {
         // Instantiate empty space state.
         let mut y = { Self::get_or_init_state(space_id, group_id, manager_ref.clone()).await? };
         let mut messages = vec![];
@@ -336,26 +327,23 @@ where
 
     /// Handle messages which effect the space membership. Each of these messages contained a
     /// pointer to an auth message and the auth message is required here.
-    async fn handle_membership_message(
+    pub(crate) async fn handle_membership_message(
         &self,
-        space_message: &M,
+        space_message: &SpaceMembershipMessage,
         auth_message: &AuthMessage<C>,
-    ) -> Result<Vec<Event<ID, C>>, SpaceError<ID, S, K, F, M, C, RS>> {
-        let SpacesArgs::SpaceMembership {
-            space_id,
+    ) -> Result<Vec<Event<ID, C>>, SpaceError<ID, S, K, F, C, RS>> {
+        let SpaceMembershipMessage {
+            id,
             group_id,
             space_dependencies,
             ..
-        } = space_message.borrow()
-        else {
-            panic!("unexpected message type");
-        };
+        } = space_message;
 
         // Get space state and current members.
         let mut y = Self::get_or_init_state(self.id, *group_id, self.manager.clone()).await?;
 
         // If we already processed this message return here.
-        if y.encryption_y.orderer.has_seen(space_message.id()) {
+        if y.encryption_y.orderer.has_seen(*id) {
             return Ok(vec![]);
         }
 
@@ -407,7 +395,7 @@ where
             let manager = self.manager.inner.write().await;
             y.encryption_y
                 .orderer
-                .add_dependency(space_message.id(), space_dependencies);
+                .add_dependency(*id, space_dependencies);
             manager
                 .store
                 .set_space(&self.id, y)
@@ -416,7 +404,7 @@ where
         }
 
         let events = if !duplicate_pointer {
-            let mut events = encryption_output_to_space_events(space_id, encryption_output);
+            let mut events = encryption_output_to_space_events(&self.id(), encryption_output);
 
             // If current and next member sets are equal it indicates that the space is not affected
             // by this auth change. This can be because the space wasn't created yet, or the auth
@@ -428,6 +416,7 @@ where
 
             // Construct space membership event.
             let membership_event = space_message_to_space_event(
+                self.id(),
                 space_message,
                 auth_message,
                 current_members,
@@ -450,15 +439,13 @@ where
     /// members (those with "read" access) is computed and only the diff processed on the
     /// encryption group.
     async fn apply_secret_member_change(
-        mut encryption_y: EncryptionGroupState<M>,
+        mut encryption_y: EncryptionGroupState,
         auth_message: &AuthMessage<C>,
         current_members: Vec<ActorId>,
         next_members: Vec<ActorId>,
         rng: &Rng,
-    ) -> Result<
-        (EncryptionGroupState<M>, Vec<EncryptionDirectMessage>),
-        SpaceError<ID, S, K, F, M, C, RS>,
-    > {
+    ) -> Result<(EncryptionGroupState, Vec<EncryptionDirectMessage>), SpaceError<ID, S, K, F, C, RS>>
+    {
         // Make the DGM aware of group members after this group membership change has been
         // processed.
         encryption_y.dcgka.dgm = EncryptionMembershipState {
@@ -515,17 +502,10 @@ where
     }
 
     /// Handle space application messages.
-    async fn handle_application_message(
+    pub(crate) async fn handle_application_message(
         &self,
-        message: &M,
-    ) -> Result<Vec<Event<ID, C>>, SpaceError<ID, S, K, F, M, C, RS>> {
-        let SpacesArgs::Application {
-            space_dependencies, ..
-        } = message.borrow()
-        else {
-            panic!("unexpected message type")
-        };
-
+        message: &ApplicationMessage,
+    ) -> Result<Vec<Event<ID, C>>, SpaceError<ID, S, K, F, C, RS>> {
         let mut y = self.state().await?;
 
         // Process encryption message.
@@ -540,7 +520,7 @@ where
         // Update dependencies.
         y.encryption_y
             .orderer
-            .add_dependency(encryption_message.id(), space_dependencies);
+            .add_dependency(encryption_message.id(), &message.space_dependencies);
 
         // Persist new state.
         let events = encryption_output_to_space_events(&y.space_id, encryption_output);
@@ -554,7 +534,7 @@ where
         Ok(events)
     }
 
-    pub async fn repair(&self) -> Result<Vec<M>, SpaceError<ID, S, K, F, M, C, RS>> {
+    pub async fn repair(&self) -> Result<Vec<F::Message>, SpaceError<ID, S, K, F, C, RS>> {
         let global_auth_y = {
             let manager = self.manager.inner.read().await;
             manager.store.auth().await.map_err(SpaceError::AuthStore)?
@@ -586,8 +566,12 @@ where
                     .expect("message present in store")
             };
 
-            let (y, space_message) =
-                Space::process_auth_message(self.manager.clone(), y, &message).await?;
+            let (y, space_message) = Space::process_auth_message(
+                self.manager.clone(),
+                y,
+                &SpacesMessage::auth(&message),
+            )
+            .await?;
             Space::set_state(self.manager.clone(), self.id(), y).await?;
 
             messages.push(space_message);
@@ -597,9 +581,7 @@ where
     }
 
     /// Get the space state.
-    pub(crate) async fn state(
-        &self,
-    ) -> Result<SpaceState<ID, M, C>, SpaceError<ID, S, K, F, M, C, RS>> {
+    pub(crate) async fn state(&self) -> Result<SpaceState<ID, C>, SpaceError<ID, S, K, F, C, RS>> {
         let manager = self.manager.inner.read().await;
         let mut space_y = manager
             .store
@@ -623,8 +605,8 @@ where
     async fn get_or_init_state(
         space_id: ID,
         group_id: ActorId,
-        manager_ref: Manager<ID, S, K, F, M, C, RS>,
-    ) -> Result<SpaceState<ID, M, C>, SpaceError<ID, S, K, F, M, C, RS>> {
+        manager_ref: Manager<ID, S, K, F, C, RS>,
+    ) -> Result<SpaceState<ID, C>, SpaceError<ID, S, K, F, C, RS>> {
         let manager = manager_ref.inner.read().await;
 
         let key_manager_y = manager.identity.key_manager().await?;
@@ -675,10 +657,10 @@ where
     }
 
     async fn set_state(
-        manager_ref: Manager<ID, S, K, F, M, C, RS>,
+        manager_ref: Manager<ID, S, K, F, C, RS>,
         space_id: ID,
-        y: SpaceState<ID, M, C>,
-    ) -> Result<(), SpaceError<ID, S, K, F, M, C, RS>> {
+        y: SpaceState<ID, C>,
+    ) -> Result<(), SpaceError<ID, S, K, F, C, RS>> {
         let manager = manager_ref.inner.write().await;
         manager
             .store
@@ -693,7 +675,7 @@ where
     }
 
     /// Id of the group associated with this space.
-    pub async fn group_id(&self) -> Result<ActorId, SpaceError<ID, S, K, F, M, C, RS>> {
+    pub async fn group_id(&self) -> Result<ActorId, SpaceError<ID, S, K, F, C, RS>> {
         let y = self.state().await?;
         Ok(y.group_id)
     }
@@ -701,7 +683,7 @@ where
     /// The members of this space.
     pub async fn members(
         &self,
-    ) -> Result<Vec<(ActorId, Access<C>)>, SpaceError<ID, S, K, F, M, C, RS>> {
+    ) -> Result<Vec<(ActorId, Access<C>)>, SpaceError<ID, S, K, F, C, RS>> {
         let y = self.state().await?;
         let mut group_members = y.auth_y.members(y.group_id);
         sort_members(&mut group_members);
@@ -709,7 +691,10 @@ where
     }
 
     /// Publish a message encrypted towards all current group members.
-    pub async fn publish(&self, plaintext: &[u8]) -> Result<M, SpaceError<ID, S, K, F, M, C, RS>> {
+    pub async fn publish(
+        &self,
+        plaintext: &[u8],
+    ) -> Result<F::Message, SpaceError<ID, S, K, F, C, RS>> {
         let mut y = self.state().await?;
 
         if !y.encryption_y.orderer.is_welcomed() {
@@ -771,7 +756,7 @@ where
 /// Space state object.
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
-pub struct SpaceState<ID, M, C>
+pub struct SpaceState<ID, C>
 where
     C: Conditions,
 {
@@ -781,10 +766,10 @@ where
     // @TODO: This contains the PKI and KMG states and other unnecessary data we don't need to
     // persist. We can make the fields public in `p2panda-encryption` and extract only the
     // information we really need.
-    pub encryption_y: EncryptionGroupState<M>,
+    pub encryption_y: EncryptionGroupState,
 }
 
-impl<ID, M, C> SpaceState<ID, M, C>
+impl<ID, C> SpaceState<ID, C>
 where
     ID: SpaceId,
     C: Conditions,
@@ -793,7 +778,7 @@ where
         space_id: ID,
         group_id: ActorId,
         auth_y: AuthGroupState<C>,
-        encryption_y: EncryptionGroupState<M>,
+        encryption_y: EncryptionGroupState,
     ) -> Self {
         Self {
             space_id,
@@ -806,12 +791,12 @@ where
 
 /// Space error type.
 #[derive(Debug, Error)]
-pub enum SpaceError<ID, S, K, F, M, C, RS>
+pub enum SpaceError<ID, S, K, F, C, RS>
 where
     ID: SpaceId,
-    S: SpacesStore<ID, M, C> + AuthStore<C> + MessageStore<M>,
+    S: SpacesStore<ID, C> + AuthStore<C> + MessageStore<ID, C>,
     K: KeyRegistryStore + KeySecretStore + Debug,
-    F: Forge<ID, M, C> + Debug,
+    F: Forge<ID, C> + Debug,
     C: Conditions,
     RS: AuthResolver<C> + Debug,
 {
@@ -822,22 +807,22 @@ where
     AuthGroup(AuthGroupError<C, RS>),
 
     #[error("{0}")]
-    Group(GroupError<ID, S, K, F, M, C, RS>),
+    Group(GroupError<ID, S, K, F, C, RS>),
 
     #[error("{0}")]
-    EncryptionGroup(EncryptionGroupError<M>),
+    EncryptionGroup(EncryptionGroupError),
 
     #[error(transparent)]
-    IdentityManager(#[from] IdentityError<ID, K, F, M, C>),
+    IdentityManager(#[from] IdentityError<ID, K, F, C>),
 
     #[error("{0}")]
     AuthStore(<S as AuthStore<C>>::Error),
 
     #[error("{0}")]
-    MessageStore(<S as MessageStore<M>>::Error),
+    MessageStore(<S as MessageStore<ID, C>>::Error),
 
     #[error("{0}")]
-    SpacesStore(<S as SpacesStore<ID, M, C>>::Error),
+    SpacesStore(<S as SpacesStore<ID, C>>::Error),
 
     #[error("{0}")]
     EncryptionOrderer(Infallible),

--- a/p2panda-spaces/src/test_utils/forge.rs
+++ b/p2panda-spaces/src/test_utils/forge.rs
@@ -20,7 +20,7 @@ pub struct TestForge<S> {
 
 impl<S> TestForge<S>
 where
-    S: MessageStore<TestSpaceId, TestConditions>,
+    S: MessageStore<SpacesMessage<TestSpaceId, TestConditions>>,
 {
     pub fn new(store: S, signing_key: SigningKey) -> Self {
         Self {
@@ -44,7 +44,7 @@ pub struct TestForgeInner {
 
 impl<S> Forge<TestSpaceId, TestConditions> for TestForge<S>
 where
-    S: MessageStore<TestSpaceId, TestConditions>,
+    S: MessageStore<SpacesMessage<TestSpaceId, TestConditions>>,
 {
     type Message = SpacesMessage<TestSpaceId, TestConditions>;
     type Error = Infallible;

--- a/p2panda-spaces/src/test_utils/forge.rs
+++ b/p2panda-spaces/src/test_utils/forge.rs
@@ -3,13 +3,13 @@
 use std::convert::Infallible;
 use std::sync::Arc;
 
-use p2panda_core::{SigningKey, VerifyingKey};
+use p2panda_core::{Hash, SigningKey, VerifyingKey};
 use tokio::sync::RwLock;
 
-use crate::message::SpacesArgs;
+use crate::message::{SpacesArgs, SpacesMessage};
 use crate::test_utils::message::SeqNum;
-use crate::test_utils::{TestConditions, TestMessage, TestSpaceId};
-use crate::traits::{AuthoredMessage, Forge, MessageStore};
+use crate::test_utils::{TestConditions, TestSpaceId};
+use crate::traits::{Forge, MessageStore};
 
 #[derive(Debug, Clone)]
 pub struct TestForge<S> {
@@ -20,7 +20,7 @@ pub struct TestForge<S> {
 
 impl<S> TestForge<S>
 where
-    S: MessageStore<TestMessage>,
+    S: MessageStore<TestSpaceId, TestConditions>,
 {
     pub fn new(store: S, signing_key: SigningKey) -> Self {
         Self {
@@ -42,10 +42,11 @@ pub struct TestForgeInner {
     signing_key: SigningKey,
 }
 
-impl<S> Forge<TestSpaceId, TestMessage, TestConditions> for TestForge<S>
+impl<S> Forge<TestSpaceId, TestConditions> for TestForge<S>
 where
-    S: MessageStore<TestMessage>,
+    S: MessageStore<TestSpaceId, TestConditions>,
 {
+    type Message = SpacesMessage<TestSpaceId, TestConditions>;
     type Error = Infallible;
 
     fn verifying_key(&self) -> VerifyingKey {
@@ -55,7 +56,7 @@ where
     async fn forge(
         &self,
         args: SpacesArgs<TestSpaceId, TestConditions>,
-    ) -> Result<TestMessage, Self::Error> {
+    ) -> Result<Self::Message, Self::Error> {
         let seq_num = {
             let mut inner = self.inner.write().await;
             let seq_num = inner.next_seq_num;
@@ -63,16 +64,17 @@ where
             seq_num
         };
 
-        let message = TestMessage {
-            seq_num,
-            verifying_key: self.verifying_key,
-            spaces_args: args,
+        let mut buffer: Vec<u8> = self.verifying_key.as_bytes().to_vec();
+        buffer.extend_from_slice(&seq_num.to_be_bytes());
+        let hash = Hash::digest(buffer).into();
+
+        let message = SpacesMessage {
+            id: hash,
+            author: self.verifying_key().into(),
+            args,
         };
 
-        self.store
-            .set_message(&message.id(), &message)
-            .await
-            .unwrap();
+        self.store.set_message(&message.id, &message).await.unwrap();
 
         Ok(message)
     }

--- a/p2panda-spaces/src/test_utils/message.rs
+++ b/p2panda-spaces/src/test_utils/message.rs
@@ -1,37 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::borrow::Borrow;
-
-use p2panda_core::{Hash, VerifyingKey};
-
-use crate::message::SpacesArgs;
+use crate::message::SpacesMessage;
 use crate::test_utils::{TestConditions, TestSpaceId};
-use crate::traits::AuthoredMessage;
-use crate::{ActorId, OperationId};
 
 pub type SeqNum = u64;
 
-#[derive(Clone, Debug)]
-pub struct TestMessage {
-    pub seq_num: SeqNum,
-    pub verifying_key: VerifyingKey,
-    pub spaces_args: SpacesArgs<TestSpaceId, TestConditions>,
-}
-
-impl AuthoredMessage for TestMessage {
-    fn id(&self) -> OperationId {
-        let mut buffer: Vec<u8> = self.verifying_key.as_bytes().to_vec();
-        buffer.extend_from_slice(&self.seq_num.to_be_bytes());
-        Hash::digest(buffer).into()
-    }
-
-    fn author(&self) -> ActorId {
-        self.verifying_key.into()
-    }
-}
-
-impl Borrow<SpacesArgs<TestSpaceId, TestConditions>> for TestMessage {
-    fn borrow(&self) -> &SpacesArgs<TestSpaceId, TestConditions> {
-        &self.spaces_args
-    }
-}
+pub type TestMessage = SpacesMessage<TestSpaceId, TestConditions>;

--- a/p2panda-spaces/src/test_utils/mod.rs
+++ b/p2panda-spaces/src/test_utils/mod.rs
@@ -34,7 +34,6 @@ pub type TestManager = Manager<
     TestStore,
     TestKeyStore,
     TestForge<TestStore>,
-    TestMessage,
     TestConditions,
     StrongRemoveResolver<TestConditions>,
 >;
@@ -44,7 +43,6 @@ pub type TestSpaceError = SpaceError<
     TestStore,
     TestKeyStore,
     TestForge<TestStore>,
-    TestMessage,
     TestConditions,
     StrongRemoveResolver<TestConditions>,
 >;

--- a/p2panda-spaces/src/test_utils/mod.rs
+++ b/p2panda-spaces/src/test_utils/mod.rs
@@ -16,7 +16,7 @@ use crate::types::StrongRemoveResolver;
 
 pub use forge::TestForge;
 pub use message::TestMessage;
-pub use store::{TestKeyStore, TestStore};
+pub use store::{MemoryStore, TestKeyStore, TestStore};
 
 pub type TestSpaceId = usize;
 

--- a/p2panda-spaces/src/test_utils/store.rs
+++ b/p2panda-spaces/src/test_utils/store.rs
@@ -10,9 +10,12 @@ use p2panda_encryption::key_registry::{KeyRegistry, KeyRegistryState};
 use tokio::sync::RwLock;
 
 use crate::OperationId;
+use crate::message::SpacesMessage;
 use crate::space::SpaceState;
 use crate::test_utils::{TestConditions, TestMessage, TestSpaceId};
-use crate::traits::{AuthStore, KeyRegistryStore, KeySecretStore, MessageStore, SpacesStore};
+use crate::traits::{
+    AuthStore, KeyRegistryStore, KeySecretStore, MessageStore, SpaceId, SpacesStore,
+};
 use crate::types::{ActorId, AuthGroupState};
 
 pub type TestStore = MemoryStore<TestMessage, TestConditions>;
@@ -23,7 +26,7 @@ where
     C: Conditions,
 {
     auth: AuthGroupState<C>,
-    spaces: HashMap<TestSpaceId, SpaceState<TestSpaceId, M, C>>,
+    spaces: HashMap<TestSpaceId, SpaceState<TestSpaceId, C>>,
     messages: HashMap<OperationId, M>,
 }
 
@@ -53,9 +56,8 @@ where
     }
 }
 
-impl<M, C> SpacesStore<TestSpaceId, M, C> for MemoryStore<M, C>
+impl<M, C> SpacesStore<TestSpaceId, C> for MemoryStore<M, C>
 where
-    M: Clone,
     C: Conditions,
 {
     type Error = Infallible;
@@ -63,7 +65,7 @@ where
     async fn space(
         &self,
         id: &TestSpaceId,
-    ) -> Result<Option<SpaceState<TestSpaceId, M, C>>, Self::Error> {
+    ) -> Result<Option<SpaceState<TestSpaceId, C>>, Self::Error> {
         let inner = self.inner.read().await;
         Ok(inner.spaces.get(id).cloned())
     }
@@ -81,7 +83,7 @@ where
     async fn set_space(
         &self,
         id: &TestSpaceId,
-        y: SpaceState<TestSpaceId, M, C>,
+        y: SpaceState<TestSpaceId, C>,
     ) -> Result<(), Self::Error> {
         let mut inner = self.inner.write().await;
         inner.spaces.insert(*id, y);
@@ -107,19 +109,26 @@ where
     }
 }
 
-impl<M, C> MessageStore<M> for MemoryStore<M, C>
+impl<SID, C> MessageStore<SID, C> for MemoryStore<SpacesMessage<SID, C>, C>
 where
-    M: Clone,
+    SID: SpaceId,
     C: Conditions,
 {
     type Error = Infallible;
 
-    async fn message(&self, id: &OperationId) -> Result<Option<M>, Self::Error> {
+    async fn message(
+        &self,
+        id: &OperationId,
+    ) -> Result<Option<SpacesMessage<SID, C>>, Self::Error> {
         let inner = self.inner.read().await;
         Ok(inner.messages.get(id).cloned())
     }
 
-    async fn set_message(&self, id: &OperationId, message: &M) -> Result<(), Self::Error> {
+    async fn set_message(
+        &self,
+        id: &OperationId,
+        message: &SpacesMessage<SID, C>,
+    ) -> Result<(), Self::Error> {
         let mut inner = self.inner.write().await;
         inner.messages.insert(*id, message.clone());
         Ok(())

--- a/p2panda-spaces/src/test_utils/store.rs
+++ b/p2panda-spaces/src/test_utils/store.rs
@@ -10,7 +10,6 @@ use p2panda_encryption::key_registry::{KeyRegistry, KeyRegistryState};
 use tokio::sync::RwLock;
 
 use crate::OperationId;
-use crate::message::SpacesMessage;
 use crate::space::SpaceState;
 use crate::test_utils::{TestConditions, TestMessage, TestSpaceId};
 use crate::traits::{
@@ -18,27 +17,27 @@ use crate::traits::{
 };
 use crate::types::{ActorId, AuthGroupState};
 
-pub type TestStore = MemoryStore<TestMessage, TestConditions>;
+pub type TestStore = MemoryStore<TestSpaceId, TestMessage, TestConditions>;
 
 #[derive(Debug)]
-pub struct MemoryStoreInner<M, C>
+pub struct MemoryStoreInner<ID, M, C>
 where
     C: Conditions,
 {
     auth: AuthGroupState<C>,
-    spaces: HashMap<TestSpaceId, SpaceState<TestSpaceId, C>>,
+    spaces: HashMap<ID, SpaceState<ID, C>>,
     messages: HashMap<OperationId, M>,
 }
 
 #[derive(Debug, Clone)]
-pub struct MemoryStore<M, C>
+pub struct MemoryStore<ID, M, C>
 where
     C: Conditions,
 {
-    pub(crate) inner: Arc<RwLock<MemoryStoreInner<M, C>>>,
+    pub(crate) inner: Arc<RwLock<MemoryStoreInner<ID, M, C>>>,
 }
 
-impl<M, C> MemoryStore<M, C>
+impl<ID, M, C> MemoryStore<ID, M, C>
 where
     C: Conditions,
 {
@@ -56,42 +55,36 @@ where
     }
 }
 
-impl<M, C> SpacesStore<TestSpaceId, C> for MemoryStore<M, C>
+impl<ID, M, C> SpacesStore<ID, C> for MemoryStore<ID, M, C>
 where
+    ID: SpaceId,
     C: Conditions,
 {
     type Error = Infallible;
 
-    async fn space(
-        &self,
-        id: &TestSpaceId,
-    ) -> Result<Option<SpaceState<TestSpaceId, C>>, Self::Error> {
+    async fn space(&self, id: &ID) -> Result<Option<SpaceState<ID, C>>, Self::Error> {
         let inner = self.inner.read().await;
         Ok(inner.spaces.get(id).cloned())
     }
 
-    async fn has_space(&self, id: &TestSpaceId) -> Result<bool, Self::Error> {
+    async fn has_space(&self, id: &ID) -> Result<bool, Self::Error> {
         let inner = self.inner.read().await;
         Ok(inner.spaces.contains_key(id))
     }
 
-    async fn spaces_ids(&self) -> Result<Vec<TestSpaceId>, Self::Error> {
+    async fn spaces_ids(&self) -> Result<Vec<ID>, Self::Error> {
         let inner = self.inner.read().await;
         Ok(inner.spaces.keys().cloned().collect())
     }
 
-    async fn set_space(
-        &self,
-        id: &TestSpaceId,
-        y: SpaceState<TestSpaceId, C>,
-    ) -> Result<(), Self::Error> {
+    async fn set_space(&self, id: &ID, y: SpaceState<ID, C>) -> Result<(), Self::Error> {
         let mut inner = self.inner.write().await;
         inner.spaces.insert(*id, y);
         Ok(())
     }
 }
 
-impl<M, C> AuthStore<C> for MemoryStore<M, C>
+impl<ID, M, C> AuthStore<C> for MemoryStore<ID, M, C>
 where
     C: Conditions,
 {
@@ -109,26 +102,20 @@ where
     }
 }
 
-impl<SID, C> MessageStore<SID, C> for MemoryStore<SpacesMessage<SID, C>, C>
+impl<ID, M, C> MessageStore<M> for MemoryStore<ID, M, C>
 where
-    SID: SpaceId,
+    ID: SpaceId,
+    M: Clone,
     C: Conditions,
 {
     type Error = Infallible;
 
-    async fn message(
-        &self,
-        id: &OperationId,
-    ) -> Result<Option<SpacesMessage<SID, C>>, Self::Error> {
+    async fn message(&self, id: &OperationId) -> Result<Option<M>, Self::Error> {
         let inner = self.inner.read().await;
         Ok(inner.messages.get(id).cloned())
     }
 
-    async fn set_message(
-        &self,
-        id: &OperationId,
-        message: &SpacesMessage<SID, C>,
-    ) -> Result<(), Self::Error> {
+    async fn set_message(&self, id: &OperationId, message: &M) -> Result<(), Self::Error> {
         let mut inner = self.inner.write().await;
         inner.messages.insert(*id, message.clone());
         Ok(())

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -2,24 +2,28 @@
 
 use std::borrow::Borrow;
 use std::collections::HashSet;
+use std::convert::Infallible;
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use assert_matches::assert_matches;
 use p2panda_auth::Access;
 use p2panda_auth::group::GroupMember;
+use p2panda_core::Topic;
 use p2panda_encryption::Rng;
 use p2panda_encryption::crypto::x25519::SecretKey;
 use p2panda_encryption::data_scheme::DirectMessage;
 use p2panda_encryption::key_bundle::{Lifetime, LongTermKeyBundle, PreKey};
 
 use crate::event::{Event, GroupActor, GroupContext, GroupEvent, SpaceContext, SpaceEvent};
+use crate::manager::Manager;
 use crate::member::Member;
 use crate::message::SpacesArgs;
 use crate::space::Space;
-use crate::test_utils::{TestPeer, TestSpaceError};
-use crate::traits::{AuthStore, AuthoredMessage, SpacesStore};
-use crate::types::AuthGroupAction;
+use crate::test_utils::{MemoryStore, TestKeyStore, TestPeer, TestSpaceError};
+use crate::traits::{AuthStore, AuthoredMessage, Forge, SpaceId, SpacesStore};
+use crate::types::{AuthGroupAction, StrongRemoveResolver};
+use crate::{ActorId, Credentials, OperationId};
 
 #[tokio::test]
 async fn create_space() {
@@ -1857,4 +1861,68 @@ async fn publish_process_separation() {
 
     let members = space.members().await.unwrap();
     assert_eq!(members, vec![(alice_id, Access::manage())]);
+}
+
+#[tokio::test]
+async fn test_utils_generics() {
+    type MySpaceId = Topic;
+    impl SpaceId for MySpaceId {}
+
+    type MyConditions = ();
+
+    #[derive(Debug, Clone)]
+    struct MyOutMessage;
+
+    impl<ID, C> Borrow<SpacesArgs<ID, C>> for MyOutMessage {
+        fn borrow(&self) -> &SpacesArgs<ID, C> {
+            todo!()
+        }
+    }
+
+    impl AuthoredMessage for MyOutMessage {
+        fn id(&self) -> OperationId {
+            todo!()
+        }
+
+        fn author(&self) -> ActorId {
+            todo!()
+        }
+    }
+
+    #[derive(Debug)]
+    struct MyForge;
+
+    impl Forge<MySpaceId, MyConditions> for MyForge {
+        type Message = MyOutMessage;
+        type Error = Infallible;
+
+        fn verifying_key(&self) -> p2panda_core::VerifyingKey {
+            todo!()
+        }
+
+        async fn forge(
+            &self,
+            _args: SpacesArgs<MySpaceId, MyConditions>,
+        ) -> Result<Self::Message, Self::Error> {
+            todo!()
+        }
+    }
+
+    type MyMemoryStore = MemoryStore<MySpaceId, MyOutMessage, MyConditions>;
+    type MyKeyStore = TestKeyStore;
+    type MyResolver = StrongRemoveResolver<MyConditions>;
+    type MyManager =
+        Manager<MySpaceId, MyMemoryStore, MyKeyStore, MyForge, MyConditions, MyResolver>;
+
+    let rng = Rng::default();
+    let credentials = Credentials::from_rng(&rng).unwrap();
+    let _manager = MyManager::new(
+        MyMemoryStore::new(),
+        MyKeyStore::new(),
+        MyForge,
+        credentials,
+        rng,
+    )
+    .await
+    .unwrap();
 }

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -1302,7 +1302,7 @@ async fn events() {
     let mut all_bob_events = vec![];
     for (idx, message) in alice_messages.iter().enumerate() {
         bob_manager.persist_message(&message).await.unwrap();
-        let bob_events = bob_manager.process(&message).await.unwrap();
+        let bob_events = bob_manager.process(message).await.unwrap();
         all_bob_events.extend(bob_events.clone());
         match idx {
             // Member auth group created.

--- a/p2panda-spaces/src/traits/forge.rs
+++ b/p2panda-spaces/src/traits/forge.rs
@@ -7,12 +7,16 @@ use p2panda_core::VerifyingKey;
 use crate::message::SpacesArgs;
 
 /// Interface for wrapping forge args in custom message types.
-pub trait Forge<ID, M, C> {
+pub trait Forge<ID, C> {
+    type Message;
     type Error: Debug;
 
     /// Public key of the local peer.
     fn verifying_key(&self) -> VerifyingKey;
 
     /// Forge and persist a new message.
-    fn forge(&self, args: SpacesArgs<ID, C>) -> impl Future<Output = Result<M, Self::Error>>;
+    fn forge(
+        &self,
+        args: SpacesArgs<ID, C>,
+    ) -> impl Future<Output = Result<Self::Message, Self::Error>>;
 }

--- a/p2panda-spaces/src/traits/mod.rs
+++ b/p2panda-spaces/src/traits/mod.rs
@@ -15,4 +15,7 @@ pub use message::AuthoredMessage;
 pub use store::{AuthStore, KeyRegistryStore, KeySecretStore, MessageStore, SpacesStore};
 
 /// Trait representing the identifier of a space.
-pub trait SpaceId: Debug + Copy + Eq + PartialEq + DeserializeOwned + Serialize {}
+pub trait SpaceId:
+    Debug + Copy + Eq + PartialEq + std::hash::Hash + DeserializeOwned + Serialize
+{
+}

--- a/p2panda-spaces/src/traits/store.rs
+++ b/p2panda-spaces/src/traits/store.rs
@@ -8,13 +8,14 @@ use p2panda_auth::traits::Conditions;
 use p2panda_encryption::key_manager::PreKeyBundlesState;
 use p2panda_encryption::key_registry::KeyRegistryState;
 
+use crate::message::SpacesMessage;
 use crate::space::SpaceState;
 use crate::traits::SpaceId;
 use crate::types::AuthGroupState;
 use crate::{ActorId, OperationId};
 
 /// Interface for setting and getting space state.
-pub trait SpacesStore<ID, M, C>
+pub trait SpacesStore<ID, C>
 where
     ID: SpaceId,
     C: Conditions,
@@ -24,7 +25,7 @@ where
     fn space(
         &self,
         id: &ID,
-    ) -> impl Future<Output = Result<Option<SpaceState<ID, M, C>>, Self::Error>>;
+    ) -> impl Future<Output = Result<Option<SpaceState<ID, C>>, Self::Error>>;
 
     fn has_space(&self, id: &ID) -> impl Future<Output = Result<bool, Self::Error>>;
 
@@ -33,7 +34,7 @@ where
     fn set_space(
         &self,
         id: &ID,
-        y: SpaceState<ID, M, C>,
+        y: SpaceState<ID, C>,
     ) -> impl Future<Output = Result<(), Self::Error>>;
 }
 
@@ -76,14 +77,17 @@ pub trait KeySecretStore {
 // @TODO: This will be replaced with `OperationStore` in `p2panda-store` as soon as it's ready
 // (currently in `stream-next` branch).
 /// Interface for inserting and getting operations.
-pub trait MessageStore<M> {
+pub trait MessageStore<SID, C> {
     type Error: Debug;
 
-    fn message(&self, id: &OperationId) -> impl Future<Output = Result<Option<M>, Self::Error>>;
+    fn message(
+        &self,
+        id: &OperationId,
+    ) -> impl Future<Output = Result<Option<SpacesMessage<SID, C>>, Self::Error>>;
 
     fn set_message(
         &self,
         id: &OperationId,
-        message: &M,
+        message: &SpacesMessage<SID, C>,
     ) -> impl Future<Output = Result<(), Self::Error>>;
 }

--- a/p2panda-spaces/src/traits/store.rs
+++ b/p2panda-spaces/src/traits/store.rs
@@ -8,7 +8,6 @@ use p2panda_auth::traits::Conditions;
 use p2panda_encryption::key_manager::PreKeyBundlesState;
 use p2panda_encryption::key_registry::KeyRegistryState;
 
-use crate::message::SpacesMessage;
 use crate::space::SpaceState;
 use crate::traits::SpaceId;
 use crate::types::AuthGroupState;
@@ -77,17 +76,14 @@ pub trait KeySecretStore {
 // @TODO: This will be replaced with `OperationStore` in `p2panda-store` as soon as it's ready
 // (currently in `stream-next` branch).
 /// Interface for inserting and getting operations.
-pub trait MessageStore<SID, C> {
+pub trait MessageStore<M> {
     type Error: Debug;
 
-    fn message(
-        &self,
-        id: &OperationId,
-    ) -> impl Future<Output = Result<Option<SpacesMessage<SID, C>>, Self::Error>>;
+    fn message(&self, id: &OperationId) -> impl Future<Output = Result<Option<M>, Self::Error>>;
 
     fn set_message(
         &self,
         id: &OperationId,
-        message: &SpacesMessage<SID, C>,
+        message: &M,
     ) -> impl Future<Output = Result<(), Self::Error>>;
 }

--- a/p2panda-spaces/src/types.rs
+++ b/p2panda-spaces/src/types.rs
@@ -201,22 +201,22 @@ impl<C> AuthResolver<C> for StrongRemoveResolver<C> where C: Conditions {}
 
 // ~~~ Encryption ~~~
 
-pub type EncryptionGroup<M> = p2panda_encryption::data_scheme::EncryptionGroup<
+pub type EncryptionGroup = p2panda_encryption::data_scheme::EncryptionGroup<
     ActorId,
     OperationId,
     KeyRegistry<ActorId>,
     EncryptionGroupMembership,
     KeyManager,
-    EncryptionOrderer<M>,
+    EncryptionOrderer,
 >;
 
-pub type EncryptionGroupState<M> = p2panda_encryption::data_scheme::GroupState<
+pub type EncryptionGroupState = p2panda_encryption::data_scheme::GroupState<
     ActorId,
     OperationId,
     KeyRegistry<ActorId>,
     EncryptionGroupMembership,
     KeyManager,
-    EncryptionOrderer<M>,
+    EncryptionOrderer,
 >;
 
 pub type EncryptionDirectMessage =
@@ -224,20 +224,20 @@ pub type EncryptionDirectMessage =
 
 pub type EncryptionControlMessage = p2panda_encryption::data_scheme::ControlMessage<ActorId>;
 
-pub type EncryptionGroupError<M> = p2panda_encryption::data_scheme::GroupError<
+pub type EncryptionGroupError = p2panda_encryption::data_scheme::GroupError<
     ActorId,
     OperationId,
     KeyRegistry<ActorId>,
     EncryptionGroupMembership,
     KeyManager,
-    EncryptionOrderer<M>,
+    EncryptionOrderer,
 >;
 
-pub type EncryptionGroupOutput<M> = p2panda_encryption::data_scheme::GroupOutput<
+pub type EncryptionGroupOutput = p2panda_encryption::data_scheme::GroupOutput<
     ActorId,
     OperationId,
     EncryptionGroupMembership,
-    EncryptionOrderer<M>,
+    EncryptionOrderer,
 >;
 
 #[cfg(test)]


### PR DESCRIPTION
- Remove top-level M generic
- Replace it with associated `Forge::Message` type
- Add method generic to `Manager::process<M>
`- Make `MessageStore` and `MemoryStore` sufficiently generic for handling custom types

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
