### PR TITLE
Do not require pre-key bundle when initialising TwoParty state as a recipient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
+### Fixed
+
+- encryption: Do not require pre-key bundle when initialising TwoParty state as a recipient [#1297](https://github.com/p2panda/p2panda/pull/1297)
+
 ## [0.7.0] - 07/07/2026
 
 ### Added

--- a/fuzz/fuzz_targets/groups_2sm.rs
+++ b/fuzz/fuzz_targets/groups_2sm.rs
@@ -53,8 +53,8 @@ fuzz_target!(|args: ([u8; 32], &[u8])| {
 
     // Alice and Bob set up the 2SM protocol handlers for each other.
 
-    let mut alice_2sm = OneTimeTwoParty::init(bob_prekey_bundle.clone());
-    let mut bob_2sm = OneTimeTwoParty::init(alice_prekey_bundle.clone());
+    let mut alice_2sm = OneTimeTwoParty::init_to_send(bob_prekey_bundle.clone());
+    let mut bob_2sm = OneTimeTwoParty::init_to_send(alice_prekey_bundle.clone());
 
     let mut to_alice_inbox = VecDeque::<Message>::with_capacity(INBOX_CAPACITY);
     let mut to_bob_inbox = VecDeque::<Message>::with_capacity(INBOX_CAPACITY);

--- a/p2panda-encryption/src/data_scheme/dcgka.rs
+++ b/p2panda-encryption/src/data_scheme/dcgka.rs
@@ -423,7 +423,7 @@ where
                     .map_err(|err| DcgkaError::PreKeyRegistry(err))?;
                 y.pki = pki_i;
                 let prekey_bundle = prekey_bundle.ok_or(DcgkaError::MissingPreKeys(*recipient))?;
-                TwoParty::<KMG, LongTermKeyBundle>::init(prekey_bundle)
+                TwoParty::<KMG, LongTermKeyBundle>::init_to_send(prekey_bundle)
             }
         };
         let (y_2sm_i, ciphertext) =
@@ -442,13 +442,7 @@ where
     ) -> DcgkaResult<ID, OP, PKI, DGM, KMG, Vec<u8>> {
         let y_2sm = match y.two_party.remove(sender) {
             Some(y_2sm) => y_2sm,
-            None => {
-                let (pki_i, prekey_bundle) = PKI::key_bundle(y.pki, sender)
-                    .map_err(|err| DcgkaError::PreKeyRegistry(err))?;
-                y.pki = pki_i;
-                let prekey_bundle = prekey_bundle.ok_or(DcgkaError::MissingPreKeys(*sender))?;
-                TwoParty::<KMG, LongTermKeyBundle>::init(prekey_bundle)
-            }
+            None => TwoParty::<KMG, LongTermKeyBundle>::init_to_receive(),
         };
         let (y_2sm_i, y_my_keys_i, plaintext) =
             TwoParty::<KMG, LongTermKeyBundle>::receive(y_2sm, y.my_keys, ciphertext)?;

--- a/p2panda-encryption/src/data_scheme/tests.rs
+++ b/p2panda-encryption/src/data_scheme/tests.rs
@@ -515,3 +515,147 @@ fn not_required_key_bundle_on_process_create() {
     assert_eq!(alice_group_secret_0, bob_group_secret_0);
     assert_eq!(alice_bundle, bob_bundle);
 }
+
+#[test]
+fn not_required_key_bundle_on_process_add() {
+    let rng = Rng::from_seed([1; 32]);
+
+    let alice = 0;
+    let bob = 1;
+
+    // Alice initialises their key material.
+
+    let alice_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
+
+    let alice_dgm = TestDgm::init(alice);
+    let alice_pki = KeyRegistry::init();
+    let alice_keys =
+        KeyManager::init_and_generate_prekey(&alice_identity_secret, Lifetime::default(), &rng)
+            .unwrap();
+
+    let alice_prekeys = KeyManager::prekey_bundle(&alice_keys).unwrap();
+
+    // Bob initialises their key material.
+
+    let bob_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
+
+    let bob_dgm = TestDgm::init(bob);
+    let bob_pki = KeyRegistry::init();
+    let bob_keys =
+        KeyManager::init_and_generate_prekey(&bob_identity_secret, Lifetime::default(), &rng)
+            .unwrap();
+
+    let bob_prekeys = KeyManager::prekey_bundle(&bob_keys).unwrap();
+
+    // Register key bundles.
+
+    // Alice registers their own and Bob's pre-key bundles.
+    let alice_pki = KeyRegistry::add_longterm_bundle(alice_pki, alice, alice_prekeys).unwrap();
+    let alice_pki = KeyRegistry::add_longterm_bundle(alice_pki, bob, bob_prekeys.clone()).unwrap();
+
+    // Bob registers their own, but not Alice's pre-key bundle.
+    let bob_pki = KeyRegistry::add_longterm_bundle(bob_pki, bob, bob_prekeys).unwrap();
+
+    // Initialise DCGKA states.
+
+    let alice_bundle = SecretBundle::init();
+    let alice_dcgka: TestDcgkaState = Dcgka::init(alice, alice_keys, alice_pki, alice_dgm);
+
+    let bob_bundle = SecretBundle::init();
+    let bob_dcgka: TestDcgkaState = Dcgka::init(bob, bob_keys, bob_pki, bob_dgm);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Alice creates a group
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    let alice_group_secret_0 = SecretBundle::generate(&alice_bundle, &rng).unwrap();
+    let (alice_dcgka, output) =
+        Dcgka::create(alice_dcgka, vec![alice], &alice_group_secret_0, &rng).unwrap();
+    let (alice_dcgka, _) = Dcgka::process(
+        alice_dcgka,
+        ProcessInput {
+            seq: MessageId {
+                sender: alice,
+                seq: 0,
+            },
+            sender: alice,
+            control_message: output.control_message.clone(),
+            direct_message: None,
+        },
+    )
+    .unwrap();
+    let alice_bundle = SecretBundle::insert(alice_bundle, alice_group_secret_0.clone());
+    assert_eq!(alice_bundle.len(), 1);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Bob processes Alice's "create" message
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    assert_eq!(output.control_message.to_string(), "create");
+
+    let (bob_dcgka, _output) = Dcgka::process(
+        bob_dcgka,
+        ProcessInput {
+            seq: MessageId {
+                sender: alice,
+                seq: 0,
+            },
+            sender: alice,
+            control_message: output.control_message.clone(),
+            direct_message: None,
+        },
+    )
+    .unwrap();
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Alice adds Bob to the group
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    let _ = SecretBundle::generate(&alice_bundle, &rng).unwrap();
+    let (alice_dcgka, output) = Dcgka::add(alice_dcgka, bob, &alice_bundle, &rng).unwrap();
+    let (_alice_dcgka, _) = Dcgka::process(
+        alice_dcgka,
+        ProcessInput {
+            seq: MessageId {
+                sender: alice,
+                seq: 1,
+            },
+            sender: alice,
+            control_message: output.control_message.clone(),
+            direct_message: None,
+        },
+    )
+    .unwrap();
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Bob processes Alice's "add" message
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    assert_eq!(output.control_message.to_string(), "add");
+
+    let direct_message = output
+        .direct_messages
+        .into_iter()
+        .find(|dm| dm.recipient == bob)
+        .expect("direct message for bob");
+
+    let (_bob_dcgka, output) = Dcgka::process(
+        bob_dcgka,
+        ProcessInput {
+            seq: MessageId {
+                sender: alice,
+                seq: 1,
+            },
+            sender: alice,
+            control_message: output.control_message.clone(),
+            direct_message: Some(direct_message),
+        },
+    )
+    .unwrap();
+
+    let GroupSecretOutput::Bundle(bob_secret_bundle_0) = output else {
+        panic!("expected group secret bundle");
+    };
+    let bob_bundle = SecretBundle::extend(bob_bundle, bob_secret_bundle_0.clone());
+    assert_eq!(bob_bundle.len(), 1);
+}

--- a/p2panda-encryption/src/data_scheme/tests.rs
+++ b/p2panda-encryption/src/data_scheme/tests.rs
@@ -407,3 +407,111 @@ fn group_operations() {
     assert_ne!(alice_bundle.latest(), bob_bundle.latest());
     assert_ne!(alice_bundle.latest(), charlie_bundle.latest());
 }
+
+#[test]
+fn not_required_key_bundle_on_process_create() {
+    let rng = Rng::from_seed([1; 32]);
+
+    let alice = 0;
+    let bob = 1;
+
+    // Alice initialises their key material.
+
+    let alice_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
+
+    let alice_dgm = TestDgm::init(alice);
+    let alice_pki = KeyRegistry::init();
+    let alice_keys =
+        KeyManager::init_and_generate_prekey(&alice_identity_secret, Lifetime::default(), &rng)
+            .unwrap();
+
+    let alice_prekeys = KeyManager::prekey_bundle(&alice_keys).unwrap();
+
+    // Bob initialises their key material.
+
+    let bob_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
+
+    let bob_dgm = TestDgm::init(bob);
+    let bob_pki = KeyRegistry::init();
+    let bob_keys =
+        KeyManager::init_and_generate_prekey(&bob_identity_secret, Lifetime::default(), &rng)
+            .unwrap();
+
+    let bob_prekeys = KeyManager::prekey_bundle(&bob_keys).unwrap();
+
+    // Register key bundles.
+
+    // Alice registers their own and Bob's pre-key bundles.
+    let alice_pki = KeyRegistry::add_longterm_bundle(alice_pki, alice, alice_prekeys).unwrap();
+    let alice_pki = KeyRegistry::add_longterm_bundle(alice_pki, bob, bob_prekeys.clone()).unwrap();
+
+    // Bob registers their own, but not Alice's pre-key bundle.
+    let bob_pki = KeyRegistry::add_longterm_bundle(bob_pki, bob, bob_prekeys).unwrap();
+
+    // Initialise DCGKA states.
+
+    let alice_bundle = SecretBundle::init();
+    let alice_dcgka: TestDcgkaState = Dcgka::init(alice, alice_keys, alice_pki, alice_dgm);
+
+    let bob_bundle = SecretBundle::init();
+    let bob_dcgka: TestDcgkaState = Dcgka::init(bob, bob_keys, bob_pki, bob_dgm);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Alice creates a group with Bob
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    let alice_group_secret_0 = SecretBundle::generate(&alice_bundle, &rng).unwrap();
+    let (alice_dcgka, output) =
+        Dcgka::create(alice_dcgka, vec![alice, bob], &alice_group_secret_0, &rng).unwrap();
+    let (_alice_dcgka, _) = Dcgka::process(
+        alice_dcgka,
+        ProcessInput {
+            seq: MessageId {
+                sender: alice,
+                seq: 0,
+            },
+            sender: alice,
+            control_message: output.control_message.clone(),
+            direct_message: None,
+        },
+    )
+    .unwrap();
+    let alice_bundle = SecretBundle::insert(alice_bundle, alice_group_secret_0.clone());
+    assert_eq!(alice_bundle.len(), 1);
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Bob processes Alice's "create" message
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    assert_eq!(output.control_message.to_string(), "create");
+
+    let direct_message = output
+        .direct_messages
+        .into_iter()
+        .find(|dm| dm.recipient == bob)
+        .expect("direct message for bob");
+
+    let (_bob_dcgka, output) = Dcgka::process(
+        bob_dcgka,
+        ProcessInput {
+            seq: MessageId {
+                sender: alice,
+                seq: 0,
+            },
+            sender: alice,
+            control_message: output.control_message.clone(),
+            direct_message: Some(direct_message),
+        },
+    )
+    .unwrap();
+
+    let GroupSecretOutput::Secret(bob_group_secret_0) = output else {
+        panic!("expected group secret");
+    };
+    let bob_bundle = SecretBundle::insert(bob_bundle, bob_group_secret_0.clone());
+    assert_eq!(bob_bundle.len(), 1);
+
+    // Alice and bob share the same group secret.
+    assert_eq!(alice_group_secret_0, bob_group_secret_0);
+    assert_eq!(alice_bundle, bob_bundle);
+}

--- a/p2panda-encryption/src/message_scheme/dcgka.rs
+++ b/p2panda-encryption/src/message_scheme/dcgka.rs
@@ -1111,7 +1111,7 @@ where
                     .map_err(|err| DcgkaError::PreKeyRegistry(err))?;
                 y.pki = pki_i;
                 let prekey_bundle = prekey_bundle.ok_or(DcgkaError::MissingPreKeys(*recipient))?;
-                TwoParty::<KMG, OneTimeKeyBundle>::init(prekey_bundle)
+                TwoParty::<KMG, OneTimeKeyBundle>::init_to_send(prekey_bundle)
             }
         };
         let (y_2sm_i, ciphertext) =
@@ -1135,7 +1135,7 @@ where
                     .map_err(|err| DcgkaError::PreKeyRegistry(err))?;
                 y.pki = pki_i;
                 let prekey_bundle = prekey_bundle.ok_or(DcgkaError::MissingPreKeys(*sender))?;
-                TwoParty::<KMG, OneTimeKeyBundle>::init(prekey_bundle)
+                TwoParty::<KMG, OneTimeKeyBundle>::init_to_send(prekey_bundle)
             }
         };
         let (y_2sm_i, y_my_keys_i, plaintext) =

--- a/p2panda-encryption/src/two_party/two_party.rs
+++ b/p2panda-encryption/src/two_party/two_party.rs
@@ -108,9 +108,6 @@ pub struct TwoPartyState<KB: KeyBundle> {
     /// Which key we use to decrypt the next incoming message.
     their_next_key_used: KeyUsed,
 
-    /// Public identity key of the other peer. We use it to verify the signature of their prekey.
-    their_identity_key: PublicKey,
-
     /// Key-material we need to encrypt the first message with the help of X3DH and prekeys.
     their_prekey_bundle: Option<KB>,
 
@@ -125,17 +122,30 @@ where
     KMG: IdentityManager<KMG::State> + PreKeyManager,
     KB: KeyBundle,
 {
-    /// Initialise new 2SM state using the other party's pre-key bundle.
-    pub fn init(their_prekey_bundle: KB) -> TwoPartyState<KB> {
+    /// Initialise new 2SM state to send a message to this receiver for the first time using the
+    /// other party's pre-key bundle.
+    pub fn init_to_send(their_prekey_bundle: KB) -> TwoPartyState<KB> {
         TwoPartyState {
             our_next_key_index: 1,
             our_min_key_index: 1,
             our_secret_keys: HashMap::new(),
             our_received_secret_key: None,
-            their_identity_key: *their_prekey_bundle.identity_key(),
             their_verifying_key: None,
             their_next_key_used: KeyUsed::PreKey,
             their_prekey_bundle: Some(their_prekey_bundle),
+        }
+    }
+
+    /// Initialise new 2SM state to receive a message from any sender for the first time.
+    pub fn init_to_receive() -> TwoPartyState<KB> {
+        TwoPartyState {
+            our_next_key_index: 1,
+            our_min_key_index: 1,
+            our_secret_keys: HashMap::new(),
+            our_received_secret_key: None,
+            their_verifying_key: None,
+            their_next_key_used: KeyUsed::PreKey,
+            their_prekey_bundle: None,
         }
     }
 
@@ -455,9 +465,6 @@ mod tests {
             KeyManager::init_and_generate_prekey(&alice_identity_secret, Lifetime::default(), &rng)
                 .unwrap();
 
-        let (alice_manager, alice_prekey_bundle) =
-            KeyManager::generate_onetime_bundle(alice_manager, &rng).unwrap();
-
         // Bob generates their key material.
 
         let bob_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
@@ -470,7 +477,7 @@ mod tests {
 
         // Alice and Bob set up the 2SM protocol handlers for each other.
 
-        let alice_2sm = OneTimeTwoParty::init(bob_prekey_bundle);
+        let alice_2sm = OneTimeTwoParty::init_to_send(bob_prekey_bundle);
 
         // Alice doesn't have any secret HPKE keys yet and will use Bob's pre-keys for X3DH.
         assert_eq!(alice_2sm.our_secret_keys.len(), 0);
@@ -478,9 +485,9 @@ mod tests {
         assert_eq!(alice_2sm.our_next_key_index, 1);
         assert_eq!(alice_2sm.their_next_key_used, KeyUsed::PreKey);
 
-        let bob_2sm = OneTimeTwoParty::init(alice_prekey_bundle);
+        let bob_2sm = OneTimeTwoParty::init_to_receive();
 
-        // Bob doesn't have any secret HPKE keys yet and will use Alice's pre-keys for X3DH.
+        // Bob doesn't have any secret HPKE keys yet and will wait for Alice reaching out.
         assert_eq!(bob_2sm.our_secret_keys.len(), 0);
         assert_eq!(bob_2sm.our_min_key_index, 1);
         assert_eq!(bob_2sm.our_next_key_index, 1);
@@ -538,8 +545,8 @@ mod tests {
         // Bob would use Alice's new secret key for decrypting future messages.
         assert_eq!(bob_2sm.their_next_key_used, KeyUsed::OwnKey(1));
 
-        // Bob still has Alice's pre-key bundle.
-        assert!(bob_2sm.their_prekey_bundle.is_some());
+        // Bob still doesn't have Alice's pre-key bundle.
+        assert!(bob_2sm.their_prekey_bundle.is_none());
 
         // 3. Alice sends another message to Bob and they receive it.
         let (alice_2sm, message_2) =
@@ -644,8 +651,6 @@ mod tests {
             KeyManager::init_and_generate_prekey(&alice_identity_secret, Lifetime::default(), &rng)
                 .unwrap();
 
-        let alice_prekey_bundle = KeyManager::prekey_bundle(&alice_manager).unwrap();
-
         // Bob generates their long-term key material.
 
         let bob_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
@@ -657,8 +662,8 @@ mod tests {
 
         // Alice and Bob set up the 2SM protocol handlers for each other.
 
-        let alice_2sm_a = LongTermTwoParty::init(bob_prekey_bundle.clone());
-        let bob_2sm_a = LongTermTwoParty::init(alice_prekey_bundle.clone());
+        let alice_2sm_a = LongTermTwoParty::init_to_send(bob_prekey_bundle.clone());
+        let bob_2sm_a = LongTermTwoParty::init_to_receive();
 
         // They start exchanging "secret messages" to each other in Group A.
 
@@ -681,8 +686,8 @@ mod tests {
 
         // Sometime later they start another group B with the same long-term pre-keys.
 
-        let alice_2sm_b = LongTermTwoParty::init(bob_prekey_bundle);
-        let bob_2sm_b = LongTermTwoParty::init(alice_prekey_bundle);
+        let alice_2sm_b = LongTermTwoParty::init_to_send(bob_prekey_bundle);
+        let bob_2sm_b = LongTermTwoParty::init_to_receive();
 
         // They start exchanging "secret messages" to each other.
 
@@ -720,9 +725,6 @@ mod tests {
             KeyManager::init_and_generate_prekey(&alice_identity_secret, Lifetime::default(), &rng)
                 .unwrap();
 
-        let (alice_manager, alice_prekey_bundle) =
-            KeyManager::generate_onetime_bundle(alice_manager, &rng).unwrap();
-
         // Bob generates their key material.
 
         let bob_identity_secret = SecretKey::from_bytes(rng.random_array().unwrap());
@@ -735,8 +737,8 @@ mod tests {
 
         // Alice and Bob set up the 2SM protocol handlers for each other.
 
-        let alice_2sm = OneTimeTwoParty::init(bob_prekey_bundle);
-        let bob_2sm = OneTimeTwoParty::init(alice_prekey_bundle);
+        let alice_2sm = OneTimeTwoParty::init_to_send(bob_prekey_bundle);
+        let bob_2sm = OneTimeTwoParty::init_to_receive();
 
         // Alice sends a message to Bob.
 


### PR DESCRIPTION
When a TwoParty state gets initialised for the first time it depends if the peer is in a sender or recipient role.

If we are in a sender role we need the pre-key bundle of the recipient, if we are in a recipient role we don't need anything.

Unfortunately this was not reflected in the code and if a recipient didn't have the key bundle of the sender it wrongly thrown an error. This patch fixes this issue and introduces two distinct initialisation methods for the TwoParty state, one for each role.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
