### PR TITLE
Implement pipeline orderer with store for event metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Highlights are marked with a pancake 🥞
 - ci: Improve GitHub actions: Use cargo-deny and cargo-hack, adjust schedule [#1233](https://github.com/p2panda/p2panda/pull/1233)
 - core: Provenance trait to get author & verify [#1254](https://github.com/p2panda/p2panda/pull/1254)
 - node: Encrypted spaces and groups management integration into high-level API [#1202](https://github.com/p2panda/p2panda/pull/1202)
+- store: Introduce `ProcessorStore` for storing event metadata from p2panda pipeline [#1262](https://github.com/p2panda/p2panda/pull/1262)
+- node: Implement `Orderer` `Processor` for pipeline [#1262](https://github.com/p2panda/p2panda/pull/1262)
 
 ### Changed
 

--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -45,6 +45,9 @@ spaces = [
   "groups",
   "encryption",
 ]
+processor = [
+  "sqlite"
+]
 macros = []
 test_utils = [
   "dep:rand",

--- a/p2panda-store/migrations/20260625082007_create_processor.sql
+++ b/p2panda-store/migrations/20260625082007_create_processor.sql
@@ -1,0 +1,6 @@
+-- SPDX-License-Identifier: MIT OR Apache-2.0
+
+CREATE TABLE IF NOT EXISTS processor_v1 (
+    id                      VARCHAR(32)     NOT NULL   PRIMARY KEY,
+    event                   BLOB            NOT NULL
+);

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -131,6 +131,8 @@ pub mod logs;
 mod macros;
 pub mod operations;
 pub mod orderer;
+#[cfg(feature = "processor")]
+pub mod processor;
 #[cfg(feature = "spaces")]
 pub mod spaces;
 #[cfg(feature = "sqlite")]

--- a/p2panda-store/src/processor/mod.rs
+++ b/p2panda-store/src/processor/mod.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Processor stores used to persist events.
+//!
+//! An implementation of the [`ProcessorStore`] trait is provided for [`SqliteStore`].
+//!
+//! [`SqliteStore`]: crate::SqliteStore
+#[cfg(feature = "sqlite")]
+mod sqlite;
+mod traits;
+
+pub use traits::ProcessorStore;

--- a/p2panda-store/src/processor/sqlite.rs
+++ b/p2panda-store/src/processor/sqlite.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use p2panda_core::Hash;
+use p2panda_core::cbor::{decode_cbor, encode_cbor};
+use serde::{Deserialize, Serialize};
+use sqlx::{query, query_scalar};
+
+use crate::processor::traits::ProcessorStore;
+
+use crate::{SqliteError, SqliteStore};
+
+impl<T> ProcessorStore<T> for SqliteStore
+where
+    T: Serialize + for<'a> Deserialize<'a>,
+{
+    type Error = SqliteError;
+
+    async fn get_event(&self, id: &Hash) -> Result<Option<T>, Self::Error> {
+        let event_bytes: Option<Vec<u8>> = self
+            .execute(async |pool| {
+                query_scalar(
+                    "
+                    SELECT
+                        event
+                    FROM
+                        processor_v1
+                    WHERE
+                        id = ?
+                    ",
+                )
+                .bind(id.to_hex())
+                .fetch_optional(pool)
+                .await
+                .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        if let Some(bytes) = event_bytes {
+            let event = decode_cbor(&bytes[..])
+                .map_err(|err| SqliteError::Decode("event".into(), err.into()))?;
+            Ok(Some(event))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn set_event(&self, id: &Hash, event: &T) -> Result<(), Self::Error> {
+        // TODO: Do we expect to only ever store an operation-related event once or might it be
+        // stored multiple times as it moves through the pipeline?
+        //
+        // If we expect multiple valid insertions then we want to rather INSERT OR REPLACE.
+        self.tx(async |tx| {
+            query(
+                "
+                INSERT OR IGNORE
+                    INTO
+                        processor_v1(id, event)
+                    VALUES
+                        (?, ?)
+                ",
+            )
+            .bind(id.to_hex())
+            .bind(encode_cbor(&event).map_err(|err| SqliteError::Encode("event".to_string(), err))?)
+            .execute(&mut **tx)
+            .await
+            .map_err(SqliteError::Sqlite)
+        })
+        .await?;
+
+        Ok(())
+    }
+}

--- a/p2panda-store/src/processor/traits.rs
+++ b/p2panda-store/src/processor/traits.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::error::Error;
+
+use p2panda_core::Hash;
+
+pub trait ProcessorStore<T> {
+    type Error: Error;
+
+    // TODO: Are we happy for `id` to be a concrete type here?
+    fn get_event(&self, id: &Hash) -> impl Future<Output = Result<Option<T>, Self::Error>>;
+
+    fn set_event(&self, id: &Hash, event: &T) -> impl Future<Output = Result<(), Self::Error>>;
+}

--- a/p2panda-store/src/processor/traits.rs
+++ b/p2panda-store/src/processor/traits.rs
@@ -4,10 +4,11 @@ use std::error::Error;
 
 use p2panda_core::Hash;
 
+// TODO: Is `ProcessorStore` the best name? Maybe `EventStore` or `EventMetadataStore` is more
+// specific and thus clearer?
 pub trait ProcessorStore<T> {
     type Error: Error;
 
-    // TODO: Are we happy for `id` to be a concrete type here?
     fn get_event(&self, id: &Hash) -> impl Future<Output = Result<Option<T>, Self::Error>>;
 
     fn set_event(&self, id: &Hash, event: &T) -> impl Future<Output = Result<(), Self::Error>>;

--- a/p2panda-stream/src/groups/processor.rs
+++ b/p2panda-stream/src/groups/processor.rs
@@ -240,8 +240,8 @@ mod tests {
     }
 
     impl Ordering<Hash> for Operation<TestExtensions> {
-        fn dependencies(&self) -> &[Hash] {
-            &self.header.extensions.dependencies
+        fn dependencies(&self) -> Vec<Hash> {
+            self.header.extensions.dependencies.to_owned()
         }
     }
 

--- a/p2panda-stream/src/ingest/operation.rs
+++ b/p2panda-stream/src/ingest/operation.rs
@@ -4,13 +4,12 @@
 use std::borrow::Borrow;
 
 use p2panda_core::prune::validate_prunable_backlink;
-use p2panda_core::{
-    Extensions, Hash, LogId, Operation, OperationError, SeqNum, VerifyingKey, validate_operation,
-};
+use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey, validate_operation};
 use p2panda_store::Transaction;
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
 use p2panda_store::topics::TopicStore;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Checks an incoming operation for log integrity and persists it into the store when valid.
@@ -36,7 +35,7 @@ where
     let operation: &Operation<E> = operation.borrow();
 
     // Validate operation format.
-    validate_operation(operation)?;
+    validate_operation(operation).map_err(|err| IngestError::InvalidOperation(err.to_string()))?;
 
     let permit = store
         .begin()
@@ -67,7 +66,8 @@ where
 
     // If no pruning flag is set, we expect the log to have integrity with the previously given
     // operation.
-    validate_prunable_backlink(past_header.as_ref(), &operation.header, prune_flag)?;
+    validate_prunable_backlink(past_header.as_ref(), &operation.header, prune_flag)
+        .map_err(|err| IngestError::InvalidOperation(err.to_string()))?;
 
     // Insert operation into store and associate its log with the given topic.
     let id = operation.hash;
@@ -91,12 +91,12 @@ where
 }
 
 /// Errors which can occur due to invalid operations or critical storage failures.
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, Error, Serialize, Deserialize)]
 pub enum IngestError {
     /// Operation can not be authenticated, has broken log- or payload integrity or doesn't follow
     /// the p2panda specification.
-    #[error(transparent)]
-    InvalidOperation(#[from] OperationError),
+    #[error("invalid operation: {0}")]
+    InvalidOperation(String),
 
     /// Critical storage failure occurred. This is usually a reason to panic.
     #[error("critical storage failure: {0}")]

--- a/p2panda-stream/src/ingest/processor.rs
+++ b/p2panda-stream/src/ingest/processor.rs
@@ -10,6 +10,7 @@ use p2panda_store::Transaction;
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
 use p2panda_store::topics::TopicStore;
+use serde::{Deserialize, Serialize};
 use tokio::sync::Notify;
 
 use crate::Processor;
@@ -97,7 +98,7 @@ where
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IngestResult {
     AlreadyExists,
     Inserted,

--- a/p2panda-stream/src/orderer/mod.rs
+++ b/p2panda-stream/src/orderer/mod.rs
@@ -8,6 +8,6 @@ mod processor;
 mod tests;
 mod traits;
 
-use orderer::CausalOrderer;
+pub use orderer::CausalOrderer;
 pub use processor::{Orderer, OrdererError};
 pub use traits::Ordering;

--- a/p2panda-stream/src/orderer/processor.rs
+++ b/p2panda-stream/src/orderer/processor.rs
@@ -42,6 +42,8 @@ where
     ID: OperationId,
     S: Transaction + OrdererStore<ID> + OperationStore<T, ID>,
 {
+    // TODO: Define result type and leverage Noop variant to pass-through.
+    // type Output = (T, OrdererResult);
     type Output = T;
 
     type Error = (Option<T>, OrdererError<T, ID, S>);
@@ -53,7 +55,7 @@ where
         };
 
         let inner = self.inner.lock().await;
-        if let Err(err) = inner.process(input.hash(), input.dependencies()).await {
+        if let Err(err) = inner.process(input.hash(), &input.dependencies()[..]).await {
             return Err((Some(input), OrdererError::OrdererStore(err)));
         };
 
@@ -144,8 +146,8 @@ mod tests {
     }
 
     impl Ordering<Hash> for Operation<TestExtension> {
-        fn dependencies(&self) -> &[Hash] {
-            &self.header.extensions.dependencies
+        fn dependencies(&self) -> Vec<Hash> {
+            self.header.extensions.dependencies.to_owned()
         }
     }
 

--- a/p2panda-stream/src/orderer/traits.rs
+++ b/p2panda-stream/src/orderer/traits.rs
@@ -8,5 +8,5 @@
 /// what messages need to be processed before we can process this messsage and give us causal /
 /// partial ordering.
 pub trait Ordering<ID> {
-    fn dependencies(&self) -> &[ID];
+    fn dependencies(&self) -> Vec<ID>;
 }

--- a/p2panda/Cargo.toml
+++ b/p2panda/Cargo.toml
@@ -34,7 +34,7 @@ p2panda-core = { workspace = true, default-features = true }
 p2panda-encryption = { workspace = true, default-features = true, features = ["test_utils"] }
 p2panda-net = { workspace = true, default-features = true }
 p2panda-spaces = { workspace = true, default-features = true }
-p2panda-store = { workspace = true, default-features = true }
+p2panda-store = { workspace = true, default-features = true, features = ["processor"] }
 p2panda-stream = { workspace = true, default-features = true, features = ["ingest", "log_prune", "orderer", "spaces"] }
 p2panda-sync = { workspace = true, default-features = true }
 pin-project = { workspace = true }

--- a/p2panda/src/processor/event.rs
+++ b/p2panda/src/processor/event.rs
@@ -6,13 +6,16 @@ use p2panda_core::traits::Digest;
 use p2panda_core::{Body, Hash, Header, LogId, Operation, PruneFlag, SeqNum, VerifyingKey};
 use p2panda_stream::ingest::{IngestArgs, IngestError, IngestResult};
 use p2panda_stream::log_prune::{LogPruneArgs, LogPruneError, LogPruneResult};
+use p2panda_stream::orderer::Ordering;
 use p2panda_stream::spaces::{SpacesError, SpacesProcessorArgs, SpacesResult};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::processor::orderer::{OrdererError, OrdererResult};
 use crate::spaces::types::{AuthCapabilities, SpacesArgs};
 
 /// Status of an event being processed by a _single_ processor in the pipeline.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ProcessorStatus<R, F> {
     /// Operation has not been processed yet.
     Pending,
@@ -23,6 +26,38 @@ pub enum ProcessorStatus<R, F> {
 
     /// An error occurred when this operation was processed. A concrete error type is attached.
     Failed(F),
+}
+
+/// Metadata required to construct a new `Event` (excluding the operation).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct EventMetadata<L, TP> {
+    pub(crate) log_id: L,
+    pub(crate) topic: TP,
+    pub(crate) prune_flag: PruneFlag,
+    pub(crate) spaces_args: Option<SpacesArgs>,
+    pub(crate) ingest: ProcessorStatus<IngestResult, IngestError>,
+}
+
+/// Extract `EventMetadata` from an `Event`.
+impl<L, E, TP> From<Event<L, E, TP>> for EventMetadata<L, TP> {
+    fn from(event: Event<L, E, TP>) -> Self {
+        let log_id = event.ingest_args.log_id;
+        let topic = event.ingest_args.topic;
+        let prune_flag = PruneFlag::new(event.ingest_args.prune_flag);
+        let spaces_args = match event.spaces_args {
+            SpacesProcessorArgs::Ignore => None,
+            SpacesProcessorArgs::Process { msg } => Some(msg.args),
+        };
+        let ingest = event.ingest;
+
+        Self {
+            log_id,
+            topic,
+            prune_flag,
+            spaces_args,
+            ingest,
+        }
+    }
 }
 
 /// Single event running through the "event processor" pipeline.
@@ -36,6 +71,9 @@ pub struct Event<L, E, TP> {
 
     /// Status of the "ingest" processor.
     pub(crate) ingest: ProcessorStatus<IngestResult, IngestError>,
+
+    /// Status of the "orderer" processor.
+    pub(crate) orderer: ProcessorStatus<OrdererResult, OrdererError>,
 
     /// Input arguments for the "log prune" processor.
     log_prune_args: LogPruneArgs<VerifyingKey, L, SeqNum>,
@@ -53,7 +91,6 @@ pub struct Event<L, E, TP> {
 impl<L, E, TP> Event<L, E, TP>
 where
     L: LogId,
-    TP: Clone,
 {
     pub(crate) fn new(
         operation: Operation<E>,
@@ -69,6 +106,7 @@ where
                 prune_flag: prune_flag.is_set(),
             },
             ingest: ProcessorStatus::Pending,
+            orderer: ProcessorStatus::Pending,
             // Do not allow pruning when spaces args are set.
             log_prune_args: if prune_flag.is_set() && spaces_args.is_none() {
                 LogPruneArgs::PruneEntriesUntil {
@@ -108,6 +146,7 @@ where
     /// Returns `true` if event has been successfully processed by the whole pipeline.
     pub fn is_completed(&self) -> bool {
         matches!(self.ingest, ProcessorStatus::Completed(_))
+            && matches!(self.orderer, ProcessorStatus::Completed(_))
             && matches!(self.log_prune, ProcessorStatus::Completed(_))
             && matches!(self.spaces, ProcessorStatus::Completed(_))
     }
@@ -115,6 +154,7 @@ where
     /// Returns `true` if event failed somewhere during processing.
     pub fn is_failed(&self) -> bool {
         matches!(self.ingest, ProcessorStatus::Failed(_))
+            || matches!(self.orderer, ProcessorStatus::Failed(_))
             || matches!(self.log_prune, ProcessorStatus::Failed(_))
             || matches!(self.spaces, ProcessorStatus::Failed(_))
     }
@@ -122,6 +162,10 @@ where
     /// Returns the error which occurred during a processing failure or `None`.
     pub fn failure_reason(&self) -> Option<ProcessorError> {
         if let ProcessorStatus::Failed(err) = &self.ingest {
+            return Some(err.to_owned().into());
+        }
+
+        if let ProcessorStatus::Failed(err) = &self.orderer {
             return Some(err.to_owned().into());
         }
 
@@ -137,6 +181,15 @@ where
     }
 }
 
+impl<L, E, TP> Ordering<Hash> for Event<L, E, TP> {
+    fn dependencies(&self) -> Vec<Hash> {
+        match &self.spaces_args {
+            SpacesProcessorArgs::Ignore => vec![],
+            SpacesProcessorArgs::Process { msg } => msg.args.dependencies(),
+        }
+    }
+}
+
 /// Operation failed during event processing of the system-level pipeline.
 ///
 /// This is likely to come from either processing invalid operations from a broken / malicious node
@@ -145,6 +198,9 @@ where
 pub enum ProcessorError {
     #[error("ingest processor failed with: {0}")]
     Ingest(#[from] IngestError),
+
+    #[error("orderer processor failed with: {0}")]
+    Orderer(#[from] OrdererError),
 
     #[error("log_prune processor failed with: {0}")]
     LogPrune(#[from] LogPruneError),

--- a/p2panda/src/processor/mod.rs
+++ b/p2panda/src/processor/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod event;
+mod orderer;
 mod pipeline;
 mod tasks;
 

--- a/p2panda/src/processor/orderer.rs
+++ b/p2panda/src/processor/orderer.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::marker::PhantomData;
+
+use p2panda_core::traits::Digest;
+use p2panda_core::{Hash, LogId, Operation};
+use p2panda_store::Transaction;
+use p2panda_store::operations::OperationStore;
+use p2panda_store::orderer::OrdererStore;
+use p2panda_store::processor::ProcessorStore;
+use p2panda_stream::Processor;
+use p2panda_stream::orderer::{CausalOrderer, Ordering};
+use thiserror::Error;
+use tokio::sync::{Mutex, Notify};
+
+use crate::processor::ProcessorStatus;
+use crate::processor::event::{Event, EventMetadata};
+
+#[derive(Clone, Debug)]
+pub enum OrdererResult {
+    Processed,
+    Ignored,
+}
+
+pub struct Orderer<S, T, L, E, TP> {
+    inner: Mutex<CausalOrderer<Hash, S>>,
+    store: S,
+    notify: Notify,
+    #[allow(clippy::type_complexity)]
+    queue: RefCell<VecDeque<(Event<L, E, TP>, OrdererResult)>>,
+    _marker: PhantomData<(T, L, E, TP)>,
+}
+
+impl<S, T, L, E, TP> Orderer<S, T, L, E, TP>
+where
+    S: Clone + Transaction + OrdererStore<Hash> + OperationStore<Operation<E>, Hash>,
+{
+    pub fn new(store: S) -> Self {
+        let inner = CausalOrderer::new(store.clone());
+
+        Self {
+            inner: Mutex::new(inner),
+            store,
+            notify: Notify::new(),
+            queue: RefCell::new(VecDeque::new()),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S, T, L, E, TP> Processor<Event<L, E, TP>> for Orderer<S, T, L, E, TP>
+where
+    S: Transaction
+        + OrdererStore<Hash>
+        + OperationStore<Operation<E>, Hash>
+        + ProcessorStore<EventMetadata<L, TP>>,
+    L: LogId,
+    TP: Clone,
+    E: Clone,
+{
+    type Output = (Event<L, E, TP>, OrdererResult);
+
+    type Error = (Option<Event<L, E, TP>>, OrdererError);
+
+    async fn process(&self, input: Event<L, E, TP>) -> Result<(), Self::Error> {
+        // Only process the operation if it was successfully ingested.
+        if let ProcessorStatus::Completed(_) = input.ingest {
+            let inner = self.inner.lock().await;
+
+            let permit = match self.store.begin().await {
+                Ok(permit) => permit,
+                Err(err) => return Err((Some(input), OrdererError::Transaction(err.to_string()))),
+            };
+
+            if let Err(err) = inner.process(input.hash(), &input.dependencies()[..]).await {
+                return Err((Some(input), OrdererError::OrdererStore(err.to_string())));
+            };
+
+            let metadata: EventMetadata<L, TP> = input.clone().into();
+
+            if let Err(err) = self.store.set_event(&input.hash(), &metadata).await {
+                return Err((Some(input), OrdererError::ProcessorStore(err.to_string())));
+            };
+
+            self.store
+                .commit(permit)
+                .await
+                .map_err(|err| (Some(input), OrdererError::Transaction(err.to_string())))?;
+        } else {
+            self.queue
+                .borrow_mut()
+                .push_back((input, OrdererResult::Ignored));
+        }
+
+        self.notify.notify_one(); // Wake up any pending next call
+
+        Ok(())
+    }
+
+    async fn next(&self) -> Result<Self::Output, Self::Error> {
+        loop {
+            // First check to see if there are any ignored events which can be returned.
+            if let Some((event, result)) = self.queue.borrow_mut().pop_front() {
+                return Ok((event, result));
+            }
+
+            let permit = self
+                .store
+                .begin()
+                .await
+                .map_err(|err| (None, OrdererError::Transaction(err.to_string())))?;
+
+            let inner = self.inner.lock().await;
+
+            if let Some(id) = inner
+                .next()
+                .await
+                .map_err(|err| (None, OrdererError::OrdererStore(err.to_string())))?
+            {
+                self.store
+                    .commit(permit)
+                    .await
+                    .map_err(|err| (None, OrdererError::Transaction(err.to_string())))?;
+
+                let operation = match self
+                    .store
+                    .get_operation(&id)
+                    .await
+                    .map_err(|err| OrdererError::OperationStore(err.to_string()))
+                {
+                    Ok(Some(operation)) => operation,
+                    Ok(None) => return Err((None, OrdererError::StoreInconsistency(id))),
+                    Err(err) => return Err((None, err)),
+                };
+
+                let EventMetadata {
+                    log_id,
+                    topic,
+                    prune_flag,
+                    spaces_args,
+                    ingest,
+                } = match self.store.get_event(&id).await {
+                    Ok(Some(metadata)) => metadata,
+                    Ok(None) => return Err((None, OrdererError::StoreInconsistency(id))),
+                    Err(err) => return Err((None, OrdererError::ProcessorStore(err.to_string()))),
+                };
+
+                let mut event = Event::new(operation, log_id, topic, prune_flag, spaces_args);
+                event.ingest = ingest;
+
+                return Ok((event, OrdererResult::Processed));
+            }
+
+            self.store
+                .commit(permit)
+                .await
+                .map_err(|err| (None, OrdererError::Transaction(err.to_string())))?;
+
+            self.notify.notified().await;
+        }
+    }
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum OrdererError {
+    #[error("could not find item with id {0} in operation store")]
+    StoreInconsistency(Hash),
+
+    #[error("{0}")]
+    OrdererStore(String),
+
+    #[error("{0}")]
+    OperationStore(String),
+
+    #[error("{0}")]
+    ProcessorStore(String),
+
+    #[error("{0}")]
+    Transaction(String),
+}

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -20,6 +20,7 @@ use tokio::task::LocalSet;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::warn;
 
+use crate::processor::orderer::Orderer;
 use crate::processor::tasks::TaskTracker;
 use crate::processor::{Event, ProcessorStatus};
 use crate::spaces::types::{SpacesManager, SpacesProcessor};
@@ -104,6 +105,8 @@ where
                     // Prepare event processing pipeline.
                     let ingest =
                         Ingest::<SqliteStore, Event<L, E, TP>, L, E, TP>::new(store.clone());
+                    let orderer =
+                        Orderer::<SqliteStore, Event<L, E, TP>, L, E, TP>::new(store.clone());
                     let log_prune =
                         LogPrune::<SqliteStore, Event<L, E, TP>, L, E>::new(store.clone());
                     let spaces = SpacesProcessor::<Event<L, E, TP>>::new(
@@ -128,6 +131,25 @@ where
                             Err((mut event, err)) => {
                                 event.ingest = ProcessorStatus::Failed(err);
                                 event
+                            }
+                        })
+                        .layer(orderer)
+                        .map(|result| match result {
+                            Ok((mut event, result)) => {
+                                event.orderer = ProcessorStatus::Completed(result);
+                                event
+                            }
+                            Err((event, err)) => {
+                                if let Some(mut event) = event {
+                                    event.orderer = ProcessorStatus::Failed(err);
+                                    event
+                                } else {
+                                    // TODO: Properly handle error case. I'm not entirely sure what
+                                    // to do here...we don't have the `event` anymore when this
+                                    // error occurs, so it's not possible to continue with
+                                    // processing.
+                                    panic!("orderer processor returned None err")
+                                }
                             }
                         })
                         .layer(log_prune)
@@ -206,7 +228,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use p2panda_core::test_utils::TestLog;
+    use p2panda_core::test_utils::{TestLog, setup_logging};
     use p2panda_core::traits::Digest;
     use p2panda_core::{PruneFlag, SigningKey, Topic};
     use p2panda_store::SqliteStore;
@@ -221,6 +243,8 @@ mod tests {
 
     #[tokio::test]
     async fn processing_operations() {
+        setup_logging();
+
         let store = SqliteStore::temporary().await;
         let tasks = TaskTracker::new();
         let credentials = Credentials::generate();


### PR DESCRIPTION
This PR is mainly concerned with introducing ordering to the `p2panda` pipeline.

Here we introduce an orderer over p2panda pipeline events which
implements the `Processor` trait. We've chosen to create a
p2panda-specific orderer to keep the implementation in `p2panda-stream`
generic - especially over the `T` input type.

A new `EventMetadata` type has been introduced; this is the data
(excluding `operation`) which is required to construct an `Event`. This
new type is inserted into the newly-introduced `ProcessorStore` when an
event is passed into the orderer. The metadata is later retrieved from
the store in the `process()` method of the orderer if an operation has
been released. The metadata can then be used to reconstruct the `Event`,
which is expected by the next processor in the pipeline.

We also introduce an internal queue for the orderer processor
which is used to temporarily store events which failed to be processed
by the ingest processor (due to validation failure, for example). These
events should not be inserted into the causal orderer but nonetheless
need to continue flowing through the pipeline. Any queued events are
returned when `next()` is called on the orderer processor.

`Serialize` and `Deserialize` have been derived in a couple of places to
allow the `EventMetadata` to be stored. The signature of the `Ordering`
trait has also be changed to return a `Vec<Hash>` instead of a
`&[Hash]`.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
