### PR TITLE
Add `accept_unmixed` function for registering a protocol under a raw known ALPN

### DIFF
--- a/p2panda-net/src/iroh_endpoint/actors/endpoint.rs
+++ b/p2panda-net/src/iroh_endpoint/actors/endpoint.rs
@@ -51,6 +51,12 @@ pub enum ToIrohEndpoint {
     /// Register protocol handler for a given ALPN (protocol identifier).
     RegisterProtocol(ProtocolId, Box<dyn DynProtocolHandler>),
 
+    /// Register a protocol handler under its raw ALPN, *without* mixing in the
+    /// network id. Use this only for protocols that intentionally interoperate
+    /// with vanilla iroh peers (e.g. iroh-blobs' `Downloader`, which dials the
+    /// bare `iroh-bytes/4` ALPN). Loses network-id isolation for that protocol.
+    RegisterProtocolUnmixed(ProtocolId, Box<dyn DynProtocolHandler>),
+
     /// Starts a connection attempt to a remote iroh endpoint and returns a future which can be
     /// awaited for establishing the final connection.
     ///
@@ -232,6 +238,20 @@ impl ThreadLocalActor for IrohEndpoint {
                 protocols.insert(mixed_protocol_id, protocol_handler);
 
                 // Inform iroh endpoint about the new protocol as well.
+                state
+                    .endpoint
+                    .as_ref()
+                    .expect(
+                        "bind always takes place first, an endpoint must exist after this point",
+                    )
+                    .set_alpns(protocols.keys().cloned().collect());
+            }
+            ToIrohEndpoint::RegisterProtocolUnmixed(alpn, protocol_handler) => {
+                debug!(alpn = %alpn.fmt_short(), "register protocol (unmixed)");
+
+                let mut protocols = state.protocols.write().await;
+                protocols.insert(alpn, protocol_handler);
+
                 state
                     .endpoint
                     .as_ref()

--- a/p2panda-net/src/iroh_endpoint/api.rs
+++ b/p2panda-net/src/iroh_endpoint/api.rs
@@ -142,6 +142,25 @@ impl Endpoint {
         Ok(())
     }
 
+    /// Register a protocol handler under its raw ALPN, without mixing in the
+    /// network id (unlike [`Self::accept`]). The protocol will interoperate with
+    /// vanilla iroh peers that dial the bare ALPN, at the cost of network-id
+    /// isolation for that one protocol.
+    pub async fn accept_unmixed<P: ProtocolHandler>(
+        &self,
+        protocol_id: impl AsRef<[u8]>,
+        protocol_handler: P,
+    ) -> Result<(), EndpointError> {
+        let protocol_id = protocol_id.as_ref().to_vec();
+        let inner = self.inner.read().await;
+        cast!(
+            inner.actor_ref.as_ref().expect("actor spawned in builder"),
+            ToIrohEndpoint::RegisterProtocolUnmixed(protocol_id, Box::new(protocol_handler))
+        )
+        .map_err(Box::new)?;
+        Ok(())
+    }
+
     /// Starts a connection attempt to a remote iroh endpoint and returns a future which can be
     /// awaited for establishing the final connection.
     ///

--- a/p2panda-net/src/iroh_endpoint/mod.rs
+++ b/p2panda-net/src/iroh_endpoint/mod.rs
@@ -13,6 +13,7 @@ mod tests;
 pub(crate) mod user_data;
 
 // Re-export useful iroh types.
+pub use iroh;
 pub use iroh::{EndpointAddr, RelayUrl};
 
 pub use api::{Endpoint, EndpointError};

--- a/p2panda-net/src/lib.rs
+++ b/p2panda-net/src/lib.rs
@@ -315,7 +315,7 @@ pub const DEFAULT_NETWORK_ID: NetworkId = [
 ];
 
 /// Hash the concatenation of the given protocol- and network identifiers.
-fn hash_protocol_id_with_network_id(
+pub fn hash_protocol_id_with_network_id(
     protocol_id: impl AsRef<[u8]>,
     network_id: NetworkId,
 ) -> Vec<u8> {

--- a/p2panda-store/src/sqlite.rs
+++ b/p2panda-store/src/sqlite.rs
@@ -226,6 +226,11 @@ impl SqliteStore {
         Self::new(pool)
     }
 
+    /// Returns a reference to the connection pool.
+    pub fn pool(&self) -> &sqlx::SqlitePool {
+        &self.pool
+    }
+
     /// Builds an in-memory SQLite database with a randomised name for testing purposes.
     #[cfg(any(test, feature = "test_utils"))]
     pub async fn temporary() -> Self {

--- a/p2panda-store/src/topics/sqlite.rs
+++ b/p2panda-store/src/topics/sqlite.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
 use p2panda_core::{LogId, VerifyingKey};
 use serde::{Deserialize, Serialize};
-use sqlx::{query, query_as};
+use sqlx::{query, query_as, query_scalar};
 
 use crate::sqlite::{DecodeError, SqliteError, SqliteStore};
 use crate::topics::TopicStore;
@@ -95,7 +95,10 @@ where
     }
 
     /// Retrieve a list of all logs associated with the provided topic for all known authors.
-    async fn resolve(&self, topic: &T) -> Result<BTreeMap<VerifyingKey, Vec<L>>, Self::Error> {
+    async fn resolve_associations(
+        &self,
+        topic: &T,
+    ) -> Result<BTreeMap<VerifyingKey, Vec<L>>, Self::Error> {
         let data_ids = self
             .execute(async |pool| {
                 query_as::<_, (String, Vec<u8>)>(
@@ -134,5 +137,45 @@ where
         }
 
         Ok(result)
+    }
+
+    /// Given a prior association, return the associated topic.
+    async fn resolve_topic(
+        &self,
+        author: &VerifyingKey,
+        data_id: &L,
+    ) -> Result<Option<T>, Self::Error> {
+        let topic = self
+            .execute(async |pool| {
+                query_scalar::<_, Vec<u8>>(
+                    "
+                    SELECT
+                        topic
+                    FROM
+                        topics_v1
+                    WHERE
+                        author = ?
+                        AND data_id = ?
+                    ",
+                )
+                .bind(author.to_string())
+                .bind(
+                    encode_cbor(&data_id)
+                        .map_err(|err| SqliteError::Encode("data_id".to_string(), err))?,
+                )
+                .fetch_optional(pool)
+                .await
+                .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        let Some(topic) = topic else {
+            return Ok(None);
+        };
+
+        let topic = decode_cbor(&topic[..])
+            .map_err(|err| SqliteError::Decode("topic".into(), err.into()))?;
+
+        Ok(Some(topic))
     }
 }

--- a/p2panda-store/src/topics/tests.rs
+++ b/p2panda-store/src/topics/tests.rs
@@ -40,8 +40,32 @@ async fn update_and_resolve_topic_mapping() {
 
     let expected_logs = BTreeMap::from([(alice, vec![topic]), (bob, vec![topic])]);
 
-    let logs = store.resolve(&topic).await.unwrap();
+    let logs = store.resolve_associations(&topic).await.unwrap();
     assert_eq!(logs, expected_logs);
+}
+
+#[tokio::test]
+async fn resolve_topic_from_association() {
+    let store = SqliteStore::temporary().await;
+
+    let topic = Topic::random();
+    let log_id = topic;
+
+    let alice = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
+    let bob = SigningKey::from_bytes(&[2u8; 32]).verifying_key();
+
+    let permit = store.begin().await.unwrap();
+    let result = store.associate(&topic, &alice, &log_id).await.unwrap();
+    assert!(result);
+    store.commit(permit).await.unwrap();
+
+    // Resolving a known association returns the topic.
+    let resolved = store.resolve_topic(&alice, &log_id).await.unwrap();
+    assert_eq!(resolved, Some(topic));
+
+    // An unknown author/data id pair returns None.
+    let resolved = store.resolve_topic(&bob, &log_id).await.unwrap();
+    assert_eq!(resolved, None::<Topic>);
 }
 
 #[tokio::test]
@@ -85,7 +109,7 @@ async fn path_based_log_ids() {
         (bob, vec![log_id_puppies]),
     ]);
 
-    let logs = store.resolve(&topic).await.unwrap();
+    let logs = store.resolve_associations(&topic).await.unwrap();
     assert_eq!(logs, expected_logs);
 }
 
@@ -122,7 +146,7 @@ async fn remove_association() {
         vec![log_id_kittens.clone(), log_id_kittens_sleepy.clone()],
     )]);
 
-    let logs = store.resolve(&topic).await.unwrap();
+    let logs = store.resolve_associations(&topic).await.unwrap();
     assert_eq!(logs, expected_logs);
 
     let permit = store.begin().await.unwrap();
@@ -138,6 +162,6 @@ async fn remove_association() {
 
     let expected_logs = BTreeMap::from([(alice, vec![log_id_kittens])]);
 
-    let logs = store.resolve(&topic).await.unwrap();
+    let logs = store.resolve_associations(&topic).await.unwrap();
     assert_eq!(logs, expected_logs);
 }

--- a/p2panda-store/src/topics/traits.rs
+++ b/p2panda-store/src/topics/traits.rs
@@ -57,6 +57,16 @@ pub trait TopicStore<T, A, D> {
         data_id: &D,
     ) -> impl Future<Output = Result<bool, Self::Error>>;
 
-    /// Retrieve all associations for the provided topic.
-    fn resolve(&self, topic: &T) -> impl Future<Output = Result<BTreeMap<A, Vec<D>>, Self::Error>>;
+    /// Retrieve all associations (author, data id pairs) for the provided topic.
+    fn resolve_associations(
+        &self,
+        topic: &T,
+    ) -> impl Future<Output = Result<BTreeMap<A, Vec<D>>, Self::Error>>;
+
+    /// Given a prior association, return the associated topic.
+    fn resolve_topic(
+        &self,
+        author: &A,
+        data_id: &D,
+    ) -> impl Future<Output = Result<Option<T>, Self::Error>>;
 }

--- a/p2panda-stream/src/ingest/operation.rs
+++ b/p2panda-stream/src/ingest/operation.rs
@@ -180,9 +180,11 @@ mod tests {
 
         // Topic "dogs" contains two logs: 0 with two operations and 1 with one operation.
         let authors =
-            <SqliteStore as TopicStore<[u8; 32], VerifyingKey, usize>>::resolve(&store, &dogs)
-                .await
-                .unwrap();
+            <SqliteStore as TopicStore<[u8; 32], VerifyingKey, usize>>::resolve_associations(
+                &store, &dogs,
+            )
+            .await
+            .unwrap();
         assert_eq!(*authors.get(&log_0.author()).unwrap(), [0]);
         assert_eq!(*authors.get(&log_1.author()).unwrap(), [1]);
 
@@ -200,9 +202,11 @@ mod tests {
 
         // Topic "cats" contains one log: 2 with four operations.
         let authors =
-            <SqliteStore as TopicStore<[u8; 32], VerifyingKey, usize>>::resolve(&store, &cats)
-                .await
-                .unwrap();
+            <SqliteStore as TopicStore<[u8; 32], VerifyingKey, usize>>::resolve_associations(
+                &store, &cats,
+            )
+            .await
+            .unwrap();
         assert_eq!(*authors.get(&log_2.author()).unwrap(), [2]);
 
         let operation = <SqliteStore as LogStore<

--- a/p2panda-sync/src/protocols/topic_log_sync.rs
+++ b/p2panda-sync/src/protocols/topic_log_sync.rs
@@ -127,7 +127,7 @@ where
         // Get the log ids which are associated with this topic query.
         let logs = self
             .store
-            .resolve(&self.topic)
+            .resolve_associations(&self.topic)
             .await
             .map_err(|err| TopicLogSyncError::TopicStore(err.to_string()))?;
 

--- a/p2panda/src/lib.rs
+++ b/p2panda/src/lib.rs
@@ -267,7 +267,7 @@ pub use p2panda_core::{Cursor, Hash, SigningKey, Topic, VerifyingKey};
 #[doc(no_inline)]
 pub use p2panda_net::iroh_endpoint::{EndpointAddr, RelayUrl};
 #[doc(no_inline)]
-pub use p2panda_net::{NetworkId, NodeId};
+pub use p2panda_net::{Endpoint, NetworkId, NodeId};
 
 pub use builder::NodeBuilder;
 #[doc(inline)]

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use futures_util::Stream;
 use p2panda_core::Topic;
 use p2panda_net::iroh_endpoint::RelayUrl;
-use p2panda_net::{NetworkId, NodeId};
+use p2panda_net::{Endpoint, NetworkId, NodeId};
 use p2panda_store::sqlite::{SqliteError, SqliteStore, SqliteStoreBuilder};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -361,6 +361,15 @@ impl Node {
     /// Returns the network identifier being used by the node.
     pub fn network_id(&self) -> NetworkId {
         self.network.network_id()
+    }
+
+    /// Returns a handle to the shared networking endpoint.
+    ///
+    /// This is the same endpoint used internally by the node for all peer-to-peer connections.
+    /// Call [`Endpoint::endpoint`] on the returned handle to access the underlying `iroh::Endpoint`,
+    /// or [`Endpoint::accept`] to register additional protocol handlers on it.
+    pub fn endpoint(&self) -> Endpoint {
+        self.network.endpoint.clone()
     }
 
     /// Inserts a bootstrap node into the local address book.

--- a/p2panda/src/processor/event.rs
+++ b/p2panda/src/processor/event.rs
@@ -26,7 +26,7 @@ pub enum ProcessorStatus<R, F> {
 #[derive(Clone, Debug)]
 pub struct Event<L, E, TP> {
     /// p2panda Operation.
-    operation: Operation<E>,
+    pub operation: Operation<E>,
 
     /// Input arguments for the "ingest" processor.
     ingest_args: IngestArgs<L, TP>,

--- a/p2panda/src/streams/acked.rs
+++ b/p2panda/src/streams/acked.rs
@@ -86,7 +86,7 @@ impl Acked {
 
         // Get state vector of local replica for all logs related to this topic.
         let local_log_heights = {
-            let logs: Logs = self.store.resolve(&self.topic).await?;
+            let logs: Logs = self.store.resolve_associations(&self.topic).await?;
             get_log_heights(&self.store, &logs).await?
         };
 

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -924,7 +924,7 @@ pub enum StreamEvent<M> {
 /// Processed operation with application message coming from a topic stream.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProcessedOperation<M> {
-    event: Event<LogId, Extensions, Topic>,
+    pub event: Event<LogId, Extensions, Topic>,
     topic: Topic,
     acked: Acked,
     message: M,


### PR DESCRIPTION
Standard `accept` mixes the NetworkId in with the ALPN. In some cases it is desirable to share an ALPN with nodes outside of the NetworkId.

In our use case we need to use `iroh_blobs::Downloader`, which uses a fixed ALPN, and this was a convenient way to hook that up.

If this is unmergeable, I'm happy for this to be a way of uncovering a better way to do this (including getting p2panda-blobs working?), or a moment of decision that we need to maintain this small fork

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
