### PR TITLE
Improve GitHub actions: Use `cargo-deny` and `cargo-hack`, adjust schedule

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust toolchain
         uses: moonrepo/setup-rust@v1
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust toolchain
         uses: moonrepo/setup-rust@v1
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust toolchain
         uses: moonrepo/setup-rust@v1
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust toolchain
         uses: moonrepo/setup-rust@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           channel: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Check project and dependencies
-        run: cargo check --all-features
+        run: cargo check --all-targets --all-features
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/deny.yaml
+++ b/.github/workflows/deny.yaml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  deny:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+
+      - name: Check known advisories, licenses etc. with cargo-deny
+        run: cargo deny --workspace --all-features check -D warnings

--- a/.github/workflows/features.yaml
+++ b/.github/workflows/features.yaml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+  push:
+    branches:
+      - main
+      - development
+
+jobs:
+  features:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: Check if feature combinations actually compile
+        run: cargo hack check --feature-powerset --workspace --depth 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ Highlights are marked with a pancake 🥞
 - spaces: Move top-level M generic to Manager::process<M>(..) [#1229](https://github.com/p2panda/p2panda/pull/1229)
 - spaces: Fix generics in MessageStore and MemoryStore [#1229](https://github.com/p2panda/p2panda/pull/1229)
 - stream: Introduce spaces processor [#1218](https://github.com/p2panda/p2panda/pull/1218)
+- ci: Improve GitHub actions: Use cargo-deny and cargo-hack, adjust schedule [#1233](https://github.com/p2panda/p2panda/pull/1233)
+
+### Fixed
+
+- encryption: Update hpke-rs to 0.6.1 to fix RUSTSEC [#1233](https://github.com/p2panda/p2panda/pull/1233)
 
 ## [0.6.1] - 22/05/2026
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,41 @@
+[graph]
+all-features = true
+
+[advisories]
+ignore = [
+    # paste is not maintained anymore - used by netlink-packet-core > .. > netwatch .. > iroh.
+    # https://github.com/rust-netlink/netlink-packet-core/issues/41
+    {
+      id = "RUSTSEC-2024-0436",
+      reason = "Advisory is notice / INFO",
+    },
+
+    # proc-macro-error2 is not maintained anymore, used by hax-lib-macros > .. > hpke-rs.
+    {
+      id = "RUSTSEC-2026-0173",
+      reason = "Advisory is notice / INFO",
+    },
+]
+
+[licenses]
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "NCSA",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+[licenses.private]
+ignore = true
+
+[bans]
+multiple-versions = "allow"
+wildcards = "allow"

--- a/p2panda-encryption/Cargo.toml
+++ b/p2panda-encryption/Cargo.toml
@@ -35,9 +35,9 @@ chacha20poly1305 = { version = "0.10.1", features = ["alloc"], default-features 
 curve25519-dalek = "4.1.3"
 hex = { workspace = true }
 hkdf = "0.12.4"
-hpke-rs = "0.2.0"
-hpke-rs-crypto = "0.2.0"
-hpke-rs-rust-crypto = "0.2.0"
+hpke-rs = "0.6.1"
+hpke-rs-crypto = "0.6.1"
+hpke-rs-rust-crypto = "0.6.1"
 p2panda-core = { workspace = true }
 rand_chacha = { version = "0.9.0", features = ["os_rng"] }
 serde = { workspace = true, features = ["derive"] }

--- a/p2panda-stream/Cargo.toml
+++ b/p2panda-stream/Cargo.toml
@@ -31,7 +31,7 @@ default = [
 ]
 groups = [
   "p2panda-auth/serde",
-  "dep:serde"
+  "dep:serde",
 ]
 ingest = []
 log_prune = []

--- a/p2panda-stream/Cargo.toml
+++ b/p2panda-stream/Cargo.toml
@@ -37,7 +37,8 @@ ingest = []
 log_prune = []
 orderer = []
 spaces = [
-  "p2panda-spaces"
+  "p2panda-auth",
+  "p2panda-spaces",
 ]
 
 [dependencies]

--- a/p2panda-stream/src/groups/processor.rs
+++ b/p2panda-stream/src/groups/processor.rs
@@ -18,7 +18,6 @@ use tracing::{debug, trace};
 
 use crate::Processor;
 use crate::groups::{GroupsArgs, GroupsOperation};
-use crate::ingest::IngestError;
 
 type GroupsCrdt<C> = group::GroupCrdt<VerifyingKey, Hash, GroupsOperation<C>, C, StrongRemove<C>>;
 type GroupsCrdtError<C> =
@@ -184,9 +183,6 @@ where
 
     #[error(transparent)]
     Groups(#[from] GroupsCrdtError<C>),
-
-    #[error(transparent)]
-    Ingest(#[from] IngestError),
 
     #[error("missing operation: {0}")]
     MissingOperation(Hash),


### PR DESCRIPTION
This PR improves our CI and fixed a couple of issues it detected:

1. Use [cargo-deny](https://embarkstudios.github.io/cargo-deny/) to check for security advisories, licenses, etc. - this is running now on each push and every day at 02:00 AM (to make sure we get informed about new advisories) and we have a new `deny.toml` file in our root
2. Use [cargo-hack](https://github.com/taiki-e/cargo-hack) to check for non-compiling feature flag combinations - this is a bit more expensive (ca. 5min running time) and gets triggered when merged to `main` and `development` and on some basic PR actions (change from draft to ready)

The fixed issues are:

* Updated `hpke-rs` version due to security issues
* Fixed missing dependencies and unused type in new processors in `p2panda-stream` when default features were disabled

Closes: https://github.com/p2panda/p2panda/issues/1167

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
