### PR TITLE
Allow event processing to handle out-of-order buffering by separating i/o streams and preserve input ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Highlights are marked with a pancake 🥞
 - encryption: Update hpke-rs to 0.6.1 to fix RUSTSEC [#1233](https://github.com/p2panda/p2panda/pull/1233)
 - spaces: Deterministic deserialization of `SpacesArgs` [#1264](https://github.com/p2panda/p2panda/pull/1264)
 - node: Unblock task tracker by introducing "pass-through" events coming from orderer [#1267](https://github.com/p2panda/p2panda/pull/1267)
+- node: Allow event processing to handle out-of-order buffering by separating i/o streams and preserve input ordering [#1271](https://github.com/p2panda/p2panda/pull/1271)
 
 ## [0.6.1] - 22/05/2026
 

--- a/p2panda-stream/src/orderer/orderer.rs
+++ b/p2panda-stream/src/orderer/orderer.rs
@@ -91,12 +91,12 @@ where
     }
 
     /// Process a new item which may be in a "ready" or "pending" state.
-    pub async fn process(&self, key: ID, dependencies: &[ID]) -> Result<(), S::Error> {
+    pub async fn process(&self, key: ID, dependencies: &[ID]) -> Result<bool, S::Error> {
         if !self.store.ready(dependencies).await? {
             self.store
                 .mark_pending(key.clone(), dependencies.to_vec())
                 .await?;
-            return Ok(());
+            return Ok(false);
         }
 
         self.store.mark_ready(key.clone()).await?;
@@ -105,7 +105,7 @@ where
         // which depend on it as they may now have transitioned into a ready state.
         self.process_pending(key).await?;
 
-        Ok(())
+        Ok(true)
     }
 
     /// Recursively check if any pending items now have their dependencies met.

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -307,6 +307,7 @@ impl Node {
             .map_err(|err| CreateStreamError(err.to_string()))?;
 
         let pipeline = Pipeline::new(
+            topic,
             self.store.clone(),
             self.tasks.clone(),
             self.spaces_manager.clone(),

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -25,6 +25,7 @@ use crate::spaces::types::{InnerSpace, NoBody, SpacesManager, SpacesManagerError
 use crate::spaces::{
     AccessLevel, ActorId, Group, GroupError, KEY_BUNDLE_LOG_ID, Member, MemberError, Space,
     SpaceError, SpaceSubscription, actor_to_topic, spaces_manager, spaces_stream,
+    to_initial_members,
 };
 use crate::streams::{
     EphemeralStreamPublisher, EphemeralStreamSubscription, Pipeline, StreamFrom, StreamPublisher,
@@ -394,25 +395,33 @@ impl Node {
 
     pub async fn create_group(
         &self,
-        _initial_members: &[(ActorId, AccessLevel)],
+        initial_members: &[(ActorId, AccessLevel)],
     ) -> Result<Group, GroupError> {
-        // TODO: refactor this to process using the tx, similar like create_space. Like this we
-        // would already receive the CREATED_GROUP event on the rx which is nice.
-        todo!();
+        let initial_members = to_initial_members(initial_members);
+        let (_, group_id, message) = self.spaces_manager.create_group(&initial_members).await?;
 
-        // let initial_members = to_initial_members(initial_members);
-        // let (_, group_id, message) = self.spaces_manager.create_group(&initial_members).await?;
-        //
-        // let topic = actor_to_topic(group_id);
-        // let event =
-        //     process_published_operation(message.into_operation(), topic, &self.pipeline).await;
-        //
-        // if let Some(err) = event.failure_reason() {
-        //     Err(err)?
-        // } else {
-        //     let group = self.group(group_id).await?.expect("");
-        //     Ok(group)
-        // }
+        let topic = actor_to_topic(group_id);
+        let (tx, rx) = self.stream::<NoBody>(topic).await?;
+
+        let processed = tx
+            .import(futures_util::stream::once(async {
+                message.into_operation()
+            }))
+            .await?;
+
+        // TODO: Would be good to get an error / report here if processing the imported operations
+        // failed. This error so far only tells us that the channel broke down.
+        if processed.await.is_err() {
+            panic!();
+        }
+
+        let inner = self
+            .spaces_manager
+            .group(group_id)
+            .await?
+            .expect("materialised group after processing operations");
+
+        Ok(Group::new(inner, tx, rx))
     }
 
     pub async fn space<M>(

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -20,18 +20,15 @@ pub use crate::builder::NodeBuilder;
 use crate::credentials::Credentials;
 use crate::forge::{Forge, OperationForge};
 use crate::network::{Network, NetworkConfig, NetworkError};
-use crate::operation::{Extensions, LogId};
-use crate::processor::{Pipeline, TaskTracker};
+use crate::operation::Extensions;
 use crate::spaces::types::{InnerSpace, NoBody, SpacesManager, SpacesManagerError};
 use crate::spaces::{
     AccessLevel, ActorId, Group, GroupError, KEY_BUNDLE_LOG_ID, Member, MemberError, Space,
     SpaceError, SpaceSubscription, actor_to_topic, spaces_manager, spaces_stream,
-    to_initial_members,
 };
 use crate::streams::{
-    EphemeralStreamPublisher, EphemeralStreamSubscription, StreamFrom, StreamPublisher,
-    StreamSubscription, SystemEvent, ephemeral_stream, event_stream, process_published_operation,
-    processed_stream,
+    EphemeralStreamPublisher, EphemeralStreamSubscription, Pipeline, StreamFrom, StreamPublisher,
+    StreamSubscription, SystemEvent, TaskTracker, ephemeral_stream, event_stream, processed_stream,
 };
 
 /// Node API with methods to establish ephemeral and eventually consistent topic streams.
@@ -41,10 +38,7 @@ pub struct Node {
     store: SqliteStore,
     forge: OperationForge,
     credentials: Credentials,
-    // NOTE: One single pipeline is currently used to handle _all_ incoming operations, independent
-    // of number of streams. While this is sufficient for most applications for now we might want to
-    // make the number of processors configurable to avoid head-of-line blocking.
-    pipeline: Pipeline<LogId, Extensions, Topic>,
+    tasks: TaskTracker,
     network: Network,
     spaces_manager: SpacesManager,
 }
@@ -93,14 +87,13 @@ impl Node {
 
         // Prepare manager which orchestrates processing of incoming operations.
         let tasks = TaskTracker::new();
-        let pipeline = Pipeline::new(store.clone(), tasks, spaces_manager.clone());
 
         Ok(Node {
             config,
             store,
             forge,
             credentials,
-            pipeline,
+            tasks,
             network,
             spaces_manager,
         })
@@ -312,13 +305,19 @@ impl Node {
             .await
             .map_err(|err| CreateStreamError(err.to_string()))?;
 
+        let pipeline = Pipeline::new(
+            self.store.clone(),
+            self.tasks.clone(),
+            self.spaces_manager.clone(),
+        );
+
         let (tx, rx) = processed_stream(
             topic,
             self.config.ack_policy,
             sync_handle,
             self.store.clone(),
             self.forge.clone(),
-            self.pipeline.clone(),
+            pipeline,
             from,
         )
         .await
@@ -395,23 +394,25 @@ impl Node {
 
     pub async fn create_group(
         &self,
-        initial_members: &[(ActorId, AccessLevel)],
+        _initial_members: &[(ActorId, AccessLevel)],
     ) -> Result<Group, GroupError> {
-        let initial_members = to_initial_members(initial_members);
-        let (_, group_id, message) = self.spaces_manager.create_group(&initial_members).await?;
+        // TODO: refactor this to process using the tx, similar like create_space. Like this we
+        // would already receive the CREATED_GROUP event on the rx which is nice.
+        todo!();
 
-        // TODO: Could refactor this to process using the tx, similar like create_space. Like this
-        // we would already receive the CREATED_GROUP event on the rx which is nice.
-        let topic = actor_to_topic(group_id);
-        let event =
-            process_published_operation(message.into_operation(), topic, &self.pipeline).await;
-
-        if let Some(err) = event.failure_reason() {
-            Err(err)?
-        } else {
-            let group = self.group(group_id).await?.expect("");
-            Ok(group)
-        }
+        // let initial_members = to_initial_members(initial_members);
+        // let (_, group_id, message) = self.spaces_manager.create_group(&initial_members).await?;
+        //
+        // let topic = actor_to_topic(group_id);
+        // let event =
+        //     process_published_operation(message.into_operation(), topic, &self.pipeline).await;
+        //
+        // if let Some(err) = event.failure_reason() {
+        //     Err(err)?
+        // } else {
+        //     let group = self.group(group_id).await?.expect("");
+        //     Ok(group)
+        // }
     }
 
     pub async fn space<M>(

--- a/p2panda/src/processor/event.rs
+++ b/p2panda/src/processor/event.rs
@@ -139,6 +139,17 @@ where
             || matches!(self.spaces, ProcessorStatus::Failed(_))
     }
 
+    /// Returns `true` if event got buffered by some processor and is therefore in "pending" state
+    /// until it'll be released by another event.
+    ///
+    /// Buffering usually takes place when an event arrives out-of-order.
+    pub fn is_pending(&self) -> bool {
+        matches!(
+            self.orderer,
+            ProcessorStatus::Completed(OrdererResult::Pending)
+        )
+    }
+
     /// Returns the error which occurred during a processing failure or `None`.
     pub fn failure_reason(&self) -> Option<ProcessorError> {
         if let ProcessorStatus::Failed(err) = &self.ingest {

--- a/p2panda/src/processor/event.rs
+++ b/p2panda/src/processor/event.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 
 use crate::processor::orderer::{OrdererArgs, OrdererError, OrdererMetadata, OrdererResult};
 use crate::spaces::types::{AuthCapabilities, SpacesArgs};
+use crate::streams::Source;
 
 /// Status of an event being processed by a _single_ processor in the pipeline.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -34,6 +35,9 @@ pub enum ProcessorStatus<R, F> {
 pub struct Event<L, E, TP> {
     /// p2panda Operation.
     pub operation: Operation<E>,
+
+    /// Source of a processed operation.
+    pub source: Source,
 
     /// Input arguments for the "ingest" processor.
     pub ingest_args: IngestArgs<L, TP>,
@@ -66,6 +70,7 @@ where
 {
     pub(crate) fn new(
         operation: Operation<E>,
+        source: Source,
         log_id: L,
         topic: TP,
         prune_flag: PruneFlag,
@@ -110,6 +115,7 @@ where
             },
             spaces: ProcessorStatus::Pending,
             operation,
+            source,
         }
     }
 
@@ -178,6 +184,7 @@ where
     pub(crate) fn noop(self) -> Self {
         Self {
             operation: self.operation,
+            source: self.source,
             ingest_args: IngestArgs {
                 log_id: self.ingest_args.log_id,
                 topic: self.ingest_args.topic,
@@ -195,13 +202,18 @@ where
 }
 
 /// Metadata required to construct a new `Event` (excluding the operation).
+// TODO: Optimize serialization for database, consider adding version number for encoding.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EventMetadata<L, TP> {
-    log_id: L,
     topic: TP,
+    // TODO: Not all fields are required here, for example log id and prune flag and spaces args are
+    // in the header extensions.
+    log_id: L,
     prune_flag: PruneFlag,
     spaces_args: Option<SpacesArgs>,
+    // TODO: Store all processors results, not only ingest.
     ingest: ProcessorStatus<IngestResult, IngestError>,
+    source: Source,
 }
 
 impl<L, E, TP> OrdererMetadata<E> for Event<L, E, TP>
@@ -221,6 +233,7 @@ where
             SpacesProcessorArgs::Process { msg } => Some(msg.args.clone()),
         };
         let ingest = self.ingest.clone();
+        let source = self.source.clone();
 
         EventMetadata {
             log_id,
@@ -228,12 +241,14 @@ where
             prune_flag,
             spaces_args,
             ingest,
+            source,
         }
     }
 
     fn from_operation(operation: Operation<E>, meta: Self::Metadata) -> Self {
         Self::new(
             operation,
+            meta.source,
             meta.log_id,
             meta.topic,
             meta.prune_flag,

--- a/p2panda/src/processor/mod.rs
+++ b/p2panda/src/processor/mod.rs
@@ -6,5 +6,5 @@ mod pipeline;
 mod tasks;
 
 pub use event::{Event, ProcessorError, ProcessorStatus};
-pub(crate) use pipeline::Pipeline;
+pub(crate) use pipeline::{Pipeline, PipelineTaskId};
 pub(crate) use tasks::TaskTracker;

--- a/p2panda/src/processor/orderer.rs
+++ b/p2panda/src/processor/orderer.rs
@@ -39,8 +39,14 @@ pub enum OrdererArgs {
 
 #[derive(Copy, Clone, Debug)]
 pub enum OrdererResult {
-    Ready,
+    /// Item was buffered and is now in "pending" state.
     Pending,
+
+    /// Item was buffered by orderer and is now marked as "ready" to be finally forwarded in correct
+    /// order.
+    Ready,
+
+    /// Item was ignored as specified in input arguments.
     Ignored,
 }
 
@@ -127,7 +133,7 @@ where
 
     async fn next(&self) -> Result<Self::Output, Self::Error> {
         loop {
-            // First check to see if there are any ignored events which can be returned.
+            // First check to see if there are any ignored or pending events which can be returned.
             if let Some((event, result)) = self.queue.borrow_mut().pop_front() {
                 return Ok((event, result));
             }

--- a/p2panda/src/processor/orderer.rs
+++ b/p2panda/src/processor/orderer.rs
@@ -37,14 +37,19 @@ pub enum OrdererArgs {
     Ignore,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub enum OrdererResult {
-    /// Item was buffered and is now in "pending" state.
+    /// Item has unmet dependencies, is buffered and now in "pending" state.
     Pending,
 
-    /// Item was buffered by orderer and is now marked as "ready" to be finally forwarded in correct
-    /// order.
-    Ready,
+    /// Item is "ready" and was a dependency for one or more operations which are "freed" now.
+    ///
+    /// This input may trigger zero to many ReadyOutput items to follow.
+    ReadyInput { dependent_operations: Vec<Hash> },
+
+    /// Item was buffered by orderer and is now marked as "ready" by another "input" item, to be
+    /// finally forwarded in correct order.
+    ReadyOutput,
 
     /// Item was ignored as specified in input arguments.
     Ignored,
@@ -56,10 +61,20 @@ impl OrdererResult {
     }
 }
 
+// TODO: Move this back to p2panda-stream.
 pub struct Orderer<S, T, E> {
     inner: Mutex<CausalOrderer<Hash, S>>,
     store: S,
     notify: Notify,
+    // We're keeping an unbound, in-memory buffer of all "freed" events here. This means that if an
+    // event frees n events, we will need to keep all n of them here. This shouldn't be a problem as
+    // long as n stays low (<100 items).
+    //
+    // The alternative is to move the logic polling from the inner orderer into "next" which allows
+    // a more atomic and memory-efficient streaming design where we only look at one item at a time.
+    // We still need a way to tell the pipeline how many items got "freed" by it to allow the
+    // correct input stream ordering to take place (see docs in pipeline.rs of p2panda crate), this
+    // functionality should be possible to add to the inner orderer.
     queue: RefCell<VecDeque<(T, OrdererResult)>>,
     _marker: PhantomData<E>,
 }
@@ -92,7 +107,7 @@ where
 {
     type Output = (T, OrdererResult);
 
-    type Error = (Option<T>, OrdererError);
+    type Error = (T, OrdererError);
 
     async fn process(&self, input: T) -> Result<(), Self::Error> {
         let args = input.borrow();
@@ -102,24 +117,99 @@ where
 
             let permit = match self.store.begin().await {
                 Ok(permit) => permit,
-                Err(err) => return Err((Some(input), OrdererError::Transaction(err.to_string()))),
+                Err(err) => return Err((input, OrdererError::Transaction(err.to_string()))),
             };
 
-            if let Err(err) = inner.process(input.hash(), dependencies).await {
-                return Err((Some(input), OrdererError::OrdererStore(err.to_string())));
-            };
+            match inner.process(input.hash(), dependencies).await {
+                // a) Item has all dependencies met, we can directly mark it as "ready".
+                Ok(true) => {
+                    let mut dependent_operations = Vec::new();
 
-            if let Err(err) = self.store.set_event(&input.hash(), &input.metadata()).await {
-                return Err((Some(input), OrdererError::ProcessorStore(err.to_string())));
-            };
+                    loop {
+                        match inner.next().await {
+                            Ok(Some(id)) => {
+                                // Ignore our own input.
+                                if id != input.hash() {
+                                    dependent_operations.push(id);
+                                }
 
-            if let Err(err) = self.store.commit(permit).await {
-                return Err((Some(input), OrdererError::Transaction(err.to_string())));
+                                continue;
+                            }
+                            Ok(None) => {
+                                break;
+                            }
+                            Err(err) => {
+                                return Err((input, OrdererError::OrdererStore(err.to_string())));
+                            }
+                        }
+                    }
+
+                    if let Err(err) = self.store.commit(permit).await {
+                        return Err((input, OrdererError::Transaction(err.to_string())));
+                    }
+
+                    let mut to_queue = Vec::new();
+
+                    for id in &dependent_operations {
+                        let operation = match self
+                            .store
+                            .get_operation(id)
+                            .await
+                            .map_err(|err| OrdererError::OperationStore(err.to_string()))
+                        {
+                            Ok(Some(operation)) => operation,
+                            Ok(None) => {
+                                return Err((input, OrdererError::StoreInconsistency(*id)));
+                            }
+                            Err(err) => return Err((input, err)),
+                        };
+
+                        let metadata = match self.store.get_event(id).await {
+                            Ok(Some(metadata)) => metadata,
+                            Ok(None) => {
+                                return Err((input, OrdererError::StoreInconsistency(*id)));
+                            }
+                            Err(err) => {
+                                return Err((input, OrdererError::ProcessorStore(err.to_string())));
+                            }
+                        };
+
+                        to_queue.push((
+                            T::from_operation(operation, metadata),
+                            OrdererResult::ReadyOutput,
+                        ));
+                    }
+
+                    // Always forward the current input first.
+                    self.queue.borrow_mut().push_back((
+                        input,
+                        OrdererResult::ReadyInput {
+                            dependent_operations,
+                        },
+                    ));
+
+                    // .. followed by all items which have been marked as "ready" by input.
+                    for item in to_queue {
+                        self.queue.borrow_mut().push_back(item);
+                    }
+                }
+
+                // b) Item doesn't have dependencies met yet, mark it as "pending", it is buffered now.
+                Ok(false) => {
+                    if let Err(err) = self.store.set_event(&input.hash(), &input.metadata()).await {
+                        return Err((input, OrdererError::ProcessorStore(err.to_string())));
+                    };
+
+                    if let Err(err) = self.store.commit(permit).await {
+                        return Err((input, OrdererError::Transaction(err.to_string())));
+                    }
+
+                    self.queue
+                        .borrow_mut()
+                        .push_back((input, OrdererResult::Pending));
+                }
+                Err(err) => return Err((input, OrdererError::OrdererStore(err.to_string()))),
             }
-
-            self.queue
-                .borrow_mut()
-                .push_back((input, OrdererResult::Pending));
         } else {
             self.queue
                 .borrow_mut()
@@ -132,56 +222,13 @@ where
     }
 
     async fn next(&self) -> Result<Self::Output, Self::Error> {
+        // TODO: If we decide to handle all logic in the "process" part (less memory efficient
+        // approach, see comment above) we should consider replacing the Processor trait with a
+        // Streamas "next" is not required anymore.
         loop {
-            // First check to see if there are any ignored or pending events which can be returned.
-            if let Some((event, result)) = self.queue.borrow_mut().pop_front() {
-                return Ok((event, result));
+            if let Some(output) = self.queue.borrow_mut().pop_front() {
+                return Ok(output);
             }
-
-            let permit = self
-                .store
-                .begin()
-                .await
-                .map_err(|err| (None, OrdererError::Transaction(err.to_string())))?;
-
-            let inner = self.inner.lock().await;
-
-            if let Some(id) = inner
-                .next()
-                .await
-                .map_err(|err| (None, OrdererError::OrdererStore(err.to_string())))?
-            {
-                self.store
-                    .commit(permit)
-                    .await
-                    .map_err(|err| (None, OrdererError::Transaction(err.to_string())))?;
-
-                let operation = match self
-                    .store
-                    .get_operation(&id)
-                    .await
-                    .map_err(|err| OrdererError::OperationStore(err.to_string()))
-                {
-                    Ok(Some(operation)) => operation,
-                    Ok(None) => return Err((None, OrdererError::StoreInconsistency(id))),
-                    Err(err) => return Err((None, err)),
-                };
-
-                let metadata = match self.store.get_event(&id).await {
-                    Ok(Some(metadata)) => metadata,
-                    Ok(None) => return Err((None, OrdererError::StoreInconsistency(id))),
-                    Err(err) => return Err((None, OrdererError::ProcessorStore(err.to_string()))),
-                };
-
-                return Ok((T::from_operation(operation, metadata), OrdererResult::Ready));
-            }
-
-            self.store
-                .commit(permit)
-                .await
-                .map_err(|err| (None, OrdererError::Transaction(err.to_string())))?;
-
-            drop(inner);
 
             self.notify.notified().await;
         }

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -148,19 +148,9 @@ where
                                     event
                                 }
                             }
-                            Err((event, err)) => {
-                                if let Some(mut event) = event {
-                                    event.orderer = ProcessorStatus::Failed(err);
-                                    event.noop()
-                                } else {
-                                    // TODO: This happens when the orderer failed due to a critical
-                                    // database failure _before_ it could resolve the attached
-                                    // event.
-                                    //
-                                    // ... we don't have the `event` anymore when this error occurs,
-                                    // so it's not possible to continue with processing.
-                                    panic!("critical database failure in orderer")
-                                }
+                            Err((mut event, err)) => {
+                                event.orderer = ProcessorStatus::Failed(err);
+                                event.noop()
                             }
                         })
                         .layer(log_prune)
@@ -484,10 +474,20 @@ mod tests {
         let result = pipeline.next().await;
         assert!(!result.is_failed());
         assert_eq!(result.hash(), event_1.hash());
-        assert_matches!(
-            result.orderer,
-            ProcessorStatus::Completed(OrdererResult::Ready)
-        );
+
+        if let ProcessorStatus::Completed(OrdererResult::Resolved {
+            mut dependent_operations,
+        }) = result.orderer
+        {
+            let mut expected_operations = vec![event_2.hash(), event_3.hash()];
+
+            expected_operations.sort();
+            dependent_operations.sort();
+
+            assert_eq!(expected_operations, dependent_operations);
+        } else {
+            panic!("unexpected orderer result");
+        }
 
         // 2 or 3 can arrive in any order.
         let mut expected_hashes: HashSet<p2panda_core::Hash> =

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -26,10 +26,10 @@ use crate::processor::tasks::TaskTracker;
 use crate::processor::{Event, ProcessorStatus};
 use crate::spaces::types::{SpacesManager, SpacesProcessor};
 
-/// Number of items which can stay in the pipeline buffer before backpressure is applied. If the
-/// buffer runs full, then sending of new operations into the processor will wait one is received
-/// by the processor.
-const PUBLISH_BUFFER_SIZE: usize = 128;
+/// Number of items which can stay in the pipeline input buffer before backpressure is applied.
+///
+/// If the buffer runs full, then sending of new operations into the processor will wait.
+const TO_PIPELINE_BUFFER_SIZE: usize = 128;
 
 /// Event processor pipeline which consists of multiple processors.
 ///
@@ -58,13 +58,21 @@ const PUBLISH_BUFFER_SIZE: usize = 128;
 ///             v
 ///           Event
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Pipeline<L, E, TP> {
     to_pipeline_tx: mpsc::Sender<Event<L, E, TP>>,
     from_pipeline_queue: Arc<Mutex<VecDeque<Event<L, E, TP>>>>,
     from_pipeline_notify: Arc<Notify>,
     tasks: TaskTracker<Event<L, E, TP>, Hash>,
+    // Re-using a pipeline across streams can lead to undesirable effects such as a) receiving
+    // unwanted output events which were not intended for the topic stream b) broadcast channel
+    // designs dropping events when running full. This !Clone marker should hopefully make you think
+    // twice about re-using pipelines.
+    _marker: NotClone,
 }
+
+#[derive(Debug)]
+struct NotClone;
 
 impl<L, E, TP> Pipeline<L, E, TP>
 where
@@ -80,12 +88,6 @@ where
     ///
     /// Users can run multiple pipelines parallely, a common task manager instance makes sure that
     /// processors do not work on the same event at the same time.
-    //
-    // NOTE: For now this creates a simple pipeline, in the future we might want different
-    // pipelines for different streams (one with almost no processing and others with more complex
-    // processing required for p2panda-spaces, etc.).
-    //
-    // NOTE: For parallelizing pipelines some sort of "work stealing" approach will be required.
     pub fn new(
         store: SqliteStore,
         tasks: TaskTracker<Event<L, E, TP>, Hash>,
@@ -152,11 +154,13 @@ where
                                     event.orderer = ProcessorStatus::Failed(err);
                                     event.noop()
                                 } else {
-                                    // TODO: Properly handle error case. I'm not entirely sure what
-                                    // to do here...we don't have the `event` anymore when this
-                                    // error occurs, so it's not possible to continue with
-                                    // processing.
-                                    panic!("orderer processor returned None err")
+                                    // TODO: This happens when the orderer failed due to a critical
+                                    // database failure _before_ it could resolve the attached
+                                    // event.
+                                    //
+                                    // ... we don't have the `event` anymore when this error occurs,
+                                    // so it's not possible to continue with processing.
+                                    panic!("critical database failure in orderer")
                                 }
                             }
                         })
@@ -212,6 +216,7 @@ where
             from_pipeline_queue,
             from_pipeline_notify,
             tasks,
+            _marker: NotClone,
         }
     }
 

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -1,21 +1,22 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::VecDeque;
 use std::fmt::Debug;
+use std::sync::Arc;
 use std::thread;
 
 use futures_util::StreamExt;
-use p2panda_core::traits::Digest;
+use p2panda_core::traits::{Digest, ShortFormat};
 use p2panda_core::{Extensions, Hash, LogId};
 use p2panda_store::SqliteStore;
 use p2panda_store::spaces::SqliteSpacesStore;
 use p2panda_stream::StreamLayerExt;
 use p2panda_stream::ingest::Ingest;
 use p2panda_stream::log_prune::LogPrune;
-use p2panda_sync::protocols::ShortFormat;
 use serde::{Deserialize, Serialize};
 use tokio::pin;
 use tokio::runtime::Builder;
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, Notify, mpsc};
 use tokio::task::LocalSet;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::warn;
@@ -59,7 +60,9 @@ const PUBLISH_BUFFER_SIZE: usize = 128;
 /// ```
 #[derive(Clone, Debug)]
 pub struct Pipeline<L, E, TP> {
-    pipeline_tx: mpsc::Sender<Event<L, E, TP>>,
+    to_pipeline_tx: mpsc::Sender<Event<L, E, TP>>,
+    from_pipeline_queue: Arc<Mutex<VecDeque<Event<L, E, TP>>>>,
+    from_pipeline_notify: Arc<Notify>,
     tasks: TaskTracker<Event<L, E, TP>, Hash>,
 }
 
@@ -88,7 +91,9 @@ where
         tasks: TaskTracker<Event<L, E, TP>, Hash>,
         spaces_manager: SpacesManager,
     ) -> Self {
-        let (pipeline_tx, pipeline_rx) = mpsc::channel(PUBLISH_BUFFER_SIZE);
+        let (to_pipeline_tx, to_pipeline_rx) = mpsc::channel(TO_PIPELINE_BUFFER_SIZE);
+        let from_pipeline_queue = Arc::new(Mutex::new(VecDeque::new()));
+        let from_pipeline_notify = Arc::new(Notify::new());
 
         {
             let tasks = tasks.clone();
@@ -97,6 +102,9 @@ where
                 .enable_all()
                 .build()
                 .expect("runtime for current thread");
+
+            let from_pipeline_queue = from_pipeline_queue.clone();
+            let from_pipeline_notify = from_pipeline_notify.clone();
 
             thread::spawn(move || {
                 let local = LocalSet::new();
@@ -114,7 +122,7 @@ where
                     );
 
                     // Receive incoming events through mpsc channel.
-                    let pipeline = ReceiverStream::new(pipeline_rx)
+                    let pipeline = ReceiverStream::new(to_pipeline_rx)
                         .layer(ingest)
                         .map(|result| match result {
                             Ok((mut event, result)) => {
@@ -177,16 +185,21 @@ where
 
                     pin!(pipeline);
 
-                    while let Some(operation) = pipeline.next().await {
-                        if let Some(err) = operation.failure_reason() {
+                    while let Some(output_event) = pipeline.next().await {
+                        if let Some(err) = output_event.failure_reason() {
                             warn!(
-                                id = %operation.hash().fmt_short(),
+                                id = %output_event.hash().fmt_short(),
                                 "failed processing event: {}",
                                 err
                             );
                         }
 
-                        tasks.mark_as_done(operation.hash(), operation).await;
+                        tasks
+                            .mark_as_done(output_event.hash(), output_event.clone())
+                            .await;
+
+                        from_pipeline_queue.lock().await.push_back(output_event);
+                        from_pipeline_notify.notify_one(); // Wake up any pending next call
                     }
                 });
 
@@ -194,7 +207,12 @@ where
             });
         }
 
-        Self { pipeline_tx, tasks }
+        Self {
+            to_pipeline_tx,
+            from_pipeline_queue,
+            from_pipeline_notify,
+            tasks,
+        }
     }
 
     /// Queue up an incoming operation to be processed by this pipeline in the background.
@@ -215,7 +233,7 @@ where
 
         // Send operation to processing pipeline, it will handle this operation eventually in a
         // concurrent "background" task.
-        let _ = self.pipeline_tx.send(input).await;
+        let _ = self.to_pipeline_tx.send(input).await;
 
         // Block and await here until the mananger received the signal that the task has finished.
         // This assures that operations are handled in-order.
@@ -223,6 +241,17 @@ where
         // Please note that the task might have finished successfully or with a processor failure,
         // we do not treat the error here on this level.
         task.ready().await
+    }
+
+    pub async fn next(&mut self) -> Event<L, E, TP> {
+        loop {
+            if let Some(output) = self.from_pipeline_queue.lock().await.pop_front() {
+                return output;
+            }
+
+            // Wait for notification that an item was added.
+            self.from_pipeline_notify.notified().await;
+        }
     }
 }
 

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashSet, VecDeque};
 use std::fmt::Debug;
+use std::hash::Hash as StdHash;
 use std::sync::Arc;
 use std::thread;
 
@@ -149,10 +150,11 @@ const TO_PIPELINE_BUFFER_SIZE: usize = 128;
 // See related issue: https://github.com/p2panda/p2panda/issues/1275
 #[derive(Clone, Debug)]
 pub struct Pipeline<L, E, TP> {
+    id: Hash,
     to_pipeline_tx: mpsc::Sender<Event<L, E, TP>>,
     from_pipeline_queue: Arc<Mutex<VecDeque<Event<L, E, TP>>>>,
     from_pipeline_notify: Arc<Notify>,
-    tasks: TaskTracker<Event<L, E, TP>, Hash>,
+    tasks: TaskTracker<Event<L, E, TP>, PipelineTaskId>,
 }
 
 impl<L, E, TP> Pipeline<L, E, TP>
@@ -170,10 +172,13 @@ where
     /// Users can run multiple pipelines parallely, a common task manager instance makes sure that
     /// processors do not work on the same event at the same time.
     pub fn new(
+        id: impl Into<Hash>,
         store: SqliteStore,
-        tasks: TaskTracker<Event<L, E, TP>, Hash>,
+        tasks: TaskTracker<Event<L, E, TP>, PipelineTaskId>,
         spaces_manager: SpacesManager,
     ) -> Self {
+        let pipeline_id = id.into();
+
         let (to_pipeline_tx, to_pipeline_rx) = mpsc::channel(TO_PIPELINE_BUFFER_SIZE);
         let from_pipeline_queue = Arc::new(Mutex::new(VecDeque::new()));
         let from_pipeline_notify = Arc::new(Notify::new());
@@ -316,10 +321,20 @@ where
                             // All dependencies have been visited, we can finally mark the "parent"
                             // input event  as done.
                             if let Some(pending) = pending.take() {
-                                tasks.mark_as_done(pending.hash(), pending).await;
+                                let task_id = PipelineTaskId {
+                                    event_id: pending.hash(),
+                                    pipeline_id,
+                                };
+
+                                tasks.mark_as_done(task_id, pending).await;
                             }
                         } else {
-                            tasks.mark_as_done(output_event.hash(), output_event).await;
+                            let task_id = PipelineTaskId {
+                                event_id: output_event.hash(),
+                                pipeline_id,
+                            };
+
+                            tasks.mark_as_done(task_id, output_event).await;
                         }
                     }
                 });
@@ -329,6 +344,7 @@ where
         }
 
         Self {
+            id: pipeline_id,
             to_pipeline_tx,
             from_pipeline_queue,
             from_pipeline_notify,
@@ -349,8 +365,13 @@ where
     /// This method does not return an error if a processor failed but instead users will need to
     /// check on the returned object itself if an error was observed.
     pub async fn process(&self, input: Event<L, E, TP>) -> Event<L, E, TP> {
+        let task_id = PipelineTaskId {
+            event_id: input.hash(),
+            pipeline_id: self.id,
+        };
+
         // Register task for this operation so the processor can mark it as *ready* later.
-        let task = self.tasks.track(input.hash()).await;
+        let task = self.tasks.track(task_id).await;
 
         // Send operation to processing pipeline, it will handle this operation eventually in a
         // concurrent "background" task.
@@ -376,6 +397,19 @@ where
     }
 }
 
+/// Identifier for a single task in the task tracker used by the pipeline.
+///
+/// Every task is grouped by the pipeline itself and then the regarding event id. Like this we can
+/// make sure that there will be no collisions across pipelines (different topic streams but same
+/// operations).
+///
+/// This is deliberately not using a hashing function to safe computing cost.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, StdHash)]
+pub struct PipelineTaskId {
+    pipeline_id: Hash,
+    event_id: Hash,
+}
+
 #[cfg(test)]
 mod tests {
     use std::assert_matches;
@@ -383,7 +417,7 @@ mod tests {
 
     use p2panda_core::test_utils::{TestLog, setup_logging};
     use p2panda_core::traits::Digest;
-    use p2panda_core::{PruneFlag, SigningKey, Topic};
+    use p2panda_core::{Hash, PruneFlag, SigningKey, Topic};
     use p2panda_store::SqliteStore;
 
     use crate::credentials::Credentials;
@@ -408,7 +442,8 @@ mod tests {
             .await
             .unwrap();
 
-        let processor = Pipeline::<LogId, (), Topic>::new(store, tasks, spaces_manager);
+        let pipeline_id = Hash::from([0; 32]);
+        let pipeline = Pipeline::<LogId, (), Topic>::new(pipeline_id, store, tasks, spaces_manager);
 
         let log = TestLog::new();
         let topic = Topic::random();
@@ -416,7 +451,7 @@ mod tests {
         let mut operation = log.operation(b"test", ());
 
         // Expect operation to be processed successfully.
-        let result = processor
+        let result = pipeline
             .process(Event::new(
                 operation.clone(),
                 Source::LocalStore,
@@ -434,7 +469,7 @@ mod tests {
         // Replace public key of operation to make it invalid. We expect the processor to fail.
         operation.header.verifying_key = SigningKey::generate().verifying_key();
 
-        let result = processor
+        let result = pipeline
             .process(Event::new(
                 operation.clone(),
                 Source::LocalStore,
@@ -462,7 +497,8 @@ mod tests {
             .await
             .unwrap();
 
-        let processor = Pipeline::<LogId, (), Topic>::new(store, tasks, spaces_manager);
+        let pipeline_id = Hash::from([0; 32]);
+        let pipeline = Pipeline::<LogId, (), Topic>::new(pipeline_id, store, tasks, spaces_manager);
 
         let mut events = Vec::new();
         let mut dependencies = Vec::new();
@@ -497,7 +533,7 @@ mod tests {
 
         for event in events {
             let event_hash = event.hash();
-            let result = processor.process(event).await;
+            let result = pipeline.process(event).await;
 
             assert_eq!(result.hash(), event_hash);
             assert!(result.is_completed());
@@ -517,7 +553,9 @@ mod tests {
             .await
             .unwrap();
 
-        let mut pipeline = Pipeline::<LogId, (), Topic>::new(store, tasks, spaces_manager);
+        let pipeline_id = Hash::from([0; 32]);
+        let mut pipeline =
+            Pipeline::<LogId, (), Topic>::new(pipeline_id, store, tasks, spaces_manager);
 
         let log_icebear = TestLog::new();
         let log_panda = TestLog::new();

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -268,6 +268,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+    use std::collections::HashSet;
+
     use p2panda_core::test_utils::{TestLog, setup_logging};
     use p2panda_core::traits::Digest;
     use p2panda_core::{PruneFlag, SigningKey, Topic};
@@ -276,8 +279,8 @@ mod tests {
     use crate::credentials::Credentials;
     use crate::forge::OperationForge;
     use crate::operation::LogId;
-    use crate::processor::TaskTracker;
-    use crate::processor::orderer::OrdererArgs;
+    use crate::processor::orderer::{OrdererArgs, OrdererResult};
+    use crate::processor::{ProcessorStatus, TaskTracker};
     use crate::spaces::spaces_manager;
 
     use super::{Event, Pipeline};
@@ -386,5 +389,120 @@ mod tests {
             assert!(result.is_completed());
             assert!(!result.is_failed());
         }
+    }
+
+    #[tokio::test]
+    async fn buffered_outputs() {
+        setup_logging();
+
+        let store = SqliteStore::temporary().await;
+        let tasks = TaskTracker::new();
+        let credentials = Credentials::generate();
+        let forge = OperationForge::new(credentials.clone(), store.clone());
+        let spaces_manager = spaces_manager(forge, credentials, store.clone())
+            .await
+            .unwrap();
+
+        let mut pipeline = Pipeline::<LogId, (), Topic>::new(store, tasks, spaces_manager);
+
+        let log_icebear = TestLog::new();
+        let log_panda = TestLog::new();
+        let log_penguin = TestLog::new();
+
+        let topic = Topic::random();
+
+        let event_1 = {
+            let mut event = Event::new(
+                log_icebear.operation(b"op", ()),
+                LogId::from_topic(topic),
+                topic,
+                PruneFlag::default(),
+                None,
+            );
+            event.orderer_args = OrdererArgs::Process {
+                dependencies: vec![],
+            };
+            event
+        };
+
+        let event_2 = {
+            let mut event = Event::new(
+                log_panda.operation(b".. or no-op", ()),
+                LogId::from_topic(topic),
+                topic,
+                PruneFlag::default(),
+                None,
+            );
+            event.orderer_args = OrdererArgs::Process {
+                dependencies: vec![event_1.hash()],
+            };
+            event
+        };
+
+        let event_3 = {
+            let mut event = Event::new(
+                log_penguin.operation(b"that's the question", ()),
+                LogId::from_topic(topic),
+                topic,
+                PruneFlag::default(),
+                None,
+            );
+            event.orderer_args = OrdererArgs::Process {
+                dependencies: vec![event_1.hash()],
+            };
+            event
+        };
+
+        // 3 and 2 depend on 1. We send event 1 at the very end and expect 2 and 3 to be freed
+        // "at the same time":
+        //
+        // [3]
+        //     \
+        //      -> [1]
+        //     /
+        // [2]
+
+        let events = [event_3.clone(), event_2.clone(), event_1.clone()];
+
+        // Input all three events, here we just expect processing to finish.
+        for event in events {
+            let event_hash = event.hash();
+            let result = pipeline.process(event).await;
+
+            assert_eq!(result.hash(), event_hash);
+            assert!(result.is_completed());
+            assert!(!result.is_failed());
+        }
+
+        // When calling "next" on the pipeline we expect the 3 events to come out:
+        let result = pipeline.next().await;
+        assert!(!result.is_failed());
+        assert_eq!(result.hash(), event_1.hash());
+        assert_matches!(
+            result.orderer,
+            ProcessorStatus::Completed(OrdererResult::Ready)
+        );
+
+        // 2 or 3 can arrive in any order.
+        let mut expected_hashes: HashSet<p2panda_core::Hash> =
+            HashSet::from_iter([event_2.hash(), event_3.hash()]);
+
+        let result = pipeline.next().await;
+        assert!(expected_hashes.remove(&result.hash()));
+        assert!(!result.is_failed());
+        assert_matches!(
+            result.orderer,
+            ProcessorStatus::Completed(OrdererResult::Ready)
+        );
+
+        let result = pipeline.next().await;
+        assert!(!result.is_failed());
+        assert!(expected_hashes.remove(&result.hash()));
+        assert_matches!(
+            result.orderer,
+            ProcessorStatus::Completed(OrdererResult::Ready)
+        );
+
+        assert_eq!(expected_hashes.len(), 0);
     }
 }

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -58,21 +58,20 @@ const TO_PIPELINE_BUFFER_SIZE: usize = 128;
 ///             v
 ///           Event
 /// ```
-#[derive(Debug)]
+///
+/// ## Cloning pipelines
+///
+/// Re-using a pipeline across streams can lead to undesirable effects such as a) receiving
+/// unwanted output events which were not intended for the topic stream b) broadcast channel designs
+/// dropping events when running full.
+/// ```
+#[derive(Clone, Debug)]
 pub struct Pipeline<L, E, TP> {
     to_pipeline_tx: mpsc::Sender<Event<L, E, TP>>,
     from_pipeline_queue: Arc<Mutex<VecDeque<Event<L, E, TP>>>>,
     from_pipeline_notify: Arc<Notify>,
     tasks: TaskTracker<Event<L, E, TP>, Hash>,
-    // Re-using a pipeline across streams can lead to undesirable effects such as a) receiving
-    // unwanted output events which were not intended for the topic stream b) broadcast channel
-    // designs dropping events when running full. This !Clone marker should hopefully make you think
-    // twice about re-using pipelines.
-    _marker: NotClone,
 }
-
-#[derive(Debug)]
-struct NotClone;
 
 impl<L, E, TP> Pipeline<L, E, TP>
 where
@@ -222,7 +221,6 @@ where
             from_pipeline_queue,
             from_pipeline_notify,
             tasks,
-            _marker: NotClone,
         }
     }
 
@@ -282,6 +280,7 @@ mod tests {
     use crate::processor::orderer::{OrdererArgs, OrdererResult};
     use crate::processor::{ProcessorStatus, TaskTracker};
     use crate::spaces::spaces_manager;
+    use crate::streams::Source;
 
     use super::{Event, Pipeline};
 
@@ -308,6 +307,7 @@ mod tests {
         let result = processor
             .process(Event::new(
                 operation.clone(),
+                Source::LocalStore,
                 LogId::from_topic(topic),
                 topic,
                 PruneFlag::default(),
@@ -325,6 +325,7 @@ mod tests {
         let result = processor
             .process(Event::new(
                 operation.clone(),
+                Source::LocalStore,
                 LogId::from_topic(topic),
                 topic,
                 PruneFlag::default(),
@@ -364,6 +365,7 @@ mod tests {
 
             let mut event = Event::new(
                 operation.clone(),
+                Source::LocalStore,
                 LogId::from_topic(topic),
                 topic,
                 PruneFlag::default(),
@@ -414,6 +416,7 @@ mod tests {
         let event_1 = {
             let mut event = Event::new(
                 log_icebear.operation(b"op", ()),
+                Source::LocalStore,
                 LogId::from_topic(topic),
                 topic,
                 PruneFlag::default(),
@@ -428,6 +431,7 @@ mod tests {
         let event_2 = {
             let mut event = Event::new(
                 log_panda.operation(b".. or no-op", ()),
+                Source::LocalStore,
                 LogId::from_topic(topic),
                 topic,
                 PruneFlag::default(),
@@ -442,6 +446,7 @@ mod tests {
         let event_3 = {
             let mut event = Event::new(
                 log_penguin.operation(b"that's the question", ()),
+                Source::LocalStore,
                 LogId::from_topic(topic),
                 topic,
                 PruneFlag::default(),

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -143,7 +143,7 @@ where
 
                                 // If the orderer returns a "pending" result we don't want to affect
                                 // any next processors anymore.
-                                if result.is_pending() {
+                                if event.is_pending() {
                                     event.noop()
                                 } else {
                                     event
@@ -198,12 +198,18 @@ where
                             );
                         }
 
+                        // This informs any process waiting for the input event to be finished.
                         tasks
                             .mark_as_done(output_event.hash(), output_event.clone())
                             .await;
 
-                        from_pipeline_queue.lock().await.push_back(output_event);
-                        from_pipeline_notify.notify_one(); // Wake up any pending next call
+                        // If the output event is "ready" (that is, _not_ pending, not being
+                        // buffered somewhere), then we can finally forward it on the output stream
+                        // towards the application layer.
+                        if !output_event.is_pending() {
+                            from_pipeline_queue.lock().await.push_back(output_event);
+                            from_pipeline_notify.notify_one(); // Wake up any pending next call
+                        }
                     }
                 });
 

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::thread;
@@ -21,7 +21,7 @@ use tokio::task::LocalSet;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::warn;
 
-use crate::processor::orderer::Orderer;
+use crate::processor::orderer::{Orderer, OrdererResult};
 use crate::processor::tasks::TaskTracker;
 use crate::processor::{Event, ProcessorStatus};
 use crate::spaces::types::{SpacesManager, SpacesProcessor};
@@ -59,12 +59,94 @@ const TO_PIPELINE_BUFFER_SIZE: usize = 128;
 ///           Event
 /// ```
 ///
-/// ## Cloning pipelines
+/// ## Important design considerations
 ///
-/// Re-using a pipeline across streams can lead to undesirable effects such as a) receiving
-/// unwanted output events which were not intended for the topic stream b) broadcast channel designs
-/// dropping events when running full.
+/// ### Task tracking
+///
+/// Every input event needs to _strictly_ lead to an equivalent output event (1:1), otherwise the
+/// process who inserted the event will await a result forever. This is managed by the task tracker.
+///
+/// For processors who buffer events (because they are out-of-order) we need to output "pending"
+/// events to inform the task tracker that the event was successfully processed and is now buffered
+/// for a while.
+///
+/// ### Cloning pipelines
+///
+/// Re-using a pipeline across streams can lead to undesirable effects such as receiving unwanted
+/// output events which were not intended for the topic stream.
+///
+/// Only clone the pipeline _within_ a topic stream. Across different topic streams a new pipeline
+/// should be created.
+///
+/// ### Failed or pending events
+///
+/// Any failed or pending event needs to strictly be "disabled" for any processor which follows
+/// after being marked as such. A failed event can be due to an unauthorized action which should not
+/// have any further effect. A pending event is "out of order" and should not have any effect _yet_
+/// until it is "ready" / in-order.
+///
+/// The event needs to still travel through the pipeline, to be successfully marked as "done" (see
+/// "Task tracking") but shouldn't cause any effects in processors anymore. This is achieved by
+/// calling the `noop` method on the event. It will set all processor arguments to "ignore".
+///
+/// ### Input / Output separation and ordering
+///
+/// Input event streams are independent from the output event stream. Both streams are supposed to
+/// be ordered, that is:
+///
+/// 1. Input events should be marked as done _after_ all caused side effects have been processed,
+///    the order on how they were input needs to be preserved, independent of buffering
+/// 2. Output events should arrive in topologically sorted, causal order (if required)
+///
+/// Both rules are important for the whole system to function correctly and not cause surprising
+/// results to the application layer.
+///
+/// Pending events are not forwarded to the output stream.
+///
+/// For upholding all orderer rules the following takes place, here shown with a simple example:
+///
+/// ```text
+/// A is dependent on B:
+/// [A] -> [B]
+///
+/// 1. A is inserted _before_ B into the pipeline:
+///
+/// [A] <- marked as "pending" since out-of-order
+/// [B] <- marked as "ready input", since in-order & freeing A
+///
+/// 2. On the *inner* output stream we receive now:
+///
+/// [A] "pending" <- not forwarded to outer output stream *
+/// [B] "ready input" *
+/// [A] "ready output"
+///
+/// *) These events were part of the input stream.
+///
+/// 3. On the *outer* output stream we receive now:
+///
+/// [B]
+/// [A]
+///
+/// 4. We wait until A was put on the output stream to mark B as done:
+///
+/// [A] <- .. is on the output stream now (step 3.)
+/// [B] <- We mark this input task as "done" now
+///
+/// Note how we've changed the ordering of A and B in Step 2. and 3. but needed to preserve the
+/// original input ordering in 4.
 /// ```
+///
+/// The topological ordering is assured by the "orderer" processor. In step 3. we can see how B is
+/// put on the output stream _before_ A even though they were input in reversed order.
+///
+/// To ensure that B is still marked _after_ all side-effects (freed A) took place we keep track of
+/// the dependents of B. When they all left the output stream we can finally mark B as done.
+///
+/// This ensures that any process awaiting the result of processing B will be marked ready in the
+/// original input order.
+//
+// FIXME: The pipeline thread keeps currently running even when the struct was dropped.
+// See related issue: https://github.com/p2panda/p2panda/issues/1275
 #[derive(Clone, Debug)]
 pub struct Pipeline<L, E, TP> {
     to_pipeline_tx: mpsc::Sender<Event<L, E, TP>>,
@@ -178,7 +260,13 @@ where
 
                     pin!(pipeline);
 
+                    let mut pending_dependencies = HashSet::<Hash>::new();
+                    let mut pending: Option<Event<L, E, TP>> = None;
+
                     while let Some(output_event) = pipeline.next().await {
+                        // TODO: We need to handle "invalidating" the pending buffers when something
+                        // went wrong _after_ the orderer processor. Otherwise these items might be
+                        // stuck here forever.
                         if let Some(err) = output_event.failure_reason() {
                             warn!(
                                 id = %output_event.hash().fmt_short(),
@@ -187,18 +275,51 @@ where
                             );
                         }
 
-                        // This informs any process waiting for the input event to be finished.
-                        // Unknown tasks are ignored.
-                        tasks
-                            .mark_as_done(output_event.hash(), output_event.clone())
-                            .await;
+                        // An event arrived which "freed" some dependent operations. This "parent"
+                        // event needs to be forwarded _first_ on the output, but we want it to be
+                        // processed _last_ on the input side. See documentation above for more
+                        // context.
+                        //
+                        // For this we are "reversing" the dependency tree and delay marking the
+                        // "parent" event as done when all dependencies have been visited.
+                        if let ProcessorStatus::Completed(OrdererResult::ReadyInput {
+                            ref dependent_operations,
+                        }) = output_event.orderer
+                        {
+                            pending_dependencies = HashSet::from_iter(dependent_operations.clone());
+                            pending = Some(output_event.clone());
+                        }
 
-                        // If the output event is "ready" (that is, _not_ pending, not being
+                        // We've visited a dependency.
+                        if let ProcessorStatus::Completed(OrdererResult::ReadyOutput) =
+                            output_event.orderer
+                        {
+                            pending_dependencies.remove(&output_event.hash());
+                        }
+
+                        // If the output event is "ready" (that is, _not_ pending / not being
                         // buffered somewhere), then we can finally forward it on the output stream
                         // towards the application layer.
+                        //
+                        // We want this to happen _before_ we mark the task as done to allow all
+                        // consumers to yield the items in correct order.
                         if !output_event.is_pending() {
-                            from_pipeline_queue.lock().await.push_back(output_event);
+                            from_pipeline_queue
+                                .lock()
+                                .await
+                                .push_back(output_event.clone());
                             from_pipeline_notify.notify_one(); // Wake up any pending next call
+                        }
+
+                        // This informs any process waiting for the input event to be finished.
+                        if pending.is_some() && pending_dependencies.is_empty() {
+                            // All dependencies have been visited, we can finally mark the "parent"
+                            // input event  as done.
+                            if let Some(pending) = pending.take() {
+                                tasks.mark_as_done(pending.hash(), pending).await;
+                            }
+                        } else {
+                            tasks.mark_as_done(output_event.hash(), output_event).await;
                         }
                     }
                 });
@@ -475,7 +596,7 @@ mod tests {
         assert!(!result.is_failed());
         assert_eq!(result.hash(), event_1.hash());
 
-        if let ProcessorStatus::Completed(OrdererResult::Resolved {
+        if let ProcessorStatus::Completed(OrdererResult::ReadyInput {
             mut dependent_operations,
         }) = result.orderer
         {
@@ -498,7 +619,7 @@ mod tests {
         assert!(!result.is_failed());
         assert_matches!(
             result.orderer,
-            ProcessorStatus::Completed(OrdererResult::Ready)
+            ProcessorStatus::Completed(OrdererResult::ReadyOutput)
         );
 
         let result = pipeline.next().await;
@@ -506,7 +627,7 @@ mod tests {
         assert!(expected_hashes.remove(&result.hash()));
         assert_matches!(
             result.orderer,
-            ProcessorStatus::Completed(OrdererResult::Ready)
+            ProcessorStatus::Completed(OrdererResult::ReadyOutput)
         );
 
         assert_eq!(expected_hashes.len(), 0);

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -198,6 +198,7 @@ where
                         }
 
                         // This informs any process waiting for the input event to be finished.
+                        // Unknown tasks are ignored.
                         tasks
                             .mark_as_done(output_event.hash(), output_event.clone())
                             .await;

--- a/p2panda/src/processor/tasks.rs
+++ b/p2panda/src/processor/tasks.rs
@@ -12,6 +12,8 @@ use tokio::sync::{Mutex, Notify, RwLock};
 /// whenever they've finished they mark the task as "ready". All processes which observe this task
 /// will be notified on this "ready" signal.
 ///
+/// ## Multiple-consumers notifier
+///
 /// Tasks are automatically de-duplicated internally, so whenever multiple processes add the same
 /// task, they will look at the same instance and get notified about it's readyness at the same
 /// time.

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -8,9 +8,12 @@ mod replay;
 mod stream;
 mod sync_metrics;
 
+use p2panda_core::{Hash, Topic};
 // Useful external types we want to re-export for convenience.
 #[doc(no_inline)]
 pub use p2panda_core::cbor::DecodeError;
+
+use crate::operation::{Extensions, LogId};
 
 pub use acked::AckedError;
 pub(crate) use ephemeral_stream::ephemeral_stream;
@@ -25,5 +28,11 @@ pub use stream::{
     ImportError, ProcessedOperation, PublishError, PublishFuture, Source, StreamEvent,
     StreamPublisher, StreamSubscription,
 };
-pub(crate) use stream::{process_published_operation, processed_stream};
+pub(crate) use stream::processed_stream;
 pub use sync_metrics::{SessionPhase, SyncError};
+
+pub(crate) type Event = crate::processor::Event<LogId, Extensions, Topic>;
+
+pub(crate) type Pipeline = crate::processor::Pipeline<LogId, Extensions, Topic>;
+
+pub(crate) type TaskTracker = crate::processor::TaskTracker<Event, Hash>;

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -8,12 +8,13 @@ mod replay;
 mod stream;
 mod sync_metrics;
 
-use p2panda_core::{Hash, Topic};
+use p2panda_core::Topic;
 // Useful external types we want to re-export for convenience.
 #[doc(no_inline)]
 pub use p2panda_core::cbor::DecodeError;
 
 use crate::operation::{Extensions, LogId};
+use crate::processor::PipelineTaskId;
 
 pub use acked::AckedError;
 pub(crate) use ephemeral_stream::ephemeral_stream;
@@ -35,4 +36,4 @@ pub(crate) type Event = crate::processor::Event<LogId, Extensions, Topic>;
 
 pub(crate) type Pipeline = crate::processor::Pipeline<LogId, Extensions, Topic>;
 
-pub(crate) type TaskTracker = crate::processor::TaskTracker<Event, Hash>;
+pub(crate) type TaskTracker = crate::processor::TaskTracker<Event, PipelineTaskId>;

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -24,11 +24,11 @@ pub use event_stream::SystemEvent;
 pub(crate) use event_stream::event_stream;
 pub use external_stream::ExternalStreamFuture;
 pub use replay::{ReplayError, StreamFrom};
+pub(crate) use stream::processed_stream;
 pub use stream::{
     ImportError, ProcessedOperation, PublishError, PublishFuture, Source, StreamEvent,
     StreamPublisher, StreamSubscription,
 };
-pub(crate) use stream::processed_stream;
 pub use sync_metrics::{SessionPhase, SyncError};
 
 pub(crate) type Event = crate::processor::Event<LogId, Extensions, Topic>;

--- a/p2panda/src/streams/replay.rs
+++ b/p2panda/src/streams/replay.rs
@@ -9,12 +9,10 @@ use thiserror::Error;
 use tokio::sync::mpsc;
 use tracing::debug;
 
-use crate::node::AckPolicy;
 use crate::operation::{Extensions, LogId, Operation};
 use crate::processor::Pipeline;
 use crate::streams::StreamEvent;
-use crate::streams::acked::Acked;
-use crate::streams::stream::{Source, process_operation};
+use crate::streams::stream::{Source, process_operation_in};
 
 /// Determines the starting point of a subscription stream.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
@@ -49,8 +47,6 @@ pub(crate) async fn replay_log_ranges<M>(
     store: &SqliteStore,
     app_tx: &mpsc::Sender<StreamEvent<M>>,
     pipeline: &Pipeline<LogId, Extensions, Topic>,
-    ack_policy: AckPolicy,
-    acked: &Acked,
     log_ranges: LogRanges<VerifyingKey, LogId>,
 ) -> Result<(), ReplayError>
 where
@@ -81,24 +77,7 @@ where
             };
 
             for (operation, _) in operations {
-                match process_operation::<M>(
-                    operation,
-                    topic,
-                    pipeline,
-                    ack_policy,
-                    acked,
-                    Source::LocalStore,
-                )
-                .await
-                {
-                    Some(event) => {
-                        app_tx
-                            .send(event)
-                            .await
-                            .map_err(|_| ReplayError::CriticalError)?;
-                    }
-                    None => continue,
-                }
+                process_operation_in(operation, Source::LocalStore, topic, pipeline).await;
             }
         }
     }

--- a/p2panda/src/streams/replay.rs
+++ b/p2panda/src/streams/replay.rs
@@ -45,7 +45,7 @@ impl From<Cursor<VerifyingKey, LogId>> for StreamFrom {
 pub(crate) async fn replay_log_ranges<M>(
     topic: Topic,
     store: &SqliteStore,
-    app_tx: &mpsc::Sender<StreamEvent<M>>,
+    to_output_tx: &mpsc::Sender<StreamEvent<M>>,
     pipeline: &Pipeline<LogId, Extensions, Topic>,
     log_ranges: LogRanges<VerifyingKey, LogId>,
 ) -> Result<(), ReplayError>
@@ -59,7 +59,7 @@ where
         return Ok(());
     }
 
-    app_tx
+    to_output_tx
         .send(StreamEvent::ReplayStarted { total_operations })
         .await
         .map_err(|_| ReplayError::CriticalError)?;
@@ -82,7 +82,7 @@ where
         }
     }
 
-    app_tx
+    to_output_tx
         .send(StreamEvent::ReplayEnded)
         .await
         .map_err(|_| ReplayError::CriticalError)?;

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -140,29 +140,60 @@ where
         .await
         .map_err(|err| CreateStreamError(err.to_string()))?;
 
+    // If any other process wants to bring an stream event forward to the application layer ("output
+    // stream"), this channel should be used.
+    let (to_output_tx, mut to_output_rx) = mpsc::channel::<StreamEvent<M>>(128);
+
+    // FIXME: Both tasks need to be gracefully shut down when the tx / rx halves got dropped,
+    // otherwise the sync session keeps running.
+    //
+    // See related issue: https://github.com/p2panda/p2panda/issues/1272
+
     // Spawn first task which receives processed "output events" from the processing pipeline, the
     // result is handled (acking, decoding, conversion to `StreamEvent`, etc.) and then finally
     // forwarded to the application layer.
     {
         let mut pipeline = pipeline.clone();
         let acked = acked.clone();
-        let app_tx = app_tx.clone();
 
         tokio::spawn(async move {
             loop {
-                // Handle resulting output events from the pipeline and forward them as stream
-                // events to application layer when applicable.
-                let from_pipeline_event = pipeline.next().await;
+                let stream_event = tokio::select! {
+                    // We need to process pipeline output events _before_ any other system events.
+                    // This is crucial to ensure correct ordering of events such as "replay started"
+                    // being followed by "processed operations" and then finally by "replay ended",
+                    // etc.
+                    biased;
 
-                if let Some(stream_event) =
-                    process_operation_out::<M>(from_pipeline_event, topic, ack_policy, &acked).await
-                {
-                    // Send processing result to application layer.
-                    //
-                    // If channel stopped working because the subscriber got dropped, ignore it as
-                    // we still might want to process locally published operations.
-                    let _ = app_tx.send(stream_event).await;
-                }
+                    // Handle resulting output events from the pipeline and forward them as stream
+                    // events to application layer, when applicable.
+                    from_pipeline_event = pipeline.next() => {
+                        if let Some(stream_event) =
+                            process_operation_out::<M>(
+                                from_pipeline_event,
+                                topic,
+                                ack_policy,
+                                &acked
+                            ).await
+                        {
+                            stream_event
+                        } else {
+                            continue;
+                        }
+                    },
+
+                    // Any other process forwarding an event (like "replay ended", etc.) to the
+                    // application layer.
+                    Some(stream_event) = to_output_rx.recv() => {
+                        stream_event
+                    }
+                };
+
+                // Send processing result to application layer.
+                //
+                // If channel stopped working because the subscriber got dropped, ignore it as
+                // we still might want to process locally published operations.
+                let _ = app_tx.send(stream_event).await;
             }
         });
     }
@@ -170,9 +201,8 @@ where
     // Spawn second task which assembles different sources of incoming operations (replays, external
     // streams, sync session, locally published, etc.) and inputs them into the processing pipeline.
     //
-    // Here we only forward "system events" to the application layer, such as "sync started" or
-    // "external stream import finished", etc. - actual application messages are handled in the task
-    // above.
+    // Here we only forward "system events" to the output stream, such as "sync started" or
+    // "external stream import finished", etc.
     {
         let store = store.clone();
         let sync_handle = sync_handle.clone();
@@ -186,7 +216,8 @@ where
                 // This will block processing of the sync stream and of locally created operations
                 // until it is complete.
                 let replay_result =
-                    replay_log_ranges(topic, &store, &app_tx, &pipeline, nacked_log_ranges).await;
+                    replay_log_ranges(topic, &store, &to_output_tx, &pipeline, nacked_log_ranges)
+                        .await;
 
                 // Errors occurring in the replay task which be returned to the user.
                 if let Err(error) = replay_result {
@@ -195,7 +226,7 @@ where
                         "error occurred in replay task: {error}"
                     );
 
-                    let _ = app_tx
+                    let _ = to_output_tx
                         .send(StreamEvent::ReplayFailed {
                             error: Arc::new(error),
                         })
@@ -310,16 +341,14 @@ where
                             },
                             ExternalStreamEvent::End {
                                 session_id
-                            } => StreamEvent::ImportEnded { session_id },
+                            } => {
+                                StreamEvent::ImportEnded { session_id }
+                            },
                         }
                     },
                 };
 
-                // Send stream events to application layer.
-                //
-                // If channel stopped working because the subscriber got dropped, ignore it as
-                // we still might want to process locally published operations.
-                let _ = app_tx.send(stream_event).await;
+                let _ = to_output_tx.send(stream_event).await;
             }
         });
     }
@@ -869,8 +898,9 @@ pub enum StreamEvent<M> {
     /// Deserializing the application message into the specified type failed.
     ///
     /// This is an application-level error and indicates an invalid application payload.
-    // TODO(adz): Since this is an applicaton-level concern we should remove encoding / decoding
-    // from our APIs. See related issue: https://github.com/p2panda/p2panda/issues/1072
+    //
+    // TODO: Since this is an applicaton-level concern we should remove encoding / decoding from our
+    // APIs. See related issue: https://github.com/p2panda/p2panda/issues/1072
     DecodeFailed { event: Event, error: DecodeError },
 
     /// Topic stream could not acknowledge events due to an internal error.

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -101,7 +101,7 @@ pub(crate) async fn processed_stream<M>(
     sync_handle: SyncHandle<Operation, TopicLogSyncEvent<Extensions>>,
     store: SqliteStore,
     forge: OperationForge,
-    mut pipeline: Pipeline,
+    pipeline: Pipeline,
     from: StreamFrom,
 ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
 where
@@ -140,8 +140,40 @@ where
         .await
         .map_err(|err| CreateStreamError(err.to_string()))?;
 
+    // Spawn first task which receives processed "output events" from the processing pipeline, the
+    // result is handled (acking, decoding, conversion to `StreamEvent`, etc.) and then finally
+    // forwarded to the application layer.
     {
+        let mut pipeline = pipeline.clone();
         let acked = acked.clone();
+        let app_tx = app_tx.clone();
+
+        tokio::spawn(async move {
+            loop {
+                // Handle resulting output events from the pipeline and forward them as stream
+                // events to application layer when applicable.
+                let from_pipeline_event = pipeline.next().await;
+
+                if let Some(stream_event) =
+                    process_operation_out::<M>(from_pipeline_event, topic, ack_policy, &acked).await
+                {
+                    // Send processing result to application layer.
+                    //
+                    // If channel stopped working because the subscriber got dropped, ignore it as
+                    // we still might want to process locally published operations.
+                    let _ = app_tx.send(stream_event).await;
+                }
+            }
+        });
+    }
+
+    // Spawn second task which assembles different sources of incoming operations (replays, external
+    // streams, sync session, locally published, etc.) and inputs them into the processing pipeline.
+    //
+    // Here we only forward "system events" to the application layer, such as "sync started" or
+    // "external stream import finished", etc. - actual application messages are handled in the task
+    // above.
+    {
         let store = store.clone();
         let sync_handle = sync_handle.clone();
 
@@ -153,16 +185,8 @@ where
             {
                 // This will block processing of the sync stream and of locally created operations
                 // until it is complete.
-                let replay_result = replay_log_ranges(
-                    topic,
-                    &store,
-                    &app_tx,
-                    &pipeline,
-                    ack_policy,
-                    &acked,
-                    nacked_log_ranges,
-                )
-                .await;
+                let replay_result =
+                    replay_log_ranges(topic, &store, &app_tx, &pipeline, nacked_log_ranges).await;
 
                 // Errors occurring in the replay task which be returned to the user.
                 if let Err(error) = replay_result {
@@ -180,12 +204,12 @@ where
             }
 
             // =========================
-            // 2. Stream external events
+            // 2. Handle incoming events
             // =========================
 
             let mut aggregator = Aggregator::new();
             loop {
-                let event = tokio::select! {
+                let stream_event = tokio::select! {
                     // Received incoming operation from remote source.
                     item = sync_stream.next() => {
                         let Some(result) = item else {
@@ -210,18 +234,8 @@ where
                             sync_metrics::SyncEvent::SyncStarted { .. } => event.into(),
                             sync_metrics::SyncEvent::SyncEnded { .. } => event.into(),
                             sync_metrics::SyncEvent::OperationReceived { operation, source } => {
-                                let Some(event) = process_operation::<M>(
-                                    *operation,
-                                    topic,
-                                    &pipeline,
-                                    ack_policy,
-                                    &acked,
-                                    source
-                                ).await else {
-                                    continue;
-                                };
-
-                                event
+                                process_operation_in(*operation, source, topic, &pipeline).await;
+                                continue;
                             },
                         }
                     }
@@ -231,9 +245,10 @@ where
                     // If the publishing channel gets closed, for example when the publisher handle
                     // got dropped, we still continue with this task, as we still might receive
                     // operations from the log sync stream.
-                    Some((operation, message, processed_tx)) = publish_rx.recv() => {
-                        let event = process_published_operation(
+                    Some((operation, _message, processed_tx)) = publish_rx.recv() => {
+                        let event = process_operation_in(
                             operation,
+                            Source::LocalStore,
                             topic,
                             &pipeline,
                         ).await;
@@ -242,23 +257,7 @@ where
                         // done here.
                         let _ = processed_tx.send(event.clone());
 
-                        // Operations with a body address the system- and application-layer while
-                        // operations without a body do _only_ address the system-layer. This
-                        // affects how we're acknowledging events in the pipeline.
-                        let result = match message {
-                            Some(message) => {
-                                ack_published_operation(message, event, topic, ack_policy, &acked).await
-                            },
-                            None => {
-                                ack_published_operation_wo_body(event, &acked).await
-                            },
-                        };
-
-                        let Some(event) = result else {
-                            continue;
-                        };
-
-                        event
+                        continue;
                     }
 
                     // Receive imported external source of operations.
@@ -285,11 +284,11 @@ where
                                 // If no active live session exists, nodes will pick up the
                                 // operation later when running the sync protocol.
                                 //
-                                // @TODO: There are two paths for operations to be published into
-                                // live-mode channels now (here and when one directly publishes
-                                // new messages). Consider if these should be unified into one
-                                // path somehow so as to avoid the chance of introducing
-                                // inconsistency later on.
+                                // TODO: There are two paths for operations to be published into
+                                // live-mode channels now (here and when one directly publishes new
+                                // messages). Consider if these should be unified into one path
+                                // somehow so as to avoid the chance of introducing inconsistency
+                                // later on.
                                 if sync_handle
                                     .publish(*operation.clone())
                                     .await.is_err() {
@@ -300,36 +299,27 @@ where
                                         )
                                     };
 
-                                let Some(event) = process_operation::<M>(
+                                process_operation_in(
                                     *operation,
+                                    Source::ExternalStream { session_id },
                                     topic,
                                     &pipeline,
-                                    ack_policy,
-                                    &acked,
-                                    Source::ExternalStream { session_id },
-                                ).await else {
-                                    continue;
-                                };
+                                ).await;
 
-                                event
+                                continue;
                             },
                             ExternalStreamEvent::End {
                                 session_id
                             } => StreamEvent::ImportEnded { session_id },
                         }
                     },
-
-                    _from_pipeline_event = pipeline.next() => {
-                        // TODO: Handle processing result and forward to application layer.
-                        continue;
-                    }
                 };
 
-                // Send processing result to application layer.
+                // Send stream events to application layer.
                 //
-                // If channel stopped working because the subscriber got dropped, ignore it as we
-                // still might want to process locally published operations.
-                let _ = app_tx.send(event).await;
+                // If channel stopped working because the subscriber got dropped, ignore it as
+                // we still might want to process locally published operations.
+                let _ = app_tx.send(stream_event).await;
             }
         });
     }
@@ -354,36 +344,47 @@ where
     Ok((tx, rx))
 }
 
-/// Process and acknowledge an incoming operation coming from an external stream (sync- or replay
-/// task).
-//
-/// When re-playing older events, this can include locally created operations.
-pub(crate) async fn process_operation<M>(
+/// Process an incoming operation in the pipeline.
+pub(crate) async fn process_operation_in(
     operation: Operation,
+    source: Source,
     topic: Topic,
     pipeline: &Pipeline,
-    ack_policy: AckPolicy,
-    acked: &Acked,
-    source: Source,
-) -> Option<StreamEvent<M>>
-where
-    M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
-{
+) -> Event {
     let log_id = operation.header.extensions.log_id();
     let prune_flag = operation.header.extensions.prune_flag();
     let spaces_args = operation.header.extensions.spaces_args();
 
-    // Send operation to processor task and wait for result. This blocks any parent stream and
-    // makes sure that all events are handled in same order.
+    // Send operation to processor task. This blocks any parent stream and makes sure that all
+    // events are handled in same order.
     let event = pipeline
         .process(Event::new(
             operation,
+            source,
             log_id,
             topic,
             prune_flag,
             spaces_args,
         ))
         .await;
+
+    // The actual output from the pipeline comes via a channel to the topic stream, see
+    // process_operation_out. The returned event here is only for (optional) inspection for users
+    // who published an operation locally and want to await until it is processed.
+    event
+}
+
+/// Handle the resulting event output coming from the processor pipeline.
+pub(crate) async fn process_operation_out<M>(
+    event: Event,
+    topic: Topic,
+    ack_policy: AckPolicy,
+    acked: &Acked,
+) -> Option<StreamEvent<M>>
+where
+    M: for<'a> Deserialize<'a> + Send + 'static,
+{
+    let source = event.source.clone();
 
     if let Some(error) = event.failure_reason() {
         warn!(
@@ -402,8 +403,8 @@ where
     // Handle message decoding for both unencrypted (from the body) and group encrypted (from the
     // extensions) cases.
     //
-    // @TODO: this is a bit of a hack, we should properly convert all spaces events and expose
-    // them to the user.
+    // TODO: this is a bit of a hack, we should properly convert all spaces events and expose them
+    // to the user.
     let decode_result =
         if let ProcessorStatus::Completed(SpacesResult::Processed { events }) = &event.spaces {
             let mut events = events.iter();
@@ -431,6 +432,7 @@ where
 
                 return None;
             };
+
             decode_cbor::<M, _>(body.as_bytes())
         };
 
@@ -471,95 +473,6 @@ where
     };
 
     Some(event)
-}
-
-/// Process an operation which was just published locally.
-///
-/// This is different from processing a remote or re-played operation coming from a stream:
-///
-/// 1. Since we know the message already we don't need to decode it.
-/// 2. We want to inform the publisher about the result of the processing if they want to. This is
-///    different from processing operations coming from an external stream where there's no
-///    explicit user call which created them.
-pub(crate) async fn process_published_operation(
-    operation: Operation,
-    topic: Topic,
-    pipeline: &Pipeline,
-) -> Event {
-    let log_id = operation.header.extensions.log_id();
-    let prune_flag = operation.header.extensions.prune_flag();
-    let spaces_args = operation.header.extensions.spaces_args();
-
-    // Send operation to processor task and wait for result. This blocks any parent stream and
-    // makes sure that all events are handled in same order.
-    let event = pipeline
-        .process(Event::new(
-            operation,
-            log_id,
-            topic,
-            prune_flag,
-            spaces_args,
-        ))
-        .await;
-
-    if let Some(err) = event.failure_reason() {
-        warn!(
-            id = %event.hash(),
-            "processing local operation failed: {}",
-            err
-        );
-    }
-
-    event
-}
-
-/// Acknowledge an operation _without a body_ which was just created locally.
-///
-/// We've published an operation without a body. In this case we _always_ automatically ack it,
-/// independent of ack policy.
-///
-/// If acking fails we inform the application-layer about it, to give them a chance to re-attempt
-/// acking it themselves.
-pub(crate) async fn ack_published_operation_wo_body<M>(
-    event: Event,
-    acked: &Acked,
-) -> Option<StreamEvent<M>> {
-    if let Err(error) = acked.ack(&event).await {
-        return Some(StreamEvent::AckFailed {
-            event,
-            error: Arc::new(error),
-        });
-    }
-
-    None
-}
-
-/// Acknowledge an operation with a body which was just created locally.
-pub(crate) async fn ack_published_operation<M>(
-    message: M,
-    event: Event,
-    topic: Topic,
-    ack_policy: AckPolicy,
-    acked: &Acked,
-) -> Option<StreamEvent<M>> {
-    if ack_policy == AckPolicy::Automatic
-        && let Err(error) = acked.ack(&event).await
-    {
-        return Some(StreamEvent::AckFailed {
-            event,
-            error: Arc::new(error),
-        });
-    }
-
-    Some(StreamEvent::Processed {
-        operation: ProcessedOperation {
-            event,
-            topic,
-            acked: acked.clone(),
-            message,
-        },
-        source: Source::LocalStore,
-    })
 }
 
 /// Publish messages into a topic stream.
@@ -1060,7 +973,7 @@ impl<M> Borrow<Header> for &ProcessedOperation<M> {
 }
 
 /// Source of a processed operation.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum Source {
     /// Source when an operation arrived via a sync session with a remote node.

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -29,13 +29,14 @@ use tracing::warn;
 use crate::forge::{Forge, ForgeError, OperationForge};
 use crate::node::{AckPolicy, CreateStreamError};
 use crate::operation::{Extensions, Header, LogId, Operation};
-use crate::processor::{Event, Pipeline, ProcessorError, ProcessorStatus};
+use crate::processor::{ProcessorError, ProcessorStatus};
 use crate::streams::acked::{Acked, AckedError};
 use crate::streams::external_stream::{
     ExternalStream, ExternalStreamEvent, ExternalStreamFuture, SessionId,
 };
 use crate::streams::replay::{ReplayError, StreamFrom, replay_log_ranges};
 use crate::streams::sync_metrics::{self, Aggregator, SessionPhase, SyncError};
+use crate::streams::{Event, Pipeline};
 
 /// Number of items which can stay in the buffer before the application-layer picks up the
 /// operations. If buffer runs full the processor will pause work and we'll apply backpressure to
@@ -100,7 +101,7 @@ pub(crate) async fn processed_stream<M>(
     sync_handle: SyncHandle<Operation, TopicLogSyncEvent<Extensions>>,
     store: SqliteStore,
     forge: OperationForge,
-    pipeline: Pipeline<LogId, Extensions, Topic>,
+    mut pipeline: Pipeline,
     from: StreamFrom,
 ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
 where
@@ -121,11 +122,8 @@ where
 
     // Channel to send locally created operations to the processing pipeline. A "oneshot" callback
     // is attached to allow publishers to await the processing result.
-    let (publish_tx, mut publish_rx) = mpsc::channel::<(
-        Operation,
-        Option<M>,
-        oneshot::Sender<Event<LogId, Extensions, Topic>>,
-    )>(PUBLISH_BUFFER_SIZE);
+    let (publish_tx, mut publish_rx) =
+        mpsc::channel::<(Operation, Option<M>, oneshot::Sender<Event>)>(PUBLISH_BUFFER_SIZE);
 
     // Channel for importing external operation streams.
     let (import_tx, mut import_rx) = mpsc::channel::<(
@@ -143,7 +141,6 @@ where
         .map_err(|err| CreateStreamError(err.to_string()))?;
 
     {
-        let pipeline = pipeline.clone();
         let acked = acked.clone();
         let store = store.clone();
         let sync_handle = sync_handle.clone();
@@ -277,7 +274,9 @@ where
                     // Receive the next ready event from any imported external source.
                     Some(event) = external_stream.next() => {
                         match event {
-                            ExternalStreamEvent::Start { session_id } => StreamEvent::ImportStarted { session_id },
+                            ExternalStreamEvent::Start {
+                                session_id
+                            } => StreamEvent::ImportStarted { session_id },
                             ExternalStreamEvent::Operation { session_id, operation } => {
                                 // Try pushing operation to other nodes if we have an active and
                                 // "live" sync session with them. This allows disseminating new
@@ -294,7 +293,11 @@ where
                                 if sync_handle
                                     .publish(*operation.clone())
                                     .await.is_err() {
-                                        warn!(session_id = session_id, operation_id = %operation.hash(), "failed sending imported operation on sync channel")
+                                        warn!(
+                                            session_id,
+                                            operation_id = %operation.hash(),
+                                            "failed sending imported operation on sync channel"
+                                        )
                                     };
 
                                 let Some(event) = process_operation::<M>(
@@ -310,8 +313,15 @@ where
 
                                 event
                             },
-                            ExternalStreamEvent::End { session_id } => StreamEvent::ImportEnded { session_id },
+                            ExternalStreamEvent::End {
+                                session_id
+                            } => StreamEvent::ImportEnded { session_id },
                         }
+                    },
+
+                    _from_pipeline_event = pipeline.next() => {
+                        // TODO: Handle processing result and forward to application layer.
+                        continue;
                     }
                 };
 
@@ -351,7 +361,7 @@ where
 pub(crate) async fn process_operation<M>(
     operation: Operation,
     topic: Topic,
-    pipeline: &Pipeline<LogId, Extensions, Topic>,
+    pipeline: &Pipeline,
     ack_policy: AckPolicy,
     acked: &Acked,
     source: Source,
@@ -474,8 +484,8 @@ where
 pub(crate) async fn process_published_operation(
     operation: Operation,
     topic: Topic,
-    pipeline: &Pipeline<LogId, Extensions, Topic>,
-) -> Event<LogId, Extensions, Topic> {
+    pipeline: &Pipeline,
+) -> Event {
     let log_id = operation.header.extensions.log_id();
     let prune_flag = operation.header.extensions.prune_flag();
     let spaces_args = operation.header.extensions.spaces_args();
@@ -511,7 +521,7 @@ pub(crate) async fn process_published_operation(
 /// If acking fails we inform the application-layer about it, to give them a chance to re-attempt
 /// acking it themselves.
 pub(crate) async fn ack_published_operation_wo_body<M>(
-    event: Event<LogId, Extensions, Topic>,
+    event: Event,
     acked: &Acked,
 ) -> Option<StreamEvent<M>> {
     if let Err(error) = acked.ack(&event).await {
@@ -527,7 +537,7 @@ pub(crate) async fn ack_published_operation_wo_body<M>(
 /// Acknowledge an operation with a body which was just created locally.
 pub(crate) async fn ack_published_operation<M>(
     message: M,
-    event: Event<LogId, Extensions, Topic>,
+    event: Event,
     topic: Topic,
     ack_policy: AckPolicy,
     acked: &Acked,
@@ -621,11 +631,7 @@ pub struct StreamPublisher<M> {
     sync_handle: Arc<SyncHandle<Operation, TopicLogSyncEvent<Extensions>>>,
     forge: OperationForge,
     #[allow(clippy::type_complexity)]
-    pub(crate) publish_tx: mpsc::Sender<(
-        Operation,
-        Option<M>,
-        oneshot::Sender<Event<LogId, Extensions, Topic>>,
-    )>,
+    pub(crate) publish_tx: mpsc::Sender<(Operation, Option<M>, oneshot::Sender<Event>)>,
     import_tx: mpsc::Sender<(
         BoxStream<'static, Operation>,
         oneshot::Sender<ExternalStreamFuture>,
@@ -743,7 +749,7 @@ where
 #[derive(Debug)]
 pub struct PublishFuture {
     hash: Hash,
-    processed_rx: oneshot::Receiver<Event<LogId, Extensions, Topic>>,
+    processed_rx: oneshot::Receiver<Event>,
 }
 
 impl PublishFuture {
@@ -754,7 +760,7 @@ impl PublishFuture {
 }
 
 impl Future for PublishFuture {
-    type Output = Result<Event<LogId, Extensions, Topic>, oneshot::error::RecvError>;
+    type Output = Result<Event, oneshot::error::RecvError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.processed_rx.poll_unpin(cx)
@@ -926,7 +932,7 @@ pub enum StreamEvent<M> {
         /// Event which failed during system-level processing.
         ///
         /// Inspect the event to find the cause of the failure.
-        event: Event<LogId, Extensions, Topic>,
+        event: Event,
 
         /// Error which occurred during processing.
         error: ProcessorError,
@@ -952,14 +958,11 @@ pub enum StreamEvent<M> {
     /// This is an application-level error and indicates an invalid application payload.
     // TODO(adz): Since this is an applicaton-level concern we should remove encoding / decoding
     // from our APIs. See related issue: https://github.com/p2panda/p2panda/issues/1072
-    DecodeFailed {
-        event: Event<LogId, Extensions, Topic>,
-        error: DecodeError,
-    },
+    DecodeFailed { event: Event, error: DecodeError },
 
     /// Topic stream could not acknowledge events due to an internal error.
     AckFailed {
-        event: Event<LogId, Extensions, Topic>,
+        event: Event,
         error: Arc<AckedError>,
     },
 }
@@ -967,7 +970,7 @@ pub enum StreamEvent<M> {
 /// Processed operation with application message coming from a topic stream.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProcessedOperation<M> {
-    event: Event<LogId, Extensions, Topic>,
+    event: Event,
     topic: Topic,
     acked: Acked,
     message: M,
@@ -1003,7 +1006,7 @@ impl<M> ProcessedOperation<M> {
 
     /// Meta-data for inspecting and debugging the processed event (failure / success status) and
     /// underlying [`Operation`] of the append-only log.
-    pub fn processed(&self) -> &Event<LogId, Extensions, Topic> {
+    pub fn processed(&self) -> &Event {
         &self.event
     }
 

--- a/p2panda/src/streams/sync_metrics.rs
+++ b/p2panda/src/streams/sync_metrics.rs
@@ -6,6 +6,7 @@ use p2panda_core::{Extensions, Operation};
 use p2panda_net::NodeId;
 use p2panda_sync::FromSync;
 use p2panda_sync::protocols::{Metrics, TopicLogSyncEvent};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::streams::StreamEvent;
@@ -165,7 +166,7 @@ impl Aggregator {
 /// The nodes then move into the `Live` phase, where any newly-published messages for the relevant
 /// topic will be sent immediately over the sync session - without the nodes first having to
 /// announce and synchronise over their respective states.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SessionPhase {
     Sync,
     Live,


### PR DESCRIPTION
Related PR: https://github.com/p2panda/p2panda/pull/1267

Closes: #1263 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
