### PR TITLE
Emit spaces events resulting from local actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Highlights are marked with a pancake 🥞
 - stream: Return input with error in orderer processor [#1249](https://github.com/p2panda/p2panda/pull/1249)
 - spaces: Use new traits and SQLite stores in spaces [#1245](https://github.com/p2panda/p2panda/pull/1245)
 - ci: Improve GitHub actions: Use cargo-deny and cargo-hack, adjust schedule [#1233](https://github.com/p2panda/p2panda/pull/1233)
+- spaces: Compute and return events from local methods [#1290](https://github.com/p2panda/p2panda/pull/1290)
+- node: Forward events resulting from local actions to app layer [#1290](https://github.com/p2panda/p2panda/pull/1290)
 
 ### Fixed
 

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -84,7 +84,7 @@ where
         y: AuthGroupState<C>,
         group_id: GroupId,
         initial_members: Vec<(ActorId, Access<C>)>,
-    ) -> Result<(AuthGroupState<C>, F::Message), GroupError<F, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, F::Message, Event<C>), GroupError<F, C, RS>> {
         let initial_members = typed_members(&y, initial_members);
 
         let auth_dependencies = y.inner.heads().into_iter().collect();
@@ -92,16 +92,8 @@ where
             initial_members: initial_members.clone(),
         };
 
-        let (y, message) = Self::process_local_control(
-            manager_ref.clone(),
-            y,
-            group_id,
-            auth_dependencies,
-            action,
-        )
-        .await?;
-
-        Ok((y, message))
+        Self::process_local_control(manager_ref.clone(), y, group_id, auth_dependencies, action)
+            .await
     }
 
     /// Add member to group with specified access level.
@@ -111,7 +103,7 @@ where
         &self,
         member: ActorId,
         access: Access<C>,
-    ) -> Result<(AuthGroupState<C>, F::Message), GroupError<F, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, F::Message, Event<C>), GroupError<F, C, RS>> {
         let y = self.manager.get_groups_state().await?;
 
         let member = typed_member(&y, member);
@@ -127,7 +119,7 @@ where
     pub async fn remove(
         &self,
         member: ActorId,
-    ) -> Result<(AuthGroupState<C>, F::Message), GroupError<F, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, F::Message, Event<C>), GroupError<F, C, RS>> {
         let y = self.manager.get_groups_state().await?;
 
         let member = typed_member(&y, member);
@@ -156,7 +148,6 @@ where
         }
 
         groups_y = AuthGroup::process(groups_y, auth_message).map_err(GroupError::AuthGroup)?;
-
         let events = auth_message_to_group_event(&groups_y, auth_message);
         Ok(Some((groups_y, events)))
     }
@@ -168,7 +159,7 @@ where
         group_id: GroupId,
         auth_dependencies: Vec<OperationId>,
         group_action: GroupAction<ActorId, C>,
-    ) -> Result<(AuthGroupState<C>, F::Message), GroupError<F, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, F::Message, Event<C>), GroupError<F, C, RS>> {
         let args = SpacesArgs::Auth {
             group_id,
             auth_dependencies,
@@ -180,10 +171,12 @@ where
             manager.identity.forge(args).await?
         };
 
-        let y =
-            AuthGroup::process(y, &SpacesMessage::auth(&message)).map_err(GroupError::AuthGroup)?;
+        let auth_message = SpacesMessage::auth(&message);
+        let y = AuthGroup::process(y, &auth_message).map_err(GroupError::AuthGroup)?;
 
-        Ok((y, message))
+        let event = auth_message_to_group_event(&y, &auth_message);
+
+        Ok((y, message, event))
     }
 
     /// Id of this group.
@@ -222,7 +215,7 @@ where
         member: ActorId,
         access: Access<C>,
     ) -> Result<F::Message, GroupError<F, C, RS>> {
-        let (y, message) = self.add(member, access).await?;
+        let (y, message, _) = self.add(member, access).await?;
         self.manager.set_groups_state(&y).await?;
 
         Ok(message)
@@ -235,7 +228,7 @@ where
         &self,
         member: ActorId,
     ) -> Result<F::Message, GroupError<F, C, RS>> {
-        let (y, message) = self.remove(member).await?;
+        let (y, message, _) = self.remove(member).await?;
         self.manager.set_groups_state(&y).await?;
 
         Ok(message)

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -176,15 +176,23 @@ where
         &self,
         id: impl Into<SpaceId>,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<(AuthGroupState<C>, SpacesState<C>, Vec<F::Message>), ManagerError<F, C, RS>> {
+    ) -> Result<
+        (
+            AuthGroupState<C>,
+            SpacesState<C>,
+            Vec<F::Message>,
+            Vec<Event<C>>,
+        ),
+        ManagerError<F, C, RS>,
+    > {
         let id = id.into();
 
-        let (groups_y, space_y, messages) =
+        let (groups_y, space_y, messages, events) =
             Space::create(self.clone(), id, initial_members.to_owned())
                 .await
                 .map_err(ManagerError::Space)?;
 
-        Ok((groups_y, space_y, messages))
+        Ok((groups_y, space_y, messages, events))
     }
 
     /// Create a new group containing initial members with associated access levels.
@@ -197,7 +205,7 @@ where
     pub async fn create_group(
         &self,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<(AuthGroupState<C>, GroupId, F::Message), ManagerError<F, C, RS>> {
+    ) -> Result<(AuthGroupState<C>, GroupId, F::Message, Event<C>), ManagerError<F, C, RS>> {
         let groups_y = self.get_groups_state().await?;
 
         // Generate random group id.
@@ -207,12 +215,12 @@ where
             signing_key.verifying_key()
         };
 
-        let (groups_y, message) =
+        let (groups_y, message, event) =
             Group::create(self.clone(), groups_y, group_id, initial_members.to_owned())
                 .await
                 .map_err(ManagerError::Group)?;
 
-        Ok((groups_y, group_id, message))
+        Ok((groups_y, group_id, message, event))
     }
 
     /// Process a spaces message.
@@ -477,7 +485,7 @@ where
     pub async fn repair_spaces(
         &self,
         space_ids: &[SpaceId],
-    ) -> Result<Vec<(SpacesState<C>, Vec<F::Message>)>, ManagerError<F, C, RS>> {
+    ) -> Result<Vec<(SpacesState<C>, Vec<F::Message>, Vec<Event<C>>)>, ManagerError<F, C, RS>> {
         let mut results = vec![];
 
         for id in space_ids {
@@ -493,7 +501,7 @@ where
             {
                 // Only members with Read or greater access can repair spaces.
                 let space_y = space.state().await?;
-                results.push((space_y, vec![]));
+                results.push((space_y, vec![], vec![]));
                 continue;
             }
 
@@ -577,11 +585,11 @@ where
     pub async fn create_group_persisted(
         &self,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<(Group<S, F, C, RS>, F::Message), ManagerError<F, C, RS>> {
-        let (groups_y, group_id, message) = self.create_group(initial_members).await?;
+    ) -> Result<(Group<S, F, C, RS>, F::Message, Event<C>), ManagerError<F, C, RS>> {
+        let (groups_y, group_id, message, events) = self.create_group(initial_members).await?;
         self.set_groups_state(&groups_y).await?;
         let group = Group::new(self.clone(), group_id);
-        Ok((group, message))
+        Ok((group, message, events))
     }
 
     /// Create a new space containing initial members and access levels.
@@ -594,8 +602,8 @@ where
         &self,
         id: SpaceId,
         initial_members: &[(ActorId, Access<C>)],
-    ) -> Result<(Space<S, F, C, RS>, Vec<F::Message>), ManagerError<F, C, RS>> {
-        let (groups_y, space_y, messages) = self.create_space(id, initial_members).await?;
+    ) -> Result<(Space<S, F, C, RS>, Vec<F::Message>, Vec<Event<C>>), ManagerError<F, C, RS>> {
+        let (groups_y, space_y, messages, events) = self.create_space(id, initial_members).await?;
         let space_id = space_y.space_id;
 
         self.set_groups_state(&groups_y).await?;
@@ -604,7 +612,7 @@ where
             .map_err(|err| StoreError::SpacesStore(err.to_string()))?;
         let space = Space::new(self.clone(), space_id);
 
-        Ok((space, messages))
+        Ok((space, messages, events))
     }
 
     /// Set the global auth state.
@@ -689,7 +697,7 @@ where
         let results = self.repair_spaces(space_ids).await?;
 
         let mut messages = vec![];
-        for (space_y, messages_inner) in results {
+        for (space_y, messages_inner, _) in results {
             let space_id = space_y.space_id;
             self.set_space_state(&space_id, &space_y.into()).await?;
             messages.extend(messages_inner);

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -36,7 +36,7 @@ use crate::types::{
     EncryptionDirectMessage, EncryptionGroup, EncryptionGroupError, EncryptionGroupState,
 };
 use crate::utils::{added_members, removed_members, secret_members, sort_members};
-use crate::{ActorId, GroupId, MemberId, OperationId, SpaceId};
+use crate::{ActorId, GroupId, MemberId, OperationId, SpaceEvent, SpaceId};
 
 /// A single encryption context with associated group of actors who will participate in the key
 /// agreement protocol.
@@ -95,7 +95,15 @@ where
         manager_ref: Manager<S, F, C, RS>,
         space_id: SpaceId,
         mut initial_members: Vec<(ActorId, Access<C>)>,
-    ) -> Result<(AuthGroupState<C>, SpacesState<C>, Vec<F::Message>), SpaceError<F, C, RS>> {
+    ) -> Result<
+        (
+            AuthGroupState<C>,
+            SpacesState<C>,
+            Vec<F::Message>,
+            Vec<Event<C>>,
+        ),
+        SpaceError<F, C, RS>,
+    > {
         let my_id = manager_ref.id();
 
         // Automatically add ourselves with "manage" level without any conditions as default.
@@ -116,13 +124,14 @@ where
 
         // Create the space group.
         let groups_y = manager_ref.get_groups_state().await?;
-        let (groups_y, create_group) =
+
+        let (groups_y, create_group, auth_event) =
             Group::create(manager_ref.clone(), groups_y, group_id, initial_members)
                 .await
                 .map_err(SpaceError::Group)?;
 
         // Apply the "create" auth message to the space state.
-        let (space_y, create_space) = Space::process_auth_message(
+        let (space_y, create_space, space_events) = Space::process_auth_message(
             manager_ref.clone(),
             space_y,
             &SpacesMessage::auth(&create_group),
@@ -133,7 +142,10 @@ where
         messages.extend(space_history);
         messages.extend([create_space]);
 
-        Ok((groups_y, space_y, messages))
+        let mut events = vec![auth_event];
+        events.extend(space_events);
+
+        Ok((groups_y, space_y, messages, events))
     }
 
     /// Add a member to the space with assigned access level.
@@ -143,23 +155,35 @@ where
         &self,
         member: impl Into<ActorId>,
         access: Access<C>,
-    ) -> Result<(AuthGroupState<C>, SpacesState<C>, F::Message, F::Message), SpaceError<F, C, RS>>
-    {
+    ) -> Result<
+        (
+            AuthGroupState<C>,
+            SpacesState<C>,
+            F::Message,
+            F::Message,
+            Vec<Event<C>>,
+        ),
+        SpaceError<F, C, RS>,
+    > {
         let member = member.into();
 
         let space_y = self.state().await?;
         let group = Group::new(self.manager.clone(), space_y.group_id);
-        let (groups_y, auth_message) =
+
+        let (groups_y, auth_message, auth_event) =
             group.add(member, access).await.map_err(SpaceError::Group)?;
 
-        let (space_y, space_message) = Space::process_auth_message(
+        let (space_y, space_message, space_events) = Space::process_auth_message(
             self.manager.clone(),
             space_y,
             &SpacesMessage::auth(&auth_message),
         )
         .await?;
 
-        Ok((groups_y, space_y, auth_message, space_message))
+        let mut events = vec![auth_event];
+        events.extend(space_events);
+
+        Ok((groups_y, space_y, auth_message, space_message, events))
     }
 
     /// Remove a member from the space.
@@ -168,22 +192,35 @@ where
     pub async fn remove(
         &self,
         member: impl Into<ActorId>,
-    ) -> Result<(AuthGroupState<C>, SpacesState<C>, F::Message, F::Message), SpaceError<F, C, RS>>
-    {
+    ) -> Result<
+        (
+            AuthGroupState<C>,
+            SpacesState<C>,
+            F::Message,
+            F::Message,
+            Vec<Event<C>>,
+        ),
+        SpaceError<F, C, RS>,
+    > {
         let member = member.into();
 
         let space_y = self.state().await?;
         let group = Group::new(self.manager.clone(), space_y.group_id);
-        let (groups_y, auth_message) = group.remove(member).await.map_err(SpaceError::Group)?;
 
-        let (space_y, space_message) = Space::process_auth_message(
+        let (groups_y, auth_message, auth_event) =
+            group.remove(member).await.map_err(SpaceError::Group)?;
+
+        let (space_y, space_message, space_events) = Space::process_auth_message(
             self.manager.clone(),
             space_y,
             &SpacesMessage::auth(&auth_message),
         )
         .await?;
 
-        Ok((groups_y, space_y, auth_message, space_message))
+        let mut events = vec![auth_event];
+        events.extend(space_events);
+
+        Ok((groups_y, space_y, auth_message, space_message, events))
     }
 
     /// Forge a "pointer" space message from an already existing auth message and apply any
@@ -193,7 +230,7 @@ where
         manager_ref: Manager<S, F, C, RS>,
         mut y: SpacesState<C>,
         auth_message: &AuthMessage<C>,
-    ) -> Result<(SpacesState<C>, F::Message), SpaceError<F, C, RS>> {
+    ) -> Result<(SpacesState<C>, F::Message, Vec<Event<C>>), SpaceError<F, C, RS>> {
         // Get current space members.
         let current_members = secret_members(y.groups_y.members(y.group_id));
 
@@ -239,7 +276,35 @@ where
             .orderer
             .add_dependency(space_message.hash(), &dependencies);
 
-        Ok((y, space_message))
+        // If current and next member sets are equal it indicates that the space is not affected
+        // by this auth change. This can be because the space wasn't created yet, or the auth
+        // change simply does not effect the members of this space. In either case we don't want
+        // to emit any membership change event.
+        if current_members == next_members {
+            return Ok((y, space_message, vec![]));
+        };
+
+        // Check if this membership change removes the local actor.
+        let me = manager_ref.id();
+        let ejected = current_members.contains(&me) && !next_members.contains(&me);
+
+        // Construct space membership event.
+        let space_event = space_message_to_space_event(
+            y.space_id,
+            &SpacesMessage::space_membership(&space_message),
+            auth_message,
+            current_members,
+            next_members,
+        );
+
+        let mut events = vec![space_event];
+        if ejected {
+            events.push(Event::Space(SpaceEvent::Ejected {
+                space_id: y.space_id,
+            }))
+        }
+
+        Ok((y, space_message, events))
     }
 
     /// Instantiate space state from existing global auth state.
@@ -324,8 +389,7 @@ where
 
         let duplicate_pointer = y.groups_y.inner.operations.contains_key(&auth_message.id());
 
-        let mut current_members = secret_members(y.groups_y.members(y.group_id));
-        current_members.sort();
+        let current_members = secret_members(y.groups_y.members(y.group_id));
 
         debug!(
             space_id = self.id().fmt_short(),
@@ -344,9 +408,7 @@ where
             y.groups_y =
                 AuthGroup::process(y.groups_y, auth_message).map_err(SpaceError::AuthGroup)?;
             // Get next space members.
-            let mut next_members = secret_members(y.groups_y.members(y.group_id));
-            next_members.sort();
-            next_members
+            secret_members(y.groups_y.members(y.group_id))
         } else {
             debug!(
                 space_id = self.id().fmt_short(),
@@ -519,7 +581,9 @@ where
         Ok(Some((y, events)))
     }
 
-    pub async fn repair(&self) -> Result<(SpacesState<C>, Vec<F::Message>), SpaceError<F, C, RS>> {
+    pub async fn repair(
+        &self,
+    ) -> Result<(SpacesState<C>, Vec<F::Message>, Vec<Event<C>>), SpaceError<F, C, RS>> {
         let groups_y = self.manager.get_groups_state().await?;
         let mut space_y = self.state().await?;
 
@@ -529,6 +593,7 @@ where
             toposort(&groups_y.inner.graph, None).expect("auth graph does not contain cycles");
 
         let mut messages = vec![];
+        let mut events = vec![];
         // @TODO: we can optimize here by calculating the diff between the current space auth
         // graph tips and the global auth graph tips. Then we could apply only the missing
         // operations rather than applying all operations as we do here.
@@ -548,7 +613,7 @@ where
                     .expect("message present in store")
             };
 
-            let (space_y_i, space_message) = Space::process_auth_message(
+            let (space_y_i, space_message, space_events) = Space::process_auth_message(
                 self.manager.clone(),
                 space_y,
                 &SpacesMessage::auth(&message),
@@ -558,9 +623,10 @@ where
             space_y = space_y_i;
 
             messages.push(space_message);
+            events.extend(space_events);
         }
 
-        Ok((space_y, messages))
+        Ok((space_y, messages, events))
     }
 
     /// Get the space state.
@@ -661,7 +727,7 @@ where
     pub async fn publish(
         &self,
         plaintext: &[u8],
-    ) -> Result<(SpacesState<C>, F::Message), SpaceError<F, C, RS>> {
+    ) -> Result<(SpacesState<C>, F::Message, Event<C>), SpaceError<F, C, RS>> {
         let mut y = self.state().await?;
 
         if !y.encryption_y.orderer.is_welcomed() {
@@ -709,7 +775,12 @@ where
             .orderer
             .add_dependency(message.hash(), &dependencies);
 
-        Ok((y, message))
+        let event = Event::Application {
+            space_id: y.space_id,
+            data: plaintext.to_owned(),
+        };
+
+        Ok((y, message, event))
     }
 }
 
@@ -734,15 +805,16 @@ where
         &self,
         member: ActorId,
         access: Access<C>,
-    ) -> Result<(F::Message, F::Message), SpaceError<F, C, RS>> {
-        let (groups_y, space_y, auth_message, space_message) = self.add(member, access).await?;
+    ) -> Result<(F::Message, F::Message, Vec<Event<C>>), SpaceError<F, C, RS>> {
+        let (groups_y, space_y, auth_message, space_message, events) =
+            self.add(member, access).await?;
 
         self.manager.set_groups_state(&groups_y).await?;
         self.manager
             .set_space_state(&self.id(), &space_y.into())
             .await?;
 
-        Ok((auth_message, space_message))
+        Ok((auth_message, space_message, events))
     }
 
     /// Remove a member from the space.
@@ -751,35 +823,37 @@ where
     pub async fn remove_persisted(
         &self,
         member: ActorId,
-    ) -> Result<(F::Message, F::Message), SpaceError<F, C, RS>> {
-        let (groups_y, space_y, auth_message, space_message) = self.remove(member).await?;
+    ) -> Result<(F::Message, F::Message, Vec<Event<C>>), SpaceError<F, C, RS>> {
+        let (groups_y, space_y, auth_message, space_message, events) = self.remove(member).await?;
 
         self.manager.set_groups_state(&groups_y).await?;
         self.manager
             .set_space_state(&self.id(), &space_y.into())
             .await?;
 
-        Ok((auth_message, space_message))
+        Ok((auth_message, space_message, events))
     }
 
     /// Publish a message encrypted towards all current group members.
     pub async fn publish_persisted(
         &self,
         plaintext: &[u8],
-    ) -> Result<F::Message, SpaceError<F, C, RS>> {
-        let (space_y, message) = self.publish(plaintext).await?;
+    ) -> Result<(F::Message, Event<C>), SpaceError<F, C, RS>> {
+        let (space_y, message, event) = self.publish(plaintext).await?;
         self.manager
             .set_space_state(&self.id(), &space_y.into())
             .await?;
-        Ok(message)
+        Ok((message, event))
     }
 
-    pub async fn repair_persisted(&self) -> Result<Vec<F::Message>, SpaceError<F, C, RS>> {
-        let (space_y, messages) = self.repair().await?;
+    pub async fn repair_persisted(
+        &self,
+    ) -> Result<(Vec<F::Message>, Vec<Event<C>>), SpaceError<F, C, RS>> {
+        let (space_y, messages, events) = self.repair().await?;
         self.manager
             .set_space_state(&self.id(), &space_y.into())
             .await?;
-        Ok(messages)
+        Ok((messages, events))
     }
 }
 

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -39,7 +39,10 @@ async fn create_space() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space, messages) = manager.create_space_persisted(space_id, &[]).await.unwrap();
+    let (space, messages, events) = manager.create_space_persisted(space_id, &[]).await.unwrap();
+
+    // Expect one auth and one spaces event.
+    assert_eq!(events.len(), 2);
 
     // We've added ourselves automatically with manage access.
     assert_eq!(
@@ -122,7 +125,7 @@ async fn send_and_receive() {
     // Alice creates a space with Bob.
 
     let space_id = SpaceId::digest(b"0");
-    let (alice_space, alice_messages) = alice
+    let (alice_space, alice_messages, _) = alice
         .manager
         .create_space_persisted(space_id, &[(bob.manager.id(), Access::write())])
         .await
@@ -138,7 +141,7 @@ async fn send_and_receive() {
     // Bob sends a message to Alice.
 
     let bob_space = bob.manager.space(space_id).await.unwrap().unwrap();
-    let message = bob_space.publish_persisted(b"Hello, Alice!").await.unwrap();
+    let (message, _) = bob_space.publish_persisted(b"Hello, Alice!").await.unwrap();
 
     // Bob's orderer state is updated.
 
@@ -197,7 +200,7 @@ async fn add_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space, messages) = manager.create_space_persisted(space_id, &[]).await.unwrap();
+    let (space, messages, _) = manager.create_space_persisted(space_id, &[]).await.unwrap();
 
     // There are two messages (one auth, and one space)
     assert_eq!(messages.len(), 2);
@@ -210,10 +213,14 @@ async fn add_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space = manager.space(space_id).await.unwrap().unwrap();
-    let (message_03, message_04) = space
+    let (message_03, message_04, events) = space
         .add_persisted(bob.manager.id(), Access::read())
         .await
         .unwrap();
+
+    // Expect one auth and one spaces event.
+    assert_eq!(events.len(), 2);
+
     let members = space.members().await.unwrap();
     drop(space);
 
@@ -287,7 +294,7 @@ async fn register_key_bundles_after_space_creation() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space, _) = manager.create_space_persisted(space_id, &[]).await.unwrap();
+    let (space, _, _) = manager.create_space_persisted(space_id, &[]).await.unwrap();
     drop(space);
 
     // Register key bundles _after_ the space was already created
@@ -330,18 +337,18 @@ async fn send_and_receive_after_add() {
     // Alice creates a space, adds Bob in a following step and then sends a message.
 
     let space_id = SpaceId::digest(b"0");
-    let (alice_space, messages) = alice
+    let (alice_space, messages, _) = alice
         .manager
         .create_space_persisted(space_id, &[])
         .await
         .unwrap();
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
-    let (message_03, message_04) = alice_space
+    let (message_03, message_04, _) = alice_space
         .add_persisted(bob_id, Access::read())
         .await
         .unwrap();
-    let message_05 = alice_space.publish_persisted(b"Hello bob").await.unwrap();
+    let (message_05, _) = alice_space.publish_persisted(b"Hello bob").await.unwrap();
 
     // Bob processes all of Alice's messages.
 
@@ -380,7 +387,7 @@ async fn add_pull_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space, messages) = manager.create_space_persisted(space_id, &[]).await.unwrap();
+    let (space, messages, _) = manager.create_space_persisted(space_id, &[]).await.unwrap();
     assert_eq!(messages.len(), 2);
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
@@ -390,7 +397,7 @@ async fn add_pull_member_to_space() {
     // ~~~~~~~~~~~~
 
     let space = manager.space(space_id).await.unwrap().unwrap();
-    let (message_03, message_04) = space
+    let (message_03, message_04, _) = space
         .add_persisted(bob.manager.id(), Access::pull())
         .await
         .unwrap();
@@ -480,7 +487,7 @@ async fn receive_control_messages() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space, messages) = alice_manager
+    let (space, messages, _) = alice_manager
         .create_space_persisted(space_id, &[])
         .await
         .unwrap();
@@ -528,12 +535,12 @@ async fn receive_control_messages() {
     // ~~~~~~~~~~~~
 
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
-    let message_03 = space.publish_persisted(&[0, 1, 2]).await.unwrap();
+    let (message_03, _) = space.publish_persisted(&[0, 1, 2]).await.unwrap();
 
     // Alice: Add new member to Space
     // ~~~~~~~~~~~~
 
-    let (message_04, message_05) = space
+    let (message_04, message_05, _) = space
         .add_persisted(bob.manager.id(), Access::read())
         .await
         .unwrap();
@@ -603,7 +610,7 @@ async fn remove_member() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space, messages) = alice_manager
+    let (space, messages, _) = alice_manager
         .create_space_persisted(space_id, &[(bob_id, Access::read())])
         .await
         .unwrap();
@@ -628,7 +635,7 @@ async fn remove_member() {
     // ~~~~~~~~~~~~
 
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
-    let (message_03, message_04) = space.remove_persisted(bob_id).await.unwrap();
+    let (message_03, message_04, _) = space.remove_persisted(bob_id).await.unwrap();
 
     let SpacesArgs::Auth { group_action, .. } = message_03.borrow() else {
         panic!("expected auth message");
@@ -699,7 +706,7 @@ async fn concurrent_removal_conflict() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space, messages) = alice_manager
+    let (space, messages, _) = alice_manager
         .create_space_persisted(space_id, &[(bob_id, Access::manage())])
         .await
         .unwrap();
@@ -729,7 +736,7 @@ async fn concurrent_removal_conflict() {
     // ~~~~~~~~~~~~
 
     let space = bob_manager.space(space_id).await.unwrap().unwrap();
-    let (message_03, message_04) = space
+    let (message_03, message_04, _) = space
         .add_persisted(claire_id, Access::read())
         .await
         .unwrap();
@@ -747,7 +754,7 @@ async fn concurrent_removal_conflict() {
     // ~~~~~~~~~~~~
 
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
-    let (message_05, message_06) = space.add_persisted(dave_id, Access::read()).await.unwrap();
+    let (message_05, message_06, _) = space.add_persisted(dave_id, Access::read()).await.unwrap();
 
     let SpacesArgs::Auth { group_action, .. } = message_05.borrow() else {
         panic!("expected auth message");
@@ -810,7 +817,7 @@ async fn space_from_existing_auth_state() {
     // Create Group with bob and claire as managers.
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = alice_manager
+    let (group, message_01, _) = alice_manager
         .create_group_persisted(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
         .await
         .unwrap();
@@ -820,10 +827,13 @@ async fn space_from_existing_auth_state() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space, messages) = alice_manager
+    let (space, messages, events) = alice_manager
         .create_space_persisted(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
+
+    // Expect one auth and one spaces event.
+    assert_eq!(events.len(), 2);
 
     // There are 3 messages:
     // 1) auth message containing "create" for the space group
@@ -915,7 +925,7 @@ async fn create_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = manager
+    let (group, message_01, _) = manager
         .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
@@ -967,7 +977,7 @@ async fn add_member_to_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = manager
+    let (group, message_01, _) = manager
         .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
@@ -1025,7 +1035,7 @@ async fn remove_member_from_group() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = manager
+    let (group, message_01, _) = manager
         .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
@@ -1079,7 +1089,7 @@ async fn receive_auth_messages() {
     // Create Group
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = alice_manager
+    let (group, message_01, _) = alice_manager
         .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
@@ -1147,7 +1157,7 @@ async fn shared_auth_state() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space_0, messages) = manager
+    let (space_0, messages, _) = manager
         .create_space_persisted(space_id, &[(alice_id, Access::manage())])
         .await
         .unwrap();
@@ -1159,7 +1169,7 @@ async fn shared_auth_state() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"1");
-    let (space_1, messages) = manager
+    let (space_1, messages, _) = manager
         .create_space_persisted(space_id, &[(alice_id, Access::manage())])
         .await
         .unwrap();
@@ -1168,22 +1178,28 @@ async fn shared_auth_state() {
     assert_eq!(messages.len(), 3);
 
     // Make Space 0 aware of this change.
-    let messages = space_0.repair_persisted().await.unwrap();
+    let (messages, events) = space_0.repair_persisted().await.unwrap();
     assert_eq!(messages.len(), 1);
+
+    // We expect no events as the space membership didn't change and global auth state was already
+    // mutated.
+    assert_eq!(events.len(), 0);
 
     // Create group A
     // ~~~~~~~~~~~~
 
-    let (group, _) = manager
+    let (group, _, _) = manager
         .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::read())])
         .await
         .unwrap();
 
     // Make Space 0 and Space 1 aware of this change.
-    let messages = space_0.repair_persisted().await.unwrap();
+    let (messages, events) = space_0.repair_persisted().await.unwrap();
     assert_eq!(messages.len(), 1);
-    let messages = space_1.repair_persisted().await.unwrap();
+    assert_eq!(events.len(), 0);
+    let (messages, events) = space_1.repair_persisted().await.unwrap();
     assert_eq!(messages.len(), 1);
+    assert_eq!(events.len(), 0);
 
     // Add group A to space 0
     // ~~~~~~~~~~~~
@@ -1194,8 +1210,9 @@ async fn shared_auth_state() {
         .unwrap();
 
     // Make Space 1 aware of this change.
-    let messages = space_1.repair_persisted().await.unwrap();
+    let (messages, events) = space_1.repair_persisted().await.unwrap();
     assert_eq!(messages.len(), 1);
+    assert_eq!(events.len(), 0);
 
     // Add group A to space 1
     // ~~~~~~~~~~~~
@@ -1206,8 +1223,9 @@ async fn shared_auth_state() {
         .unwrap();
 
     // Make Space 0 aware of this change.
-    let messages = space_0.repair_persisted().await.unwrap();
+    let (messages, events) = space_0.repair_persisted().await.unwrap();
     assert_eq!(messages.len(), 1);
+    assert_eq!(events.len(), 0);
 
     // Add claire to the group
     // ~~~~~~~~~~~~
@@ -1218,10 +1236,15 @@ async fn shared_auth_state() {
         .unwrap();
 
     // Both Space 0 and Space 1 need to be made aware of this change.
-    let messages = space_0.repair_persisted().await.unwrap();
+    let (messages, events) = space_0.repair_persisted().await.unwrap();
     assert_eq!(messages.len(), 1);
-    let messages = space_1.repair_persisted().await.unwrap();
+    // This change brings claire into the space membership group so we expect one space event
+    // signaling this change.
+    assert_eq!(events.len(), 1);
+
+    let (messages, events) = space_1.repair_persisted().await.unwrap();
     assert_eq!(messages.len(), 1);
+    assert_eq!(events.len(), 1);
 
     // Both space 0 and space 1 should now include claire.
     let expected_members = vec![
@@ -1269,37 +1292,47 @@ async fn events() {
     let mut alice_messages = vec![];
 
     // Create Group with bob and claire as managers.
-    let (group, auth_message) = alice_manager
+    let (group, auth_message, _) = alice_manager
         .create_group_persisted(&[(bob_id, Access::manage()), (claire_id, Access::manage())])
         .await
         .unwrap();
     let member_group_id = group.id();
+
     alice_messages.push(auth_message);
 
     // Create Space with group as member
     let space_id = SpaceId::digest(b"0");
-    let (space, messages) = alice_manager
+    let (space, messages, events) = alice_manager
         .create_space_persisted(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
     let space_group_id = space.group_id().await.unwrap();
     assert_eq!(messages.len(), 3);
+    assert_eq!(events.len(), 2);
     alice_messages.extend(messages);
 
     // Add dave to space with read access
-    let (auth_message, space_message) = space.add_persisted(dave_id, Access::read()).await.unwrap();
+    let (auth_message, space_message, events) =
+        space.add_persisted(dave_id, Access::read()).await.unwrap();
+    assert_eq!(events.len(), 2);
     alice_messages.extend([auth_message, space_message]);
 
     // Remove dave from space
-    let (auth_message, space_message) = space.remove_persisted(dave_id).await.unwrap();
+    let (auth_message, space_message, events) = space.remove_persisted(dave_id).await.unwrap();
+    assert_eq!(events.len(), 2);
     alice_messages.extend([auth_message, space_message]);
 
     // Add dave back into space with pull access
-    let (auth_message, space_message) = space.add_persisted(dave_id, Access::pull()).await.unwrap();
+    let (auth_message, space_message, events) =
+        space.add_persisted(dave_id, Access::pull()).await.unwrap();
+    // Only expect one auth event as adding a member with pull access does not change the
+    // membership of the space (those given the group secret).
+    assert_eq!(events.len(), 1);
     alice_messages.extend([auth_message, space_message]);
 
     // Remove member group from space
-    let (auth_message, space_message) = space.remove_persisted(group.id()).await.unwrap();
+    let (auth_message, space_message, events) = space.remove_persisted(group.id()).await.unwrap();
+    assert_eq!(events.len(), 2);
     alice_messages.extend([auth_message, space_message]);
 
     // Test basic expected event types.
@@ -1410,7 +1443,7 @@ async fn idempotent_api() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (_, messages) = alice_manager
+    let (_, messages, _) = alice_manager
         .create_space_persisted(space_id, &[])
         .await
         .unwrap();
@@ -1488,7 +1521,7 @@ async fn repair_space() {
     // Alice: Create Group with Bob as a manager.
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = alice_manager
+    let (group, message_01, _) = alice_manager
         .create_group_persisted(&[(bob_id, Access::manage())])
         .await
         .unwrap();
@@ -1498,7 +1531,7 @@ async fn repair_space() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space, messages) = alice_manager
+    let (space, messages, _) = alice_manager
         .create_space_persisted(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
@@ -1610,7 +1643,7 @@ async fn duplicate_auth_state_references() {
     // Alice: Create Group with Bob as a manager.
     // ~~~~~~~~~~~~
 
-    let (group, message_01) = alice_manager
+    let (group, message_01, _) = alice_manager
         .create_group_persisted(&[(bob_id, Access::manage())])
         .await
         .unwrap();
@@ -1620,7 +1653,7 @@ async fn duplicate_auth_state_references() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space, messages) = alice_manager
+    let (space, messages, _) = alice_manager
         .create_space_persisted(space_id, &[(member_group_id, Access::read())])
         .await
         .unwrap();
@@ -1813,7 +1846,7 @@ async fn process_operation_from_expired_member() {
     bob.manager.register_member(&expired_bob).await.unwrap();
 
     // Alice creates a space with Bob.
-    let (_space, messages) = alice
+    let (_space, messages, _) = alice
         .manager
         .create_space_persisted(
             SpaceId::digest(b"0"),
@@ -1846,7 +1879,7 @@ async fn publish_process_separation() {
     // ~~~~~~~~~~~~
 
     // We drop the returned states as we are only interested in the forged operations.
-    let (_groups_y, space_y, messages) = Space::create(manager.clone(), space_id, vec![])
+    let (_groups_y, space_y, messages, _events) = Space::create(manager.clone(), space_id, vec![])
         .await
         .unwrap();
     let group_id = space_y.group_id;
@@ -1877,4 +1910,31 @@ async fn publish_process_separation() {
 
     let members = space.members().await.unwrap();
     assert_eq!(members, vec![(alice_id, Access::manage())]);
+}
+
+#[tokio::test]
+async fn ejected_event() {
+    let alice = TestPeer::new(0).await;
+    let manager = alice.manager.clone();
+    let alice_id = manager.id();
+
+    // Create Space
+    // ~~~~~~~~~~~~
+
+    let space_id = SpaceId::digest(b"0");
+    let (space, _, events) = manager.create_space_persisted(space_id, &[]).await.unwrap();
+
+    // Expect one auth and one spaces event.
+    assert_eq!(events.len(), 2);
+
+    // Remove self from space
+    // ~~~~~~~~~~~~
+
+    let (_, _, events) = space.remove_persisted(alice_id).await.unwrap();
+    // We expect 3 events.
+    assert_eq!(events.len(), 3);
+
+    // The last event is an "ejected".
+    let ejected_event = events.last().unwrap();
+    assert_matches!(ejected_event, Event::Space(SpaceEvent::Ejected { .. }))
 }

--- a/p2panda-spaces/src/utils.rs
+++ b/p2panda-spaces/src/utils.rs
@@ -50,8 +50,7 @@ pub(crate) fn added_members(
     next_members: Vec<MemberId>,
 ) -> Vec<MemberId> {
     let mut members = next_members
-        .iter()
-        .cloned()
+        .into_iter()
         .filter(|actor| !current_members.contains(actor))
         .collect::<Vec<_>>();
     members.sort();
@@ -63,8 +62,7 @@ pub(crate) fn removed_members(
     next_members: Vec<MemberId>,
 ) -> Vec<MemberId> {
     let mut members = current_members
-        .iter()
-        .cloned()
+        .into_iter()
         .filter(|actor| !next_members.contains(actor))
         .collect::<Vec<_>>();
     members.sort();

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -32,8 +32,9 @@ use crate::spaces::{
     to_initial_members,
 };
 use crate::streams::{
-    EphemeralStreamPublisher, EphemeralStreamSubscription, Pipeline, StreamFrom, StreamPublisher,
-    StreamSubscription, SystemEvent, TaskTracker, ephemeral_stream, event_stream, processed_stream,
+    EphemeralStreamPublisher, EphemeralStreamSubscription, Pipeline, StreamEvent, StreamFrom,
+    StreamPublisher, StreamSubscription, SystemEvent, TaskTracker, ephemeral_stream, event_stream,
+    processed_stream,
 };
 
 /// Node API with methods to establish ephemeral and eventually consistent topic streams.
@@ -409,7 +410,12 @@ impl Node {
         // state here, the processor would detect that we already processed this control message
         // and therefore not emit any events.
         let initial_members = to_initial_members(initial_members);
-        let (_, group_id, message) = self.spaces_manager.create_group(&initial_members).await?;
+
+        // @TODO: Group events are currently not forwarded to the user. It's not clear which
+        // channel these should be sent on, the spaces stream, a stream for the specific group, or
+        // a global groups stream.
+        let (_, group_id, message, _events) =
+            self.spaces_manager.create_group(&initial_members).await?;
 
         let topic = actor_to_topic(group_id);
         let (tx, _rx) = self.stream::<NoBody>(topic).await?;
@@ -573,16 +579,16 @@ impl Node {
         // members. I (sam) removed it from the API for now as without a manual member
         // registration flow a user likely doesn't have access to any member key bundles at the
         // point of space creation.
-        let (_, space_y, create_space_messages) =
+        let (groups_y, space_y, create_space_messages, events) =
             self.spaces_manager.create_space(space_id, &[]).await?;
 
-        // @TODO: We need to refactor the spaces API so that locally created operations can be
-        // handled via the call to Manager::process and then persisted in the spaces processor.
-        // Until we have this spaces events for our own locally created operations won't be
-        // emitted to users (as the processor thinks the operation was already processed and skips.
         let permit = self.store.begin().await?;
 
+        // Persist the computed groups and spaces state to the stores.
         let spaces_store = SqliteSpacesStore::<Extensions>::new(self.store.clone());
+        spaces_store
+            .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
+            .await?;
         spaces_store
             .set_space_state_tx(&space_id, &SpacesStoreState::from(space_y))
             .await?;
@@ -590,10 +596,6 @@ impl Node {
         self.store.commit(permit).await?;
 
         // Process the -spaces events by importing them as an "external stream".
-        //
-        // @TODO: Related to above comment. Even though the state is already mutated & persisted
-        // locally we're still sending the messages to the pipeline. Revisit this when state does
-        // indeed need to be persisted here instead of in the pipeline.
         let mut messages = vec![key_bundle_message];
         messages.extend(create_space_messages);
 
@@ -611,6 +613,20 @@ impl Node {
         if processed.await.is_err() {
             panic!();
         }
+
+        // Manually forward the resulting spaces events to the application layer.
+        let events = events
+            .into_iter()
+            .filter_map(|event| match event {
+                p2panda_spaces::Event::Space(space_event) => Some(StreamEvent::Space(space_event)),
+                _ => None,
+            })
+            .collect();
+
+        tx.to_output_tx
+            .send(events)
+            .await
+            .map_err(|_| SpaceError::AppSend)?;
 
         let inner = self
             .spaces_manager

--- a/p2panda/src/spaces/group.rs
+++ b/p2panda/src/spaces/group.rs
@@ -91,7 +91,10 @@ impl Group {
         actor: impl Into<ActorId>,
         access: AccessLevel,
     ) -> Result<GroupFuture, GroupError> {
-        let (_, message) = self
+        // @TODO: Group events are currently not forwarded to the user. It's not clear which
+        // channel these should be sent on, the spaces stream, a stream for the specific group, or
+        // a global groups stream.
+        let (_, message, _events) = self
             .inner
             .add(
                 actor.into(),
@@ -116,7 +119,10 @@ impl Group {
     }
 
     pub async fn remove(&self, actor: impl Into<ActorId>) -> Result<GroupFuture, GroupError> {
-        let (_, message) = self.inner.remove(actor.into()).await?;
+        // @TODO: Group events are currently not forwarded to the user. It's not clear which
+        // channel these should be sent on, the spaces stream, a stream for the specific group, or
+        // a global groups stream.
+        let (_, message, _events) = self.inner.remove(actor.into()).await?;
 
         let processed = self
             .tx

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -12,6 +12,7 @@ use p2panda_store::operations::OperationStore;
 use p2panda_store::spaces::SpacesStore as SpacesStoreTrait;
 use p2panda_store::topics::TopicStore;
 use p2panda_store::{SqliteError, SqliteStore, Transaction};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::mpsc::{self};
 use tokio::sync::oneshot;
@@ -24,7 +25,7 @@ use crate::operation::Operation;
 use crate::spaces::group_log_id;
 use crate::spaces::types::{AuthCapabilities, SpacesArgs, SpacesStore};
 use crate::spaces::{SpacesManagerError, types::SpacesManager};
-use crate::streams::ExternalStreamFuture;
+use crate::streams::{ExternalStreamFuture, StreamEvent};
 
 const REPAIR_FREQUENCY_SECS: u64 = 1;
 
@@ -39,7 +40,7 @@ const REPAIR_FREQUENCY_SECS: u64 = 1;
 /// 3) associate missing groups logs with the space topic
 ///
 /// All new messages will be sent into the topic stream to be processed and forwarded to other peers.
-pub(crate) async fn repair_space(
+pub(crate) async fn repair_space<M>(
     space_id: SpaceId,
     manager: &SpacesManager,
     store: &SqliteStore,
@@ -47,6 +48,7 @@ pub(crate) async fn repair_space(
         BoxStream<'static, Operation>,
         oneshot::Sender<ExternalStreamFuture>,
     )>,
+    to_output_tx: &mpsc::Sender<Vec<StreamEvent<M>>>,
 ) -> Result<bool, RepairError> {
     let spaces_store = SpacesStore::new(store.clone());
 
@@ -126,7 +128,7 @@ pub(crate) async fn repair_space(
     let mut repaired = manager.repair_spaces(&[space_id]).await?;
 
     // Forging these spaces messages will also associate any group logs with this space topic.
-    let Some((space_y, spaces_messages)) = repaired.pop() else {
+    let Some((space_y, spaces_messages, events)) = repaired.pop() else {
         // This can happen if we didn't receive any space control messages yet.
         debug!(
             node_id = manager.id().fmt_short(),
@@ -176,6 +178,19 @@ pub(crate) async fn repair_space(
     // Await processing of operations to be complete.
     ready_rx.await?;
 
+    let events = events
+        .into_iter()
+        .filter_map(|event| match event {
+            p2panda_spaces::Event::Space(space_event) => Some(StreamEvent::Space(space_event)),
+            _ => None,
+        })
+        .collect();
+
+    to_output_tx
+        .send(events)
+        .await
+        .map_err(|_| RepairError::AppSend)?;
+
     debug!(
         node_id = manager.id().fmt_short(),
         space_id = space_id.fmt_short(),
@@ -188,7 +203,7 @@ pub(crate) async fn repair_space(
 
 /// Spawn the repair task which triggers work on a schedule or from being signalled from elsewhere
 /// in the node API.
-pub(crate) fn spawn_repair_task(
+pub(crate) fn spawn_repair_task<M>(
     topic: Topic,
     manager: SpacesManager,
     store: SqliteStore,
@@ -196,8 +211,12 @@ pub(crate) fn spawn_repair_task(
         BoxStream<'static, Operation>,
         oneshot::Sender<ExternalStreamFuture>,
     )>,
+    to_output_tx: mpsc::Sender<Vec<StreamEvent<M>>>,
     mut repair_rx: mpsc::Receiver<oneshot::Sender<Result<bool, RepairError>>>,
-) -> JoinHandle<()> {
+) -> JoinHandle<()>
+where
+    M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
+{
     tokio::spawn(async move {
         loop {
             let reply_tx = tokio::select! {
@@ -215,7 +234,8 @@ pub(crate) fn spawn_repair_task(
                 _ = sleep(Duration::from_secs(REPAIR_FREQUENCY_SECS)) => None,
             };
 
-            let result = repair_space(topic.into(), &manager, &store, &import_tx).await;
+            let result =
+                repair_space(topic.into(), &manager, &store, &import_tx, &to_output_tx).await;
 
             if let Err(ref err) = result {
                 warn!("failed to repair spaces: {}", err);
@@ -242,4 +262,7 @@ pub enum RepairError {
 
     #[error("import ready channel broken")]
     Recv(#[from] RecvError),
+
+    #[error("application send channel broken")]
+    AppSend,
 }

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -5,8 +5,11 @@ use std::task::{Context, Poll};
 
 use futures_util::{FutureExt, Stream, StreamExt};
 use p2panda_auth::{Access, AccessLevel};
+use p2panda_core::Hash;
 use p2panda_core::cbor::{EncodeError, encode_cbor};
+use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
 use p2panda_spaces::{ActorId, MemberId, SpaceContext, SpaceId, SpacesStoreState};
+use p2panda_store::groups::GroupsStore;
 use p2panda_store::spaces::{SpacesStore, SqliteSpacesStore};
 use p2panda_store::{SqliteError, SqliteStore, Transaction};
 use serde::{Deserialize, Serialize};
@@ -74,13 +77,12 @@ where
         //
         // We could also handle this outside of p2panda-spaces, simply by coming up with an argument
         // in the extensions for the spaces processor in p2panda-stream.
-        let (_, message) = self.inner.publish(&body_bytes).await?;
+        let (_, message, _event) = self.inner.publish(&body_bytes).await?;
 
         // @TODO: We don't need to persist the spaces state here as it's possible for the spaces
         // processor to handle our own operations. Not doing this has the benefit of allowing
-        // application events to be emitted from the spaces processor already (otherwise the would
-        // be ignored as already processed). This comment can be removed when we persist spaces
-        // state in the processor in all places.
+        // application events to be emitted from the spaces processor, rather than having to
+        // construct and send them here manually.
         let processed = self
             .tx
             .import(futures_util::stream::once(async {
@@ -98,12 +100,12 @@ where
         &self,
         actor: impl Into<ActorId>,
         access: AccessLevel,
-    ) -> Result<SpaceFuture, SpaceError> {
+    ) -> Result<(), SpaceError> {
         // Before performing any action we trigger and await return from a space repair which will
         // ensure we have incorporated the latest groups changes into the space.
         self.repair().await?;
 
-        let (_, space_y, auth_message, space_message) = self
+        let (groups_y, space_y, auth_message, space_message, events) = self
             .inner
             .add(
                 actor.into(),
@@ -117,11 +119,9 @@ where
         let permit = self.store.begin().await?;
 
         // Persist the computed groups and spaces state to the stores.
-        //
-        // @TODO: We need to refactor the spaces API so that locally created operations can be
-        // handled via the call to Manager::process and then persisted in the spaces processor.
-        // Until we have this spaces events for our own locally created operations won't be
-        // emitted to users (as the processor thinks the operation was already processed and skips.
+        self.store
+            .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
+            .await?;
         self.store
             .set_space_state_tx(&self.id(), &SpacesStoreState::from(space_y))
             .await?;
@@ -136,27 +136,40 @@ where
             ]))
             .await?;
 
-        Ok(SpaceFuture {
-            processed,
-            space_id: self.inner.id(),
-        })
+        processed.await?;
+
+        // Manually forward the resulting spaces events to the application layer.
+        let events = events
+            .into_iter()
+            .filter_map(|event| match event {
+                p2panda_spaces::Event::Space(space_event) => Some(StreamEvent::Space(space_event)),
+                _ => None,
+            })
+            .collect();
+
+        self.tx
+            .to_output_tx
+            .send(events)
+            .await
+            .map_err(|_| SpaceError::AppSend)?;
+
+        Ok(())
     }
 
-    pub async fn remove(&self, actor: impl Into<ActorId>) -> Result<SpaceFuture, SpaceError> {
+    pub async fn remove(&self, actor: impl Into<ActorId>) -> Result<(), SpaceError> {
         // Before performing any action we trigger and await return from a space repair which will
         // ensure we have incorporated the latest groups changes into the space.
         self.repair().await?;
 
-        let (_, space_y, auth_message, space_message) = self.inner.remove(actor.into()).await?;
+        let (groups_y, space_y, auth_message, space_message, events) =
+            self.inner.remove(actor.into()).await?;
 
         let permit = self.store.begin().await?;
 
         // Persist the computed groups and spaces state to the stores.
-        //
-        // @TODO: We need to refactor the spaces API so that locally created operations can be
-        // handled via the call to Manager::process and then persisted in the spaces processor.
-        // Until we have this spaces events for our own locally created operations won't be
-        // emitted to users (as the processor thinks the operation was already processed and skips.
+        self.store
+            .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
+            .await?;
         self.store
             .set_space_state_tx(&self.id(), &SpacesStoreState::from(space_y))
             .await?;
@@ -171,10 +184,24 @@ where
             ]))
             .await?;
 
-        Ok(SpaceFuture {
-            processed,
-            space_id: self.inner.id(),
-        })
+        processed.await?;
+
+        // Manually forward the resulting spaces events to the application layer.
+        let events = events
+            .into_iter()
+            .filter_map(|event| match event {
+                p2panda_spaces::Event::Space(space_event) => Some(StreamEvent::Space(space_event)),
+                _ => None,
+            })
+            .collect();
+
+        self.tx
+            .to_output_tx
+            .send(events)
+            .await
+            .map_err(|_| SpaceError::AppSend)?;
+
+        Ok(())
     }
 
     pub async fn members(&self) -> Result<Vec<(MemberId, AccessLevel)>, SpaceError> {
@@ -283,6 +310,9 @@ pub enum SpaceError {
 
     #[error("couldn't process spaces change due to broken channel")]
     Recv(#[from] RecvError),
+
+    #[error("couldn't send event due to broken app channel")]
+    AppSend,
 
     #[error(transparent)]
     RepairSpace(#[from] RepairSpaceError),

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -17,7 +17,7 @@ use p2panda_net::sync::SyncHandle;
 // TODO: Replace with ShortFormat from p2panda-core.
 // See: https://github.com/p2panda/p2panda/issues/1270
 use p2panda_net::utils::ShortFormat;
-use p2panda_spaces::{GroupEvent, SpaceEvent};
+use p2panda_spaces::SpaceEvent;
 use p2panda_store::SqliteStore;
 use p2panda_store::operations::OperationStore;
 use p2panda_stream::spaces::SpacesResult;
@@ -32,7 +32,7 @@ use crate::forge::{Forge, ForgeError, OperationForge};
 use crate::node::{AckPolicy, CreateStreamError};
 use crate::operation::{Extensions, Header, LogId, Operation};
 use crate::processor::{ProcessorError, ProcessorStatus};
-use crate::spaces::types::{AuthCapabilities, SpacesManager};
+use crate::spaces::types::SpacesManager;
 use crate::spaces::{RepairError, spawn_repair_task};
 use crate::streams::acked::{Acked, AckedError};
 use crate::streams::external_stream::{
@@ -157,6 +157,7 @@ where
         spaces_manager.clone(),
         store.clone(),
         import_tx.clone(),
+        to_output_tx.clone(),
         repair_rx,
     );
 
@@ -224,6 +225,7 @@ where
     {
         let store = store.clone();
         let sync_handle = sync_handle.clone();
+        let to_output_tx = to_output_tx.clone();
 
         tokio::spawn(async move {
             // =======================
@@ -384,6 +386,7 @@ where
         publish_tx,
         import_tx,
         repair_tx,
+        to_output_tx,
         _marker: PhantomData,
     };
 
@@ -501,8 +504,10 @@ where
                     forward_events.push(StreamEvent::KeyBundle(*author))
                 }
 
-                p2panda_spaces::Event::Group(group_event) => {
-                    forward_events.push(StreamEvent::Group(group_event.to_owned()))
+                p2panda_spaces::Event::Group(_) => {
+                    // @TODO: It's not clear if group events should be forwarded on the spaces
+                    // stream, so for now we don't forward any.
+                    // forward_events.push(StreamEvent::Group(group_event.to_owned()))
                 }
 
                 p2panda_spaces::Event::Space(space_event) => {
@@ -639,6 +644,7 @@ pub struct StreamPublisher<M> {
         BoxStream<'static, Operation>,
         oneshot::Sender<ExternalStreamFuture>,
     )>,
+    pub(crate) to_output_tx: mpsc::Sender<Vec<StreamEvent<M>>>,
     pub(crate) repair_tx: mpsc::Sender<oneshot::Sender<Result<bool, RepairError>>>,
     _marker: PhantomData<M>,
 }
@@ -974,8 +980,11 @@ pub enum StreamEvent<M> {
     /// Space has been created or modified.
     Space(SpaceEvent),
 
+    // @TODO: It's not clear where group events should be forwarded so we don't send any for now
+    // and therefore this variant is commented out.
+    //
     /// Group has been created or modified.
-    Group(GroupEvent<AuthCapabilities>),
+    // Group(GroupEvent<AuthCapabilities>),
 
     /// Key bundle has been processed.
     KeyBundle(VerifyingKey),

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
 use p2panda::operation::Header;
 use p2panda::streams::StreamEvent;
 use p2panda_auth::{Access, AccessLevel};
 use p2panda_core::{cbor::decode_cbor, test_utils::setup_logging};
-use p2panda_spaces::{GroupEvent, SpaceEvent};
+use p2panda_spaces::SpaceEvent;
 use serde::{Deserialize, Serialize};
+use tokio::time::sleep;
 use tokio_stream::StreamExt;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -29,6 +30,13 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create a space with only us inside.
     let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
+
+    // Panda receives a space created event for their own action.
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+            break;
+        };
+    }
 
     // We can manage (nested) groups (useful for multi-device, etc.)
     let penguin_laptop = p2panda::spawn().await?;
@@ -74,21 +82,35 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Panda receives the group.
-    while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Group(GroupEvent::Created { .. }) = event {
+    // @TODO: Switch to observing groups events when this is implemented.
+    loop {
+        let group = panda.group(penguin.id()).await?;
+        if group.is_some() {
             break;
-        };
+        }
+        sleep(Duration::from_secs(1)).await;
     }
 
     // Penguin mobile receives the group.
-    while let Some(event) = penguin_mobile_rx.next().await {
-        if let StreamEvent::Group(GroupEvent::Created { .. }) = event {
+    // @TODO: Switch to observing groups events when this is implemented.
+    loop {
+        let group = penguin_mobile.group(penguin.id()).await?;
+        if group.is_some() {
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    panda_space.add(penguin, AccessLevel::Read).await?;
+
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
+            assert_eq!(added.len(), 2);
+            assert!(added.contains(&penguin_laptop.id()));
+            assert!(added.contains(&penguin_mobile.id()));
             break;
         };
     }
-
-    let ready = panda_space.add(penguin, AccessLevel::Read).await?;
-    ready.await?;
 
     while let Some(event) = penguin_laptop_rx.next().await {
         if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
@@ -194,18 +216,32 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
         };
     }
 
-    // @TODO: Uncomment when own events are emitted on event stream.
-    // while let Some(event) = panda_rx.next().await {
-    //     if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
-    //         break;
-    //     };
-    // }
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+            break;
+        };
+    }
 
     // Panda adds penguin as a member of the space.
     //
     // They can do this because they received their key bundle by now.
-    let ready = panda_space.add(penguin.id(), AccessLevel::Read).await?;
-    assert!(ready.await.is_ok());
+    panda_space.add(penguin.id(), AccessLevel::Read).await?;
+
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
+            assert_eq!(added.len(), 1);
+            assert!(added.contains(&penguin.id()));
+            break;
+        };
+    }
+
+    while let Some(event) = penguin_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
+            assert_eq!(added.len(), 1);
+            assert!(added.contains(&penguin.id()));
+            break;
+        };
+    }
 
     // Panda publishes a message to all members.
     let message = SecretData {
@@ -267,7 +303,7 @@ async fn encode_decode() -> Result<(), Box<dyn std::error::Error>> {
     // Access the inner spaces manager so we can directly create and access an add message.
     let spaces_manager = panda.spaces_manager();
     let space = spaces_manager.space(space.id()).await?.unwrap();
-    let (_, _, _, space_message) = space.add(penguin.id(), Access::read()).await?;
+    let (_, _, _, space_message, _) = space.add(penguin.id(), Access::read()).await?;
 
     // Encode and decode the add operation.
     let operation = space_message.into_operation();
@@ -300,7 +336,7 @@ async fn sync_repair_space() -> Result<(), Box<dyn std::error::Error>> {
 
     // They then subscribe, as does panda.
     let (_penguin_space, mut penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
-    let (panda_space, _panda_rx) = panda.create_space::<SecretData>(topic).await?;
+    let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
 
     while let Some(event) = penguin_rx.next().await {
         if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
@@ -308,19 +344,52 @@ async fn sync_repair_space() -> Result<(), Box<dyn std::error::Error>> {
         };
     }
 
-    // @TODO: Uncomment when own events are emitted on event stream.
-    // while let Some(event) = panda_rx.next().await {
-    //     if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
-    //         break;
-    //     };
-    // }
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+            break;
+        };
+    }
+
+    // Panda materialized the group.
+    // @TODO: Switch to observing groups events when this is implemented.
+    loop {
+        let group = panda.group(penguin_group.id()).await?;
+        if group.is_some() {
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    // Penguin mobile materialized the group.
+    // @TODO: Switch to observing groups events when this is implemented.
+    loop {
+        let group = penguin.group(penguin_group.id()).await?;
+        if group.is_some() {
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
 
     // We expect panda to be able to add penguin group as a space member now.
-    let ready = panda_space
+    panda_space
         .add(penguin_group.id(), AccessLevel::Read)
         .await?;
 
-    assert!(ready.await.is_ok());
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
+            assert_eq!(added.len(), 1);
+            assert!(added.contains(&penguin.id()));
+            break;
+        };
+    }
+
+    while let Some(event) = penguin_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
+            assert_eq!(added.len(), 1);
+            assert!(added.contains(&penguin.id()));
+            break;
+        };
+    }
 
     Ok(())
 }
@@ -347,40 +416,46 @@ async fn live_repair_space() -> Result<(), Box<dyn std::error::Error>> {
         };
     }
 
-    // @TODO: Uncomment when own events are emitted on event stream.
-    // while let Some(event) = panda_rx.next().await {
-    //     if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
-    //         break;
-    //     };
-    // }
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+            break;
+        };
+    }
 
     // And then creates a group.
     let penguin_group = penguin
         .create_group(&[(penguin.id(), AccessLevel::Manage)])
         .await?;
 
+    // Panda materialized the group.
+    // @TODO: Switch to observing groups events when this is implemented.
+    loop {
+        let group = panda.group(penguin_group.id()).await?;
+        if group.is_some() {
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    // We expect panda to be able to add penguin group to the space.
+    panda_space
+        .add(penguin_group.id(), AccessLevel::Read)
+        .await?;
+
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Group(GroupEvent::Created { group_id, .. }) = event
-            && group_id == penguin_group.id()
-        {
+        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
+            assert_eq!(added.len(), 1);
+            assert!(added.contains(&penguin.id()));
             break;
         };
     }
 
-    // @TODO: Uncomment when own events are emitted on event stream.
-    // while let Some(event) = penguin_rx.next().await {
-    //     if let StreamEvent::Group(GroupEvent::Created { group_id, .. }) = event
-    //         && group_id == penguin_group.id()
-    //     {
-    //         break;
-    //     };
-    // }
-
-    // We expect panda to be able to add penguin group to the space.
-    let ready = panda_space
-        .add(penguin_group.id(), AccessLevel::Read)
-        .await?;
-    assert!(ready.await.is_ok());
-
+    while let Some(event) = penguin_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
+            assert_eq!(added.len(), 1);
+            assert!(added.contains(&penguin.id()));
+            break;
+        };
+    }
     Ok(())
 }


### PR DESCRIPTION
This PR corrects an issue where space membership changes resulting from calling API methods locally did not result in events being sent on the stream subscription stream. To fix this events are forwarded directly onto the stream in the node API when Node::create_space, Space::add or Space::remove are called.

The issue itself is a result of the fact that locally forged operations cannot be re-processed by the spaces manager without significant changes to the underlying p2panda-spaces APIs. This may rather signal that changes to the event sourcing design are required. Any more involved solution will be tackled in further follow-up tasks.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
