### PR TITLE
Task for repairing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Highlights are marked with a pancake 🥞
 - node: Implement `Orderer` `Processor` for pipeline [#1262](https://github.com/p2panda/p2panda/pull/1262)
 - node: Associate key bundle, groups and spaces logs with log topic [#1264](https://github.com/p2panda/p2panda/pull/1264)
 - node: Handle spaces events when processing pipeline event [#1276](https://github.com/p2panda/p2panda/pull/1276)
+- node: Task for repairing spaces [#1277](https://github.com/p2panda/p2panda/pull/1277)
 
 ### Changed
 

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -403,8 +403,11 @@ where
         self.inner.members(group_id)
     }
 
-    /// All groups which have ever been created on this groups state.
-    pub fn seen_groups(&self) -> Vec<ID> {
+    /// All groups which exist in the groups context.
+    /// 
+    /// This includes groups which have no parent -> child relation to each other, as opposed to
+    /// the groups() method which traverses all sub-groups of a single parent.
+    pub fn groups_global(&self) -> Vec<ID> {
         self.inner
             .operations
             .values()

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -403,6 +403,21 @@ where
         self.inner.members(group_id)
     }
 
+    /// All groups which have ever been created on this groups state.
+    pub fn seen_groups(&self) -> Vec<ID> {
+        self.inner
+            .operations
+            .iter()
+            .filter_map(|(_, message)| {
+                if let GroupAction::Create { .. } = message.action() {
+                    Some(message.group_id())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     /// Get all transitive groups inside a group.
     ///
     /// This method recurses into all sub-groups and returns a resolved list of nested group members

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -407,8 +407,8 @@ where
     pub fn seen_groups(&self) -> Vec<ID> {
         self.inner
             .operations
-            .iter()
-            .filter_map(|(_, message)| {
+            .values()
+            .filter_map(|message| {
                 if let GroupAction::Create { .. } = message.action() {
                     Some(message.group_id())
                 } else {

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -404,7 +404,7 @@ where
     }
 
     /// All groups which exist in the groups context.
-    /// 
+    ///
     /// This includes groups which have no parent -> child relation to each other, as opposed to
     /// the groups() method which traverses all sub-groups of a single parent.
     pub fn groups_global(&self) -> Vec<ID> {

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -65,7 +65,7 @@ where
     C: Conditions,
     RS: AuthResolver<C>,
 {
-    pub(crate) fn new(manager_ref: Manager<S, F, C, RS>, id: GroupId) -> Self {
+    pub fn new(manager_ref: Manager<S, F, C, RS>, id: GroupId) -> Self {
         Self {
             manager: manager_ref,
             id,

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -65,7 +65,7 @@ where
     C: Conditions,
     RS: AuthResolver<C>,
 {
-    pub fn new(manager_ref: Manager<S, F, C, RS>, id: GroupId) -> Self {
+    pub(crate) fn new(manager_ref: Manager<S, F, C, RS>, id: GroupId) -> Self {
         Self {
             manager: manager_ref,
             id,

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -494,6 +494,7 @@ where
                 // Only members with Read or greater access can repair spaces.
                 let space_y = space.state().await?;
                 results.push((space_y, vec![]));
+                continue;
             }
 
             let result = space.repair().await.map_err(ManagerError::Space)?;

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -485,6 +485,17 @@ where
                 continue;
             };
 
+            if !space
+                .members()
+                .await?
+                .iter()
+                .any(|(id, access)| *id == self.id() && *access >= Access::<C>::read())
+            {
+                // Only members with Read or greater access can repair spaces.
+                let space_y = space.state().await?;
+                results.push((space_y, vec![]));
+            }
+
             let result = space.repair().await.map_err(ManagerError::Space)?;
             results.push(result);
         }

--- a/p2panda-spaces/src/utils.rs
+++ b/p2panda-spaces/src/utils.rs
@@ -13,7 +13,7 @@ pub(crate) fn typed_member<C: Conditions>(
     y: &AuthGroupState<C>,
     member: ActorId,
 ) -> GroupMember<ActorId> {
-    if y.members(member).is_empty() {
+    if !y.seen_groups().contains(&member) {
         GroupMember::Individual(member)
     } else {
         GroupMember::Group(member)

--- a/p2panda-spaces/src/utils.rs
+++ b/p2panda-spaces/src/utils.rs
@@ -13,7 +13,7 @@ pub(crate) fn typed_member<C: Conditions>(
     y: &AuthGroupState<C>,
     member: ActorId,
 ) -> GroupMember<ActorId> {
-    if !y.seen_groups().contains(&member) {
+    if !y.groups_global().contains(&member) {
         GroupMember::Individual(member)
     } else {
         GroupMember::Group(member)

--- a/p2panda-store/src/spaces/sqlite.rs
+++ b/p2panda-store/src/spaces/sqlite.rs
@@ -35,6 +35,10 @@ impl<E> SqliteSpacesStore<E> {
             _phantom: PhantomData,
         }
     }
+
+    pub fn inner(&self) -> SqliteStore {
+        self.store.clone()
+    }
 }
 
 impl<ARG, E> SpacesMessageStore<ARG> for SqliteSpacesStore<E>

--- a/p2panda/src/forge.rs
+++ b/p2panda/src/forge.rs
@@ -124,6 +124,7 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
 
             trace!(
                 id = operation.hash.fmt_short(),
+                author = self.credentials.verifying_key().fmt_short(),
                 log_id = Hash::from(log_id.as_bytes()).fmt_short(),
                 seq = operation.header.seq_num,
                 "operation created"

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -412,7 +412,7 @@ impl Node {
         let (_, group_id, message) = self.spaces_manager.create_group(&initial_members).await?;
 
         let topic = actor_to_topic(group_id);
-        let (tx, rx) = self.stream::<NoBody>(topic).await?;
+        let (tx, _rx) = self.stream::<NoBody>(topic).await?;
 
         let processed = tx
             .import(futures_util::stream::once(async {
@@ -426,13 +426,12 @@ impl Node {
             panic!();
         }
 
-        let inner = self
-            .spaces_manager
+        let group = self
             .group(group_id)
             .await?
             .expect("materialised group after processing operations");
 
-        Ok(Group::new(inner, tx, rx))
+        Ok(group)
     }
 
     pub async fn space<M>(

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -597,7 +597,6 @@ impl Node {
         let mut messages = vec![key_bundle_message];
         messages.extend(create_space_messages);
 
-        println!("import {} messages", messages.len());
         let processed = tx
             .import(futures_util::stream::iter(
                 messages.into_iter().map(|message| message.into_operation()),

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -467,7 +467,7 @@ impl Node {
             .await?
             .unwrap_or_default();
 
-        for group_id in y.seen_groups() {
+        for group_id in y.groups_global() {
             debug!(
                 group_id = group_id.fmt_short(),
                 space_id = space_id.fmt_short(),

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -3,11 +3,12 @@
 use std::fmt::Debug;
 
 use futures_util::Stream;
+use p2panda_core::traits::ShortFormat;
 use p2panda_core::{Hash, Topic};
 use p2panda_net::iroh_endpoint::RelayUrl;
 use p2panda_net::{NetworkId, NodeId};
 use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
-use p2panda_spaces::{GroupId, SpaceId, SpacesStoreState};
+use p2panda_spaces::{AuthGroupState, GroupId, SpaceId, SpacesStoreState};
 use p2panda_store::groups::GroupsStore;
 use p2panda_store::spaces::{SpacesStore, SqliteSpacesStore};
 use p2panda_store::sqlite::{SqliteError, SqliteStore, SqliteStoreBuilder};
@@ -15,16 +16,19 @@ use p2panda_store::topics::TopicStore;
 use p2panda_store::{Transaction, tx};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::debug;
 
 pub use crate::builder::NodeBuilder;
 use crate::credentials::Credentials;
 use crate::forge::{Forge, OperationForge};
 use crate::network::{Network, NetworkConfig, NetworkError};
 use crate::operation::Extensions;
-use crate::spaces::types::{InnerSpace, NoBody, SpacesManager, SpacesManagerError};
+use crate::spaces::types::{
+    AuthCapabilities, InnerSpace, NoBody, SpacesManager, SpacesManagerError,
+};
 use crate::spaces::{
     AccessLevel, ActorId, Group, GroupError, KEY_BUNDLE_LOG_ID, Member, MemberError, Space,
-    SpaceError, SpaceSubscription, actor_to_topic, spaces_manager, spaces_stream,
+    SpaceError, SpaceSubscription, actor_to_topic, group_log_id, spaces_manager, spaces_stream,
     to_initial_members,
 };
 use crate::streams::{
@@ -319,6 +323,7 @@ impl Node {
             sync_handle,
             self.store.clone(),
             self.forge.clone(),
+            self.spaces_manager.clone(),
             pipeline,
             from,
         )
@@ -398,6 +403,11 @@ impl Node {
         &self,
         initial_members: &[(ActorId, AccessLevel)],
     ) -> Result<Group, GroupError> {
+        // We don't persist the groups state here as we can rely on the spaces processor to do
+        // this. This is important because we rely on groups events being emitted from the
+        // pipeline so that we can react to them for eg. repairing spaces. If we persisted the
+        // state here, the processor would detect that we already processed this control message
+        // and therefore not emit any events.
         let initial_members = to_initial_members(initial_members);
         let (_, group_id, message) = self.spaces_manager.create_group(&initial_members).await?;
 
@@ -445,20 +455,45 @@ impl Node {
     {
         let space_id = space_id.into();
 
+        let permit = self.store.begin().await?;
+
+        // Associate all group logs we have with the space topic, this handles the "first time
+        // subscription" case where we want to sync all groups logs up-front.
+        //
+        // @TODO: This can be removed once we have a working orderer as then the repair task can
+        // be relied upon.
+        let y: AuthGroupState<AuthCapabilities> = self
+            .store
+            .get_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID))
+            .await?
+            .unwrap_or_default();
+
+        for group_id in y.seen_groups() {
+            debug!(
+                group_id = group_id.fmt_short(),
+                space_id = space_id.fmt_short(),
+                "associate group log with space topic"
+            );
+            self.store
+                .associate(&Topic::from(space_id), &self.id(), &group_log_id(group_id))
+                .await?;
+        }
+
         // Associate the space topic with the key bundle logs.
         //
         // This does _not_ happen during ingest as at that point there is no topic which could be
         // used to perform this association. The same key bundle log can be associated with many
-        // spaces.
-        tx!(&self.store, {
-            self.store
-                .associate(
-                    &Topic::from(space_id),
-                    &self.id(),
-                    &Hash::digest(KEY_BUNDLE_LOG_ID),
-                )
-                .await
-        })?;
+        // spaces. And it can't happen in the forge as a user may never actually publish into a
+        // space.
+        self.store
+            .associate(
+                &Topic::from(space_id),
+                &self.id(),
+                &Hash::digest(KEY_BUNDLE_LOG_ID),
+            )
+            .await?;
+
+        self.store.commit(permit).await?;
 
         let topic = space_id;
         let inner = self
@@ -529,22 +564,9 @@ impl Node {
         //
         // @TODO: this is a rather naive approach, we likely want some service that periodically
         // publishes key bundles.
-        let message = self.spaces_manager.key_bundle_message().await?;
+        let key_bundle_message = self.spaces_manager.key_bundle_message().await?;
 
-        let operation = message.into_operation();
-        let processed = tx
-            .import(futures_util::stream::once(async { operation }))
-            .await?;
-
-        // Wait until processing the events has finished.
-
-        // TODO: Would be good to get an error / report here if processing the imported operations
-        // failed. This error so far only tells us that the channel broke down.
-        if processed.await.is_err() {
-            panic!();
-        }
-
-        // Issue the event to create a space.
+        // Issue the events to create a space.
         //
         // We always create a space with only us as the initial members.
         //
@@ -552,25 +574,16 @@ impl Node {
         // members. I (sam) removed it from the API for now as without a manual member
         // registration flow a user likely doesn't have access to any member key bundles at the
         // point of space creation.
-        let (groups_y, space_y, messages) = self.spaces_manager.create_space(space_id, &[]).await?;
+        let (_, space_y, create_space_messages) =
+            self.spaces_manager.create_space(space_id, &[]).await?;
 
-        // Persist the computed groups and spaces state to the stores and make required group log
-        // associations.
-        //
-        // @TODO: This needs some thought. We're persisting state here, rather than expecting this
-        // to happen in the processor, because it's not possible to re-create locally performed
-        // state changes from the messages alone. _If_ we have to persist here, then transactions
-        // need to be considered more carefully, we would need to make this write part of the same
-        // transaction where the operations are forged.
-        //
-        // @TODO: We don't strictly need to persist the groups state here as this is re-creatable
-        // with only the operation in the processor.
+        // @TODO: We need to refactor the spaces API so that locally created operations can be
+        // handled via the call to Manager::process and then persisted in the spaces processor.
+        // Until we have this spaces events for our own locally created operations won't be
+        // emitted to users (as the processor thinks the operation was already processed and skips.
         let permit = self.store.begin().await?;
 
         let spaces_store = SqliteSpacesStore::<Extensions>::new(self.store.clone());
-        spaces_store
-            .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
-            .await?;
         spaces_store
             .set_space_state_tx(&space_id, &SpacesStoreState::from(space_y))
             .await?;
@@ -580,8 +593,12 @@ impl Node {
         // Process the -spaces events by importing them as an "external stream".
         //
         // @TODO: Related to above comment. Even though the state is already mutated & persisted
-        // locally we're still sending the messages to the pipeline. Revisit this if state does
+        // locally we're still sending the messages to the pipeline. Revisit this when state does
         // indeed need to be persisted here instead of in the pipeline.
+        let mut messages = vec![key_bundle_message];
+        messages.extend(create_space_messages);
+
+        println!("import {} messages", messages.len());
         let processed = tx
             .import(futures_util::stream::iter(
                 messages.into_iter().map(|message| message.into_operation()),

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -207,10 +207,8 @@ where
                         LogPrune::<SqliteStore, Event<L, E, TP>, L, E>::new(store.clone());
 
                     let spaces_store = SqliteSpacesStore::new(store);
-                    let spaces = SpacesProcessor::<Event<L, E, TP>>::new(
-                        spaces_store.clone(),
-                        spaces_manager.clone(),
-                    );
+                    let spaces =
+                        SpacesProcessor::<Event<L, E, TP>>::new(spaces_store, spaces_manager);
 
                     // Receive incoming events through mpsc channel.
                     let pipeline = ReceiverStream::new(to_pipeline_rx)

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -198,15 +198,18 @@ where
                 let local = LocalSet::new();
 
                 local.spawn_local(async move {
+                    let me = spaces_manager.id();
                     // Prepare event processing pipeline.
                     let ingest =
                         Ingest::<SqliteStore, Event<L, E, TP>, L, E, TP>::new(store.clone());
                     let orderer = Orderer::<SqliteStore, Event<L, E, TP>, E>::new(store.clone());
                     let log_prune =
                         LogPrune::<SqliteStore, Event<L, E, TP>, L, E>::new(store.clone());
+
+                    let spaces_store = SqliteSpacesStore::new(store);
                     let spaces = SpacesProcessor::<Event<L, E, TP>>::new(
-                        SqliteSpacesStore::new(store),
-                        spaces_manager,
+                        spaces_store.clone(),
+                        spaces_manager.clone(),
                     );
 
                     // Receive incoming events through mpsc channel.
@@ -274,6 +277,7 @@ where
                         // stuck here forever.
                         if let Some(err) = output_event.failure_reason() {
                             warn!(
+                                me = me.fmt_short(),
                                 id = %output_event.hash().fmt_short(),
                                 "failed processing event: {}",
                                 err

--- a/p2panda/src/spaces/forge.rs
+++ b/p2panda/src/spaces/forge.rs
@@ -2,7 +2,6 @@
 
 use p2panda_auth::group::GroupAction;
 use p2panda_core::cbor::encode_cbor;
-use p2panda_core::traits::Digest;
 use p2panda_core::{Hash, Topic, VerifyingKey};
 use p2panda_store::operations::OperationStore;
 use p2panda_store::topics::TopicStore;
@@ -236,38 +235,12 @@ pub(crate) async fn make_space_group_log_associations(
     };
 
     // Associate all group logs for members introduced by this operation.
-    let Some(SpacesArgs::Auth { group_action, .. }) =
-        groups_operation.header.extensions.spaces_args()
-    else {
-        return Err(SpacesForgeError::MissingGroupsArgs(groups_operation.hash()));
-    };
-
-    // @TODO: Maybe it's enough to only associate the group log on group creation?
-    let sub_groups = match group_action {
-        GroupAction::Create { initial_members } => initial_members
-            .into_iter()
-            .filter_map(|(member, _)| {
-                if member.is_group() {
-                    Some(member.id())
-                } else {
-                    None
-                }
-            })
-            .collect(),
-        GroupAction::Add { member, .. } => {
-            if member.is_group() {
-                vec![member.id()]
-            } else {
-                vec![]
-            }
-        }
-        // We don't handle removals here, this is a concern of a higher layer which may even
-        // require consensus.
-        _ => vec![],
-    };
-
-    // For every new sub-group in a space group associate the logs with this space.
-    for group_id in sub_groups {
+    if let Some(SpacesArgs::Auth {
+        group_id,
+        group_action: GroupAction::Create { .. },
+        ..
+    }) = groups_operation.header.extensions.spaces_args()
+    {
         // Every author maintains their own log of control messages _per_ group.
         let log_id = group_log_id(group_id);
 
@@ -288,7 +261,7 @@ pub(crate) async fn make_space_group_log_associations(
         store
             .associate(&Topic::from(space_id), &me, &log_id)
             .await?;
-    }
+    };
 
     let log_id = group_log_id(space_group_id);
     debug!(

--- a/p2panda/src/spaces/forge.rs
+++ b/p2panda/src/spaces/forge.rs
@@ -98,7 +98,7 @@ impl p2panda_spaces::Forge<AuthCapabilities> for OperationForge {
         // TODO: Do we need to query graph tips here for causal ordering or is this taken care off
         // by -spaces? If yes, are declaring _all_ dependencies really it's concern or only the ones
         // which are relevant to the spaces protocol?
-        let operation = match args.clone() {
+        let operation = match args {
             // 1. Key Bundle logs.
             p2panda_spaces::SpacesArgs::KeyBundle { ref key_bundle } => {
                 // TODO: Check actual encoding format of key bundle. Will require versioning.
@@ -274,7 +274,7 @@ pub(crate) async fn make_space_group_log_associations(
         debug!(
             topic = space_id.fmt_short(),
             group_id = group_id.fmt_short(),
-            log_ig = Hash::from(log_id.as_bytes()).fmt_short(),
+            log_id = Hash::from(log_id.as_bytes()).fmt_short(),
             "associate group log with space topic"
         );
 

--- a/p2panda/src/spaces/forge.rs
+++ b/p2panda/src/spaces/forge.rs
@@ -2,6 +2,7 @@
 
 use p2panda_auth::group::GroupAction;
 use p2panda_core::cbor::encode_cbor;
+use p2panda_core::traits::Digest;
 use p2panda_core::{Hash, Topic, VerifyingKey};
 use p2panda_store::operations::OperationStore;
 use p2panda_store::topics::TopicStore;
@@ -97,7 +98,7 @@ impl p2panda_spaces::Forge<AuthCapabilities> for OperationForge {
         // TODO: Do we need to query graph tips here for causal ordering or is this taken care off
         // by -spaces? If yes, are declaring _all_ dependencies really it's concern or only the ones
         // which are relevant to the spaces protocol?
-        let operation = match args {
+        let operation = match args.clone() {
             // 1. Key Bundle logs.
             p2panda_spaces::SpacesArgs::KeyBundle { ref key_bundle } => {
                 // TODO: Check actual encoding format of key bundle. Will require versioning.
@@ -132,8 +133,6 @@ impl p2panda_spaces::Forge<AuthCapabilities> for OperationForge {
                 space_id,
                 group_id,
                 auth_message_id,
-                // @TODO: add "related groups" here and then we don't need to do queries in the
-                // make_group_topic_associations.
                 ..
             } => {
                 // Every author maintains their own log of control messages _per_ space.
@@ -150,7 +149,7 @@ impl p2panda_spaces::Forge<AuthCapabilities> for OperationForge {
                 // @TODO: We want to create the operation and make the log associations in one transaction.
                 let permit = self.store.begin().await?;
 
-                make_group_topic_associations(
+                make_space_group_log_associations(
                     &self.store,
                     Forge::verifying_key(self),
                     space_id,
@@ -212,7 +211,7 @@ fn space_log_id(space_id: Hash) -> LogId {
     })
 }
 
-fn group_log_id(group_id: VerifyingKey) -> LogId {
+pub(crate) fn group_log_id(group_id: VerifyingKey) -> LogId {
     LogId::digest(&{
         let mut bytes = Vec::new();
         bytes.extend_from_slice(group_id.as_bytes());
@@ -224,39 +223,26 @@ fn group_log_id(group_id: VerifyingKey) -> LogId {
     })
 }
 
-#[derive(Debug, Error)]
-pub enum SpacesForgeError {
-    #[error(transparent)]
-    Sqlite(#[from] SqliteError),
-
-    #[error(transparent)]
-    Forge(#[from] ForgeError),
-
-    #[error("missing auth groups operation: {0}")]
-    MissingGroupsOperation(Hash),
-
-    #[error("missing args from groups operation: {0}")]
-    MissingGroupsArgs(Hash),
-}
-
-pub(crate) async fn make_group_topic_associations(
+pub(crate) async fn make_space_group_log_associations(
     store: &SqliteStore,
     me: VerifyingKey,
     space_id: Hash,
     space_group_id: VerifyingKey,
     groups_message_id: Hash,
 ) -> Result<(), SpacesForgeError> {
-    let Some(auth_operation): Option<Operation> = store.get_operation(&groups_message_id).await?
+    let Some(groups_operation): Option<Operation> = store.get_operation(&groups_message_id).await?
     else {
         return Err(SpacesForgeError::MissingGroupsOperation(groups_message_id));
     };
 
+    // Associate all group logs for members introduced by this operation.
     let Some(SpacesArgs::Auth { group_action, .. }) =
-        auth_operation.header.extensions.spaces_args()
+        groups_operation.header.extensions.spaces_args()
     else {
-        return Err(SpacesForgeError::MissingGroupsArgs(groups_message_id));
+        return Err(SpacesForgeError::MissingGroupsArgs(groups_operation.hash()));
     };
 
+    // @TODO: Maybe it's enough to only associate the group log on group creation?
     let sub_groups = match group_action {
         GroupAction::Create { initial_members } => initial_members
             .into_iter()
@@ -304,10 +290,33 @@ pub(crate) async fn make_group_topic_associations(
             .await?;
     }
 
+    let log_id = group_log_id(space_group_id);
+    debug!(
+        topic = space_id.fmt_short(),
+        group_id = space_group_id.fmt_short(),
+        log_ig = Hash::from(log_id.as_bytes()).fmt_short(),
+        "associate space group log with space topic"
+    );
+
     // Also associate the spaces group itself.
     store
-        .associate(&Topic::from(space_id), &me, &group_log_id(space_group_id))
+        .associate(&Topic::from(space_id), &me, &log_id)
         .await?;
 
     Ok(())
+}
+
+#[derive(Debug, Error)]
+pub enum SpacesForgeError {
+    #[error(transparent)]
+    Sqlite(#[from] SqliteError),
+
+    #[error(transparent)]
+    Forge(#[from] ForgeError),
+
+    #[error("missing auth groups operation: {0}")]
+    MissingGroupsOperation(Hash),
+
+    #[error("missing args from groups operation: {0}")]
+    MissingGroupsArgs(Hash),
 }

--- a/p2panda/src/spaces/forge.rs
+++ b/p2panda/src/spaces/forge.rs
@@ -294,7 +294,7 @@ pub(crate) async fn make_space_group_log_associations(
     debug!(
         topic = space_id.fmt_short(),
         group_id = space_group_id.fmt_short(),
-        log_ig = Hash::from(log_id.as_bytes()).fmt_short(),
+        log_id = Hash::from(log_id.as_bytes()).fmt_short(),
         "associate space group log with space topic"
     );
 

--- a/p2panda/src/spaces/mod.rs
+++ b/p2panda/src/spaces/mod.rs
@@ -20,7 +20,7 @@ pub use p2panda_spaces::{ActorId, GroupContext, GroupId, MemberId, SpaceContext,
 pub(crate) use forge::{KEY_BUNDLE_LOG_ID, group_log_id};
 pub use group::{Group, GroupError, GroupEvent, GroupFuture};
 pub use member::{GroupActor, Member, MemberError};
-pub(crate) use repair::spawn_repair_task;
+pub(crate) use repair::{RepairError, spawn_repair_task};
 pub(crate) use space::spaces_stream;
 pub use space::{Space, SpaceError, SpaceEvent, SpaceFuture, SpaceSubscription};
 pub use types::SpacesManagerError;

--- a/p2panda/src/spaces/mod.rs
+++ b/p2panda/src/spaces/mod.rs
@@ -4,6 +4,7 @@ mod forge;
 mod group;
 mod member;
 pub(crate) mod message;
+mod repair;
 mod space;
 pub(crate) mod types;
 
@@ -16,9 +17,10 @@ pub use p2panda_auth::AccessLevel;
 pub use p2panda_spaces::manager::ManagerError;
 pub use p2panda_spaces::{ActorId, GroupContext, GroupId, MemberId, SpaceContext, SpaceId};
 
-pub(crate) use forge::KEY_BUNDLE_LOG_ID;
+pub(crate) use forge::{KEY_BUNDLE_LOG_ID, group_log_id};
 pub use group::{Group, GroupError, GroupEvent, GroupFuture};
 pub use member::{GroupActor, Member, MemberError};
+pub(crate) use repair::spawn_repair_task;
 pub(crate) use space::spaces_stream;
 pub use space::{Space, SpaceError, SpaceEvent, SpaceFuture, SpaceSubscription};
 pub use types::SpacesManagerError;

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -26,7 +26,7 @@ use crate::spaces::types::{AuthCapabilities, SpacesArgs, SpacesStore};
 use crate::spaces::{SpacesManagerError, types::SpacesManager};
 use crate::streams::ExternalStreamFuture;
 
-const REPAIR_DELAY_SECS: u64 = 1;
+const REPAIR_FREQUENCY_SECS: u64 = 1;
 
 /// Repairing a space involves incorporating missing groups operations observed on the global groups
 /// context but not yet published into the space.
@@ -212,17 +212,15 @@ pub(crate) fn spawn_repair_task(
                     }
                 }
                 // Scheduled repair triggered.
-                _ = sleep(Duration::from_secs(REPAIR_DELAY_SECS)) => None,
+                _ = sleep(Duration::from_secs(REPAIR_FREQUENCY_SECS)) => None,
             };
 
-            // Repair the space.
             let result = repair_space(topic.into(), &manager, &store, &import_tx).await;
 
             if let Err(ref err) = result {
                 warn!("failed to repair spaces: {}", err);
             }
 
-            // Return the result.
             if let Some(reply_tx) = reply_tx {
                 let _ = reply_tx.send(result);
             }

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::time::Duration;
+
+use futures_util::stream::BoxStream;
+use p2panda_core::traits::{Provenance, ShortFormat};
+use p2panda_core::{Hash, Topic};
+use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
+use p2panda_spaces::{AuthGroupState, SpaceId, SpacesStoreState};
+use p2panda_store::groups::GroupsStore;
+use p2panda_store::operations::OperationStore;
+use p2panda_store::spaces::{SpacesStore as SpacesStoreTrait, SqliteSpacesStore};
+use p2panda_store::topics::TopicStore;
+use p2panda_store::{SqliteError, SqliteStore, Transaction};
+use thiserror::Error;
+use tokio::sync::mpsc::{self};
+use tokio::sync::oneshot;
+use tokio::sync::oneshot::error::RecvError;
+use tokio::task::JoinHandle;
+use tokio::time::sleep;
+use tracing::{debug, warn};
+
+use crate::operation::{Extensions, Operation};
+use crate::spaces::group_log_id;
+use crate::spaces::types::{AuthCapabilities, SpacesArgs};
+use crate::spaces::{SpacesManagerError, types::SpacesManager};
+use crate::streams::ExternalStreamFuture;
+
+const REPAIR_DELAY_SECS: u64 = 1;
+
+// Repairing a space involves incorporating missing groups operations observed on the global groups
+// context but not yet published into the space.
+//
+// There are 3 steps to this process:
+//
+// 1) re-publish missing groups operations into the space topic
+// 2) create and publish space membership operations for each missing groups operation (only read
+//    members can do this)
+// 3) associate missing groups logs with the space topic
+//
+// All new messages will be sent into the topic stream to be processed and forwarded to other peers.
+pub(crate) async fn repair_space(
+    topic: Topic,
+    manager: &SpacesManager,
+    store: &SqliteStore,
+    import_tx: &mpsc::Sender<(
+        BoxStream<'static, Operation>,
+        oneshot::Sender<ExternalStreamFuture>,
+    )>,
+) -> Result<bool, RepairError> {
+    let spaces_store = SqliteSpacesStore::<Extensions>::new(store.clone());
+
+    // Identify if this space needs repairing.
+    //
+    // @TODO: optimize this query by only checking the one space we're concerned with here.
+    let space_id = SpaceId::from(topic);
+    let space_ids = match manager.spaces_repair_required().await {
+        Ok(ids) => ids,
+        Err(err) => {
+            return Err(err.into());
+        }
+    };
+
+    // If not return now already.
+    if space_ids.is_empty() || !space_ids.contains(&space_id) {
+        return Ok(false);
+    }
+
+    // Attempt to repair the space. As we pass in an array containing a single space id there will
+    // be only ever max one result returned.
+    //
+    // @TODO: This method uses transactions internally (eg. in the Forge) and so we can't make
+    // everything part of one transaction on this level yet. It isn't a source of bugs though so
+    // for now this is ok.
+    let mut repaired = manager.repair_spaces(&[space_id]).await?;
+
+    // Forging these spaces messages will also associate any group logs with this space topic.
+    let Some((space_y, spaces_messages)) = repaired.pop() else {
+        // This can happen if we didn't receive any space messages yet, or we're not a member with
+        // read access.
+        debug!(
+            node_id = manager.id().fmt_short(),
+            space_id = space_id.fmt_short(),
+            "space not yet materialised"
+        );
+        return Ok(false);
+    };
+
+    let permit = store.begin().await?;
+
+    // Collect all groups operations in our global context that the space is missing.
+    let groups_y: AuthGroupState<AuthCapabilities> = spaces_store
+        .get_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID))
+        .await?
+        .unwrap_or_default();
+
+    let mut groups_operations = vec![];
+    for id in groups_y.inner.operations.keys() {
+        if space_y.groups_y.inner.operations.contains_key(id) {
+            continue;
+        }
+
+        let Some(operation): Option<Operation> = store.get_operation_tx(id).await? else {
+            warn!("missing expected auth groups operation");
+            continue;
+        };
+
+        // Ignore non-groups operations.
+        let Some(SpacesArgs::Auth {
+            group_id,
+            group_action,
+            ..
+        }) = operation.header.extensions.spaces_args()
+        else {
+            warn!("expected auth groups operation");
+            continue;
+        };
+
+        // If this is a create operation then associate the groups log with this space topic.
+        if group_action.is_create() {
+            store
+                .associate(
+                    &Topic::from(space_id),
+                    &operation.author(),
+                    &group_log_id(group_id),
+                )
+                .await?;
+        }
+
+        groups_operations.push(operation)
+    }
+
+    // If no _space_ messages were returned from repairing then no state change occurred and we
+    // don't need to persist here. This occurs when we are not a _read_ member of the space (yet).
+    if !spaces_messages.is_empty() {
+        // @TODO: Again, once we can process our own spaces messages then we no longer
+        // need to persist this state here.
+        let space_id = space_y.space_id;
+        spaces_store
+            .set_space_state_tx(&space_id, &SpacesStoreState::from(space_y))
+            .await?;
+    }
+
+    // If there are no messages to send then exit here.
+    if spaces_messages.is_empty() && groups_operations.is_empty() {
+        store.commit(permit).await?;
+        return Ok(false);
+    }
+
+    let op_count = groups_operations.len() + spaces_messages.len();
+    let operations = groups_operations.into_iter().chain(
+        spaces_messages
+            .into_iter()
+            .map(|message| message.into_operation()),
+    );
+
+    // Send the resulting operations into the stream.
+    let stream = Box::pin(futures_util::stream::iter(operations));
+    let (ready_tx, _ready_rx) = oneshot::channel::<ExternalStreamFuture>();
+    import_tx
+        .send((stream, ready_tx))
+        .await
+        .map_err(|err| RepairError::SendToProcessor(err.to_string()))?;
+
+    // Don't await processing otherwise we'd block the stream.
+    store.commit(permit).await?;
+
+    debug!(
+        node_id = manager.id().fmt_short(),
+        space_id = space_id.fmt_short(),
+        operations = op_count,
+        "space repaired"
+    );
+
+    Ok(true)
+}
+
+pub(crate) fn spawn_repair_task(
+    topic: Topic,
+    manager: SpacesManager,
+    store: SqliteStore,
+    import_tx: mpsc::Sender<(
+        BoxStream<'static, Operation>,
+        oneshot::Sender<ExternalStreamFuture>,
+    )>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            sleep(Duration::from_secs(REPAIR_DELAY_SECS)).await;
+            if let Err(err) = repair_space(topic, &manager, &store, &import_tx).await {
+                warn!("failed to repair spaces: {}", err);
+            }
+        }
+    })
+}
+
+#[derive(Debug, Error)]
+#[allow(clippy::large_enum_variant)] // TODO: Reduce size of spaces error types.
+pub enum RepairError {
+    #[error(transparent)]
+    Store(#[from] SqliteError),
+
+    #[error(transparent)]
+    SpacesManager(#[from] SpacesManagerError),
+
+    #[error("could not send to processor pipeline: {0}")]
+    SendToProcessor(String),
+
+    #[error(transparent)]
+    Recv(#[from] RecvError),
+}

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -9,19 +9,20 @@ use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
 use p2panda_spaces::{AuthGroupState, SpaceId, SpacesStoreState};
 use p2panda_store::groups::GroupsStore;
 use p2panda_store::operations::OperationStore;
-use p2panda_store::spaces::{SpacesStore as SpacesStoreTrait, SqliteSpacesStore};
+use p2panda_store::spaces::SpacesStore as SpacesStoreTrait;
 use p2panda_store::topics::TopicStore;
 use p2panda_store::{SqliteError, SqliteStore, Transaction};
 use thiserror::Error;
 use tokio::sync::mpsc::{self};
 use tokio::sync::oneshot;
+use tokio::sync::oneshot::error::RecvError;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{debug, warn};
 
-use crate::operation::{Extensions, Operation};
+use crate::operation::Operation;
 use crate::spaces::group_log_id;
-use crate::spaces::types::{AuthCapabilities, SpacesArgs};
+use crate::spaces::types::{AuthCapabilities, SpacesArgs, SpacesStore};
 use crate::spaces::{SpacesManagerError, types::SpacesManager};
 use crate::streams::ExternalStreamFuture;
 
@@ -47,7 +48,7 @@ pub(crate) async fn repair_space(
         oneshot::Sender<ExternalStreamFuture>,
     )>,
 ) -> Result<bool, RepairError> {
-    let spaces_store = SqliteSpacesStore::<Extensions>::new(store.clone());
+    let spaces_store = SpacesStore::new(store.clone());
 
     // Identify if this space needs repairing.
     //
@@ -64,29 +65,13 @@ pub(crate) async fn repair_space(
         return Ok(false);
     }
 
-    // Attempt to repair the space. As we pass in an array containing a single space id there will
-    // be only ever max one result returned.
-    //
-    // @TODO: This method uses transactions internally (eg. in the Forge) and so we can't make
-    // everything part of one transaction on this level yet. It isn't a source of bugs though so
-    // for now this is ok.
-    let mut repaired = manager.repair_spaces(&[space_id]).await?;
-
-    // Forging these spaces messages will also associate any group logs with this space topic.
-    let Some((space_y, spaces_messages)) = repaired.pop() else {
-        // This can happen if we didn't receive any space messages yet, or we're not a member with
-        // read access.
-        debug!(
-            node_id = manager.id().fmt_short(),
-            space_id = space_id.fmt_short(),
-            "space not yet materialised"
-        );
-        return Ok(false);
-    };
-
+    // Collect all missing groups operations. These will be imported into the space and forwarded
+    // to live-mode peers.
     let permit = store.begin().await?;
 
-    // Collect all groups operations in our global context that the space is missing.
+    let space_y: Option<SpacesStoreState<AuthCapabilities>> =
+        spaces_store.get_space_state_tx(&space_id).await?;
+
     let groups_y: AuthGroupState<AuthCapabilities> = spaces_store
         .get_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID))
         .await?
@@ -94,7 +79,9 @@ pub(crate) async fn repair_space(
 
     let mut groups_operations = vec![];
     for id in groups_y.inner.operations.keys() {
-        if space_y.groups_y.inner.operations.contains_key(id) {
+        if let Some(ref y) = space_y
+            && y.groups_y.inner.operations.contains_key(id)
+        {
             continue;
         }
 
@@ -128,40 +115,66 @@ pub(crate) async fn repair_space(
         groups_operations.push(operation)
     }
 
-    // If no _space_ messages were returned from repairing then no state change occurred and we
+    store.commit(permit).await?;
+
+    // Attempt to repair the space. As we pass in an array containing a single space id there will
+    // be only ever max one result returned.
+    //
+    // @TODO: This method uses transactions internally (eg. in the Forge) and so we can't make
+    // everything part of one transaction on this level yet. It isn't a source of bugs though so
+    // for now this is ok.
+    let mut repaired = manager.repair_spaces(&[space_id]).await?;
+
+    // Forging these spaces messages will also associate any group logs with this space topic.
+    let Some((space_y, spaces_messages)) = repaired.pop() else {
+        // This can happen if we didn't receive any space control messages yet.
+        debug!(
+            node_id = manager.id().fmt_short(),
+            space_id = space_id.fmt_short(),
+            "space not yet materialised"
+        );
+        return Ok(false);
+    };
+
+    // If no space messages were forged during repairing then no state change occurred and we
     // don't need to persist here. This occurs when we are not a _read_ member of the space (yet).
+    //
+    // @TODO: Once control messages are encrypted it will not be possible for non-read members to
+    // receives any control messages and so this logic can be refactored.
     if !spaces_messages.is_empty() {
-        // @TODO: Again, once we can process our own spaces messages then we no longer
+        let permit = store.begin().await?;
+
+        // @TODO: Once we can process our own spaces messages then we no longer
         // need to persist this state here.
         let space_id = space_y.space_id;
         spaces_store
             .set_space_state_tx(&space_id, &SpacesStoreState::from(space_y))
             .await?;
-    }
 
-    store.commit(permit).await?;
+        store.commit(permit).await?;
+    }
 
     // If there are no messages to send then exit here.
     if spaces_messages.is_empty() && groups_operations.is_empty() {
         return Ok(false);
     }
 
+    // Send all resulting operations into the stream.
     let op_count = groups_operations.len() + spaces_messages.len();
     let operations = groups_operations.into_iter().chain(
         spaces_messages
             .into_iter()
             .map(|message| message.into_operation()),
     );
-
-    // Send the resulting operations into the stream.
     let stream = Box::pin(futures_util::stream::iter(operations));
-    let (ready_tx, _ready_rx) = oneshot::channel::<ExternalStreamFuture>();
+    let (ready_tx, ready_rx) = oneshot::channel::<ExternalStreamFuture>();
     import_tx
         .send((stream, ready_tx))
         .await
         .map_err(|err| RepairError::SendToProcessor(err.to_string()))?;
 
-    // Don't await processing otherwise we'd block the stream.
+    // Await processing of operations to be complete.
+    ready_rx.await?;
 
     debug!(
         node_id = manager.id().fmt_short(),
@@ -173,6 +186,8 @@ pub(crate) async fn repair_space(
     Ok(true)
 }
 
+/// Spawn the repair task which triggers work on a schedule or from being signalled from elsewhere
+/// in the node API.
 pub(crate) fn spawn_repair_task(
     topic: Topic,
     manager: SpacesManager,
@@ -181,13 +196,36 @@ pub(crate) fn spawn_repair_task(
         BoxStream<'static, Operation>,
         oneshot::Sender<ExternalStreamFuture>,
     )>,
+    mut repair_rx: mpsc::Receiver<oneshot::Sender<Result<bool, RepairError>>>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
-            if let Err(err) = repair_space(topic.into(), &manager, &store, &import_tx).await {
+            let reply_tx = tokio::select! {
+                // We received a signal to repair the space.
+                msg = repair_rx.recv() => {
+                    match msg {
+                        Some(reply_tx) => Some(reply_tx),
+                        None => {
+                            // If the repair_tx is dropped then we can exit this task.
+                            return;
+                        }
+                    }
+                }
+                // Scheduled repair triggered.
+                _ = sleep(Duration::from_secs(REPAIR_DELAY_SECS)) => None,
+            };
+
+            // Repair the space.
+            let result = repair_space(topic.into(), &manager, &store, &import_tx).await;
+
+            if let Err(ref err) = result {
                 warn!("failed to repair spaces: {}", err);
             }
-            sleep(Duration::from_secs(REPAIR_DELAY_SECS)).await;
+
+            // Return the result.
+            if let Some(reply_tx) = reply_tx {
+                let _ = reply_tx.send(result);
+            }
         }
     })
 }
@@ -203,4 +241,7 @@ pub enum RepairError {
 
     #[error("could not send to processor pipeline: {0}")]
     SendToProcessor(String),
+
+    #[error("import ready channel broken")]
+    Recv(#[from] RecvError),
 }

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -15,7 +15,6 @@ use p2panda_store::{SqliteError, SqliteStore, Transaction};
 use thiserror::Error;
 use tokio::sync::mpsc::{self};
 use tokio::sync::oneshot;
-use tokio::sync::oneshot::error::RecvError;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{debug, warn};
@@ -28,19 +27,19 @@ use crate::streams::ExternalStreamFuture;
 
 const REPAIR_DELAY_SECS: u64 = 1;
 
-// Repairing a space involves incorporating missing groups operations observed on the global groups
-// context but not yet published into the space.
-//
-// There are 3 steps to this process:
-//
-// 1) re-publish missing groups operations into the space topic
-// 2) create and publish space membership operations for each missing groups operation (only read
-//    members can do this)
-// 3) associate missing groups logs with the space topic
-//
-// All new messages will be sent into the topic stream to be processed and forwarded to other peers.
+/// Repairing a space involves incorporating missing groups operations observed on the global groups
+/// context but not yet published into the space.
+///
+/// There are 3 steps to this process:
+///
+/// 1) re-publish missing groups operations into the space topic
+/// 2) create and publish space membership operations for each missing groups operation (only read
+///    members can do this)
+/// 3) associate missing groups logs with the space topic
+///
+/// All new messages will be sent into the topic stream to be processed and forwarded to other peers.
 pub(crate) async fn repair_space(
-    topic: Topic,
+    space_id: SpaceId,
     manager: &SpacesManager,
     store: &SqliteStore,
     import_tx: &mpsc::Sender<(
@@ -53,7 +52,6 @@ pub(crate) async fn repair_space(
     // Identify if this space needs repairing.
     //
     // @TODO: optimize this query by only checking the one space we're concerned with here.
-    let space_id = SpaceId::from(topic);
     let space_ids = match manager.spaces_repair_required().await {
         Ok(ids) => ids,
         Err(err) => {
@@ -141,9 +139,10 @@ pub(crate) async fn repair_space(
             .await?;
     }
 
+    store.commit(permit).await?;
+
     // If there are no messages to send then exit here.
     if spaces_messages.is_empty() && groups_operations.is_empty() {
-        store.commit(permit).await?;
         return Ok(false);
     }
 
@@ -163,7 +162,6 @@ pub(crate) async fn repair_space(
         .map_err(|err| RepairError::SendToProcessor(err.to_string()))?;
 
     // Don't await processing otherwise we'd block the stream.
-    store.commit(permit).await?;
 
     debug!(
         node_id = manager.id().fmt_short(),
@@ -186,10 +184,10 @@ pub(crate) fn spawn_repair_task(
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
-            sleep(Duration::from_secs(REPAIR_DELAY_SECS)).await;
-            if let Err(err) = repair_space(topic, &manager, &store, &import_tx).await {
+            if let Err(err) = repair_space(topic.into(), &manager, &store, &import_tx).await {
                 warn!("failed to repair spaces: {}", err);
             }
+            sleep(Duration::from_secs(REPAIR_DELAY_SECS)).await;
         }
     })
 }
@@ -205,7 +203,4 @@ pub enum RepairError {
 
     #[error("could not send to processor pipeline: {0}")]
     SendToProcessor(String),
-
-    #[error(transparent)]
-    Recv(#[from] RecvError),
 }

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -171,7 +171,7 @@ where
         Ok(result)
     }
 
-    pub async fn repair(&self) -> Result<SpaceFuture, SpaceError> {
+    pub(crate) async fn repair(&self) -> Result<SpaceFuture, SpaceError> {
         let (space_y, messages) = self.inner.repair().await?;
 
         let permit = self.store.begin().await?;

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::borrow::Borrow;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -7,16 +8,18 @@ use futures_util::{FutureExt, Stream, StreamExt};
 use p2panda_auth::{Access, AccessLevel};
 use p2panda_core::cbor::{EncodeError, encode_cbor};
 use p2panda_spaces::{ActorId, MemberId, SpaceContext, SpaceId, SpacesStoreState};
+use p2panda_store::operations::OperationStore;
 use p2panda_store::spaces::{SpacesStore, SqliteSpacesStore};
 use p2panda_store::{SqliteError, SqliteStore, Transaction};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::RecvError;
+use tracing::warn;
 
 use crate::node::CreateStreamError;
-use crate::operation::Extensions;
-use crate::spaces::types::{InnerSpace, InnerSpaceError, SpacesManagerError};
+use crate::operation::{Extensions, Operation};
+use crate::spaces::types::{InnerSpace, InnerSpaceError, SpacesArgs, SpacesManagerError};
 use crate::streams::{
     ExternalStreamFuture, ImportError, ProcessedOperation, Source, StreamEvent, StreamPublisher,
     StreamSubscription,
@@ -42,9 +45,6 @@ pub(crate) fn spaces_stream<M>(
 // TODO: We need a way to automatically publish key bundles (if configured, it should also be an
 // option to _not_ do that to only allow initial key agreement through side channels which is more
 // private).
-//
-// TODO: Automatically repair spaces (detect missing group changes and apply them to affected
-// spaces), ideally with a throttle logic.
 #[derive(Debug)]
 pub struct Space<M> {
     inner: InnerSpace,
@@ -97,7 +97,13 @@ where
         access: AccessLevel,
     ) -> Result<SpaceFuture, SpaceError> {
         // Before perfoming any further actions we "repair" the space, which incorporates any
-        // group changes it may be missing.
+        // group changes it may be missing. This is the same functionality as offered by the
+        // running repair task, however we do it here as well in order to avoid the case where the
+        // task hasn't picked up some recent groups changes.
+        //
+        // @TODO: We could instead signal the repair task to do it's work and await the response
+        // before continuing. That has the benefit of also pushing new groups messages into the
+        // spaces stream for live-mode peers.
         self.repair().await?.await?;
 
         let (_, space_y, auth_message, space_message) = self
@@ -141,7 +147,13 @@ where
 
     pub async fn remove(&self, actor: impl Into<ActorId>) -> Result<SpaceFuture, SpaceError> {
         // Before perfoming any further actions we "repair" the space, which incorporates any
-        // group changes it may be missing.
+        // group changes it may be missing. This is the same functionality as offered by the
+        // running repair task, however we do it here as well in order to avoid the case where the
+        // task hasn't picked up some recent groups changes.
+        //
+        // @TODO: We could instead signal the repair task to do it's work and await the response
+        // before continuing. That has the benefit of also pushing new groups messages into the
+        // spaces stream for live-mode peers.
         self.repair().await?.await?;
 
         let (_, _, auth_message, space_message) = self.inner.remove(actor.into()).await?;
@@ -171,10 +183,37 @@ where
         Ok(result)
     }
 
+    /// Incorporate missing groups messages into the space, any resulting operations are
+    /// published live into the space topic.
     pub(crate) async fn repair(&self) -> Result<SpaceFuture, SpaceError> {
-        let (space_y, messages) = self.inner.repair().await?;
+        let (space_y, spaces_messages) = self.inner.repair().await?;
 
         let permit = self.store.begin().await?;
+
+        let mut operations = vec![];
+
+        // @TODO: Returning these groups messages from the Space::repair method p2panda-spaces
+        // would allow us to skip this step.
+        for message in spaces_messages.iter() {
+            // Ignore non-groups operations.
+            let SpacesArgs::SpaceMembership {
+                auth_message_id, ..
+            } = message.borrow()
+            else {
+                warn!("expected space membership operation");
+                continue;
+            };
+
+            let store = self.store.inner();
+            let Some(operation): Option<Operation> =
+                store.get_operation_tx(auth_message_id).await?
+            else {
+                warn!("missing expected auth groups operation");
+                continue;
+            };
+
+            operations.push(operation)
+        }
 
         // Persist the space state to the stores.
         //
@@ -188,11 +227,15 @@ where
 
         self.store.commit(permit).await?;
 
+        operations.extend(
+            spaces_messages
+                .into_iter()
+                .map(|message| message.into_operation()),
+        );
+
         let processed = self
             .tx
-            .import(futures_util::stream::iter(
-                messages.into_iter().map(|message| message.into_operation()),
-            ))
+            .import(futures_util::stream::iter(operations))
             .await?;
 
         Ok(SpaceFuture {
@@ -310,7 +353,7 @@ pub enum SpaceError {
     #[error(transparent)]
     Store(#[from] SqliteError),
 
-    #[error(transparent)]
+    #[error("couldn't process spaces change due to broken channel")]
     Recv(#[from] RecvError),
 }
 

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -77,7 +77,7 @@ where
         // processor to handle our own operations. Not doing this has the benefit of allowing
         // application events to be emitted from the spaces processor already (otherwise the would
         // be ignored as already processed). This comment can be removed when we persist spaces
-        // state in the processor in all places. 
+        // state in the processor in all places.
         let processed = self
             .tx
             .import(futures_util::stream::once(async {

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -5,16 +5,14 @@ use std::task::{Context, Poll};
 
 use futures_util::{FutureExt, Stream, StreamExt};
 use p2panda_auth::{Access, AccessLevel};
-use p2panda_core::Hash;
 use p2panda_core::cbor::{EncodeError, encode_cbor};
-use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
 use p2panda_spaces::{ActorId, MemberId, SpaceContext, SpaceId, SpacesStoreState};
-use p2panda_store::groups::GroupsStore;
 use p2panda_store::spaces::{SpacesStore, SqliteSpacesStore};
 use p2panda_store::{SqliteError, SqliteStore, Transaction};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::oneshot;
+use tokio::sync::oneshot::error::RecvError;
 
 use crate::node::CreateStreamError;
 use crate::operation::Extensions;
@@ -73,18 +71,13 @@ where
         //
         // We could also handle this outside of p2panda-spaces, simply by coming up with an argument
         // in the extensions for the spaces processor in p2panda-stream.
-        let (space_y, message) = self.inner.publish(&body_bytes).await?;
+        let (_, message) = self.inner.publish(&body_bytes).await?;
 
-        let permit = self.store.begin().await?;
-
-        // Persist the computed groups and spaces state to the stores and make required group log
-        // associations.
-        self.store
-            .set_space_state_tx(&self.id(), &SpacesStoreState::from(space_y))
-            .await?;
-
-        self.store.commit(permit).await?;
-
+        // @TODO: We don't need to persist the spaces state here as it's possible for the spaces
+        // processor to handle our own operations. Not doing this has the benefit of allowing
+        // application events to be emitted from the spaces processor already (otherwise the would
+        // be ignored as already processed). This comment can be removed when we persist spaces
+        // state in the processor in all places. 
         let processed = self
             .tx
             .import(futures_util::stream::once(async {
@@ -103,7 +96,11 @@ where
         actor: impl Into<ActorId>,
         access: AccessLevel,
     ) -> Result<SpaceFuture, SpaceError> {
-        let (groups_y, space_y, auth_message, space_message) = self
+        // Before perfoming any further actions we "repair" the space, which incorporates any
+        // group changes it may be missing.
+        self.repair().await?.await?;
+
+        let (_, space_y, auth_message, space_message) = self
             .inner
             .add(
                 actor.into(),
@@ -116,20 +113,12 @@ where
 
         let permit = self.store.begin().await?;
 
-        // Persist the computed groups and spaces state to the stores and make required group log
-        // associations.
+        // Persist the computed groups and spaces state to the stores.
         //
-        // @TODO: This needs some thought. We're persisting state here, rather than expecting this
-        // to happen in the processor, because it's not possible to re-create locally performed
-        // state changes from the messages alone. _If_ we have to persist here, then transactions
-        // need to be considered more carefully, we would need to make this write part of the same
-        // transaction where the operations are forged.
-        //
-        // @TODO: We don't strictly need to persist the groups state here as this is re-creatable
-        // with only the operation in the processor.
-        self.store
-            .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
-            .await?;
+        // @TODO: We need to refactor the spaces API so that locally created operations can be
+        // handled via the call to Manager::process and then persisted in the spaces processor.
+        // Until we have this spaces events for our own locally created operations won't be
+        // emitted to users (as the processor thinks the operation was already processed and skips.
         self.store
             .set_space_state_tx(&self.id(), &SpacesStoreState::from(space_y))
             .await?;
@@ -151,6 +140,10 @@ where
     }
 
     pub async fn remove(&self, actor: impl Into<ActorId>) -> Result<SpaceFuture, SpaceError> {
+        // Before perfoming any further actions we "repair" the space, which incorporates any
+        // group changes it may be missing.
+        self.repair().await?.await?;
+
         let (_, _, auth_message, space_message) = self.inner.remove(actor.into()).await?;
 
         let processed = self
@@ -178,6 +171,36 @@ where
         Ok(result)
     }
 
+    pub async fn repair(&self) -> Result<SpaceFuture, SpaceError> {
+        let (space_y, messages) = self.inner.repair().await?;
+
+        let permit = self.store.begin().await?;
+
+        // Persist the space state to the stores.
+        //
+        // @TODO: We need to refactor the spaces API so that locally created operations can be
+        // handled via the call to Manager::process and then persisted in the spaces processor.
+        // Until we have this spaces events for our own locally created operations won't be
+        // emitted to users (as the processor thinks the operation was already processed and skips.
+        self.store
+            .set_space_state_tx(&self.id(), &SpacesStoreState::from(space_y))
+            .await?;
+
+        self.store.commit(permit).await?;
+
+        let processed = self
+            .tx
+            .import(futures_util::stream::iter(
+                messages.into_iter().map(|message| message.into_operation()),
+            ))
+            .await?;
+
+        Ok(SpaceFuture {
+            processed,
+            space_id: self.inner.id(),
+        })
+    }
+
     // TODO: "actors" method to return the _non-flattened_ actors in a group. This will help to
     // build multi-device applications.
 }
@@ -189,7 +212,7 @@ pub struct SpaceSubscription<M> {
 
 impl<M> Stream for SpaceSubscription<M>
 where
-    M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
+    M: std::fmt::Debug + Serialize + for<'a> Deserialize<'a> + Send + 'static,
 {
     type Item = SpaceEvent<M>;
 
@@ -286,6 +309,9 @@ pub enum SpaceError {
 
     #[error(transparent)]
     Store(#[from] SqliteError),
+
+    #[error(transparent)]
+    Recv(#[from] RecvError),
 }
 
 #[derive(Debug, Error)]

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -196,35 +196,10 @@ impl<M> Stream for SpaceSubscription<M>
 where
     M: std::fmt::Debug + Serialize + for<'a> Deserialize<'a> + Send + 'static,
 {
-    type Item = SpaceEvent<M>;
+    type Item = StreamEvent<M>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        loop {
-            let result = self.rx.poll_next_unpin(cx);
-
-            let event = match result {
-                Poll::Ready(Some(event)) => event,
-                Poll::Ready(None) => {
-                    return Poll::Ready(None);
-                }
-                Poll::Pending => {
-                    return Poll::Pending;
-                }
-            };
-
-            // TODO: Properly convert to SpaceEvent.
-            match event {
-                StreamEvent::Processed { operation, source } => {
-                    return Poll::Ready(Some(SpaceEvent::Processed {
-                        operation: Box::new(operation),
-                        source,
-                    }));
-                }
-                _ => {
-                    continue;
-                }
-            }
-        }
+        self.rx.poll_next_unpin(cx)
     }
 }
 

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::borrow::Borrow;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -8,18 +7,18 @@ use futures_util::{FutureExt, Stream, StreamExt};
 use p2panda_auth::{Access, AccessLevel};
 use p2panda_core::cbor::{EncodeError, encode_cbor};
 use p2panda_spaces::{ActorId, MemberId, SpaceContext, SpaceId, SpacesStoreState};
-use p2panda_store::operations::OperationStore;
 use p2panda_store::spaces::{SpacesStore, SqliteSpacesStore};
 use p2panda_store::{SqliteError, SqliteStore, Transaction};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio::sync::mpsc::error::SendError;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::RecvError;
-use tracing::warn;
 
 use crate::node::CreateStreamError;
-use crate::operation::{Extensions, Operation};
-use crate::spaces::types::{InnerSpace, InnerSpaceError, SpacesArgs, SpacesManagerError};
+use crate::operation::Extensions;
+use crate::spaces::RepairError;
+use crate::spaces::types::{InnerSpace, InnerSpaceError, SpacesManagerError};
 use crate::streams::{
     ExternalStreamFuture, ImportError, ProcessedOperation, Source, StreamEvent, StreamPublisher,
     StreamSubscription,
@@ -62,6 +61,10 @@ where
 
     #[allow(clippy::result_large_err)]
     pub async fn publish(&self, message: M) -> Result<SpaceFuture, PublishSpaceError> {
+        // Before publishing messages we trigger and await return from a space repair which will
+        // ensure we have incorporated the latest groups changes into the space.
+        self.repair().await?;
+
         // TODO: We'll remove custom `M` types in the future, users will only provide bytes on this
         // level.
         let body_bytes = encode_cbor(&message)?;
@@ -96,15 +99,9 @@ where
         actor: impl Into<ActorId>,
         access: AccessLevel,
     ) -> Result<SpaceFuture, SpaceError> {
-        // Before perfoming any further actions we "repair" the space, which incorporates any
-        // group changes it may be missing. This is the same functionality as offered by the
-        // running repair task, however we do it here as well in order to avoid the case where the
-        // task hasn't picked up some recent groups changes.
-        //
-        // @TODO: We could instead signal the repair task to do it's work and await the response
-        // before continuing. That has the benefit of also pushing new groups messages into the
-        // spaces stream for live-mode peers.
-        self.repair().await?.await?;
+        // Before performing any action we trigger and await return from a space repair which will
+        // ensure we have incorporated the latest groups changes into the space.
+        self.repair().await?;
 
         let (_, space_y, auth_message, space_message) = self
             .inner
@@ -146,15 +143,9 @@ where
     }
 
     pub async fn remove(&self, actor: impl Into<ActorId>) -> Result<SpaceFuture, SpaceError> {
-        // Before perfoming any further actions we "repair" the space, which incorporates any
-        // group changes it may be missing. This is the same functionality as offered by the
-        // running repair task, however we do it here as well in order to avoid the case where the
-        // task hasn't picked up some recent groups changes.
-        //
-        // @TODO: We could instead signal the repair task to do it's work and await the response
-        // before continuing. That has the benefit of also pushing new groups messages into the
-        // spaces stream for live-mode peers.
-        self.repair().await?.await?;
+        // Before performing any action we trigger and await return from a space repair which will
+        // ensure we have incorporated the latest groups changes into the space.
+        self.repair().await?;
 
         let (_, _, auth_message, space_message) = self.inner.remove(actor.into()).await?;
 
@@ -185,63 +176,11 @@ where
 
     /// Incorporate missing groups messages into the space, any resulting operations are
     /// published live into the space topic.
-    pub(crate) async fn repair(&self) -> Result<SpaceFuture, SpaceError> {
-        let (space_y, spaces_messages) = self.inner.repair().await?;
-
-        let permit = self.store.begin().await?;
-
-        let mut operations = vec![];
-
-        // @TODO: Returning these groups messages from the Space::repair method p2panda-spaces
-        // would allow us to skip this step.
-        for message in spaces_messages.iter() {
-            // Ignore non-groups operations.
-            let SpacesArgs::SpaceMembership {
-                auth_message_id, ..
-            } = message.borrow()
-            else {
-                warn!("expected space membership operation");
-                continue;
-            };
-
-            let store = self.store.inner();
-            let Some(operation): Option<Operation> =
-                store.get_operation_tx(auth_message_id).await?
-            else {
-                warn!("missing expected auth groups operation");
-                continue;
-            };
-
-            operations.push(operation)
-        }
-
-        // Persist the space state to the stores.
-        //
-        // @TODO: We need to refactor the spaces API so that locally created operations can be
-        // handled via the call to Manager::process and then persisted in the spaces processor.
-        // Until we have this spaces events for our own locally created operations won't be
-        // emitted to users (as the processor thinks the operation was already processed and skips.
-        self.store
-            .set_space_state_tx(&self.id(), &SpacesStoreState::from(space_y))
-            .await?;
-
-        self.store.commit(permit).await?;
-
-        operations.extend(
-            spaces_messages
-                .into_iter()
-                .map(|message| message.into_operation()),
-        );
-
-        let processed = self
-            .tx
-            .import(futures_util::stream::iter(operations))
-            .await?;
-
-        Ok(SpaceFuture {
-            processed,
-            space_id: self.inner.id(),
-        })
+    pub(crate) async fn repair(&self) -> Result<bool, RepairSpaceError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx.repair_tx.send(tx).await?;
+        let repaired = rx.await??;
+        Ok(repaired)
     }
 
     // TODO: "actors" method to return the _non-flattened_ actors in a group. This will help to
@@ -355,6 +294,9 @@ pub enum SpaceError {
 
     #[error("couldn't process spaces change due to broken channel")]
     Recv(#[from] RecvError),
+
+    #[error(transparent)]
+    RepairSpace(#[from] RepairSpaceError),
 }
 
 #[derive(Debug, Error)]
@@ -371,4 +313,20 @@ pub enum PublishSpaceError {
 
     #[error(transparent)]
     Store(#[from] SqliteError),
+
+    #[error(transparent)]
+    RepairSpace(#[from] RepairSpaceError),
+}
+
+#[derive(Debug, Error)]
+#[allow(clippy::large_enum_variant)] // TODO: Reduce size of spaces error types.
+pub enum RepairSpaceError {
+    #[error(transparent)]
+    Repair(#[from] RepairError),
+
+    #[error("failed to send on space repair task channel")]
+    Send(#[from] SendError<oneshot::Sender<Result<bool, RepairError>>>),
+
+    #[error("couldn't receive reply from repair task due to broken channel")]
+    Recv(#[from] RecvError),
 }

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use core::panic;
 use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -33,7 +32,8 @@ use crate::forge::{Forge, ForgeError, OperationForge};
 use crate::node::{AckPolicy, CreateStreamError};
 use crate::operation::{Extensions, Header, LogId, Operation};
 use crate::processor::{ProcessorError, ProcessorStatus};
-use crate::spaces::types::AuthCapabilities;
+use crate::spaces::spawn_repair_task;
+use crate::spaces::types::{AuthCapabilities, SpacesManager};
 use crate::streams::acked::{Acked, AckedError};
 use crate::streams::external_stream::{
     ExternalStream, ExternalStreamEvent, ExternalStreamFuture, SessionId,
@@ -105,6 +105,7 @@ pub(crate) async fn processed_stream<M>(
     sync_handle: SyncHandle<Operation, TopicLogSyncEvent<Extensions>>,
     store: SqliteStore,
     forge: OperationForge,
+    spaces_manager: SpacesManager,
     pipeline: Pipeline,
     from: StreamFrom,
 ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
@@ -147,6 +148,14 @@ where
     // If any other process wants to bring an stream event forward to the application layer ("output
     // stream"), this channel should be used.
     let (to_output_tx, mut to_output_rx) = mpsc::channel::<Vec<StreamEvent<M>>>(128);
+
+    // Task concerned with repairing a space.
+    let repair_task_handle = spawn_repair_task(
+        topic,
+        spaces_manager.clone(),
+        store.clone(),
+        import_tx.clone(),
+    );
 
     // FIXME: Both tasks need to be gracefully shut down when the tx / rx halves got dropped,
     // otherwise the sync session keeps running.
@@ -359,6 +368,9 @@ where
 
                 let _ = to_output_tx.send(stream_events).await;
             }
+
+            // Abort the repair task.
+            repair_task_handle.abort();
         });
     }
 

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -32,8 +32,8 @@ use crate::forge::{Forge, ForgeError, OperationForge};
 use crate::node::{AckPolicy, CreateStreamError};
 use crate::operation::{Extensions, Header, LogId, Operation};
 use crate::processor::{ProcessorError, ProcessorStatus};
-use crate::spaces::spawn_repair_task;
 use crate::spaces::types::{AuthCapabilities, SpacesManager};
+use crate::spaces::{RepairError, spawn_repair_task};
 use crate::streams::acked::{Acked, AckedError};
 use crate::streams::external_stream::{
     ExternalStream, ExternalStreamEvent, ExternalStreamFuture, SessionId,
@@ -149,12 +149,15 @@ where
     // stream"), this channel should be used.
     let (to_output_tx, mut to_output_rx) = mpsc::channel::<Vec<StreamEvent<M>>>(128);
 
+    let (repair_tx, repair_rx) = mpsc::channel(1);
+
     // Task concerned with repairing a space.
     let repair_task_handle = spawn_repair_task(
         topic,
         spaces_manager.clone(),
         store.clone(),
         import_tx.clone(),
+        repair_rx,
     );
 
     // FIXME: Both tasks need to be gracefully shut down when the tx / rx halves got dropped,
@@ -380,6 +383,7 @@ where
         forge,
         publish_tx,
         import_tx,
+        repair_tx,
         _marker: PhantomData,
     };
 
@@ -635,6 +639,7 @@ pub struct StreamPublisher<M> {
         BoxStream<'static, Operation>,
         oneshot::Sender<ExternalStreamFuture>,
     )>,
+    pub(crate) repair_tx: mpsc::Sender<oneshot::Sender<Result<bool, RepairError>>>,
     _marker: PhantomData<M>,
 }
 

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -64,7 +64,7 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
     let (penguin_mobile_space, mut penguin_mobile_rx) =
         penguin_mobile.space::<SecretData>(topic).await.unwrap();
 
-    sleep(Duration::from_secs(3)).await;
+    sleep(Duration::from_secs(4)).await;
 
     let members = panda_space.members().await?;
     assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
@@ -148,7 +148,7 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
 
     // Wait some time for key bundle, groups and space logs to sync.
     // @TODO: replace sleep when spaces events are watchable.
-    sleep(Duration::from_secs(2)).await;
+    sleep(Duration::from_secs(3)).await;
 
     // Panda adds penguin as a member of the space.
     //
@@ -181,7 +181,6 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // penguin also receives the message.
-    // @TODO: currently fails because of operation decoding bug.
     loop {
         let Some(event) = penguin_rx.next().await else {
             panic!("unexpected stream closure");
@@ -192,10 +191,6 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(&message, operation.message());
         break;
     }
-
-    // @TODO: assert that penguin has also successfully joined the space and can publish a
-    // message. This would often fail now due to ordering not yet being implemented.
-
     Ok(())
 }
 

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -3,56 +3,130 @@
 use std::time::Duration;
 
 use p2panda::{operation::Header, spaces::SpaceEvent};
-use p2panda_auth::Access;
+use p2panda_auth::{Access, AccessLevel};
 use p2panda_core::{cbor::decode_cbor, test_utils::setup_logging};
+use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
 use tokio_stream::StreamExt;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct SecretData {
+    title: String,
+    content: String,
+}
 
 #[tokio::test]
 async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
     setup_logging();
 
-    // use p2panda::SigningKey;
-    // use p2panda_auth::AccessLevel;
     use p2panda::Topic;
-    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize, Deserialize)]
-    struct SecretData {
-        title: String,
-        content: String,
-    }
-
-    let node = p2panda::spawn().await?;
+    let panda = p2panda::spawn().await?;
 
     // Spaces behave like topic-streams, just that they're encrypted towards members.
     let topic = Topic::random();
 
     // Create a space with only us inside.
-    let (_space, _rx) = node.create_space::<SecretData>(topic).await?;
+    let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
 
-    // TODO
     // We can manage (nested) groups (useful for multi-device, etc.)
-    // let penguin_laptop = SigningKey::generate().verifying_key();
-    // let penguin_mobile = SigningKey::generate().verifying_key();
-    //
-    // let penguin = node
-    //     .create_group(&[
-    //         (penguin_laptop, AccessLevel::Read),
-    //         (penguin_mobile, AccessLevel::Write),
-    //     ])
-    //     .await?;
-    //
-    // // .. and add them to the space as well.
-    // space.add(penguin, AccessLevel::Read).await?;
-    //
-    // // Every message published into a space can be decrypted by it's members.
-    // space
-    //     .publish(SecretData {
-    //         title: "My favorite things".to_string(),
-    //         content: "Hello, everyone!".to_string(),
-    //     })
-    //     .await?;
+    let penguin_laptop = p2panda::spawn().await?;
+    let penguin_mobile = p2panda::spawn().await?;
+
+    {
+        // Penguin subscribes to the space in order to publish some key bundles.
+        let (_, _penguin_laptop_rx) = penguin_laptop.space::<SecretData>(topic).await.unwrap();
+        let (_, _penguin_mobile_rx) = penguin_mobile.space::<SecretData>(topic).await.unwrap();
+
+        // Wait some time for key bundle, groups and space logs to sync.
+        // @TODO: replace sleep when spaces events are watchable.
+        sleep(Duration::from_secs(4)).await;
+    }
+
+    // @TODO: currently these group messages are _not_ sent via live-mode for the spaces topic.
+    // Need to consider how best to get access to the sync handle in the node API to make this
+    // possible.
+    let penguin = panda
+        .create_group(&[
+            (penguin_laptop.id(), AccessLevel::Read),
+            (penguin_mobile.id(), AccessLevel::Write),
+        ])
+        .await?;
+
+    // .. and add them to the space as well.
+    let ready = panda_space.add(penguin, AccessLevel::Read).await?;
+    ready.await?;
+
+    // @TODO: Penguins subscribe to the space topic again in order to get the groups messages via
+    // sync.
+    let (penguin_laptop_space, mut penguin_laptop_rx) =
+        penguin_laptop.space::<SecretData>(topic).await.unwrap();
+    let (penguin_mobile_space, mut penguin_mobile_rx) =
+        penguin_mobile.space::<SecretData>(topic).await.unwrap();
+
+    sleep(Duration::from_secs(3)).await;
+
+    println!("assert space members");
+
+    let members = panda_space.members().await?;
+    assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
+    assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
+    assert!(members.contains(&(panda.id(), AccessLevel::Manage)));
+
+    let members = penguin_laptop_space.members().await?;
+    assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
+    assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
+    assert!(members.contains(&(panda.id(), AccessLevel::Manage)));
+
+    let members = penguin_mobile_space.members().await?;
+    assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
+    assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
+    assert!(members.contains(&(panda.id(), AccessLevel::Manage)));
+
+    // Every message published into a space can be decrypted by it's members.
+    let message = SecretData {
+        title: "My favorite things".to_string(),
+        content: "Hello, everyone!".to_string(),
+    };
+    let ready = panda_space.publish(message.clone()).await?;
+    ready.await?;
+
+    println!("await panda message");
+    // Panda receives the message they sent.
+    loop {
+        let Some(event) = panda_rx.next().await else {
+            panic!("unexpected stream closure");
+        };
+        let SpaceEvent::Processed { operation, .. } = event else {
+            continue;
+        };
+        assert_eq!(&message, operation.message());
+        break;
+    }
+
+    // penguin laptop receives the message.
+    loop {
+        let Some(event) = penguin_laptop_rx.next().await else {
+            panic!("unexpected stream closure");
+        };
+        let SpaceEvent::Processed { operation, .. } = event else {
+            continue;
+        };
+        assert_eq!(&message, operation.message());
+        break;
+    }
+
+    // penguin mobile receives the message.
+    loop {
+        let Some(event) = penguin_mobile_rx.next().await else {
+            panic!("unexpected stream closure");
+        };
+        let SpaceEvent::Processed { operation, .. } = event else {
+            continue;
+        };
+        assert_eq!(&message, operation.message());
+        break;
+    }
 
     Ok(())
 }
@@ -63,13 +137,6 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
 
     use p2panda::Topic;
     use p2panda_auth::AccessLevel;
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-    struct SecretData {
-        title: String,
-        content: String,
-    }
 
     let topic = Topic::random();
 
@@ -79,14 +146,12 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
     // Penguin subscribes to the space (and publishes a key bundle).
     let (_penguin_space, mut penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
 
-    sleep(Duration::from_secs(3)).await;
-
     // Panda creates and subscribes to a space.
     let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
 
     // Wait some time for key bundle, groups and space logs to sync.
     // @TODO: replace sleep when spaces events are watchable.
-    sleep(Duration::from_secs(3)).await;
+    sleep(Duration::from_secs(2)).await;
 
     // Panda adds penguin as a member of the space.
     //
@@ -99,10 +164,15 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
         title: "My favorite things".to_string(),
         content: "Hello, everyone!".to_string(),
     };
+
+    sleep(Duration::from_secs(2)).await;
     let ready = panda_space.publish(message.clone()).await?;
     assert!(ready.await.is_ok());
 
+    sleep(Duration::from_secs(1)).await;
+
     // Panda receives the message they sent.
+    println!("await panda receive");
     loop {
         let Some(event) = panda_rx.next().await else {
             panic!("unexpected stream closure");
@@ -116,6 +186,7 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
 
     // penguin also receives the message.
     // @TODO: currently fails because of operation decoding bug.
+    println!("await penguin receive");
     loop {
         let Some(event) = penguin_rx.next().await else {
             panic!("unexpected stream closure");
@@ -168,6 +239,70 @@ async fn encode_decode() -> Result<(), Box<dyn std::error::Error>> {
 
     // This fails half the time.
     assert_eq!(header.hash(), decoded_header.hash());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sync_repair_space() -> Result<(), Box<dyn std::error::Error>> {
+    setup_logging();
+
+    use p2panda::Topic;
+    use p2panda_auth::AccessLevel;
+
+    let topic = Topic::random();
+
+    let panda = p2panda::spawn().await?;
+    let penguin = p2panda::spawn().await?;
+
+    // Penguin creates a group before subscribing to the space.
+    let penguin_group = penguin
+        .create_group(&[(penguin.id(), AccessLevel::Manage)])
+        .await?;
+
+    // They then subscribe, as does panda.
+    let (_penguin_space, _penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
+    let (panda_space, _panda_rx) = panda.create_space::<SecretData>(topic).await?;
+    sleep(Duration::from_secs(5)).await;
+
+    // We expect panda to be able to add penguin group as a space member now.
+    let ready = panda_space
+        .add(penguin_group.id(), AccessLevel::Read)
+        .await?;
+    assert!(ready.await.is_ok());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn live_repair_space() -> Result<(), Box<dyn std::error::Error>> {
+    setup_logging();
+
+    use p2panda::Topic;
+    use p2panda_auth::AccessLevel;
+
+    let topic = Topic::random();
+
+    let panda = p2panda::spawn().await?;
+    let penguin = p2panda::spawn().await?;
+
+    // Penguin subscribes to the space.
+    let (_penguin_space, _penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
+    let (panda_space, _panda_rx) = panda.create_space::<SecretData>(topic).await?;
+    sleep(Duration::from_secs(3)).await;
+
+    // And then creates a group.
+    let penguin_group = penguin
+        .create_group(&[(penguin.id(), AccessLevel::Manage)])
+        .await?;
+
+    sleep(Duration::from_secs(3)).await;
+
+    // We expect panda to be able to add penguin group to the space.
+    let ready = panda_space
+        .add(penguin_group.id(), AccessLevel::Read)
+        .await?;
+    assert!(ready.await.is_ok());
 
     Ok(())
 }

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::time::Duration;
+use std::collections::HashSet;
 
-use p2panda::{operation::Header, spaces::SpaceEvent};
+use p2panda::operation::Header;
+use p2panda::streams::StreamEvent;
 use p2panda_auth::{Access, AccessLevel};
 use p2panda_core::{cbor::decode_cbor, test_utils::setup_logging};
+use p2panda_spaces::{GroupEvent, SpaceEvent};
 use serde::{Deserialize, Serialize};
-use tokio::time::sleep;
 use tokio_stream::StreamExt;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -33,38 +34,79 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
     let penguin_laptop = p2panda::spawn().await?;
     let penguin_mobile = p2panda::spawn().await?;
 
-    {
-        // Penguin subscribes to the space in order to publish some key bundles.
-        let (_, _penguin_laptop_rx) = penguin_laptop.space::<SecretData>(topic).await.unwrap();
-        let (_, _penguin_mobile_rx) = penguin_mobile.space::<SecretData>(topic).await.unwrap();
+    // Penguin subscribes to the space in order to publish some key bundles.
+    let (penguin_laptop_space, mut penguin_laptop_rx) =
+        penguin_laptop.space::<SecretData>(topic).await.unwrap();
+    let (penguin_mobile_space, mut penguin_mobile_rx) =
+        penguin_mobile.space::<SecretData>(topic).await.unwrap();
 
-        // Wait some time for key bundle, groups and space logs to sync.
-        // @TODO: replace sleep when spaces events are watchable.
-        sleep(Duration::from_secs(4)).await;
+    // Panda receives both penguins key bundles.
+    let mut expected = HashSet::from([penguin_laptop.id(), penguin_mobile.id()]);
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::KeyBundle(verifying_key) = event {
+            expected.remove(&verifying_key);
+            if expected.is_empty() {
+                break;
+            }
+        };
     }
 
-    // @TODO: currently these group messages are _not_ sent via live-mode for the spaces topic.
-    // Need to consider how best to get access to the sync handle in the node API to make this
-    // possible.
-    let penguin = panda
+    // Penguin laptop receives space created event.
+    while let Some(event) = penguin_laptop_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+            break;
+        };
+    }
+
+    // Penguin mobile receives space created event.
+    while let Some(event) = penguin_mobile_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+            break;
+        };
+    }
+
+    // Penguin creates a device group (on their laptop).
+    let penguin = penguin_laptop
         .create_group(&[
             (penguin_laptop.id(), AccessLevel::Read),
             (penguin_mobile.id(), AccessLevel::Write),
         ])
         .await?;
 
-    // .. and add them to the space as well.
+    // Panda receives the group.
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Group(GroupEvent::Created { .. }) = event {
+            break;
+        };
+    }
+
+    // Penguin mobile receives the group.
+    while let Some(event) = penguin_mobile_rx.next().await {
+        if let StreamEvent::Group(GroupEvent::Created { .. }) = event {
+            break;
+        };
+    }
+
     let ready = panda_space.add(penguin, AccessLevel::Read).await?;
     ready.await?;
 
-    // @TODO: Penguins subscribe to the space topic again in order to get the groups messages via
-    // sync.
-    let (penguin_laptop_space, mut penguin_laptop_rx) =
-        penguin_laptop.space::<SecretData>(topic).await.unwrap();
-    let (penguin_mobile_space, mut penguin_mobile_rx) =
-        penguin_mobile.space::<SecretData>(topic).await.unwrap();
+    while let Some(event) = penguin_laptop_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
+            assert_eq!(added.len(), 2);
+            assert!(added.contains(&penguin_laptop.id()));
+            assert!(added.contains(&penguin_mobile.id()));
+            break;
+        };
+    }
 
-    sleep(Duration::from_secs(4)).await;
+    while let Some(event) = penguin_mobile_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
+            assert_eq!(added.len(), 2);
+            assert!(added.contains(&penguin_laptop.id()));
+            assert!(added.contains(&penguin_mobile.id()));
+            break;
+        };
+    }
 
     let members = panda_space.members().await?;
     assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
@@ -94,7 +136,7 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
         let Some(event) = panda_rx.next().await else {
             panic!("unexpected stream closure");
         };
-        let SpaceEvent::Processed { operation, .. } = event else {
+        let StreamEvent::Processed { operation, .. } = event else {
             continue;
         };
         assert_eq!(&message, operation.message());
@@ -106,7 +148,7 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
         let Some(event) = penguin_laptop_rx.next().await else {
             panic!("unexpected stream closure");
         };
-        let SpaceEvent::Processed { operation, .. } = event else {
+        let StreamEvent::Processed { operation, .. } = event else {
             continue;
         };
         assert_eq!(&message, operation.message());
@@ -118,7 +160,7 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
         let Some(event) = penguin_mobile_rx.next().await else {
             panic!("unexpected stream closure");
         };
-        let SpaceEvent::Processed { operation, .. } = event else {
+        let StreamEvent::Processed { operation, .. } = event else {
             continue;
         };
         assert_eq!(&message, operation.message());
@@ -146,9 +188,18 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
     // Panda creates and subscribes to a space.
     let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
 
-    // Wait some time for key bundle, groups and space logs to sync.
-    // @TODO: replace sleep when spaces events are watchable.
-    sleep(Duration::from_secs(3)).await;
+    while let Some(event) = penguin_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+            break;
+        };
+    }
+
+    // @TODO: Uncomment when own events are emitted on event stream.
+    // while let Some(event) = panda_rx.next().await {
+    //     if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+    //         break;
+    //     };
+    // }
 
     // Panda adds penguin as a member of the space.
     //
@@ -162,18 +213,15 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
         content: "Hello, everyone!".to_string(),
     };
 
-    sleep(Duration::from_secs(2)).await;
     let ready = panda_space.publish(message.clone()).await?;
     assert!(ready.await.is_ok());
-
-    sleep(Duration::from_secs(1)).await;
 
     // Panda receives the message they sent.
     loop {
         let Some(event) = panda_rx.next().await else {
             panic!("unexpected stream closure");
         };
-        let SpaceEvent::Processed { operation, .. } = event else {
+        let StreamEvent::Processed { operation, .. } = event else {
             continue;
         };
         assert_eq!(&message, operation.message());
@@ -185,7 +233,7 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
         let Some(event) = penguin_rx.next().await else {
             panic!("unexpected stream closure");
         };
-        let SpaceEvent::Processed { operation, .. } = event else {
+        let StreamEvent::Processed { operation, .. } = event else {
             continue;
         };
         assert_eq!(&message, operation.message());
@@ -251,14 +299,27 @@ async fn sync_repair_space() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // They then subscribe, as does panda.
-    let (_penguin_space, _penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
+    let (_penguin_space, mut penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
     let (panda_space, _panda_rx) = panda.create_space::<SecretData>(topic).await?;
-    sleep(Duration::from_secs(5)).await;
+
+    while let Some(event) = penguin_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+            break;
+        };
+    }
+
+    // @TODO: Uncomment when own events are emitted on event stream.
+    // while let Some(event) = panda_rx.next().await {
+    //     if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+    //         break;
+    //     };
+    // }
 
     // We expect panda to be able to add penguin group as a space member now.
     let ready = panda_space
         .add(penguin_group.id(), AccessLevel::Read)
         .await?;
+
     assert!(ready.await.is_ok());
 
     Ok(())
@@ -277,16 +338,43 @@ async fn live_repair_space() -> Result<(), Box<dyn std::error::Error>> {
     let penguin = p2panda::spawn().await?;
 
     // Penguin subscribes to the space.
-    let (_penguin_space, _penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
-    let (panda_space, _panda_rx) = panda.create_space::<SecretData>(topic).await?;
-    sleep(Duration::from_secs(3)).await;
+    let (_penguin_space, mut penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
+    let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
+
+    while let Some(event) = penguin_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+            break;
+        };
+    }
+
+    // @TODO: Uncomment when own events are emitted on event stream.
+    // while let Some(event) = panda_rx.next().await {
+    //     if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+    //         break;
+    //     };
+    // }
 
     // And then creates a group.
     let penguin_group = penguin
         .create_group(&[(penguin.id(), AccessLevel::Manage)])
         .await?;
 
-    sleep(Duration::from_secs(3)).await;
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Group(GroupEvent::Created { group_id, .. }) = event
+            && group_id == penguin_group.id()
+        {
+            break;
+        };
+    }
+
+    // @TODO: Uncomment when own events are emitted on event stream.
+    // while let Some(event) = penguin_rx.next().await {
+    //     if let StreamEvent::Group(GroupEvent::Created { group_id, .. }) = event
+    //         && group_id == penguin_group.id()
+    //     {
+    //         break;
+    //     };
+    // }
 
     // We expect panda to be able to add penguin group to the space.
     let ready = panda_space

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -66,8 +66,6 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
 
     sleep(Duration::from_secs(3)).await;
 
-    println!("assert space members");
-
     let members = panda_space.members().await?;
     assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
     assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
@@ -91,7 +89,6 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
     let ready = panda_space.publish(message.clone()).await?;
     ready.await?;
 
-    println!("await panda message");
     // Panda receives the message they sent.
     loop {
         let Some(event) = panda_rx.next().await else {
@@ -172,7 +169,6 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
     sleep(Duration::from_secs(1)).await;
 
     // Panda receives the message they sent.
-    println!("await panda receive");
     loop {
         let Some(event) = panda_rx.next().await else {
             panic!("unexpected stream closure");
@@ -186,7 +182,6 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
 
     // penguin also receives the message.
     // @TODO: currently fails because of operation decoding bug.
-    println!("await penguin receive");
     loop {
         let Some(event) = penguin_rx.next().await else {
             panic!("unexpected stream closure");


### PR DESCRIPTION
This change introduces a task which is dedicated to "repairing" spaces which we are subscribed to. Repairing a space involves incorporating missing groups operations observed on the global groups context but not yet published into the space.

There are 3 steps to this process:

1) re-publish missing groups operations into the space topic
2) create and publish space membership operations for each missing groups operation (only read members can do this)
3) associate missing groups logs with the space topic

All new messages will be sent into the topic stream to be processed and forwarded to other peers.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
