### PR TITLE
Clean-up workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,24 @@ members = [
 [workspace.lints.rust]
 
 [workspace.dependencies]
-ciborium = { version = "0.2.2" }
+blake3 = { version = "1.8.5" }
+futures-channel = { version = "0.3.32" }
+futures-test = { version = "0.3.32" }
 futures-util = { version = "0.3.32", default-features = false }
 hex = { version = "0.4.3" }
+mock_instant = { version = "0.6.1" }
+pin-project = { version = "1.1.13" }
+rand = { version = "0.10.1" }
+rand_chacha = { version = "0.10.0" }
+serde = { version = "1.0.228" }
+serde_bytes = { version = "0.11.19" }
+thiserror = { version = "2.0.18" }
+tokio = { version = "1.52.3", default-features = false }
+tokio-stream = { version = "0.1.18", default-features = false }
+tracing = { version = "0.1.44" }
+tracing-subscriber = { version = "0.3.23" }
+
+# p2panda workspace
 p2panda = { path = "p2panda", version = "0.6.1", default-features = false }
 p2panda-auth = { path = "p2panda-auth", version = "0.6.1", default-features = false }
 p2panda-core = { path = "p2panda-core", version = "0.6.1", default-features = false }
@@ -31,11 +46,3 @@ p2panda-spaces = { path = "p2panda-spaces", version = "0.6.1", default-features 
 p2panda-store = { path = "p2panda-store", version = "0.6.1", default-features = false }
 p2panda-stream = { path = "p2panda-stream", version = "0.6.1", default-features = false }
 p2panda-sync = { path = "p2panda-sync", version = "0.6.1", default-features = false }
-rand = { version = "0.10.1" }
-rand_chacha = { version = "0.10.0" }
-serde = { version = "1.0.228" }
-thiserror = { version = "2.0.18" }
-tokio = { version = "1.52.3", default-features = false }
-tokio-stream = { version = "0.1.18" }
-tracing = { version = "0.1.44" }
-tracing-subscriber = { version = "0.3.23" }

--- a/p2panda-auth/Cargo.toml
+++ b/p2panda-auth/Cargo.toml
@@ -18,6 +18,9 @@ rust-version = "1.94"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[lints]
+workspace = true
+
 [features]
 default = []
 test_utils = [
@@ -26,8 +29,12 @@ test_utils = [
   "dep:tracing-subscriber",
   "serde",
 ]
-serde = ["dep:serde"]
-test = ["test_utils"]
+serde = [
+  "dep:serde",
+]
+test = [
+  "test_utils",
+]
 
 [dependencies]
 p2panda-core = { workspace = true, default-features = true }
@@ -40,15 +47,10 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.102"
-ciborium = "0.2.2"
-futures-util = "0.3.32"
+futures-util = { workspace = true }
 p2panda-auth = { path = ".", features = ["test_utils"] }
 p2panda-core = { workspace = true, default-features = true, features = ["test_utils"] }
 p2panda-net = { workspace = true, default-features = true }
 p2panda-store = { workspace = true, default-features = true, features = ["test_utils"] }
-p2panda-sync = { workspace = true, default-features = true }
 p2panda-stream = { workspace = true, features = ["ingest", "groups"] }
-
-[lints]
-workspace = true
+p2panda-sync = { workspace = true, default-features = true }

--- a/p2panda-auth/examples/groups.rs
+++ b/p2panda-auth/examples/groups.rs
@@ -28,7 +28,6 @@ use std::borrow::Borrow;
 use std::collections::VecDeque;
 use std::thread;
 
-use anyhow::Result;
 use futures_util::StreamExt;
 use p2panda_auth::group::{GroupAction, GroupCrdtState, GroupMember};
 use p2panda_auth::traits::Operation as GroupsOperationTrait;
@@ -109,7 +108,7 @@ impl<E> Borrow<Operation<E>> for IngestEvent<E> {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     setup_logging();
 
     let signing_key = SigningKey::generate();
@@ -287,12 +286,14 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn input_loop(line_tx: mpsc::Sender<String>) -> Result<()> {
+fn input_loop(line_tx: mpsc::Sender<String>) -> Result<(), std::io::Error> {
     let mut buffer = String::new();
     let stdin = std::io::stdin();
     loop {
         stdin.read_line(&mut buffer)?;
-        line_tx.blocking_send(buffer.clone())?;
+        line_tx
+            .blocking_send(buffer.clone())
+            .map_err(|err| std::io::Error::other(err))?;
         buffer.clear();
     }
 }

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -831,6 +831,8 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
+    pub use p2panda_core::cbor::{decode_cbor, encode_cbor};
+
     use crate::Access;
     use crate::group::{GroupCrdtError, GroupMember, GroupMembershipError};
     use crate::test_utils::{
@@ -1761,11 +1763,10 @@ pub(crate) mod tests {
         assert_eq!(members, vec![(ALICE, Access::manage())]);
 
         // Serialize auth state to cbor bytes.
-        let mut bytes = vec![];
-        ciborium::ser::into_writer(&y_i, &mut bytes).unwrap();
+        let bytes = encode_cbor(&y_i).unwrap();
 
         // Deserialize auth state from cbor bytes.
-        let y_i_de: TestGroupState = ciborium::from_reader(&bytes[..]).unwrap();
+        let y_i_de: TestGroupState = decode_cbor(&bytes[..]).unwrap();
 
         // Assert members are the same.
         let members = y_i_de.members(G1);

--- a/p2panda-core/Cargo.toml
+++ b/p2panda-core/Cargo.toml
@@ -22,20 +22,25 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [features]
-default = ["prune"]
+default = [
+  "prune",
+]
 prune = []
-test_utils = ["dep:mock_instant", "dep:tracing-subscriber"]
+test_utils = [
+  "dep:mock_instant",
+  "dep:tracing-subscriber",
+]
 
 [dependencies]
 arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
-blake3 = "1.8.1"
-ciborium = { workspace = true }
+blake3 = { workspace = true }
+ciborium = { version = "0.2.2" }
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 hex = { workspace = true, features = ["serde"] }
-mock_instant = { version = "0.6.0", optional = true }
+mock_instant = { workspace = true, optional = true }
 rand = "0.8.5"
 serde = { workspace = true, features = ["derive"] }
-serde_bytes = { version = "0.11.17" }
+serde_bytes = { workspace = true }
 thiserror = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
 

--- a/p2panda-discovery/Cargo.toml
+++ b/p2panda-discovery/Cargo.toml
@@ -31,7 +31,7 @@ test_utils = [
 ]
 
 [dependencies]
-blake3 = "1.8.2"
+blake3 = { workspace = true }
 futures-util = { workspace = true, features = ["sink"] }
 p2panda-core = { workspace = true }
 p2panda-store = { workspace = true }
@@ -42,7 +42,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"], optional = true }
 
 [dev-dependencies]
-futures-channel = { version = "0.3.31", features = ["sink"] }
+futures-channel = { workspace = true, features = ["sink"] }
 p2panda-discovery = { path = ".", features = ["test_utils"] }
 p2panda-store = { workspace = true, features = ["test_utils", "sqlite", "macros"] }
 tokio = { workspace = true, features = ["macros", "rt", "sync"] }

--- a/p2panda-encryption/Cargo.toml
+++ b/p2panda-encryption/Cargo.toml
@@ -41,7 +41,7 @@ hpke-rs-rust-crypto = "0.2.0"
 p2panda-core = { workspace = true }
 rand_chacha = { version = "0.9.0", features = ["os_rng"] }
 serde = { workspace = true, features = ["derive"] }
-serde_bytes = "0.11.17"
+serde_bytes = { workspace = true }
 sha2 = "0.10.8"
 subtle = "2.6.1"
 thiserror = { workspace = true }

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -69,7 +69,7 @@ test_utils = [
 ]
 
 [dependencies]
-futures-channel = "0.3.31"
+futures-channel = { workspace = true }
 futures-util = { workspace = true, default-features = true }
 hex =  { workspace = true }
 iroh = { version = "1.0.0", default-features = false, features = ["tls-ring"], optional = true }
@@ -81,23 +81,22 @@ p2panda-discovery = { workspace = true, default-features = true, optional = true
 p2panda-store = { workspace = true }
 p2panda-sync = { workspace = true, default-features = true, optional = true }
 postcard = { version = "1.1.3", default-features = false, features = ["alloc", "use-std"] }
-ractor = "0.15.8"
+ractor = "0.15.13"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = true, features = ["rt", "sync"] }
-tokio-stream = { version = "0.1.17", features = ["sync"] }
+tokio-stream = { workspace = true, features = ["sync"] }
 tokio-util = { version = "0.7.16", features = ["codec", "compat"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.100"
 assert_matches = "1.5.0"
 clap = { version = "4.5.54", features = ["derive"] }
-futures-test = "0.3.31"
-mock_instant = "0.6.0"
+futures-test = { workspace = true }
+mock_instant = { workspace = true }
 p2panda-discovery = { workspace = true, default-features = true, features = ["test_utils"] }
 p2panda-net = { path = ".", features = ["test_utils"] }
 p2panda-store = { workspace = true, default-features = true, features = ["test_utils"] }

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -29,7 +29,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
 use clap::Parser;
 use futures_util::StreamExt;
 use iroh::EndpointAddr;
@@ -90,7 +89,7 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     setup_logging();
 
     let args = Args::parse();
@@ -349,12 +348,14 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn input_loop(line_tx: mpsc::Sender<String>) -> Result<()> {
+fn input_loop(line_tx: mpsc::Sender<String>) -> Result<(), std::io::Error> {
     let mut buffer = String::new();
     let stdin = std::io::stdin();
     loop {
         stdin.read_line(&mut buffer)?;
-        line_tx.blocking_send(buffer.clone())?;
+        line_tx
+            .blocking_send(buffer.clone())
+            .map_err(|err| std::io::Error::other(err))?;
         buffer.clear();
     }
 }

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -49,7 +49,7 @@ thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, default-features = true, features = ["sync"], optional = true }
 
 [dev-dependencies]
-futures-test = "0.3.31"
+futures-test = { workspace = true }
 p2panda-core = { workspace = true, features = ["test_utils"] }
 p2panda-store = { path = ".", features = ["test_utils"] }
 tokio = { workspace = true, default-features = true, features = ["rt", "macros"] }

--- a/p2panda-stream/Cargo.toml
+++ b/p2panda-stream/Cargo.toml
@@ -41,23 +41,23 @@ spaces = [
 ]
 
 [dependencies]
-futures-core = { version = "0.3.31", default-features = false, features = ["alloc"] }
+futures-util = { workspace = true }
 p2panda-auth = { workspace = true, optional = true }
 p2panda-core = { workspace = true, default-features = true }
 p2panda-spaces = { workspace = true, default-features = true, optional = true }
 p2panda-store = { workspace = true, default-features = true }
-pin-project = "1.1.10"
+pin-project = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["rt", "sync", "macros"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-futures-test = { version = "0.3.31" }
+futures-test = { workspace = true, features = ["std"] }
 futures-util = { workspace = true, features = ["alloc"] }
 p2panda-auth = { workspace = true, default-features = true, features = ["test_utils"] }
 p2panda-core = { workspace = true, default-features = true, features = ["test_utils"] }
 p2panda-store = { workspace = true, default-features = true, features = ["test_utils"] }
 serde = { workspace = true }
 tokio = { workspace = true, default-features = true, features = ["macros", "rt", "sync", "time"] }
-tokio-stream = { version = "0.1.17", default-features = false }
+tokio-stream = { workspace = true }

--- a/p2panda-stream/src/processors/stream.rs
+++ b/p2panda-stream/src/processors/stream.rs
@@ -3,7 +3,7 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures_core::Stream;
+use futures_util::Stream;
 use pin_project::pin_project;
 
 use crate::processors::Processor;

--- a/p2panda-sync/Cargo.toml
+++ b/p2panda-sync/Cargo.toml
@@ -30,8 +30,8 @@ test_utils = [
 ]
 
 [dependencies]
-futures = "0.3.31"
-futures-util = { workspace = true, default-features = true }
+futures-channel = { workspace = true }
+futures-util = { workspace = true, default-features = true, features = ["sink"] }
 p2panda-core = { workspace = true, default-features = true }
 p2panda-store = { workspace = true, default-features = true }
 pin-project-lite = "0.2.16"
@@ -39,7 +39,7 @@ rand = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = true, features = ["macros", "sync"] }
-tokio-stream = { version = "0.1.17", features = ["sync"] }
+tokio-stream = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
 

--- a/p2panda-sync/src/manager/event_stream.rs
+++ b/p2panda-sync/src/manager/event_stream.rs
@@ -5,9 +5,9 @@ use std::hash::Hash as StdHash;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::channel::mpsc;
-use futures::stream::SelectAll;
-use futures::{SinkExt, Stream, StreamExt};
+use futures_channel::mpsc;
+use futures_util::sink::SinkExt;
+use futures_util::stream::{SelectAll, Stream, StreamExt};
 use p2panda_core::traits::Digest;
 use p2panda_core::{Extensions, Hash};
 use tokio_stream::wrappers::BroadcastStream;

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -7,22 +7,19 @@
 mod event_stream;
 mod session_map;
 
-pub use event_stream::ManagerEventStream;
-use p2panda_store::topics::TopicStore;
-pub use session_map::SessionTopicMap;
-
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash as StdHash;
 use std::marker::PhantomData;
 use std::pin::Pin;
 
-use futures::channel::mpsc;
-use futures::future::ready;
-use futures::stream::SelectAll;
-use futures::{Sink, SinkExt, Stream, StreamExt};
+use futures_channel::mpsc;
+use futures_util::future::ready;
+use futures_util::sink::{Sink, SinkExt};
+use futures_util::stream::{SelectAll, Stream, StreamExt};
 use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
 use p2panda_store::logs::LogStore;
+use p2panda_store::topics::TopicStore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::broadcast;
@@ -36,6 +33,9 @@ use crate::protocols::{TopicLogSync, TopicLogSyncError, TopicLogSyncEvent};
 use crate::traits::Manager;
 use crate::{FromSync, SessionConfig, ToSync};
 
+pub use event_stream::ManagerEventStream;
+pub use session_map::SessionTopicMap;
+
 static CHANNEL_BUFFER: usize = 1028;
 
 pub type ToTopicSync<E> = ToSync<Operation<E>>;
@@ -48,7 +48,7 @@ pub type ToTopicSync<E> = ToSync<Operation<E>>;
 ///
 /// A handle can be acquired to a sync session via the session_handle method for sending any live
 /// mode operations to a specific session. It's expected that users map sessions (by their id) to
-/// any topic subscriptions in order to understand the correct mappings.  
+/// any topic subscriptions in order to understand the correct mappings.
 ///
 /// There are two points where message deduplication occurs; 1) per-subscription deduplication of
 /// received operations across all sessions for this manager occurs in the event stream 2)
@@ -241,8 +241,8 @@ mod tests {
     use std::time::Duration;
 
     use assert_matches::assert_matches;
-    use futures::channel::mpsc;
-    use futures::{SinkExt, StreamExt};
+    use futures_channel::mpsc;
+    use futures_util::{SinkExt, StreamExt};
     use p2panda_core::test_utils::setup_logging;
     use p2panda_core::{Body, Operation, Topic};
     use p2panda_store::SqliteStore;

--- a/p2panda-sync/src/manager/session_map.rs
+++ b/p2panda-sync/src/manager/session_map.rs
@@ -85,7 +85,7 @@ where
 mod tests {
     use std::collections::HashSet;
 
-    use futures::channel::mpsc;
+    use futures_channel::mpsc;
     use p2panda_core::Topic;
 
     use crate::manager::SessionTopicMap;

--- a/p2panda-sync/src/protocols/log_sync.rs
+++ b/p2panda-sync/src/protocols/log_sync.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 
-use futures::{Sink, SinkExt, Stream, StreamExt, stream};
+use futures_util::{Sink, SinkExt, Stream, StreamExt, stream};
 use p2panda_core::cbor::{DecodeError, decode_cbor};
 use p2panda_core::logs::{LogHeights, LogRanges, compare};
 use p2panda_core::{Body, Extensions, Hash, Header, LogId, Operation, SeqNum, VerifyingKey};
@@ -514,8 +514,8 @@ mod tests {
     use std::collections::BTreeMap;
 
     use assert_matches::assert_matches;
-    use futures::StreamExt;
-    use futures::channel::mpsc;
+    use futures_channel::mpsc;
+    use futures_util::StreamExt;
     use p2panda_core::test_utils::setup_logging;
     use p2panda_core::{Body, Hash};
     use p2panda_store::operations::OperationStore;

--- a/p2panda-sync/src/protocols/topic_handshake.rs
+++ b/p2panda-sync/src/protocols/topic_handshake.rs
@@ -4,8 +4,8 @@
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 
-use futures::channel::mpsc;
-use futures::{Sink, SinkExt, Stream, StreamExt};
+use futures_channel::mpsc;
+use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/p2panda-sync/src/protocols/topic_log_sync.rs
+++ b/p2panda-sync/src/protocols/topic_log_sync.rs
@@ -8,8 +8,8 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::channel::mpsc;
-use futures::{Sink, SinkExt, Stream, StreamExt};
+use futures_channel::mpsc;
+use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use p2panda_core::{Body, Extensions, Hash, Header, LogId, Operation, SeqNum, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
@@ -607,8 +607,8 @@ pub mod tests {
     use std::collections::BTreeMap;
 
     use assert_matches::assert_matches;
-    use futures::channel::mpsc;
-    use futures::{SinkExt, StreamExt};
+    use futures_channel::mpsc;
+    use futures_util::{SinkExt, StreamExt};
     use p2panda_core::test_utils::setup_logging;
     use p2panda_core::{Body, Operation, Topic};
 

--- a/p2panda-sync/src/test_utils.rs
+++ b/p2panda-sync/src/test_utils.rs
@@ -3,9 +3,8 @@
 //! Test utilities.
 use std::collections::BTreeMap;
 
-use futures::{FutureExt, SinkExt, Stream, StreamExt};
-
-use futures::channel::mpsc;
+use futures_channel::mpsc;
+use futures_util::{FutureExt, SinkExt, Stream, StreamExt};
 use p2panda_core::{Body, Hash, Header, Operation, SeqNum, SigningKey, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;

--- a/p2panda-sync/src/traits.rs
+++ b/p2panda-sync/src/traits.rs
@@ -5,7 +5,7 @@ use std::error::Error as StdError;
 use std::fmt::Debug;
 use std::pin::Pin;
 
-use futures::Sink;
+use futures_util::Sink;
 use futures_util::Stream;
 use serde::{Deserialize, Serialize};
 

--- a/p2panda/Cargo.toml
+++ b/p2panda/Cargo.toml
@@ -34,7 +34,7 @@ p2panda-net = { workspace = true, default-features = true }
 p2panda-store = { workspace = true, default-features = true }
 p2panda-stream = { workspace = true, default-features = true, features = ["ingest", "log_prune"] }
 p2panda-sync = { workspace = true, default-features = true }
-pin-project = "1.1.10"
+pin-project = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = true, features = ["sync"] }
@@ -43,7 +43,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
 
 [dev-dependencies]
-mock_instant = "0.6.0"
+mock_instant = { workspace = true }
 p2panda = { path = ".", features = ["test_utils"] }
 p2panda-core = { workspace = true, default-features = true, features = ["test_utils"] }
 p2panda-store = { workspace = true, default-features = true, features = ["test_utils"] }


### PR DESCRIPTION
Mini cleanup: Use workspace-level dependencies a bit more, remove some crates which didn't have much function.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
