### PR TITLE
Wait for missing key bundle dependencies when processing spaces messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Highlights are marked with a pancake 🥞
 - node: Associate key bundle, groups and spaces logs with log topic [#1264](https://github.com/p2panda/p2panda/pull/1264)
 - node: Handle spaces events when processing pipeline event [#1276](https://github.com/p2panda/p2panda/pull/1276)
 - encryption: Get X3DH ciphertext from direct msgs [#1280](https://github.com/p2panda/p2panda/pull/1280)
+- encryption: Get bundle by prekey id in registry [#1280](https://github.com/p2panda/p2panda/pull/1280)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Highlights are marked with a pancake 🥞
 - node: Implement `Orderer` `Processor` for pipeline [#1262](https://github.com/p2panda/p2panda/pull/1262)
 - node: Associate key bundle, groups and spaces logs with log topic [#1264](https://github.com/p2panda/p2panda/pull/1264)
 - node: Handle spaces events when processing pipeline event [#1276](https://github.com/p2panda/p2panda/pull/1276)
+- encryption: Get X3DH ciphertext from direct msgs [#1280](https://github.com/p2panda/p2panda/pull/1280)
 
 ### Changed
 

--- a/p2panda-encryption/src/data_scheme/dcgka.rs
+++ b/p2panda-encryption/src/data_scheme/dcgka.rs
@@ -19,7 +19,7 @@ use crate::traits::{
     GroupMembership, IdentityHandle, IdentityManager, IdentityRegistry, OperationId, PreKeyManager,
     PreKeyRegistry,
 };
-use crate::two_party::{TwoParty, TwoPartyError, TwoPartyMessage, TwoPartyState};
+use crate::two_party::{TwoParty, TwoPartyError, TwoPartyMessage, TwoPartyState, X3dhCiphertext};
 
 /// A decentralized continuous group key agreement protocol (DCGKA) for p2panda's "data encryption"
 /// scheme with forward secrecy and post-compromise security.
@@ -602,6 +602,21 @@ where
         match self.content {
             DirectMessageContent::Welcome { .. } => DirectMessageType::Welcome,
             DirectMessageContent::TwoParty { .. } => DirectMessageType::TwoParty,
+        }
+    }
+
+    /// Returns the X3DH ciphertext with the used pre-key identifiers.
+    ///
+    /// Returns None if key-agreement between the two parties was not initial and HPKE was used.
+    pub fn x3dh_ciphertext(&self) -> Option<&X3dhCiphertext> {
+        let two_party = match &self.content {
+            DirectMessageContent::Welcome { ciphertext, .. } => &ciphertext.ciphertext,
+            DirectMessageContent::TwoParty { ciphertext } => &ciphertext.ciphertext,
+        };
+
+        match two_party {
+            crate::two_party::TwoPartyCiphertext::PreKey(x3dh) => Some(x3dh),
+            crate::two_party::TwoPartyCiphertext::Hpke(_) => None,
         }
     }
 }

--- a/p2panda-encryption/src/key_registry.rs
+++ b/p2panda-encryption/src/key_registry.rs
@@ -243,9 +243,6 @@ pub enum KeyRegistryError {
     #[error(transparent)]
     KeyBundle(#[from] KeyBundleError),
 
-    #[error("no key bundles found")]
-    KeyBundlesNotFound,
-
     #[error("all available key bundles of this member expired")]
     KeyBundlesExpired,
 }

--- a/p2panda-encryption/src/key_registry.rs
+++ b/p2panda-encryption/src/key_registry.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::crypto::x25519::PublicKey;
-use crate::key_bundle::{KeyBundleError, LongTermKeyBundle, OneTimeKeyBundle, latest_key_bundle};
+use crate::key_bundle::{
+    KeyBundleError, LongTermKeyBundle, OneTimeKeyBundle, PreKeyId, latest_key_bundle,
+};
 use crate::traits::{IdentityHandle, IdentityRegistry, KeyBundle, PreKeyRegistry};
 
 /// Key registry to maintain public key material of other members we've collected.
@@ -149,6 +151,28 @@ where
             .and_then(|bundles| bundles.pop());
         Ok((y, bundle))
     }
+
+    fn key_bundle_by_prekey_id(
+        mut y: Self::State,
+        id: &ID,
+        prekey_id: &PreKeyId,
+    ) -> Result<(Self::State, Option<OneTimeKeyBundle>), Self::Error> {
+        let mut bundle = None;
+
+        let Some(bundles) = y.onetime_bundles.get_mut(id) else {
+            return Ok((y, None));
+        };
+
+        // Identify a one-time key using the same long-term pre-key and remove it from collection.
+        if let Some(pos) = bundles
+            .iter()
+            .position(|bundle| bundle.signed_prekey() == prekey_id)
+        {
+            bundle = Some(bundles.swap_remove(pos))
+        }
+
+        Ok((y, bundle))
+    }
 }
 
 impl<ID> PreKeyRegistry<ID, LongTermKeyBundle> for KeyRegistry<ID>
@@ -172,6 +196,30 @@ where
         // Even though key bundles are available we couldn't find any non-expired ones.
         if !bundles.is_empty() && valid_bundle.is_none() {
             return Err(KeyRegistryError::KeyBundlesExpired);
+        }
+
+        Ok((y, valid_bundle))
+    }
+
+    fn key_bundle_by_prekey_id(
+        y: Self::State,
+        id: &ID,
+        prekey_id: &PreKeyId,
+    ) -> Result<(Self::State, Option<LongTermKeyBundle>), Self::Error> {
+        let Some(bundles) = y.longterm_bundles.get(id) else {
+            return Ok((y, None));
+        };
+
+        let valid_bundle = bundles
+            .iter()
+            .find(|bundle| bundle.signed_prekey() == prekey_id)
+            .cloned();
+
+        if let Some(valid_bundle) = &valid_bundle {
+            valid_bundle
+                .lifetime()
+                .verify()
+                .map_err(|err| KeyBundleError::from(err))?;
         }
 
         Ok((y, valid_bundle))

--- a/p2panda-encryption/src/traits/key_registry.rs
+++ b/p2panda-encryption/src/traits/key_registry.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 use crate::crypto::x25519::PublicKey;
+use crate::key_bundle::PreKeyId;
 
 /// Manages public identity keys of other members.
 pub trait IdentityRegistry<ID, Y> {
@@ -21,4 +22,10 @@ pub trait PreKeyRegistry<ID, KB> {
     type Error: Error;
 
     fn key_bundle(y: Self::State, id: &ID) -> Result<(Self::State, Option<KB>), Self::Error>;
+
+    fn key_bundle_by_prekey_id(
+        y: Self::State,
+        id: &ID,
+        prekey_id: &PreKeyId,
+    ) -> Result<(Self::State, Option<KB>), Self::Error>;
 }

--- a/p2panda-encryption/src/two_party/two_party.rs
+++ b/p2panda-encryption/src/two_party/two_party.rs
@@ -213,8 +213,8 @@ pub enum KeyUsed {
 /// information needs to be added in applications.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TwoPartyMessage {
-    ciphertext: TwoPartyCiphertext,
-    key_used: KeyUsed,
+    pub ciphertext: TwoPartyCiphertext,
+    pub key_used: KeyUsed,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR introduces the following changes across crates:

`p2panda-encryption`

- [x] Introduce a way to get used pre key id's from direct messages
- [x] Introduce a way to not only get the latest key bundle but also by id

`p2panda`

- [ ] Key bundle buffer which holds operations back if the key bundles are not available yet, this is likely living in a new "decryption buffer"

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
