### PR TITLE
Unblock task tracker by introducing "pass-through" events coming from orderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Highlights are marked with a pancake 🥞
 
 - encryption: Update hpke-rs to 0.6.1 to fix RUSTSEC [#1233](https://github.com/p2panda/p2panda/pull/1233)
 - spaces: Deterministic deserialization of `SpacesArgs` [#1264](https://github.com/p2panda/p2panda/pull/1264)
+- node: Unblock task tracker by introducing "pass-through" events coming from orderer [#1267](https://github.com/p2panda/p2panda/pull/1267)
 
 ## [0.6.1] - 22/05/2026
 

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -406,8 +406,8 @@ impl Node {
         let event =
             process_published_operation(message.into_operation(), topic, &self.pipeline).await;
 
-        if event.is_failed() {
-            Err(event.failure_reason().expect("error"))?
+        if let Some(err) = event.failure_reason() {
+            Err(err)?
         } else {
             let group = self.group(group_id).await?.expect("");
             Ok(group)

--- a/p2panda/src/processor/event.rs
+++ b/p2panda/src/processor/event.rs
@@ -159,6 +159,28 @@ where
 
         None
     }
+
+    /// Turn all processor arguments into no-ops by setting them to "ignore".
+    ///
+    /// This will cause this event to not be processed by _any_ next processors. Usually we want to
+    /// call this after an failure happenend.
+    pub(crate) fn noop(self) -> Self {
+        Self {
+            operation: self.operation,
+            ingest_args: IngestArgs {
+                log_id: self.ingest_args.log_id,
+                topic: self.ingest_args.topic,
+                prune_flag: false,
+            },
+            ingest: self.ingest,
+            orderer_args: OrdererArgs::Ignore,
+            orderer: self.orderer,
+            log_prune_args: LogPruneArgs::Ignore,
+            log_prune: self.log_prune,
+            spaces_args: SpacesProcessorArgs::Ignore,
+            spaces: self.spaces,
+        }
+    }
 }
 
 /// Metadata required to construct a new `Event` (excluding the operation).

--- a/p2panda/src/processor/event.rs
+++ b/p2panda/src/processor/event.rs
@@ -3,15 +3,16 @@
 use std::borrow::Borrow;
 
 use p2panda_core::traits::Digest;
-use p2panda_core::{Body, Hash, Header, LogId, Operation, PruneFlag, SeqNum, VerifyingKey};
+use p2panda_core::{
+    Body, Extensions, Hash, Header, LogId, Operation, PruneFlag, SeqNum, VerifyingKey,
+};
 use p2panda_stream::ingest::{IngestArgs, IngestError, IngestResult};
 use p2panda_stream::log_prune::{LogPruneArgs, LogPruneError, LogPruneResult};
-use p2panda_stream::orderer::Ordering;
 use p2panda_stream::spaces::{SpacesError, SpacesProcessorArgs, SpacesResult};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::processor::orderer::{OrdererError, OrdererResult};
+use crate::processor::orderer::{OrdererArgs, OrdererError, OrdererMetadata, OrdererResult};
 use crate::spaces::types::{AuthCapabilities, SpacesArgs};
 
 /// Status of an event being processed by a _single_ processor in the pipeline.
@@ -28,64 +29,35 @@ pub enum ProcessorStatus<R, F> {
     Failed(F),
 }
 
-/// Metadata required to construct a new `Event` (excluding the operation).
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct EventMetadata<L, TP> {
-    pub(crate) log_id: L,
-    pub(crate) topic: TP,
-    pub(crate) prune_flag: PruneFlag,
-    pub(crate) spaces_args: Option<SpacesArgs>,
-    pub(crate) ingest: ProcessorStatus<IngestResult, IngestError>,
-}
-
-/// Extract `EventMetadata` from an `Event`.
-impl<L, E, TP> From<Event<L, E, TP>> for EventMetadata<L, TP> {
-    fn from(event: Event<L, E, TP>) -> Self {
-        let log_id = event.ingest_args.log_id;
-        let topic = event.ingest_args.topic;
-        let prune_flag = PruneFlag::new(event.ingest_args.prune_flag);
-        let spaces_args = match event.spaces_args {
-            SpacesProcessorArgs::Ignore => None,
-            SpacesProcessorArgs::Process { msg } => Some(msg.args),
-        };
-        let ingest = event.ingest;
-
-        Self {
-            log_id,
-            topic,
-            prune_flag,
-            spaces_args,
-            ingest,
-        }
-    }
-}
-
 /// Single event running through the "event processor" pipeline.
 #[derive(Clone, Debug)]
 pub struct Event<L, E, TP> {
     /// p2panda Operation.
-    operation: Operation<E>,
+    pub operation: Operation<E>,
 
     /// Input arguments for the "ingest" processor.
-    ingest_args: IngestArgs<L, TP>,
+    pub ingest_args: IngestArgs<L, TP>,
 
     /// Status of the "ingest" processor.
-    pub(crate) ingest: ProcessorStatus<IngestResult, IngestError>,
+    pub ingest: ProcessorStatus<IngestResult, IngestError>,
+
+    /// Input arguments for the "orderer" processor.
+    pub orderer_args: OrdererArgs,
 
     /// Status of the "orderer" processor.
-    pub(crate) orderer: ProcessorStatus<OrdererResult, OrdererError>,
+    pub orderer: ProcessorStatus<OrdererResult, OrdererError>,
 
     /// Input arguments for the "log prune" processor.
-    log_prune_args: LogPruneArgs<VerifyingKey, L, SeqNum>,
+    pub log_prune_args: LogPruneArgs<VerifyingKey, L, SeqNum>,
 
     /// Status of the "log prune" processor.
-    pub(crate) log_prune: ProcessorStatus<LogPruneResult, LogPruneError>,
+    pub log_prune: ProcessorStatus<LogPruneResult, LogPruneError>,
 
     /// Input arguments for the "spaces" processor.
-    pub(crate) spaces_args: SpacesProcessorArgs<AuthCapabilities>,
+    pub spaces_args: SpacesProcessorArgs<AuthCapabilities>,
 
     /// Status of the "spaces" processor.
-    pub(crate) spaces: ProcessorStatus<SpacesResult<AuthCapabilities>, SpacesError>,
+    pub spaces: ProcessorStatus<SpacesResult<AuthCapabilities>, SpacesError>,
 }
 
 impl<L, E, TP> Event<L, E, TP>
@@ -106,16 +78,24 @@ where
                 prune_flag: prune_flag.is_set(),
             },
             ingest: ProcessorStatus::Pending,
+            orderer_args: OrdererArgs::Process {
+                dependencies: match &spaces_args {
+                    Some(args) => args.dependencies(),
+                    None => vec![],
+                },
+            },
             orderer: ProcessorStatus::Pending,
-            // Do not allow pruning when spaces args are set.
-            log_prune_args: if prune_flag.is_set() && spaces_args.is_none() {
-                LogPruneArgs::PruneEntriesUntil {
-                    author: operation.header.verifying_key,
-                    log_id,
-                    seq_num: operation.header.seq_num,
+            log_prune_args: {
+                // Do not allow pruning when spaces args are set.
+                if prune_flag.is_set() && spaces_args.is_none() {
+                    LogPruneArgs::PruneEntriesUntil {
+                        author: operation.header.verifying_key,
+                        log_id,
+                        seq_num: operation.header.seq_num,
+                    }
+                } else {
+                    LogPruneArgs::Ignore
                 }
-            } else {
-                LogPruneArgs::Ignore
             },
             log_prune: ProcessorStatus::Pending,
             spaces_args: match spaces_args {
@@ -128,8 +108,8 @@ where
                 },
                 None => SpacesProcessorArgs::Ignore,
             },
-            operation,
             spaces: ProcessorStatus::Pending,
+            operation,
         }
     }
 
@@ -181,12 +161,51 @@ where
     }
 }
 
-impl<L, E, TP> Ordering<Hash> for Event<L, E, TP> {
-    fn dependencies(&self) -> Vec<Hash> {
-        match &self.spaces_args {
-            SpacesProcessorArgs::Ignore => vec![],
-            SpacesProcessorArgs::Process { msg } => msg.args.dependencies(),
+/// Metadata required to construct a new `Event` (excluding the operation).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EventMetadata<L, TP> {
+    log_id: L,
+    topic: TP,
+    prune_flag: PruneFlag,
+    spaces_args: Option<SpacesArgs>,
+    ingest: ProcessorStatus<IngestResult, IngestError>,
+}
+
+impl<L, E, TP> OrdererMetadata<E> for Event<L, E, TP>
+where
+    L: LogId,
+    E: Extensions,
+    TP: Clone + Serialize + for<'a> Deserialize<'a>,
+{
+    type Metadata = EventMetadata<L, TP>;
+
+    fn metadata(&self) -> Self::Metadata {
+        let log_id = self.ingest_args.log_id.clone();
+        let topic = self.ingest_args.topic.clone();
+        let prune_flag = PruneFlag::new(self.ingest_args.prune_flag);
+        let spaces_args = match &self.spaces_args {
+            SpacesProcessorArgs::Ignore => None,
+            SpacesProcessorArgs::Process { msg } => Some(msg.args.clone()),
+        };
+        let ingest = self.ingest.clone();
+
+        EventMetadata {
+            log_id,
+            topic,
+            prune_flag,
+            spaces_args,
+            ingest,
         }
+    }
+
+    fn from_operation(operation: Operation<E>, meta: Self::Metadata) -> Self {
+        Self::new(
+            operation,
+            meta.log_id,
+            meta.topic,
+            meta.prune_flag,
+            meta.spaces_args,
+        )
     }
 }
 
@@ -228,6 +247,16 @@ where
 {
     fn borrow(&self) -> &IngestArgs<L, TP> {
         &self.ingest_args
+    }
+}
+
+impl<L, E, TP> Borrow<OrdererArgs> for Event<L, E, TP>
+where
+    L: LogId,
+    TP: Clone,
+{
+    fn borrow(&self) -> &OrdererArgs {
+        &self.orderer_args
     }
 }
 

--- a/p2panda/src/processor/event.rs
+++ b/p2panda/src/processor/event.rs
@@ -163,7 +163,7 @@ where
     /// Turn all processor arguments into no-ops by setting them to "ignore".
     ///
     /// This will cause this event to not be processed by _any_ next processors. Usually we want to
-    /// call this after an failure happenend.
+    /// call this after a processor failure happenend.
     pub(crate) fn noop(self) -> Self {
         Self {
             operation: self.operation,

--- a/p2panda/src/processor/orderer.rs
+++ b/p2panda/src/processor/orderer.rs
@@ -1,22 +1,41 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 
 use p2panda_core::traits::Digest;
-use p2panda_core::{Hash, LogId, Operation};
+use p2panda_core::{Extensions, Hash, Operation};
 use p2panda_store::Transaction;
 use p2panda_store::operations::OperationStore;
 use p2panda_store::orderer::OrdererStore;
 use p2panda_store::processor::ProcessorStore;
 use p2panda_stream::Processor;
-use p2panda_stream::orderer::{CausalOrderer, Ordering};
+use p2panda_stream::orderer::CausalOrderer;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{Mutex, Notify};
 
-use crate::processor::ProcessorStatus;
-use crate::processor::event::{Event, EventMetadata};
+pub trait OrdererMetadata<E> {
+    /// Metadata attached to an input event we want to persist in database next to ordering info.
+    type Metadata: Serialize + for<'de> Deserialize<'de>;
+
+    /// Extract metadata from input.
+    fn metadata(&self) -> Self::Metadata;
+
+    /// Re-construct input from operation and persisted metadata.
+    fn from_operation(operation: Operation<E>, meta: Self::Metadata) -> Self;
+}
+
+#[derive(Clone, Default, Debug)]
+pub enum OrdererArgs {
+    Process {
+        dependencies: Vec<Hash>,
+    },
+    #[default]
+    Ignore,
+}
 
 #[derive(Clone, Debug)]
 pub enum OrdererResult {
@@ -24,16 +43,15 @@ pub enum OrdererResult {
     Ignored,
 }
 
-pub struct Orderer<S, T, L, E, TP> {
+pub struct Orderer<S, T, E> {
     inner: Mutex<CausalOrderer<Hash, S>>,
     store: S,
     notify: Notify,
-    #[allow(clippy::type_complexity)]
-    queue: RefCell<VecDeque<(Event<L, E, TP>, OrdererResult)>>,
-    _marker: PhantomData<(T, L, E, TP)>,
+    queue: RefCell<VecDeque<(T, OrdererResult)>>,
+    _marker: PhantomData<E>,
 }
 
-impl<S, T, L, E, TP> Orderer<S, T, L, E, TP>
+impl<S, T, E> Orderer<S, T, E>
 where
     S: Clone + Transaction + OrdererStore<Hash> + OperationStore<Operation<E>, Hash>,
 {
@@ -50,23 +68,23 @@ where
     }
 }
 
-impl<S, T, L, E, TP> Processor<Event<L, E, TP>> for Orderer<S, T, L, E, TP>
+impl<S, T, E> Processor<T> for Orderer<S, T, E>
 where
     S: Transaction
         + OrdererStore<Hash>
         + OperationStore<Operation<E>, Hash>
-        + ProcessorStore<EventMetadata<L, TP>>,
-    L: LogId,
-    TP: Clone,
-    E: Clone,
+        + ProcessorStore<T::Metadata>,
+    T: OrdererMetadata<E> + Borrow<OrdererArgs> + Digest<Hash>,
+    E: Extensions,
 {
-    type Output = (Event<L, E, TP>, OrdererResult);
+    type Output = (T, OrdererResult);
 
-    type Error = (Option<Event<L, E, TP>>, OrdererError);
+    type Error = (Option<T>, OrdererError);
 
-    async fn process(&self, input: Event<L, E, TP>) -> Result<(), Self::Error> {
-        // Only process the operation if it was successfully ingested.
-        if let ProcessorStatus::Completed(_) = input.ingest {
+    async fn process(&self, input: T) -> Result<(), Self::Error> {
+        let args = input.borrow();
+
+        if let OrdererArgs::Process { dependencies } = args {
             let inner = self.inner.lock().await;
 
             let permit = match self.store.begin().await {
@@ -74,13 +92,11 @@ where
                 Err(err) => return Err((Some(input), OrdererError::Transaction(err.to_string()))),
             };
 
-            if let Err(err) = inner.process(input.hash(), &input.dependencies()[..]).await {
+            if let Err(err) = inner.process(input.hash(), dependencies).await {
                 return Err((Some(input), OrdererError::OrdererStore(err.to_string())));
             };
 
-            let metadata: EventMetadata<L, TP> = input.clone().into();
-
-            if let Err(err) = self.store.set_event(&input.hash(), &metadata).await {
+            if let Err(err) = self.store.set_event(&input.hash(), &input.metadata()).await {
                 return Err((Some(input), OrdererError::ProcessorStore(err.to_string())));
             };
 
@@ -135,28 +151,24 @@ where
                     Err(err) => return Err((None, err)),
                 };
 
-                let EventMetadata {
-                    log_id,
-                    topic,
-                    prune_flag,
-                    spaces_args,
-                    ingest,
-                } = match self.store.get_event(&id).await {
+                let metadata = match self.store.get_event(&id).await {
                     Ok(Some(metadata)) => metadata,
                     Ok(None) => return Err((None, OrdererError::StoreInconsistency(id))),
                     Err(err) => return Err((None, OrdererError::ProcessorStore(err.to_string()))),
                 };
 
-                let mut event = Event::new(operation, log_id, topic, prune_flag, spaces_args);
-                event.ingest = ingest;
-
-                return Ok((event, OrdererResult::Processed));
+                return Ok((
+                    T::from_operation(operation, metadata),
+                    OrdererResult::Processed,
+                ));
             }
 
             self.store
                 .commit(permit)
                 .await
                 .map_err(|err| (None, OrdererError::Transaction(err.to_string())))?;
+
+            drop(inner);
 
             self.notify.notified().await;
         }

--- a/p2panda/src/processor/orderer.rs
+++ b/p2panda/src/processor/orderer.rs
@@ -37,10 +37,17 @@ pub enum OrdererArgs {
     Ignore,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum OrdererResult {
-    Processed,
+    Ready,
+    Pending,
     Ignored,
+}
+
+impl OrdererResult {
+    pub fn is_pending(&self) -> bool {
+        matches!(self, OrdererResult::Pending)
+    }
 }
 
 pub struct Orderer<S, T, E> {
@@ -100,10 +107,13 @@ where
                 return Err((Some(input), OrdererError::ProcessorStore(err.to_string())));
             };
 
-            self.store
-                .commit(permit)
-                .await
-                .map_err(|err| (Some(input), OrdererError::Transaction(err.to_string())))?;
+            if let Err(err) = self.store.commit(permit).await {
+                return Err((Some(input), OrdererError::Transaction(err.to_string())));
+            }
+
+            self.queue
+                .borrow_mut()
+                .push_back((input, OrdererResult::Pending));
         } else {
             self.queue
                 .borrow_mut()
@@ -157,10 +167,7 @@ where
                     Err(err) => return Err((None, OrdererError::ProcessorStore(err.to_string()))),
                 };
 
-                return Ok((
-                    T::from_operation(operation, metadata),
-                    OrdererResult::Processed,
-                ));
+                return Ok((T::from_operation(operation, metadata), OrdererResult::Ready));
             }
 
             self.store

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -237,6 +237,7 @@ mod tests {
     use crate::forge::OperationForge;
     use crate::operation::LogId;
     use crate::processor::TaskTracker;
+    use crate::processor::orderer::OrdererArgs;
     use crate::spaces::spaces_manager;
 
     use super::{Event, Pipeline};
@@ -291,5 +292,59 @@ mod tests {
         assert_eq!(result.hash(), operation.hash());
         assert!(!result.is_completed());
         assert!(result.is_failed());
+    }
+
+    #[tokio::test]
+    async fn out_of_order() {
+        setup_logging();
+
+        let store = SqliteStore::temporary().await;
+        let tasks = TaskTracker::new();
+        let credentials = Credentials::generate();
+        let forge = OperationForge::new(credentials.clone(), store.clone());
+        let spaces_manager = spaces_manager(forge, credentials, store.clone())
+            .await
+            .unwrap();
+
+        let processor = Pipeline::<LogId, (), Topic>::new(store, tasks, spaces_manager);
+
+        let mut events = Vec::new();
+        let mut dependencies = Vec::new();
+
+        // Create many operations in own logs (each depth 1) which are dependent on each other
+        // (multi-writer). We reverse the order of how they are processed afterwards, so we need to
+        // process everything in "the worst order possible".
+        let topic = Topic::random();
+        for _ in 0..255 {
+            let log = TestLog::new();
+            let operation = log.operation(b"op", ());
+
+            let mut event = Event::new(
+                operation.clone(),
+                LogId::from_topic(topic),
+                topic,
+                PruneFlag::default(),
+                None,
+            );
+
+            event.orderer_args = OrdererArgs::Process {
+                dependencies: dependencies,
+            };
+
+            events.push(event);
+
+            dependencies = vec![operation.hash()];
+        }
+
+        events.reverse();
+
+        for event in events {
+            let event_hash = event.hash();
+            let result = processor.process(event).await;
+
+            assert_eq!(result.hash(), event_hash);
+            assert!(result.is_completed());
+            assert!(!result.is_failed());
+        }
     }
 }

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -130,7 +130,14 @@ where
                         .map(|result| match result {
                             Ok((mut event, result)) => {
                                 event.orderer = ProcessorStatus::Completed(result);
-                                event
+
+                                // If the orderer returns a "pending" result we don't want to affect
+                                // any next processors anymore.
+                                if result.is_pending() {
+                                    event.noop()
+                                } else {
+                                    event
+                                }
                             }
                             Err((event, err)) => {
                                 if let Some(mut event) = event {

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -106,20 +106,13 @@ where
                     // Prepare event processing pipeline.
                     let ingest =
                         Ingest::<SqliteStore, Event<L, E, TP>, L, E, TP>::new(store.clone());
-                    let orderer =
-                        Orderer::<SqliteStore, Event<L, E, TP>, L, E, TP>::new(store.clone());
+                    let orderer = Orderer::<SqliteStore, Event<L, E, TP>, E>::new(store.clone());
                     let log_prune =
                         LogPrune::<SqliteStore, Event<L, E, TP>, L, E>::new(store.clone());
                     let spaces = SpacesProcessor::<Event<L, E, TP>>::new(
                         SqliteSpacesStore::new(store),
                         spaces_manager,
                     );
-
-                    // TODO: Add orderer. Unfortunately this might come with a refactoring of the
-                    // ordering logic as we loose the input type (T or Event) during buffering.
-                    //
-                    // It might work out if we allow to store the input object as well in the
-                    // buffer, not sure if that's the right path right now.
 
                     // Receive incoming events through mpsc channel.
                     let pipeline = ReceiverStream::new(pipeline_rx)
@@ -146,8 +139,8 @@ where
                             Err((event, err)) => {
                                 if let Some(mut event) = event {
                                     event.orderer = ProcessorStatus::Failed(err);
-                                    // As processing the operation failed here we should ignore it in
-                                    // the spaces processor.
+                                    // As processing the operation failed here we should ignore it
+                                    // in the spaces processor.
                                     event.spaces_args = SpacesProcessorArgs::Ignore;
                                     event
                                 } else {

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -11,7 +11,6 @@ use p2panda_store::spaces::SqliteSpacesStore;
 use p2panda_stream::StreamLayerExt;
 use p2panda_stream::ingest::Ingest;
 use p2panda_stream::log_prune::LogPrune;
-use p2panda_stream::spaces::SpacesProcessorArgs;
 use p2panda_sync::protocols::ShortFormat;
 use serde::{Deserialize, Serialize};
 use tokio::pin;
@@ -124,10 +123,7 @@ where
                             }
                             Err((mut event, err)) => {
                                 event.ingest = ProcessorStatus::Failed(err);
-                                // As processing the operation failed here we should ignore it in
-                                // the spaces processor.
-                                event.spaces_args = SpacesProcessorArgs::Ignore;
-                                event
+                                event.noop()
                             }
                         })
                         .layer(orderer)
@@ -139,10 +135,7 @@ where
                             Err((event, err)) => {
                                 if let Some(mut event) = event {
                                     event.orderer = ProcessorStatus::Failed(err);
-                                    // As processing the operation failed here we should ignore it
-                                    // in the spaces processor.
-                                    event.spaces_args = SpacesProcessorArgs::Ignore;
-                                    event
+                                    event.noop()
                                 } else {
                                     // TODO: Properly handle error case. I'm not entirely sure what
                                     // to do here...we don't have the `event` anymore when this
@@ -160,7 +153,7 @@ where
                             }
                             Err((mut event, err)) => {
                                 event.log_prune = ProcessorStatus::Failed(err);
-                                event
+                                event.noop()
                             }
                         })
                         .layer(spaces)
@@ -171,7 +164,7 @@ where
                             }
                             Err((mut event, err)) => {
                                 event.spaces = ProcessorStatus::Failed(err);
-                                event
+                                event.noop()
                             }
                         });
 

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -375,9 +375,7 @@ where
         ))
         .await;
 
-    if event.is_failed() {
-        let error = event.failure_reason().expect("event has failed");
-
+    if let Some(error) = event.failure_reason() {
         warn!(
             id = %event.hash(),
             "processing operation failed: {}",
@@ -494,9 +492,7 @@ pub(crate) async fn process_published_operation(
         ))
         .await;
 
-    if event.is_failed() {
-        let err = event.failure_reason().expect("event has failed");
-
+    if let Some(err) = event.failure_reason() {
         warn!(
             id = %event.hash(),
             "processing local operation failed: {}",


### PR DESCRIPTION
The current pipeline is designed in a strictly symmetric manner: One input event causes exactly one output event. With the introduction of an orderer and -spaces this changes significantly: One single event can result in nothing (because it got buffered by the orderer) or into many events (because buffered operations got freed, etc.).

The task tracker is the one enforcing this strict 1:1 rule. On top it's enforcing strict ordering of events, things are not allowed to be processed in parallel.

This design is blocking because the task tracker is waiting for a task to finish before it allows the new task to come in. In this PR we're fixing this simply by introducing a "noop" event coming from the orderer. So _something_ is informing the task tracker that it is "done".

The other scenario requires a larger refactoring of the task tracker and is handled in a second PR.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
