### PR TITLE
Filter application events authored by concurrently removed members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Highlights are marked with a pancake 🥞
 - stream: Hooks processor to register event callbacks in streaming pipeline [#1339](https://github.com/p2panda/p2panda/pull/1339)
 - spaces: Safe key bundle registration by cross-signing X3DH identity- and verifying-keys [#1332](https://github.com/p2panda/p2panda/pull/1332)
 - node: Membership change validation in Group API [#1336](https://github.com/p2panda/p2panda/pull/1336)
+- stream: Filter out spaces application messages from concurrently removed members [#1291](https://github.com/p2panda/p2panda/pull/1291)
 
 ### Changed
 

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -27,6 +27,12 @@ pub struct SpacesMessage<C> {
     pub args: SpacesArgs<C>,
 }
 
+impl<C> SpacesMessage<C> {
+    pub fn is_application_message(&self) -> bool {
+        matches!(self.args, SpacesArgs::Application { .. })
+    }
+}
+
 impl<C> Borrow<SpacesArgs<C>> for SpacesMessage<C> {
     fn borrow(&self) -> &SpacesArgs<C> {
         &self.args

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -28,6 +28,12 @@ pub struct SpacesMessage<C> {
     pub args: SpacesArgs<C>,
 }
 
+impl<C> SpacesMessage<C> {
+    pub fn is_application_message(&self) -> bool {
+        matches!(self.args, SpacesArgs::Application { .. })
+    }
+}
+
 impl<C> Borrow<SpacesArgs<C>> for SpacesMessage<C> {
     fn borrow(&self) -> &SpacesArgs<C> {
         &self.args

--- a/p2panda-stream/src/spaces/processor.rs
+++ b/p2panda-stream/src/spaces/processor.rs
@@ -66,7 +66,7 @@ where
 
         let result = if let SpacesProcessorArgs::Process { msg } = input_args {
             // Process incoming event.
-            let (groups_y, space_y, events) = match self.manager.process(msg).await {
+            let (groups_y, space_y, mut events) = match self.manager.process(msg).await {
                 Ok(result) => result,
                 Err(err) => return Err((input, SpacesError::SpacesManager(err.to_string()))),
             };
@@ -92,6 +92,29 @@ where
 
             if let Some(y) = space_y {
                 let space_id = y.space_id;
+
+                // Filter out application events from removed members who previously had write or
+                // manage access.
+                //
+                // Messages authored by removed members are still applied to the local state by
+                // this processor; all we are doing is ensuring that the application-related events
+                // are not forwarded up to the user.
+                //
+                // This check serves to catch any messages which were already being processed after
+                // a member lost their write or manage access.
+                if msg.is_application_message() {
+                    let mut is_member = false;
+
+                    for (member, access) in y.groups_y.members(y.group_id) {
+                        if member == msg.author && (access.is_write() || access.is_manage()) {
+                            is_member = true;
+                        }
+                    }
+
+                    if !is_member {
+                        events.retain(|event| !matches!(event, Event::Application { .. }));
+                    };
+                }
 
                 if let Err(err) = self
                     .store

--- a/p2panda-stream/src/spaces/processor.rs
+++ b/p2panda-stream/src/spaces/processor.rs
@@ -66,7 +66,7 @@ where
 
         let result = if let SpacesProcessorArgs::Process { msg } = input_args {
             // Process incoming event.
-            let (groups_y, space_y, events) = match self.manager.process(msg).await {
+            let (groups_y, space_y, mut events) = match self.manager.process(msg).await {
                 Ok(result) => result,
                 Err(err) => return Err((input, SpacesError::SpacesManager(err.to_string()))),
             };
@@ -92,6 +92,36 @@ where
 
             if let Some(y) = space_y {
                 let space_id = y.space_id;
+
+                // Filter out application events if the author has concurrently lost their write
+                // access.
+                //
+                // This case occurs if a member published messages before receiving the control
+                // message which removed them. Their claim to have access write is still
+                // historically valid, however we have already learned that they have actually
+                // been removed.
+                //
+                // NOTE: Application _and_ control messages are partially-ordered based on their
+                // causal relationships, application messages are always emitted together with the
+                // member's (create/add) welcome message. For that reason application messages
+                // from members which have been removed at a causally later point (not
+                // concurrently) will not be affected by this filter and are correctly forwarded
+                // to the application layer.
+                if msg.is_application_message() {
+                    let mut is_member = false;
+
+                    // Check if the message author is still a member of the group from our local
+                    // perspective.
+                    for (member, access) in y.groups_y.members(y.group_id) {
+                        if member == msg.author && (access.is_write() || access.is_manage()) {
+                            is_member = true;
+                        }
+                    }
+
+                    if !is_member {
+                        events.retain(|event| !matches!(event, Event::Application { .. }));
+                    };
+                }
 
                 if let Err(err) = self
                     .store

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -29,7 +29,7 @@ use crate::spaces::message::SpacesMessage;
 use crate::spaces::types::{AuthCapabilities, InnerSpace, InnerSpaceError, SpacesManagerError};
 use crate::spaces::{RepairError, RepairStrategy};
 use crate::streams::{
-    ImportError, LocalStreamFuture, StreamEvent, StreamPublisher, StreamSubscription,
+    CloseError, ImportError, LocalStreamFuture, StreamEvent, StreamPublisher, StreamSubscription,
     group_to_system_event, to_stream_event,
 };
 
@@ -318,6 +318,11 @@ where
                 .map(|(actor, access)| (*actor, access.level))
                 .collect()
         })
+    }
+
+    /// Gracefully close the space and any associated sync sessions.
+    pub async fn close(self) -> Result<(), CloseError> {
+        self.tx.close().await
     }
 
     /// Incorporate missing groups messages into the space, any resulting operations are

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -29,7 +29,7 @@ pub use event_stream::SystemEvent;
 pub(crate) use event_stream::event_stream;
 pub use external_stream::ExternalStreamFuture;
 pub(crate) use local_stream::LocalStreamFuture;
-pub use publisher::{ImportError, PublishError, PublishFuture, StreamPublisher};
+pub use publisher::{CloseError, ImportError, PublishError, PublishFuture, StreamPublisher};
 pub use replay::{ReplayError, StreamFrom};
 pub use stream::{ForwardEvent, ProcessedOperation, Source, StreamEvent};
 pub(crate) use stream::{group_to_system_event, processed_stream, to_stream_event};

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -384,3 +384,104 @@ async fn live_repair_space() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn application_messages_from_removed_members_are_filtered()
+-> Result<(), Box<dyn std::error::Error>> {
+    // Panda creates a space and Penguin joins it.
+    // Panda adds Penguin to the space.
+    // Penguin publishes a message into the space; Panda receives it.
+    // Panda removes Penguin from the space.
+    // Penguin publishes a second message into the space.
+    // Panda receives stream events related to the removal of Penguin but does _not_ receive an
+    // application message on the events stream.
+
+    setup_logging();
+
+    use p2panda::Topic;
+    use p2panda_auth::AccessLevel;
+
+    let topic = Topic::random();
+
+    let panda = p2panda::spawn().await?;
+    let penguin = p2panda::spawn().await?;
+
+    // Penguin subscribes to the space.
+    let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
+    let (penguin_space, mut penguin_rx) = penguin.space::<SecretData>(topic).await?;
+
+    while let Some(event) = penguin_rx.next().await {
+        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+            break;
+        };
+    }
+
+    // Panda adds Penguin as a member of the space.
+    //
+    // They can do this because they received their key bundle by now.
+    let ready = panda_space.add(penguin.id(), AccessLevel::Write).await?;
+    assert!(ready.await.is_ok());
+
+    // Penguin publishes a message to all members.
+    let message = SecretData {
+        title: "My favorite things".to_string(),
+        content: "Hello, everyone!".to_string(),
+    };
+
+    let ready = penguin_space.publish(message.clone()).await?;
+    assert!(ready.await.is_ok());
+
+    // Panda receives the message from Penguin.
+    loop {
+        let Some(event) = panda_rx.next().await else {
+            panic!("unexpected stream closure");
+        };
+        let StreamEvent::Processed { operation, .. } = event else {
+            continue;
+        };
+        assert_eq!(&message, operation.message());
+        break;
+    }
+
+    // Panda removes Penguin.
+    let ready = panda_space.remove(penguin.id()).await?;
+    assert!(ready.await.is_ok());
+
+    // Penguin publishes a second message to all members.
+    let message = SecretData {
+        title: "Hurtful words".to_string(),
+        content: "Panda can't jump very high".to_string(),
+    };
+
+    let ready = penguin_space.publish(message.clone()).await?;
+    assert!(ready.await.is_ok());
+
+    let mut import_started = false;
+    let mut group_removed = false;
+    let mut import_ended = false;
+
+    // Panda receives the second message from penguin.
+    //
+    // Since Panda has removed Penguin, we do not expect `StreamEvent::Processed` to be emitted.
+    loop {
+        let Some(event) = panda_rx.next().await else {
+            panic!("unexpected stream closure");
+        };
+
+        match event {
+            StreamEvent::ImportStarted { .. } => import_started = true,
+            StreamEvent::ImportEnded { .. } => import_ended = true,
+            StreamEvent::Group(GroupEvent::Removed { .. }) => group_removed = true,
+            StreamEvent::Processed { .. } => {
+                panic!("unexpected application message after member removal")
+            }
+            _ => (),
+        }
+
+        if import_started && group_removed && import_ended {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -3,6 +3,7 @@
 use core::panic;
 use std::assert_matches;
 use std::collections::HashSet;
+use std::time::Duration;
 
 use p2panda::Topic;
 use p2panda::spaces::{
@@ -892,4 +893,220 @@ async fn group_events() {
             break;
         };
     }
+}
+
+#[tokio::test]
+async fn application_messages_from_concurrently_removed_members_filtered()
+-> Result<(), Box<dyn std::error::Error>> {
+    setup_logging();
+
+    use p2panda::Topic;
+    use p2panda_auth::AccessLevel;
+
+    let topic = Topic::random();
+
+    let panda = p2panda::spawn().await?;
+    let penguin = p2panda::spawn().await?;
+
+    // Panda creates a space.
+    let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
+
+    // Penguin subscribes to the space.
+    let (penguin_space, mut penguin_rx) = penguin.space::<SecretData>(topic).await?;
+
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Member(member) = event {
+            if member == penguin.id() {
+                break;
+            }
+        };
+    }
+
+    // Panda adds Penguin as a member of the space.
+    panda_space.add(penguin.id(), AccessLevel::Write).await?;
+
+    while let Some(event) = penguin_rx.next().await {
+        let StreamEvent::Space { members, .. } = event else {
+            continue;
+        };
+
+        if members.iter().any(|(member, _)| *member == penguin.id()) {
+            break;
+        }
+    }
+
+    // Penguin publishes a message to all members.
+    let message = SecretData {
+        title: "My favorite things".to_string(),
+        content: "Hello, everyone!".to_string(),
+    };
+
+    let ready = penguin_space.publish(message.clone()).await?;
+    assert!(ready.await.is_ok());
+
+    // Panda receives the message from Penguin.
+    loop {
+        let Some(event) = panda_rx.next().await else {
+            panic!("unexpected stream closure");
+        };
+        let StreamEvent::Processed { operation, .. } = event else {
+            continue;
+        };
+        assert_eq!(&message, operation.message());
+        break;
+    }
+
+    let penguin_id = penguin.id();
+
+    // Penguin unsubscribes from the space.
+    penguin_space.close().await?;
+
+    // Panda removes Penguin.
+    panda_space
+        .remove(penguin_id)
+        .await
+        .expect("panda removes penguin");
+
+    // Penguin subscribes to the space again and immediately publishes a new message, before they
+    // had time to sync panda's remove message.
+    let (penguin_space, _penguin_rx) = penguin.space::<SecretData>(topic).await?;
+
+    let message = SecretData {
+        title: "Hurtful words".to_string(),
+        content: "Panda can't jump very high".to_string(),
+    };
+
+    let ready = penguin_space
+        .publish(message.clone())
+        .await
+        .expect("can publish message to group");
+    assert!(ready.await.is_ok());
+
+    // Panda will receive the second message from penguin, however it will not be forwarded to the
+    // app layer as they know penguin has been removed (concurrent to the application message
+    // being published).
+    let mut penguin_removed = false;
+    let mut penguin_message_filtered = true;
+    let sleep = tokio::time::sleep(Duration::from_secs(3));
+    tokio::pin!(sleep);
+
+    loop {
+        tokio::select! {
+            event = panda_rx.next() => {
+                match event {
+                    Some(StreamEvent::Space {
+                        inner: SpaceEvent::Removed { .. },
+                        ..
+                    }) => penguin_removed = true,
+                    Some(StreamEvent::Processed { .. }) => penguin_message_filtered = false,
+                    None => panic!("unexpected stream closure"),
+                    _ => (),
+                }
+            }
+            _ = &mut sleep => {
+                break;
+            }
+        }
+    }
+
+    assert!(penguin_removed);
+    assert!(penguin_message_filtered);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn application_messages_from_causally_later_removed_members_not_filtered()
+-> Result<(), Box<dyn std::error::Error>> {
+    setup_logging();
+
+    use p2panda::Topic;
+    use p2panda_auth::AccessLevel;
+
+    let topic = Topic::random();
+
+    let panda = p2panda::spawn().await?;
+    let penguin = p2panda::spawn().await?;
+    let tiger = p2panda::spawn().await?;
+
+    // Panda creates a space.
+    let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
+
+    // Penguin subscribes to the space.
+    let (penguin_space, mut penguin_rx) = penguin.space::<SecretData>(topic).await?;
+
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Member(member) = event {
+            if member == penguin.id() {
+                break;
+            }
+        };
+    }
+
+    // Panda adds Penguin as a member of the space.
+    panda_space.add(penguin.id(), AccessLevel::Write).await?;
+
+    while let Some(event) = penguin_rx.next().await {
+        let StreamEvent::Space { members, .. } = event else {
+            continue;
+        };
+
+        if members.iter().any(|(member, _)| *member == penguin.id()) {
+            break;
+        }
+    }
+
+    // Penguin publishes a message to all members.
+    let message = SecretData {
+        title: "My favorite things".to_string(),
+        content: "Hello, everyone!".to_string(),
+    };
+
+    let ready = penguin_space.publish(message.clone()).await?;
+    assert!(ready.await.is_ok());
+
+    // Panda receives the message from Penguin.
+    loop {
+        let Some(event) = panda_rx.next().await else {
+            panic!("unexpected stream closure");
+        };
+        let StreamEvent::Processed { operation, .. } = event else {
+            continue;
+        };
+        assert_eq!(&message, operation.message());
+        break;
+    }
+
+    // Panda removes Penguin.
+    panda_space.remove(penguin.id()).await?;
+
+    // Tiger subscribes to the space.
+    let (_tiger_space, mut tiger_rx) = tiger.space::<SecretData>(topic).await?;
+
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Member(member) = event {
+            if member == tiger.id() {
+                break;
+            }
+        };
+    }
+
+    // Panda adds Tiger as a member of the space.
+    panda_space.add(tiger.id(), AccessLevel::Read).await?;
+
+    // Tiger receives the message from Penguin even though they have since been removed.
+    loop {
+        let Some(event) = tiger_rx.next().await else {
+            panic!("unexpected stream closure");
+        };
+
+        let StreamEvent::Processed { operation, .. } = event else {
+            continue;
+        };
+
+        assert_eq!(&message, operation.message());
+        break;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Here we modify the spaces processor to ensure that application-related
events authored by concurrently removed members are not forwarded to the
user.

Concretely, the flow which is addressed is as follows:

- Alice removes Bob from Space A
- Bob publishes a message to the Space A <-- concurrent to the remove
- Claire receives the remove and correctly removes Bob as a member of Space A
- Claire receives Bob's message, by looking at the "claimed" proof/dependencies Bob is authorized, but we know that they have been concurrently removed by Alice

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
