### PR TITLE
Spaces store traits with SQLite implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Highlights are marked with a pancake 🥞
 - auth: More methods (`traverse_members`, `groups`) to traverse and filter graph [#1242](https://github.com/p2panda/p2panda/pull/1242)
 - auth: Allow ordinary members to remove themselves from group [#1234](https://github.com/p2panda/p2panda/pull/1234)
 - Introduce SQLite implementations of `KeySecretsStore` and `KeyRegistryStore` [#1230](https://github.com/p2panda/p2panda/pull/1230)
+- SQLite implementations of spaces stores [#1241](https://github.com/p2panda/p2panda/pull/1241)
 
 ### Changed
 

--- a/p2panda-net/examples/chat.rs
+++ b/p2panda-net/examples/chat.rs
@@ -240,7 +240,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         );
                     }
                     SyncEvent::OperationReceived { operation, .. } => {
-                        if <SqliteStore as OperationStore<Operation, Hash, LogId>>::has_operation(
+                        if <SqliteStore as OperationStore<Operation, Hash>>::has_operation(
                             &store,
                             &operation.hash,
                         )

--- a/p2panda-store/migrations/20260616100207_create_spaces.sql
+++ b/p2panda-store/migrations/20260616100207_create_spaces.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+CREATE TABLE IF NOT EXISTS spaces_v1 (
+    id                      BLOB            NOT NULL       PRIMARY KEY,
+    state                   BLOB            NOT NULL
+);

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -128,6 +128,7 @@ pub mod logs;
 mod macros;
 pub mod operations;
 pub mod orderer;
+pub mod spaces;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 pub mod topics;

--- a/p2panda-store/src/operations/sqlite.rs
+++ b/p2panda-store/src/operations/sqlite.rs
@@ -28,19 +28,21 @@ const HAS_OPERATION: &str = "
         hash = ?
 ";
 
-impl<E, L> OperationStore<Operation<E>, Hash, L> for SqliteStore
+impl<E> OperationStore<Operation<E>, Hash> for SqliteStore
 where
     E: Extensions,
-    L: LogId,
 {
     type Error = SqliteError;
 
-    async fn insert_operation(
+    async fn insert_operation<L>(
         &self,
         id: &Hash,
         operation: &Operation<E>,
         log_id: &L,
-    ) -> Result<bool, Self::Error> {
+    ) -> Result<bool, Self::Error>
+    where
+        L: LogId,
+    {
         let result = self
             .tx(async |tx| {
                 query(

--- a/p2panda-store/src/operations/tests.rs
+++ b/p2panda-store/src/operations/tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use p2panda_core::test_utils::TestLog;
-use p2panda_core::{Hash, Operation, Topic};
+use p2panda_core::{Hash, Operation};
 
 use crate::operations::OperationStore;
 use crate::{SqliteStore, Transaction};
@@ -54,13 +54,13 @@ async fn insert_get_delete_operations() {
     // ~~~
 
     assert!(
-        OperationStore::<Operation<()>, Hash, Topic>::has_operation(&store, &operation_1.hash)
+        OperationStore::<Operation<()>, Hash>::has_operation(&store, &operation_1.hash)
             .await
             .unwrap()
     );
     // Operation 2 was not inserted.
     assert!(
-        !OperationStore::<Operation<()>, Hash, Topic>::has_operation(&store, &operation_2.hash)
+        !OperationStore::<Operation<()>, Hash>::has_operation(&store, &operation_2.hash)
             .await
             .unwrap()
     );
@@ -69,13 +69,13 @@ async fn insert_get_delete_operations() {
     // ~~~
 
     assert_eq!(
-        OperationStore::<Operation<()>, Hash, Topic>::get_operation(&store, &operation_4.hash)
+        OperationStore::<Operation<()>, Hash>::get_operation(&store, &operation_4.hash)
             .await
             .unwrap(),
         Some(operation_4.clone())
     );
     assert_eq!(
-        OperationStore::<Operation<()>, Hash, Topic>::get_operation(&store, &operation_2.hash)
+        OperationStore::<Operation<()>, Hash>::get_operation(&store, &operation_2.hash)
             .await
             .unwrap(),
         None
@@ -87,13 +87,13 @@ async fn insert_get_delete_operations() {
     let permit = store.begin().await.unwrap();
 
     assert!(
-        OperationStore::<Operation<()>, Hash, Topic>::delete_operation(&store, &operation_4.hash)
+        OperationStore::<Operation<()>, Hash>::delete_operation(&store, &operation_4.hash)
             .await
             .unwrap(),
     );
     // Deleting the same item again returns false.
     assert!(
-        !OperationStore::<Operation<()>, Hash, Topic>::delete_operation(&store, &operation_4.hash)
+        !OperationStore::<Operation<()>, Hash>::delete_operation(&store, &operation_4.hash)
             .await
             .unwrap(),
     );

--- a/p2panda-store/src/operations/traits.rs
+++ b/p2panda-store/src/operations/traits.rs
@@ -2,22 +2,24 @@
 
 use std::error::Error;
 
+use p2panda_core::LogId;
+
 /// Interface for storing, deleting and querying operations.
 ///
 /// The concrete type of an "operation" is generic and implementors can use the same interface for
 /// different approaches: sets, append-only logs, hash-graphs (DAG) etc.
-pub trait OperationStore<T, ID, C> {
+pub trait OperationStore<T, ID> {
     type Error: Error;
 
     /// Insert an operation.
     ///
     /// Returns `true` when the insert occurred, or `false` when the operation already existed and
     /// no insertion occurred.
-    fn insert_operation(
+    fn insert_operation<L: LogId>(
         &self,
         id: &ID,
         operation: &T,
-        collection_id: &C,
+        collection_id: &L,
     ) -> impl Future<Output = Result<bool, Self::Error>>;
 
     /// Get an operation by id.

--- a/p2panda-store/src/spaces/mod.rs
+++ b/p2panda-store/src/spaces/mod.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+mod sqlite;
+#[cfg(test)]
+mod tests;
+mod traits;
+
+pub use sqlite::SqliteSpacesStore;
+pub use traits::{SpacesMessageStore, SpacesStore, SpacesStoreWrite};
+
+use p2panda_core::{Hash, VerifyingKey};
+
+/// Spaces message type with generic parameter for additional arguments.
+// @TODO: this type is so generic that it could actually be used / defined somewhere else. It
+// represents a message with id and author, replacing the need for trait interfaces.
+#[derive(Debug, Clone)]
+pub struct SpacesMessage<T> {
+    pub id: Hash,
+    pub author: VerifyingKey,
+    pub args: T,
+}

--- a/p2panda-store/src/spaces/sqlite.rs
+++ b/p2panda-store/src/spaces/sqlite.rs
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::borrow::Borrow;
+use std::marker::PhantomData;
+
+use p2panda_core::cbor::{decode_cbor, encode_cbor};
+use p2panda_core::{Extensions, Hash, Operation};
+use serde::{Deserialize, Serialize};
+use sqlx::{query, query_as};
+
+use crate::groups::GroupsStore;
+use crate::operations::OperationStore;
+use crate::spaces::traits::SpacesMessageStore;
+use crate::spaces::{SpacesMessage, SpacesStore, SpacesStoreWrite};
+use crate::sqlite::TransactionPermit;
+use crate::{SqliteError, SqliteStore};
+
+/// Concrete SqliteSpacesStore type which wraps the SqliteStore.
+pub struct SqliteSpacesStore<E> {
+    store: SqliteStore,
+    _phantom: PhantomData<E>,
+}
+
+impl<E> SqliteSpacesStore<E> {
+    pub fn new(store: SqliteStore) -> Self {
+        Self {
+            store,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn inner(&self) -> SqliteStore {
+        self.store.clone()
+    }
+}
+
+impl<A, E> SpacesMessageStore<Hash, A> for SqliteSpacesStore<E>
+where
+    A: Clone,
+    E: Extensions + Borrow<A>,
+{
+    type Error = SqliteError;
+
+    async fn get_spaces_message(&self, id: &Hash) -> Result<Option<SpacesMessage<A>>, Self::Error> {
+        match <SqliteStore as OperationStore<Operation<E>, Hash>>::get_operation(&self.store, id)
+            .await?
+        {
+            Some(operation) => {
+                let args = operation.header().extensions.borrow().clone();
+                let message = SpacesMessage {
+                    id: operation.hash,
+                    author: operation.header().verifying_key,
+                    args,
+                };
+                Ok(Some(message))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+impl<ID, S, E> SpacesStore<ID, S> for SqliteSpacesStore<E>
+where
+    ID: for<'a> Deserialize<'a> + Serialize,
+    S: for<'a> Deserialize<'a> + Serialize,
+{
+    type Error = SqliteError;
+
+    async fn get_space_state_tx(&self, id: &ID) -> Result<Option<S>, Self::Error> {
+        let row = self
+            .store
+            .tx(async |tx| {
+                query_as::<_, (Vec<u8>,)>(
+                    "
+                    SELECT
+                        state
+                    FROM
+                        spaces_v1
+                    WHERE
+                        id = ?
+                    ",
+                )
+                .bind(encode_cbor(&id).map_err(|err| SqliteError::Encode("id".to_string(), err))?)
+                .fetch_optional(&mut **tx)
+                .await
+                .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        let Some((state_bytes,)) = row else {
+            return Ok(None);
+        };
+
+        let state = decode_cbor(&state_bytes[..])
+            .map_err(|err| SqliteError::Decode("state".into(), err.into()))?;
+
+        Ok(Some(state))
+    }
+
+    async fn has_space(&self, id: &ID) -> Result<bool, Self::Error> {
+        let result = self
+            .store
+            .execute(async |pool| {
+                query_as::<_, (Vec<u8>,)>(
+                    "
+                    SELECT
+                        id
+                    FROM
+                        spaces_v1
+                    WHERE
+                        id = ?
+                    ",
+                )
+                .bind(encode_cbor(&id).map_err(|err| SqliteError::Encode("id".to_string(), err))?)
+                .fetch_optional(pool)
+                .await
+                .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        Ok(result.is_some())
+    }
+
+    async fn space_ids(&self) -> Result<Vec<ID>, Self::Error> {
+        let result = self
+            .store
+            .execute(async |pool| {
+                query_as::<_, (Vec<u8>,)>(
+                    "
+                    SELECT
+                        id
+                    FROM
+                        spaces_v1
+                    ",
+                )
+                .fetch_all(pool)
+                .await
+                .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        let result: Result<Vec<ID>, _> = result
+            .into_iter()
+            .map(|(id_bytes,)| decode_cbor::<ID, _>(&id_bytes[..]))
+            .collect();
+
+        result.map_err(|err| SqliteError::Decode("state".into(), err.into()))
+    }
+}
+
+impl<ID, S, E> SpacesStoreWrite<ID, S> for SqliteSpacesStore<E>
+where
+    ID: for<'a> Deserialize<'a> + Serialize,
+    S: for<'a> Deserialize<'a> + Serialize,
+{
+    type Error = SqliteError;
+
+    async fn set_space_state_tx(&self, id: &ID, state: &S) -> Result<(), Self::Error> {
+        self.store
+            .tx(async |tx| {
+                query(
+                    "
+                INSERT OR REPLACE
+                INTO
+                    spaces_v1 (
+                        id,
+                        state
+                    )
+                VALUES
+                    (?, ?)
+                ",
+                )
+                .bind(encode_cbor(&id).map_err(|err| SqliteError::Encode("id".to_string(), err))?)
+                .bind(
+                    encode_cbor(&state)
+                        .map_err(|err| SqliteError::Encode("state".to_string(), err))?,
+                )
+                .execute(&mut **tx)
+                .await
+                .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl<ID, S, E> GroupsStore<ID, S> for SqliteSpacesStore<E>
+where
+    ID: for<'a> Deserialize<'a> + Serialize,
+    S: for<'a> Deserialize<'a> + Serialize,
+{
+    type Error = SqliteError;
+
+    async fn set_groups_state_tx(&self, id: &ID, state: &S) -> Result<(), SqliteError> {
+        self.store.set_groups_state_tx(id, state).await
+    }
+
+    async fn get_groups_state_tx(&self, id: &ID) -> Result<Option<S>, SqliteError> {
+        self.store.get_groups_state_tx(id).await
+    }
+}
+
+impl<E> crate::traits::Transaction for SqliteSpacesStore<E> {
+    type Error = SqliteError;
+
+    type Permit = TransactionPermit;
+
+    async fn begin(&self) -> Result<TransactionPermit, SqliteError> {
+        self.store.begin().await
+    }
+
+    async fn rollback(&self, permit: TransactionPermit) -> Result<(), SqliteError> {
+        self.store.rollback(permit).await
+    }
+
+    async fn commit(&self, permit: TransactionPermit) -> Result<(), SqliteError> {
+        self.store.commit(permit).await
+    }
+}

--- a/p2panda-store/src/spaces/tests.rs
+++ b/p2panda-store/src/spaces/tests.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::borrow::Borrow;
+
+use p2panda_core::Hash;
+use serde::{Deserialize, Serialize};
+
+use crate::spaces::{SpacesMessageStore, SpacesStore, SpacesStoreWrite};
+use crate::{SqliteStore, tx_unwrap};
+
+// Additional message arguments required by and defined in p2panda-spaces.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct SpacesArgs;
+
+// Here we fix the generic arguments on SpacesMessage, this would happen in p2panda-spaces.
+type SpacesMessage = crate::spaces::SpacesMessage<SpacesArgs>;
+
+// Extension type defined in p2panda.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct SpacesExtensions {
+    args: SpacesArgs,
+}
+
+// Required Borrow<SpacesArgs> will be implemented in p2panda.
+impl Borrow<SpacesArgs> for SpacesExtensions {
+    fn borrow(&self) -> &SpacesArgs {
+        &self.args
+    }
+}
+
+type SqliteSpacesStore = crate::spaces::SqliteSpacesStore<SpacesExtensions>;
+type SpaceId = u32;
+type SpaceState = String;
+
+#[tokio::test]
+async fn verify_generics() {
+    // Construct concrete SqliteSpacesStore which bounds the persisted message type to
+    // `Operation<SpacesExtensions>`.
+    let inner = SqliteStore::temporary().await;
+    let store = SqliteSpacesStore::new(inner);
+
+    // We can query the store now.
+    let id = Hash::from_bytes([0; 32]);
+    let message: Option<SpacesMessage> = store.get_spaces_message(&id).await.unwrap();
+
+    // Although there are no operations inserted so we expect None.
+    assert!(message.is_none());
+}
+
+#[tokio::test]
+async fn get_set_spaces_state() {
+    let inner = SqliteStore::temporary().await;
+    let store = SqliteSpacesStore::new(inner);
+
+    let space_state = String::from("Some important state");
+    let space_id = 0;
+    tx_unwrap!(store, {
+        store.set_space_state_tx(&space_id, &space_state).await
+    })
+    .unwrap();
+
+    let y: Option<SpaceState> =
+        tx_unwrap!(store, { store.get_space_state_tx(&space_id).await }).unwrap();
+
+    assert!(y.is_some());
+    let y = y.unwrap();
+    assert_eq!(y, space_state);
+
+    let has_space =
+        <SqliteSpacesStore as SpacesStore<SpaceId, SpaceState>>::has_space(&store, &space_id)
+            .await
+            .unwrap();
+    assert!(has_space);
+
+    let non_existent_space_id = 1;
+    let y: Option<SpaceState> = tx_unwrap!(store, {
+        store.get_space_state_tx(&non_existent_space_id).await
+    })
+    .unwrap();
+    assert!(y.is_none());
+
+    let has_space = <SqliteSpacesStore as SpacesStore<SpaceId, SpaceState>>::has_space(
+        &store,
+        &non_existent_space_id,
+    )
+    .await
+    .unwrap();
+    assert!(!has_space);
+}
+
+#[tokio::test]
+async fn get_space_ids() {
+    let inner = SqliteStore::temporary().await;
+    let store = SqliteSpacesStore::new(inner);
+
+    let space_state = String::from("Some important state");
+    tx_unwrap!(store, { store.set_space_state_tx(&0, &space_state).await }).unwrap();
+    tx_unwrap!(store, { store.set_space_state_tx(&1, &space_state).await }).unwrap();
+    tx_unwrap!(store, { store.set_space_state_tx(&2, &space_state).await }).unwrap();
+
+    let space_ids: Vec<SpaceId> =
+        <SqliteSpacesStore as SpacesStore<SpaceId, SpaceState>>::space_ids(&store)
+            .await
+            .unwrap();
+
+    assert_eq!(space_ids, vec![0, 1, 2]);
+}

--- a/p2panda-store/src/spaces/traits.rs
+++ b/p2panda-store/src/spaces/traits.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::error::Error;
+
+use crate::spaces::SpacesMessage;
+
+pub trait SpacesMessageStore<ID, A> {
+    type Error: Error;
+
+    fn get_spaces_message(
+        &self,
+        id: &ID,
+    ) -> impl Future<Output = Result<Option<SpacesMessage<A>>, Self::Error>>;
+}
+
+pub trait SpacesStore<ID, S> {
+    type Error: Error;
+
+    fn get_space_state_tx(&self, id: &ID) -> impl Future<Output = Result<Option<S>, Self::Error>>;
+
+    fn has_space(&self, id: &ID) -> impl Future<Output = Result<bool, Self::Error>>;
+
+    fn space_ids(&self) -> impl Future<Output = Result<Vec<ID>, Self::Error>>;
+}
+
+pub trait SpacesStoreWrite<ID, S> {
+    type Error: Error;
+
+    fn set_space_state_tx(&self, id: &ID, y: &S) -> impl Future<Output = Result<(), Self::Error>>;
+}

--- a/p2panda-stream/src/ingest/operation.rs
+++ b/p2panda-stream/src/ingest/operation.rs
@@ -26,7 +26,7 @@ pub async fn ingest_operation<S, T, L, E, TP>(
 ) -> Result<bool, IngestError>
 where
     S: Transaction
-        + OperationStore<Operation<E>, Hash, L>
+        + OperationStore<Operation<E>, Hash>
         + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<TP, VerifyingKey, L>,
     T: Borrow<Operation<E>>,

--- a/p2panda-stream/src/ingest/processor.rs
+++ b/p2panda-stream/src/ingest/processor.rs
@@ -26,7 +26,7 @@ pub struct Ingest<S, T, L, E, TP> {
 impl<S, T, L, E, TP> Ingest<S, T, L, E, TP>
 where
     S: Transaction
-        + OperationStore<Operation<E>, Hash, L>
+        + OperationStore<Operation<E>, Hash>
         + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<TP, VerifyingKey, L>,
     L: LogId,
@@ -45,7 +45,7 @@ where
 impl<S, T, L, E, TP> Processor<T> for Ingest<S, T, L, E, TP>
 where
     S: Transaction
-        + OperationStore<Operation<E>, Hash, L>
+        + OperationStore<Operation<E>, Hash>
         + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<TP, VerifyingKey, L>,
     T: Borrow<Operation<E>> + Borrow<IngestArgs<L, TP>>,

--- a/p2panda-stream/src/orderer/processor.rs
+++ b/p2panda-stream/src/orderer/processor.rs
@@ -22,7 +22,7 @@ pub struct Orderer<T, ID, S> {
 impl<T, ID, S> Orderer<T, ID, S>
 where
     ID: OperationId,
-    S: Clone + Transaction + OrdererStore<ID> + OperationStore<T, ID, u64>,
+    S: Clone + Transaction + OrdererStore<ID> + OperationStore<T, ID>,
 {
     pub fn new(store: S) -> Self {
         let inner = CausalOrderer::new(store.clone());
@@ -40,7 +40,7 @@ impl<T, ID, S> Processor<T> for Orderer<T, ID, S>
 where
     T: Digest<ID> + Ordering<ID>,
     ID: OperationId,
-    S: Transaction + OrdererStore<ID> + OperationStore<T, ID, u64>,
+    S: Transaction + OrdererStore<ID> + OperationStore<T, ID>,
 {
     type Output = T;
 
@@ -106,7 +106,7 @@ pub enum OrdererError<T, ID, S>
 where
     T: Ordering<ID>,
     ID: OperationId,
-    S: Transaction + OrdererStore<ID> + OperationStore<T, ID, u64>,
+    S: Transaction + OrdererStore<ID> + OperationStore<T, ID>,
 {
     #[error("could not find item with id {0} in operation store")]
     StoreInconsistency(ID),
@@ -115,7 +115,7 @@ where
     OrdererStore(<S as OrdererStore<ID>>::Error),
 
     #[error("{0}")]
-    OperationStore(<S as OperationStore<T, ID, u64>>::Error),
+    OperationStore(<S as OperationStore<T, ID>>::Error),
 
     #[error("{0}")]
     Transaction(<S as Transaction>::Error),

--- a/p2panda-sync/src/protocols/log_sync.rs
+++ b/p2panda-sync/src/protocols/log_sync.rs
@@ -924,7 +924,7 @@ mod tests {
 
             if let LogSyncEvent::OperationReceived { .. } = event {
                 tx_unwrap!(&peer_a.store, {
-                    <SqliteStore as OperationStore<Operation<()>, Hash, ()>>::delete_operation(
+                    <SqliteStore as OperationStore<Operation<()>, Hash>>::delete_operation(
                         &peer_a.store,
                         &to_be_pruned_log[0],
                     )

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -84,7 +84,7 @@ where
     where
         S: Clone
             + Transaction
-            + OperationStore<Operation<E>, Hash, L>
+            + OperationStore<Operation<E>, Hash>
             + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
             + TopicStore<TP, VerifyingKey, L>
             + Send

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -751,9 +751,7 @@ impl<M> StreamSubscription<M> {
     /// applicaton-level processing has successfully finished. See high-level description in
     /// [`Node::stream`](crate::node::Node::stream) for more details.
     pub async fn ack(&self, id: Hash) -> Result<(), AckedError> {
-        if let Some(operation) =
-            OperationStore::<_, _, LogId>::get_operation(&self.store, &id).await?
-        {
+        if let Some(operation) = OperationStore::<_, _>::get_operation(&self.store, &id).await? {
             self.acked.ack(&operation.header).await?;
         }
 


### PR DESCRIPTION
Introduces `SpacesStore`, `SpacesStoreWrite` and `SpacesMessageStore` traits in p2panda-store along with SQLite implementations on new concrete store type `SqliteSpacesStore`.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
