### PR TITLE
Support partial merge of groups graph into space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Highlights are marked with a pancake 🥞
 - spaces: Compute and return events from local methods [#1290](https://github.com/p2panda/p2panda/pull/1290)
 - node: Forward events resulting from local actions to app layer [#1290](https://github.com/p2panda/p2panda/pull/1290)
 - node: Cancel processed stream tasks on drop of stream handles [#1300](https://github.com/p2panda/p2panda/pull/1300)
+- spaces: Support partial merge of auth state into a space [#1299](https://github.com/p2panda/p2panda/pull/1299)
 
 ### Changed
 

--- a/fuzz/fuzz_targets/auth_group.rs
+++ b/fuzz/fuzz_targets/auth_group.rs
@@ -34,8 +34,11 @@ const ROOT_GROUP_ID: char = '0';
 /// Max number of "rounds" in which members can publish operations.
 const MAX_ACTION_ROUNDS: usize = 6;
 
+/// Min operations per actor, per round.
+const MIN_ACTOR_OPERATIONS_PER_ROUND: u8 = 2;
+
 /// Max operations per actor, per round.
-const MAX_ACTOR_OPERATIONS_PER_ROUND: u8 = 6;
+const MAX_ACTOR_OPERATIONS_PER_ROUND: u8 = 8;
 
 /// Max concurrent branches.
 const MAX_BRANCHES: u8 = 6;
@@ -241,7 +244,8 @@ impl Member {
             initial_members: initial_members.clone(),
         };
 
-        let dependencies = self.groups_y.inner.heads();
+        let include = action.required_groups();
+        let dependencies = self.groups_y.inner.heads(&include);
         let operation = TestOperation {
             id: rand::random(),
             author: self.id(),
@@ -251,8 +255,13 @@ impl Member {
         };
 
         self.groups_y = TestGroup::process(self.groups_y.clone(), &operation).unwrap();
-        self.auth_heads_ref
-            .replace(self.groups_y.inner.heads().into_iter().collect());
+        self.auth_heads_ref.replace(
+            self.groups_y
+                .inner
+                .heads(&operation.required_groups())
+                .into_iter()
+                .collect(),
+        );
 
         let suggestion = Suggestion::Valid(TestGroupAction::Action(GroupAction::Create {
             initial_members,
@@ -308,7 +317,10 @@ impl Member {
         let result = match action {
             TestGroupAction::Noop => Ok(None),
             TestGroupAction::Action(action) => {
-                let dependencies = self.groups_y.inner.heads();
+                let mut include = action.required_groups();
+                include.push(group_id);
+
+                let dependencies = self.groups_y.inner.heads(&include);
                 let operation = TestOperation {
                     id: rand::random(),
                     author: self.id(),
@@ -333,7 +345,7 @@ impl Member {
                 };
                 self.groups_y = groups_y_i;
                 self.auth_heads_ref
-                    .replace(self.groups_y.inner.heads().into_iter().collect());
+                    .replace(self.groups_y.inner.heads(&include).into_iter().collect());
 
                 Ok(Some(operation))
             }
@@ -393,8 +405,13 @@ impl Member {
                 }
             }
         };
-        self.auth_heads_ref
-            .replace(self.groups_y.inner.heads().into_iter().collect());
+        self.auth_heads_ref.replace(
+            self.groups_y
+                .inner
+                .heads(&operation.required_groups())
+                .into_iter()
+                .collect(),
+        );
 
         self.processed.push(operation.id());
 
@@ -711,7 +728,11 @@ fuzz_target!(|seed: [u8; 32]| {
 
         // Each member suggests a next operations and pushes them to the global partition queue.
         for partition_members in partition_map.values() {
-            for _ in 0..random_range(1, MAX_ACTOR_OPERATIONS_PER_ROUND, &mut rng) {
+            for _ in 0..random_range(
+                MIN_ACTOR_OPERATIONS_PER_ROUND,
+                MAX_ACTOR_OPERATIONS_PER_ROUND,
+                &mut rng,
+            ) {
                 for partition_member in partition_members {
                     let (suggestion, group_id) = {
                         let member = members.get(partition_member).unwrap();

--- a/p2panda-auth/src/group/action.rs
+++ b/p2panda-auth/src/group/action.rs
@@ -38,4 +38,27 @@ where
     pub fn is_create(&self) -> bool {
         matches!(self, GroupAction::Create { .. })
     }
+
+    /// Returns groups which are dependant on being able to process this action.
+    ///
+    /// This calculation looks into the members being added / removed by the action and returns
+    /// only the members which are groups.
+    pub fn required_groups(&self) -> Vec<ID> {
+        let members = match self {
+            GroupAction::Create { initial_members } => {
+                initial_members.iter().map(|(member, _)| member).collect()
+            }
+            GroupAction::Add { member, .. }
+            | GroupAction::Remove { member }
+            | GroupAction::Promote { member, .. }
+            | GroupAction::Demote { member, .. } => vec![member],
+        };
+        members
+            .iter()
+            .filter_map(|member| match member {
+                crate::group::GroupMember::Individual(_) => None,
+                crate::group::GroupMember::Group(id) => Some(*id),
+            })
+            .collect::<Vec<_>>()
+    }
 }

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -6,8 +6,9 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
+use petgraph::algo::toposort;
 use petgraph::prelude::DiGraphMap;
-use petgraph::visit::{Bfs, DfsPostOrder, IntoNodeIdentifiers, NodeIndexable, Reversed};
+use petgraph::visit::{DfsPostOrder, IntoNodeIdentifiers, NodeIndexable, Reversed};
 #[cfg(any(test, feature = "serde"))]
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -46,6 +47,9 @@ where
     #[error("missing dependency {0} for operation {1}")]
     MissingDependencies(OP, OP),
 
+    #[error("non-create operation received for unknown group: {0}")]
+    UnknownGroup(ID),
+
     #[error("group cycle detected adding {0} to {1} operation={2}")]
     GroupCycle(ID, ID, OP),
 
@@ -63,6 +67,9 @@ pub(crate) type GroupStates<ID, C> = HashMap<ID, GroupMembersState<GroupMember<I
 
 /// Inner state object for `GroupCrdt` which contains the actual groups state,
 /// including operation graph and membership snapshots.
+///
+/// @TODO: We no longer need a separation between the inner and outer state objects, they can be
+/// merged into one.
 #[derive(Clone, Debug)]
 #[cfg_attr(any(test, feature = "serde"), derive(Deserialize, Serialize))]
 pub struct GroupCrdtInnerState<ID, OP, M, C>
@@ -109,8 +116,8 @@ where
     M: Operation<ID, OP, C>,
     C: Conditions,
 {
-    /// Current tips for the groups operation graph.
-    pub fn heads(&self) -> HashSet<OP> {
+    /// Current tips for all groups in the operation graph.
+    pub(crate) fn heads_global(&self) -> HashSet<OP> {
         self.graph
             // TODO: clone required here when converting the GraphMap into a Graph. We do this
             // because the GraphMap api does not include the "externals" method, where as the
@@ -126,35 +133,78 @@ where
             .collect::<HashSet<_>>()
     }
 
-    /// Get graph tips filtered to only those which included "create" operation for passed group
-    /// ids in their causal history.
-    pub fn heads_filtered(&self, groups: &[ID]) -> HashSet<OP> {
-        let global_heads = self.heads();
-        global_heads
-            .into_iter()
-            .filter(|id| {
-                let reversed = Reversed(&self.graph);
-                let mut bfs = Bfs::new(&reversed, *id);
-                while let Some(inner_id) = bfs.next(&reversed) {
-                    let operation = self
-                        .operations
-                        .get(&inner_id)
-                        .expect("operation in graph is present in store");
-                    if operation.action().is_create() && groups.contains(&operation.group_id()) {
-                        return true;
-                    }
-                }
-                false
-            })
-            .collect()
+    /// Returns graph tips for a section of the operation graph covering only the passed groups
+    /// (and their dependencies).
+    pub fn heads(&self, groups: &[ID]) -> HashSet<OP> {
+        let graph = self.filtered_graph(groups);
+        graph
+            .clone()
+            .into_graph::<usize>()
+            .externals(petgraph::Direction::Outgoing)
+            .map(|idx| graph.from_index(idx.index()))
+            .collect::<HashSet<_>>()
+    }
+
+    /// Returns a vector of operation ids in their topologically sorted order where only
+    /// operations relating to the passed groups (and their dependencies) are included.
+    pub fn toposort(&self, groups: &[ID]) -> Vec<OP> {
+        let graph = self.filtered_graph(groups);
+        toposort(&graph, None).expect("graph has a cycle")
+    }
+
+    /// Returns a graph filtered to only the operations which contain actions effecting the passed
+    /// groups (and their dependencies). This is required when selectively merging changes from
+    /// one groups graph into another.  
+    pub(crate) fn filtered_graph(&self, groups: &[ID]) -> DiGraphMap<OP, ()> {
+        let mut group_dependencies = HashSet::new();
+        for group_id in groups {
+            group_dependencies.insert(*group_id);
+            group_dependencies.extend(self.groups(*group_id).into_iter().map(|(id, _)| id));
+        }
+
+        let mut graph = self.graph.clone();
+        for (id, operation) in self.operations.iter() {
+            if !group_dependencies.contains(&operation.group_id()) {
+                graph.remove_node(*id);
+            }
+        }
+        graph
+    }
+
+    /// Return a graph with only predecessor nodes of the passed heads included. This is required
+    /// when wanting to validate an operation against a specific point in the groups graph
+    /// history.
+    pub(crate) fn trimmed_graph(&self, heads: &HashSet<OP>) -> DiGraphMap<OP, ()> {
+        // Collect predecessors of the given heads.
+        let mut graph = self.graph.clone();
+        let mut predecessors = HashSet::new();
+        for dependency in heads {
+            let reversed = Reversed(&graph);
+            let mut dfs_rev = DfsPostOrder::new(&reversed, *dependency);
+            while let Some(id) = dfs_rev.next(&reversed) {
+                predecessors.insert(id);
+            }
+        }
+
+        // Remove all other nodes from the graph.
+        let to_remove: Vec<_> = graph
+            .node_identifiers()
+            .filter(|n| !predecessors.contains(n))
+            .collect();
+
+        for node in &to_remove {
+            graph.remove_node(*node);
+        }
+
+        graph
     }
 
     /// Current group states.
     ///
     /// This method gets the state at all graph tips and then merges them together into one new
-    /// state which represents the current state of the groups.
+    /// state which represents the current membership of all groups.
     pub fn current_state(&self) -> GroupStates<ID, C> {
-        self.merge_states(&self.heads())
+        self.merge_states(&self.heads_global())
             .expect("states exist for processed operations")
     }
 
@@ -325,8 +375,7 @@ where
     }
 }
 
-/// State object for `GroupCrdt` containing an orderer state and the inner
-/// state.
+/// State object for `GroupCrdt`.
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "test_utils"), derive(Clone))]
 #[cfg_attr(
@@ -440,15 +489,10 @@ where
         self.inner.current_state().contains_key(&group_id)
     }
 
-    /// Current tips for the groups operation graph.
-    pub fn heads(&self) -> Vec<OP> {
-        self.inner.heads().into_iter().collect()
-    }
-
-    /// Get graph tips filtered to only those which included "create" operation for passed group
-    /// ids in their causal history.
-    pub fn heads_filtered(&self, groups: &[ID]) -> Vec<OP> {
-        self.inner.heads_filtered(groups).into_iter().collect()
+    /// Returns graph tips for a section of the operation graph covering only the passed groups
+    /// (and their dependencies).
+    pub fn heads(&self, groups: &[ID]) -> Vec<OP> {
+        self.inner.heads(groups).into_iter().collect()
     }
 }
 
@@ -489,8 +533,6 @@ where
 /// - RS : generic resolver which contains logic for deciding when group state
 ///   rebuilds are required, and how concurrent actions are handled. See the
 ///   `resolver` module for different implementations.
-/// - ORD: orderer which exposes an API for creating and processing operations
-///   with meta-data which allow them to be processed in partial order.
 #[derive(Clone, Debug, Default)]
 pub struct GroupCrdt<ID, OP, M, C, RS> {
     _phantom: PhantomData<(ID, OP, M, C, RS)>,
@@ -508,6 +550,24 @@ where
         GroupCrdtState {
             inner: GroupCrdtInnerState::default(),
         }
+    }
+
+    /// Calculate the graph heads which are required dependencies of a group action.
+    ///
+    /// This looks at the groups which are effected by the passed action, filters the global graph
+    /// to only operations for these groups, and then calculates the heads. This is required when
+    /// constructing a new operation to be processed and appended to the graph.
+    pub fn heads(
+        y: &GroupCrdtState<ID, OP, M, C>,
+        group_id: ID,
+        action: &GroupAction<ID, C>,
+    ) -> Vec<OP> {
+        // Compute the auth graph heads to include as dependencies based on the groups included in
+        // this action. This means any groups being added / removed in the action, plus the id of
+        // the parent group itself.
+        let mut include = action.required_groups();
+        include.push(group_id);
+        y.inner.heads(&include).into_iter().collect()
     }
 
     /// Process an operation created locally or received from a remote peer.
@@ -549,6 +609,10 @@ where
         // We don't need to check the state change result as validation was already performed
         // above.
         let mut groups_y = y.inner.state_at(&dependencies)?;
+        if !operation.action().is_create() && !groups_y.contains_key(&group_id) {
+            return Err(GroupCrdtError::UnknownGroup(group_id));
+        }
+
         groups_y = apply_action(
             groups_y,
             group_id,
@@ -603,13 +667,8 @@ where
             _ => (),
         };
 
-        let dependencies = HashSet::from_iter(operation.dependencies().clone());
-
-        // Rebuild the graph to the state referred to in the operations' dependencies..
-        let temp_inner_y = Self::rebuild_at(y.inner.clone(), dependencies)?;
-
         // Detect if this operation would cause a nested group cycle.
-        if temp_inner_y.would_create_cycle(operation) {
+        if y.inner.would_create_cycle(operation) {
             let parent_group = operation.group_id();
 
             // Only adds cause a cycle, we just access the member id here.
@@ -627,14 +686,27 @@ where
             ));
         }
 
+        let heads = HashSet::from_iter(operation.dependencies().clone());
+
+        // If this operation is not being appended directly to our current local state we need to
+        // remove any operations from the graph which are concurrent or sequentially later to the
+        // operations' claimed dependencies.
+        let (groups_y, ignore) = if y.inner.heads(&operation.required_groups()) != heads {
+            // @TODO: Can we avoid cloning here?
+            let inner = Self::rebuild_at(y.inner.clone(), heads)?;
+            (inner.current_state(), inner.ignore)
+        } else {
+            (y.inner.current_state(), y.inner.ignore.clone())
+        };
+
         // Apply the operation onto the temporary state.
         let result = apply_action(
-            temp_inner_y.current_state(),
+            groups_y,
             operation.group_id(),
             operation.id(),
             operation.author(),
             &operation.action(),
-            &temp_inner_y.ignore,
+            &ignore,
         );
 
         match result {
@@ -662,35 +734,8 @@ where
         mut y: GroupCrdtInnerState<ID, OP, M, C>,
         heads: HashSet<OP>,
     ) -> Result<GroupCrdtInnerState<ID, OP, M, C>, GroupCrdtError<ID, OP>> {
-        // If this operation is concurrent to our current local state we need to rebuild the graph
-        // to the operations' claimed dependencies in order to validate it correctly.
-        if y.heads() != heads {
-            // Collect predecessors of the new operation.
-            let mut predecessors = HashSet::new();
-            for dependency in heads {
-                let reversed = Reversed(&y.graph);
-                let mut dfs_rev = DfsPostOrder::new(&reversed, dependency);
-                while let Some(id) = dfs_rev.next(&reversed) {
-                    predecessors.insert(id);
-                }
-            }
-
-            // Remove all other nodes from the graph.
-            let to_remove: Vec<_> = y
-                .graph
-                .node_identifiers()
-                .filter(|n| !predecessors.contains(n))
-                .collect();
-
-            for node in &to_remove {
-                y.graph.remove_node(*node);
-            }
-
-            y = RS::process(y).map_err(|err| GroupCrdtError::Resolver(err.to_string()))?;
-            Ok(y)
-        } else {
-            Ok(y)
-        }
+        y.graph = y.trimmed_graph(&heads);
+        RS::process(y).map_err(|err| GroupCrdtError::Resolver(err.to_string()))
     }
 
     /// Get group members and access levels at a specific point in a groups history.
@@ -700,8 +745,12 @@ where
         heads: HashSet<OP>,
         group_id: ID,
     ) -> Result<Vec<(ID, Access<C>)>, GroupCrdtError<ID, OP>> {
-        let y = Self::rebuild_at(y.inner.clone(), heads)?;
-        Ok(y.members(group_id))
+        if y.inner.heads(&[group_id]) != heads {
+            let inner = Self::rebuild_at(y.inner.clone(), heads)?;
+            Ok(inner.members(group_id))
+        } else {
+            Ok(y.members(group_id))
+        }
     }
 
     /// Add an operation to the auth graph and operation map.
@@ -1832,5 +1881,90 @@ pub(crate) mod tests {
         // Assert members are the same.
         let members = y_i_de.members(G1);
         assert_eq!(members, vec![(ALICE, Access::manage())]);
+    }
+
+    #[test]
+    fn partitioned_group_graphs() {
+        let y = TestGroupState::new();
+
+        let op1 = create_group(
+            ALICE,
+            0,
+            G1,
+            vec![(GroupMember::Individual(ALICE), Access::manage())],
+            vec![],
+        );
+
+        let y_i = TestGroup::process(y, &op1).unwrap();
+        let mut members = y_i.members(G1);
+        members.sort();
+        assert_eq!(members, vec![(ALICE, Access::manage())]);
+
+        let op2 = create_group(
+            BOB,
+            1,
+            G2,
+            vec![(GroupMember::Individual(BOB), Access::manage())],
+            vec![],
+        );
+
+        let y_ii = TestGroup::process(y_i, &op2).unwrap();
+        let mut members = y_ii.members(G2);
+        members.sort();
+        assert_eq!(members, vec![(BOB, Access::manage())]);
+
+        let op3 = add_member(
+            ALICE,
+            2,
+            G1,
+            GroupMember::Group(G2),
+            Access::read(),
+            vec![op1.id(), op2.id()],
+        );
+
+        let y_iii = TestGroup::process(y_ii, &op3).unwrap();
+        let mut individuals = y_iii.members(G1);
+        individuals.sort();
+        assert_eq!(
+            individuals,
+            vec![(ALICE, Access::manage()), (BOB, Access::read())]
+        );
+
+        let mut groups = y_iii.groups(G1);
+        groups.sort();
+        assert_eq!(groups, vec![(G2, Access::read())]);
+
+        let heads = y_iii.heads(&[G1, G2]);
+        assert_eq!(heads, vec![op3.id()]);
+
+        let op4 = create_group(
+            BOB,
+            3,
+            G3,
+            vec![(GroupMember::Individual(BOB), Access::manage())],
+            vec![],
+        );
+
+        // Heads and sorted operations for group 1 & 2
+        let y_iv = TestGroup::process(y_iii, &op4).unwrap();
+        let heads = y_iv.heads(&[G1, G2]);
+        assert_eq!(heads, vec![op3.id()]);
+        let mut sorted = y_iv.inner.toposort(&[G1, G2]);
+        sorted.sort();
+        assert_eq!(sorted, vec![0, 1, 2]);
+
+        // Heads and sorted operations for group 1 & 2
+        let heads = y_iv.heads(&[G3]);
+        assert_eq!(heads, vec![op4.id()]);
+        let mut sorted = y_iv.inner.toposort(&[G3]);
+        sorted.sort();
+        assert_eq!(sorted, vec![3]);
+
+        let mut heads = y_iv.heads(&[G1, G2, G3]);
+        heads.sort();
+        assert_eq!(heads, vec![op3.id(), op4.id()]);
+        let mut sorted = y_iv.inner.toposort(&[G1, G2, G3]);
+        sorted.sort();
+        assert_eq!(sorted, vec![0, 1, 2, 3]);
     }
 }

--- a/p2panda-auth/src/group/resolver.rs
+++ b/p2panda-auth/src/group/resolver.rs
@@ -63,7 +63,7 @@ where
     /// Identify if an operation should trigger a group state rebuild.
     fn rebuild_required(y: &Self::State, operation: &M) -> Result<bool, Self::Error> {
         let dependencies = operation.dependencies().into_iter().collect();
-        Ok(y.heads() != dependencies)
+        Ok(y.heads(&operation.required_groups()) != dependencies)
     }
 
     /// Process the group operation graph, producing a new filter and re-building all state

--- a/p2panda-auth/src/traits/operation.rs
+++ b/p2panda-auth/src/traits/operation.rs
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::group::GroupAction;
+use crate::traits::IdentityHandle;
 
 /// Interface to express required information from operations processed by any auth graph
 /// implementation.
 ///
 /// Applications implementing these traits should authenticate the original sender of each
 /// operation.
-pub trait Operation<ID, OP, C = ()> {
+pub trait Operation<ID, OP, C = ()>
+where
+    ID: IdentityHandle,
+{
     /// Id of this operation.
     fn id(&self) -> OP;
 
@@ -22,4 +26,14 @@ pub trait Operation<ID, OP, C = ()> {
 
     /// The group action.
     fn action(&self) -> GroupAction<ID, C>;
+
+    /// Returns groups which are dependant on being able to process this action.
+    ///
+    /// This calculation returns the ids of groups required for processing the action as well as
+    /// the target group itself.
+    fn required_groups(&self) -> Vec<ID> {
+        let mut members = self.action().required_groups();
+        members.push(self.group_id());
+        members
+    }
 }

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -26,7 +26,7 @@ use crate::message::{SpacesArgs, SpacesMessage};
 use crate::store::SpacesStoreState;
 use crate::types::{AuthGroup, AuthGroupAction, AuthGroupError, AuthGroupState};
 use crate::utils::{sort_members, typed_member, typed_members};
-use crate::{ActorId, GroupId, MemberId, OperationId};
+use crate::{ActorId, GroupId, MemberId};
 
 /// A single group which exists in the global auth context.
 ///
@@ -85,14 +85,10 @@ where
         initial_members: Vec<(ActorId, Access<C>)>,
     ) -> Result<(AuthGroupState<C>, F::Message, Event<C>), GroupError<F, C>> {
         let initial_members = typed_members(&y, initial_members);
-
-        let auth_dependencies = y.inner.heads().into_iter().collect();
         let action = AuthGroupAction::Create {
             initial_members: initial_members.clone(),
         };
-
-        Self::process_local_control(manager_ref.clone(), y, group_id, auth_dependencies, action)
-            .await
+        Self::process_local_control(manager_ref.clone(), y, group_id, action).await
     }
 
     /// Add member to group with specified access level.
@@ -104,12 +100,9 @@ where
         access: Access<C>,
     ) -> Result<(AuthGroupState<C>, F::Message, Event<C>), GroupError<F, C>> {
         let y = self.manager.get_groups_state().await?;
-
         let member = typed_member(&y, member);
-        let dependencies = y.inner.heads().into_iter().collect();
         let action = AuthGroupAction::Add { member, access };
-
-        Self::process_local_control(self.manager.clone(), y, self.id, dependencies, action).await
+        Self::process_local_control(self.manager.clone(), y, self.id, action).await
     }
 
     /// Remove member from group.
@@ -120,12 +113,9 @@ where
         member: ActorId,
     ) -> Result<(AuthGroupState<C>, F::Message, Event<C>), GroupError<F, C>> {
         let y = self.manager.get_groups_state().await?;
-
         let member = typed_member(&y, member);
-        let dependencies = y.inner.heads().into_iter().collect();
         let action = AuthGroupAction::Remove { member };
-
-        Self::process_local_control(self.manager.clone(), y, self.id, dependencies, action).await
+        Self::process_local_control(self.manager.clone(), y, self.id, action).await
     }
 
     /// Process a remote message.
@@ -157,13 +147,17 @@ where
         manager_ref: Manager<S, F, C>,
         y: AuthGroupState<C>,
         group_id: GroupId,
-        auth_dependencies: Vec<OperationId>,
-        group_action: GroupAction<ActorId, C>,
+        action: GroupAction<ActorId, C>,
     ) -> Result<(AuthGroupState<C>, F::Message, Event<C>), GroupError<F, C>> {
+        // Compute the auth graph heads to include as dependencies based on the groups included in
+        // this action. This means any groups being added / removed in the action, plus the id of
+        // the parent group itself.
+        let dependencies = AuthGroup::heads(&y, group_id, &action);
+
         let args = SpacesArgs::Auth {
             group_id,
-            auth_dependencies,
-            group_action,
+            auth_dependencies: dependencies,
+            group_action: action,
         };
 
         let message = {

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -386,6 +386,7 @@ where
         Ok(y.unwrap_or_default())
     }
 
+    /// Get space state.
     pub(crate) async fn get_space_state(
         &self,
         id: &SpaceId,
@@ -413,34 +414,25 @@ where
         Ok(y)
     }
 
-    /// Returns a list of all spaces which are "out-of-sync" with the global shared auth state.
-    pub async fn spaces_repair_required(&self) -> Result<Vec<SpaceId>, ManagerError<F, C>> {
+    /// Return `true` if the space is missing operations from the passed groups.
+    pub async fn space_repair_required(
+        &self,
+        space_id: SpaceId,
+        groups: &[GroupId],
+    ) -> Result<bool, ManagerError<F, C>> {
         let groups_y = self.get_groups_state().await?;
 
-        let space_ids = {
-            let manager = self.inner.read().await;
-            manager
-                .store
-                .space_ids()
-                .await
-                .map_err(|err| StoreError::SpacesStore(err.to_string()))?
+        let Some(space_y) = self.get_space_state(&space_id).await? else {
+            return Err(ManagerError::SpaceNotFound(space_id));
         };
 
-        let mut in_need_of_repair = vec![];
-        for id in space_ids {
-            let space_y = self
-                .get_space_state(&id)
-                .await?
-                .expect("space present in store");
-            if space_y.groups_y.inner.heads() != groups_y.inner.heads() {
-                in_need_of_repair.push(id);
-            }
-        }
+        let space_heads = space_y.groups_y.inner.heads(groups);
+        let global_heads = groups_y.inner.heads(groups);
 
-        Ok(in_need_of_repair)
+        Ok(space_heads != global_heads)
     }
 
-    /// Publish a reference to any auth messages missing from the passed spaces.
+    /// Publish a reference to any auth messages missing from a space.
     ///
     /// Each space holds a copy of the shared auth state by publishing a reference to each auth
     /// control message it witnesses. A space can get out-of-sync with this shared state if auth
@@ -458,7 +450,7 @@ where
     ///       [x] <-------------- [z]
     /// ```
     ///
-    /// On identifying that a space needs "repairing" by calling spaces_repair_required(), _any_
+    /// On identifying that a space needs "repairing" by calling space_repair_required(), _any_
     /// current space member can publish a message into the space referencing the missing auth
     /// message.
     ///
@@ -481,34 +473,29 @@ where
     /// A sensible approach to detecting and repairing spaces will involve processing messages in
     /// logical batches and only detecting and repairing any out-of-sync spaces after a batch has
     /// been processed. Alternatively some scheduling or throttling logic could be employed.
-    pub async fn repair_spaces(
+    pub async fn repair_space(
         &self,
-        space_ids: &[SpaceId],
-    ) -> Result<Vec<(SpacesState<C>, Vec<F::Message>, Vec<Event<C>>)>, ManagerError<F, C>> {
-        let mut results = vec![];
+        space_id: SpaceId,
+        groups: &[GroupId],
+    ) -> Result<(SpacesState<C>, Vec<F::Message>, Vec<Event<C>>), ManagerError<F, C>> {
+        let Some(space) = self.space(space_id).await? else {
+            return Err(ManagerError::SpaceNotFound(space_id));
+        };
 
-        for id in space_ids {
-            let Some(space) = self.space(*id).await? else {
-                continue;
-            };
-
-            if !space
-                .members()
-                .await?
-                .iter()
-                .any(|(id, access)| *id == self.id() && *access >= Access::<C>::read())
-            {
-                // Only members with Read or greater access can repair spaces.
-                let space_y = space.state().await?;
-                results.push((space_y, vec![], vec![]));
-                continue;
-            }
-
-            let result = space.repair().await.map_err(ManagerError::Space)?;
-            results.push(result);
+        if !space
+            .members()
+            .await?
+            .iter()
+            .any(|(id, access)| *id == self.id() && *access >= Access::<C>::read())
+        {
+            // Only members with Read or greater access can repair spaces.
+            let space_y = space.state().await?;
+            return Ok((space_y, vec![], vec![]));
         }
 
-        Ok(results)
+        let result = space.repair(groups).await.map_err(ManagerError::Space)?;
+
+        Ok(result)
     }
 
     async fn handle_space_membership_message(
@@ -688,6 +675,39 @@ where
         Ok(events)
     }
 
+    pub async fn repair_spaces(
+        &self,
+        space_ids: &[SpaceId],
+    ) -> Result<Vec<(SpacesState<C>, Vec<F::Message>, Vec<Event<C>>)>, ManagerError<F, C>> {
+        let mut results = vec![];
+
+        for id in space_ids {
+            let Some(space) = self.space(*id).await? else {
+                continue;
+            };
+
+            if !space
+                .members()
+                .await?
+                .iter()
+                .any(|(id, access)| *id == self.id() && *access >= Access::<C>::read())
+            {
+                // Only members with Read or greater access can repair spaces.
+                let space_y = space.state().await?;
+                results.push((space_y, vec![], vec![]));
+                continue;
+            }
+
+            let result = space
+                .repair(&[space.group_id().await?])
+                .await
+                .map_err(ManagerError::Space)?;
+            results.push(result);
+        }
+
+        Ok(results)
+    }
+
     pub async fn repair_spaces_persisted(
         &self,
         space_ids: &[SpaceId],
@@ -764,6 +784,9 @@ where
         "received space message with id {0} before auth message {1}, maybe it arrived out-of-order"
     )]
     MissingAuthMessage(Hash, Hash),
+
+    #[error("space not found {0}")]
+    SpaceNotFound(SpaceId),
 
     #[error("unexpected message variant, expected auth {0}")]
     IncorrectMessageVariant(Hash),

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 
 use p2panda_auth::Access;
+use p2panda_auth::group::GroupMember;
 use p2panda_auth::traits::{Conditions, Operation};
 use p2panda_auth::validation::{VerifyClaimedWriteError, verify_claimed_write_access};
 use p2panda_core::traits::{Digest, ShortFormat};
@@ -18,7 +19,6 @@ use p2panda_store::groups::GroupsStore;
 use p2panda_store::key_registry::KeyRegistryStore;
 use p2panda_store::key_secrets::KeySecretsStore;
 use p2panda_store::spaces::{SpacesMessageStore, SpacesStore};
-use petgraph::algo::toposort;
 use thiserror::Error;
 use tracing::debug;
 
@@ -37,7 +37,7 @@ use crate::types::{
     AuthGroup, AuthGroupAction, AuthGroupError, AuthGroupState, EncryptionDirectMessage,
     EncryptionGroup, EncryptionGroupError, EncryptionGroupState,
 };
-use crate::utils::{added_members, removed_members, secret_members, sort_members};
+use crate::utils::{added_members, removed_members, secret_members, sort_members, typed_members};
 use crate::{ActorId, GroupId, MemberId, OperationId, SpaceEvent, SpaceId, StrongRemoveResolver};
 
 /// A single encryption context with associated group of actors who will participate in the key
@@ -124,13 +124,22 @@ where
             signing_key.verifying_key()
         };
 
-        // Instantiate new space state from existing global auth state.
-        let (space_y, space_history) =
-            Self::from_group(manager_ref.clone(), space_id, group_id).await?;
-
-        // Create the space group.
         let groups_y = manager_ref.get_groups_state().await?;
 
+        // Compute the groups to include in the space history based on initial group members.
+        let include = typed_members(&groups_y, initial_members.clone())
+            .iter()
+            .filter_map(|(member, _)| match member {
+                GroupMember::Individual(_) => None,
+                GroupMember::Group(id) => Some(*id),
+            })
+            .collect::<Vec<_>>();
+
+        // Instantiate new space state from existing global auth state.
+        let (space_y, space_history) =
+            Self::from_group(manager_ref.clone(), space_id, group_id, &include).await?;
+
+        // Create the space group.
         let (groups_y, create_group, auth_event) =
             Group::create(manager_ref.clone(), groups_y, group_id, initial_members).await?;
 
@@ -318,6 +327,7 @@ where
         manager_ref: Manager<S, F, C>,
         space_id: SpaceId,
         group_id: GroupId,
+        include: &[GroupId],
     ) -> Result<(SpacesState<C>, Vec<F::Message>), SpaceError<F, C>> {
         // Instantiate empty space state.
         let mut y = { Self::get_or_init_state(space_id, group_id, manager_ref.clone()).await? };
@@ -331,9 +341,7 @@ where
         let groups_y = manager_ref.get_groups_state().await?;
         let mut manager = manager_ref.inner.write().await;
         let mut space_dependencies = vec![];
-        let operations =
-            toposort(&groups_y.inner.graph, None).expect("auth graph does not contain cycles");
-        for id in operations {
+        for id in groups_y.inner.toposort(include) {
             let operation = groups_y
                 .inner
                 .operations
@@ -586,42 +594,26 @@ where
 
     pub async fn repair(
         &self,
+        groups: &[GroupId],
     ) -> Result<(SpacesState<C>, Vec<F::Message>, Vec<Event<C>>), SpaceError<F, C>> {
         let groups_y = self.manager.get_groups_state().await?;
         let mut space_y = self.state().await?;
 
-        // @TODO: here we need to account for the new Groups::heads_filtered(..) approach to
-        // calculating dependencies and only include the ones strictly necessary for this space.
-        let operation_ids =
-            toposort(&groups_y.inner.graph, None).expect("auth graph does not contain cycles");
-
         let mut messages = vec![];
         let mut events = vec![];
         // @TODO: we can optimize here by calculating the diff between the current space auth
-        // graph tips and the global auth graph tips. Then we could apply only the missing
-        // operations rather than applying all operations as we do here.
-        for id in operation_ids {
+        // graph tips and the global auth graph tips. Then we could apply only the diff, rather
+        // than processing all operations as we do here.
+        let sorted = groups_y.inner.toposort(groups);
+        for id in sorted {
             // This auth message has already been processed by the space.
             if space_y.groups_y.inner.operations.contains_key(&id) {
                 continue;
             };
 
-            let message = {
-                let manager = self.manager.inner.read().await;
-                manager
-                    .store
-                    .get_spaces_message(&id)
-                    .await
-                    .map_err(|err| StoreError::MessageStore(err.to_string()))?
-                    .expect("message present in store")
-            };
-
-            let (space_y_i, space_message, space_events) = Space::process_auth_message(
-                self.manager.clone(),
-                space_y,
-                &SpacesMessage::auth(&message),
-            )
-            .await?;
+            let operation = groups_y.inner.operations.get(&id).unwrap();
+            let (space_y_i, space_message, space_events) =
+                Space::process_auth_message(self.manager.clone(), space_y, operation).await?;
 
             space_y = space_y_i;
 
@@ -721,9 +713,24 @@ where
     /// The members of this space.
     pub async fn members(&self) -> Result<Vec<(MemberId, Access<C>)>, SpaceError<F, C>> {
         let y = self.state().await?;
-        let mut group_members = y.groups_y.members(y.group_id);
-        sort_members(&mut group_members);
-        Ok(group_members)
+        let mut members = y.groups_y.members(y.group_id);
+        sort_members(&mut members);
+        Ok(members)
+    }
+
+    pub async fn root_groups(&self) -> Result<Vec<(MemberId, Access<C>)>, SpaceError<F, C>> {
+        let y = self.state().await?;
+        let mut members: Vec<(VerifyingKey, Access<C>)> = y
+            .groups_y
+            .root_members(y.group_id)
+            .into_iter()
+            .filter_map(|(member, access)| match member {
+                p2panda_auth::group::GroupMember::Individual(_) => None,
+                p2panda_auth::group::GroupMember::Group(id) => Some((id, access)),
+            })
+            .collect();
+        sort_members(&mut members);
+        Ok(members)
     }
 
     /// Publish a message encrypted towards all current group members.
@@ -762,7 +769,7 @@ where
             let args = SpacesArgs::Application {
                 space_id: y.space_id,
                 space_dependencies: dependencies.clone(),
-                proof: y.groups_y.heads(),
+                proof: y.groups_y.heads(&[y.group_id]),
                 group_secret_id,
                 nonce,
                 ciphertext,
@@ -850,8 +857,9 @@ where
 
     pub async fn repair_persisted(
         &self,
+        groups: &[GroupId],
     ) -> Result<(Vec<F::Message>, Vec<Event<C>>), SpaceError<F, C>> {
-        let (space_y, messages, events) = self.repair().await?;
+        let (space_y, messages, events) = self.repair(groups).await?;
         self.manager
             .set_space_state(&self.id(), &space_y.into())
             .await?;

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -97,7 +97,10 @@ async fn create_space() {
 
     // Orderer states have been updated.
     let groups_y = manager.get_groups_state().await.unwrap();
-    assert_eq!(HashSet::from([message_01.hash()]), groups_y.inner.heads());
+    assert_eq!(
+        HashSet::from([message_01.hash()]),
+        groups_y.inner.heads(&[*group_id])
+    );
 
     let y = manager.get_space_state(&space.id()).await.unwrap().unwrap();
     assert_eq!(vec![message_02.hash()], y.orderer.heads());
@@ -281,7 +284,10 @@ async fn add_member_to_space() {
     assert_eq!(vec![message_04.hash()], y.orderer.heads());
 
     let groups_y = manager.get_groups_state().await.unwrap();
-    assert_eq!(HashSet::from([message_03.hash()]), groups_y.inner.heads());
+    assert_eq!(
+        HashSet::from([message_03.hash()]),
+        groups_y.inner.heads(&[*group_id])
+    );
 }
 
 #[tokio::test]
@@ -451,7 +457,10 @@ async fn add_pull_member_to_space() {
 
     // Auth order has been updated.
     let groups_y = manager.get_groups_state().await.unwrap();
-    assert_eq!(HashSet::from([message_03.hash()]), groups_y.inner.heads());
+    assert_eq!(
+        HashSet::from([message_03.hash()]),
+        groups_y.inner.heads(&[*group_id])
+    );
 
     let y = manager.get_space_state(&space_id).await.unwrap().unwrap();
     // Encryption order has been updated.
@@ -509,7 +518,10 @@ async fn receive_control_messages() {
         let groups_y = bob_manager.get_groups_state().await.unwrap();
         let members = groups_y.members(group_id);
         assert_eq!(members, vec![(alice_id, Access::manage())]);
-        assert_eq!(HashSet::from([message_01.hash()]), groups_y.inner.heads());
+        assert_eq!(
+            HashSet::from([message_01.hash()]),
+            groups_y.inner.heads(&[group_id])
+        );
     }
 
     bob.persist_operation(&message_02).await.unwrap();
@@ -572,7 +584,10 @@ async fn receive_control_messages() {
 
     // Orderer states have been updated.
     let groups_y = bob_manager.get_groups_state().await.unwrap();
-    assert_eq!(HashSet::from([message_04.hash()]), groups_y.inner.heads());
+    assert_eq!(
+        HashSet::from([message_04.hash()]),
+        groups_y.inner.heads(&[group_id])
+    );
 
     let y = bob_manager
         .get_space_state(&space_id)
@@ -961,7 +976,10 @@ async fn create_group() {
 
     // Orderer state has been updated.
     let groups_y = manager.get_groups_state().await.unwrap();
-    assert_eq!(HashSet::from([message_01.hash()]), groups_y.inner.heads());
+    assert_eq!(
+        HashSet::from([message_01.hash()]),
+        groups_y.inner.heads(&[*group_id])
+    );
 }
 
 #[tokio::test]
@@ -982,6 +1000,9 @@ async fn add_member_to_group() {
         .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::manage())])
         .await
         .unwrap();
+
+    let members = group.members().await.unwrap();
+    assert_eq!(members.len(), 2);
 
     let message_02 = group
         .add_persisted(claire_id, Access::read())
@@ -1021,7 +1042,10 @@ async fn add_member_to_group() {
 
     // Orderer state has been updated.
     let groups_y = manager.get_groups_state().await.unwrap();
-    assert_eq!(HashSet::from([message_02.hash()]), groups_y.inner.heads());
+    assert_eq!(
+        HashSet::from([message_02.hash()]),
+        groups_y.inner.heads(&[*group_id])
+    );
 }
 
 #[tokio::test]
@@ -1071,7 +1095,10 @@ async fn remove_member_from_group() {
 
     // Orderer state has been updated.
     let groups_y = manager.get_groups_state().await.unwrap();
-    assert_eq!(HashSet::from([message_02.hash()]), groups_y.inner.heads());
+    assert_eq!(
+        HashSet::from([message_02.hash()]),
+        groups_y.inner.heads(&[*group_id])
+    );
 }
 
 #[tokio::test]
@@ -1125,11 +1152,15 @@ async fn receive_auth_messages() {
 
     // Orderer state has been updated.
     let groups_y = bob_manager.get_groups_state().await.unwrap();
-    assert_eq!(HashSet::from([message_02.hash()]), groups_y.inner.heads());
+    assert_eq!(
+        HashSet::from([message_02.hash()]),
+        groups_y.inner.heads(&[group_id])
+    );
 }
 
 #[tokio::test]
 async fn shared_auth_state() {
+    setup_logging();
     let alice = TestPeer::new(0).await;
     let bob = <TestPeer>::new(1).await;
     let claire = <TestPeer>::new(2).await;
@@ -1152,13 +1183,13 @@ async fn shared_auth_state() {
     let bob_id = bob.manager.id();
     let claire_id = claire.manager.id();
 
-    let manager = alice.manager.clone();
+    let alice_manager = alice.manager.clone();
 
     // Create Space 0
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"0");
-    let (space_0, messages, _) = manager
+    let (space_0, messages, _) = alice_manager
         .create_space_persisted(space_id, &[(alice_id, Access::manage())])
         .await
         .unwrap();
@@ -1170,35 +1201,28 @@ async fn shared_auth_state() {
     // ~~~~~~~~~~~~
 
     let space_id = SpaceId::digest(b"1");
-    let (space_1, messages, _) = manager
+    let (space_1, messages, _) = alice_manager
         .create_space_persisted(space_id, &[(alice_id, Access::manage())])
         .await
         .unwrap();
 
-    // One auth message, two space messages (one for history, one for the Space 1 create).
-    assert_eq!(messages.len(), 3);
-
-    // Make Space 0 aware of this change.
-    let (messages, events) = space_0.repair_persisted().await.unwrap();
-    assert_eq!(messages.len(), 1);
-
-    // We expect no events as the space membership didn't change and global auth state was already
-    // mutated.
-    assert_eq!(events.len(), 0);
+    // One auth message, one space messages. There is no history included as there are no groups
+    // in the initial members.
+    assert_eq!(messages.len(), 2);
 
     // Create group A
     // ~~~~~~~~~~~~
 
-    let (group, _, _) = manager
+    let (group, _, _) = alice_manager
         .create_group_persisted(&[(alice_id, Access::manage()), (bob_id, Access::read())])
         .await
         .unwrap();
 
     // Make Space 0 and Space 1 aware of this change.
-    let (messages, events) = space_0.repair_persisted().await.unwrap();
+    let (messages, events) = space_0.repair_persisted(&[group.id()]).await.unwrap();
     assert_eq!(messages.len(), 1);
     assert_eq!(events.len(), 0);
-    let (messages, events) = space_1.repair_persisted().await.unwrap();
+    let (messages, events) = space_1.repair_persisted(&[group.id()]).await.unwrap();
     assert_eq!(messages.len(), 1);
     assert_eq!(events.len(), 0);
 
@@ -1210,11 +1234,6 @@ async fn shared_auth_state() {
         .await
         .unwrap();
 
-    // Make Space 1 aware of this change.
-    let (messages, events) = space_1.repair_persisted().await.unwrap();
-    assert_eq!(messages.len(), 1);
-    assert_eq!(events.len(), 0);
-
     // Add group A to space 1
     // ~~~~~~~~~~~~
 
@@ -1222,11 +1241,6 @@ async fn shared_auth_state() {
         .add_persisted(group.id(), Access::read())
         .await
         .unwrap();
-
-    // Make Space 0 aware of this change.
-    let (messages, events) = space_0.repair_persisted().await.unwrap();
-    assert_eq!(messages.len(), 1);
-    assert_eq!(events.len(), 0);
 
     // Add claire to the group
     // ~~~~~~~~~~~~
@@ -1237,13 +1251,13 @@ async fn shared_auth_state() {
         .unwrap();
 
     // Both Space 0 and Space 1 need to be made aware of this change.
-    let (messages, events) = space_0.repair_persisted().await.unwrap();
+    let (messages, events) = space_0.repair_persisted(&[group.id()]).await.unwrap();
     assert_eq!(messages.len(), 1);
     // This change brings claire into the space membership group so we expect one space event
     // signaling this change.
     assert_eq!(events.len(), 1);
 
-    let (messages, events) = space_1.repair_persisted().await.unwrap();
+    let (messages, events) = space_1.repair_persisted(&[group.id()]).await.unwrap();
     assert_eq!(messages.len(), 1);
     assert_eq!(events.len(), 1);
 
@@ -1564,13 +1578,9 @@ async fn repair_space() {
         .await
         .unwrap();
 
-    // Detect if any spaces require repairing.
-    let repair_required = alice_manager.spaces_repair_required().await.unwrap();
-    assert_eq!(vec![space_id], repair_required);
-
     // Trigger repair of the space.
     let messages = alice_manager
-        .repair_spaces_persisted(&repair_required)
+        .repair_spaces_persisted(&vec![space_id])
         .await
         .unwrap();
     let message_05 = messages[0].clone();
@@ -1685,13 +1695,9 @@ async fn duplicate_auth_state_references() {
         .await
         .unwrap();
 
-    // Detect if any spaces require repairing.
-    let repair_required = alice_manager.spaces_repair_required().await.unwrap();
-    assert_eq!(vec![space_id], repair_required);
-
     // Trigger repair of the space.
     let messages = alice_manager
-        .repair_spaces_persisted(&repair_required)
+        .repair_spaces_persisted(&vec![space_id])
         .await
         .unwrap();
     let message_05 = messages[0].clone();
@@ -1718,13 +1724,9 @@ async fn duplicate_auth_state_references() {
     // Bob: repair the space (as alice's auth pointer not yet received)
     // ~~~~~~~~~~~~
 
-    // Detect if any spaces require repairing.
-    let repair_required = bob_manager.spaces_repair_required().await.unwrap();
-    assert_eq!(vec![space_id], repair_required);
-
     // Trigger repair of the space.
     let messages = bob_manager
-        .repair_spaces_persisted(&repair_required)
+        .repair_spaces_persisted(&vec![space_id])
         .await
         .unwrap();
     let _ = messages[0].clone();

--- a/p2panda-stream/src/groups/processor.rs
+++ b/p2panda-stream/src/groups/processor.rs
@@ -617,7 +617,7 @@ mod tests {
                     (GroupMember::Group(bobby_device_group), Access::write()),
                 ],
             },
-            dependencies: y.heads_filtered(&[alice_device_group, bobby_device_group]),
+            dependencies: y.heads(&[alice_device_group, bobby_device_group]),
         };
         let create_alice_bobby_chat_03: Operation<TestExtensions> =
             alice_log.operation(&[], TestExtensions::from(args));
@@ -716,7 +716,7 @@ mod tests {
                     (GroupMember::Group(cathy_device_group), Access::write()),
                 ],
             },
-            dependencies: y.heads_filtered(&[bobby_device_group, cathy_device_group]),
+            dependencies: y.heads(&[bobby_device_group, cathy_device_group]),
         };
         let create_bobby_cathy_chat_04: Operation<TestExtensions> =
             cathy_log.operation(&[], TestExtensions::from(args));

--- a/p2panda/src/spaces/mod.rs
+++ b/p2panda/src/spaces/mod.rs
@@ -20,7 +20,7 @@ pub use p2panda_spaces::{ActorId, GroupContext, GroupId, MemberId, SpaceContext,
 pub(crate) use forge::{KEY_BUNDLE_LOG_ID, group_log_id};
 pub use group::{Group, GroupError, GroupEvent, GroupFuture};
 pub use member::{GroupActor, Member, MemberError};
-pub(crate) use repair::{RepairError, spawn_repair_task};
+pub(crate) use repair::{RepairError, RepairStrategy, spawn_repair_task};
 pub(crate) use space::spaces_stream;
 pub use space::{
     AddSpaceMemberError, PublishSpaceError, RemoveSpaceMemberError, Space, SpaceError, SpaceEvent,

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -6,7 +6,7 @@ use futures_util::stream::BoxStream;
 use p2panda_core::traits::{Provenance, ShortFormat};
 use p2panda_core::{Hash, Topic};
 use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
-use p2panda_spaces::{AuthGroupState, SpaceId, SpacesStoreState};
+use p2panda_spaces::{AuthGroupState, GroupId, SpaceId, SpacesStoreState};
 use p2panda_store::groups::GroupsStore;
 use p2panda_store::operations::OperationStore;
 use p2panda_store::spaces::SpacesStore as SpacesStoreTrait;
@@ -19,7 +19,7 @@ use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::RecvError;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use crate::operation::Operation;
 use crate::spaces::group_log_id;
@@ -29,8 +29,38 @@ use crate::streams::{LocalStreamFuture, StreamEvent};
 
 const REPAIR_FREQUENCY_SECS: u64 = 1;
 
-/// Repairing a space involves incorporating missing groups operations observed on the global groups
-/// context but not yet published into the space.
+/// Strategy by which a space should be repaired.
+///
+/// When merging operations from the shared groups state into a space there are two possible
+/// approaches.
+///
+/// ## Global
+///
+/// Operations for all known groups are merged into the space, even if they are not used in the
+/// space yet. This results in improved discoverability (new groups are "automatically"
+/// discovered) at the expense of privacy (even if a group is not added to a space it is
+/// replicated on the space topic).
+///
+/// ## Partial
+///
+/// Only operations for groups added to a space (via a local action or by explicit association)
+/// are merged into the space. This results in improved privacy as there is no group "leakage"
+/// from the shared state into the space, however it means the initial "discovery" of a new
+/// to-be-added group must be solved via another channel (side-channel, dedicated topic, etc..).
+///
+/// @TODO: This initial discovery mechanism is not yet implemented, it may be solved via invite
+/// tokens, or manually exporting and then registering a member group. Therefore all spaces use
+/// the "Global" strategy for now.
+#[derive(Debug)]
+pub enum RepairStrategy {
+    Global,
+    Partial(Vec<GroupId>),
+}
+
+/// Repairing a space is the process of merging missing auth operations from the shared groups
+/// state into a space. This keeps the space membership up-to-date with concurrent changes and
+/// ensures that all required auth operations are encrypted and sent to other nodes subscribed the
+/// space.
 ///
 /// There are 3 steps to this process:
 ///
@@ -39,9 +69,11 @@ const REPAIR_FREQUENCY_SECS: u64 = 1;
 ///    members can do this)
 /// 3) associate missing groups logs with the space topic
 ///
-/// All new messages will be sent into the topic stream to be processed and forwarded to other peers.
+/// All new messages will be sent into the topic stream to be processed and forwarded to other
+/// peers.
 pub(crate) async fn repair_space<M>(
     space_id: SpaceId,
+    scope: RepairStrategy,
     manager: &SpacesManager,
     store: &SqliteStore,
     import_local_tx: &mpsc::Sender<(
@@ -52,10 +84,37 @@ pub(crate) async fn repair_space<M>(
 ) -> Result<bool, RepairError> {
     let spaces_store = SpacesStore::new(store.clone());
 
+    // Collect all missing groups operations. These will be imported into the space and forwarded
+    // to live-mode peers.
+    let permit = store.begin().await?;
+
+    let Some(space_y): Option<SpacesStoreState<AuthCapabilities>> =
+        spaces_store.get_space_state_tx(&space_id).await?
+    else {
+        // This can happen if we didn't receive any space control messages yet.
+        trace!(
+            node_id = manager.id().fmt_short(),
+            space_id = space_id.fmt_short(),
+            "space not yet materialised"
+        );
+        store.commit(permit).await?;
+        return Ok(false);
+    };
+
+    let groups_y: AuthGroupState<AuthCapabilities> = spaces_store
+        .get_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID))
+        .await?
+        .unwrap_or_default();
+
+    store.commit(permit).await?;
+
+    let include = match scope {
+        RepairStrategy::Global => groups_y.groups_global(),
+        RepairStrategy::Partial(group_ids) => group_ids,
+    };
+
     // Identify if this space needs repairing.
-    //
-    // @TODO: optimize this query by only checking the one space we're concerned with here.
-    let space_ids = match manager.spaces_repair_required().await {
+    let repair = match manager.space_repair_required(space_id, &include).await {
         Ok(ids) => ids,
         Err(err) => {
             return Err(err.into());
@@ -63,7 +122,7 @@ pub(crate) async fn repair_space<M>(
     };
 
     // If not return now already.
-    if space_ids.is_empty() || !space_ids.contains(&space_id) {
+    if !repair {
         return Ok(false);
     }
 
@@ -71,23 +130,13 @@ pub(crate) async fn repair_space<M>(
     // to live-mode peers.
     let permit = store.begin().await?;
 
-    let space_y: Option<SpacesStoreState<AuthCapabilities>> =
-        spaces_store.get_space_state_tx(&space_id).await?;
-
-    let groups_y: AuthGroupState<AuthCapabilities> = spaces_store
-        .get_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID))
-        .await?
-        .unwrap_or_default();
-
     let mut groups_operations = vec![];
-    for id in groups_y.inner.operations.keys() {
-        if let Some(ref y) = space_y
-            && y.groups_y.inner.operations.contains_key(id)
-        {
+    for id in groups_y.inner.toposort(&include) {
+        if space_y.groups_y.inner.operations.contains_key(&id) {
             continue;
         }
 
-        let Some(operation): Option<Operation> = store.get_operation_tx(id).await? else {
+        let Some(operation): Option<Operation> = store.get_operation_tx(&id).await? else {
             warn!("missing expected auth groups operation");
             continue;
         };
@@ -122,21 +171,12 @@ pub(crate) async fn repair_space<M>(
     // Attempt to repair the space. As we pass in an array containing a single space id there will
     // be only ever max one result returned.
     //
+    // Forging these spaces messages will also associate any group logs with this space topic.
+    //
     // @TODO: This method uses transactions internally (eg. in the Forge) and so we can't make
     // everything part of one transaction on this level yet. It isn't a source of bugs though so
     // for now this is ok.
-    let mut repaired = manager.repair_spaces(&[space_id]).await?;
-
-    // Forging these spaces messages will also associate any group logs with this space topic.
-    let Some((space_y, spaces_messages, events)) = repaired.pop() else {
-        // This can happen if we didn't receive any space control messages yet.
-        debug!(
-            node_id = manager.id().fmt_short(),
-            space_id = space_id.fmt_short(),
-            "space not yet materialised"
-        );
-        return Ok(false);
-    };
+    let (space_y, spaces_messages, events) = manager.repair_space(space_id, &include).await?;
 
     // If no space messages were forged during repairing then no state change occurred and we
     // don't need to persist here. This occurs when we are not a _read_ member of the space (yet).
@@ -146,8 +186,6 @@ pub(crate) async fn repair_space<M>(
     if !spaces_messages.is_empty() {
         let permit = store.begin().await?;
 
-        // @TODO: Once we can process our own spaces messages then we no longer
-        // need to persist this state here.
         let space_id = space_y.space_id;
         spaces_store
             .set_space_state_tx(&space_id, &SpacesStoreState::from(space_y))
@@ -203,6 +241,7 @@ pub(crate) async fn repair_space<M>(
 
 /// Spawn the repair task which triggers work on a schedule or from being signalled from elsewhere
 /// in the node API.
+#[allow(clippy::type_complexity)]
 pub(crate) fn spawn_repair_task<M>(
     topic: Topic,
     manager: SpacesManager,
@@ -212,18 +251,18 @@ pub(crate) fn spawn_repair_task<M>(
         oneshot::Sender<LocalStreamFuture>,
     )>,
     to_output_tx: mpsc::Sender<Vec<StreamEvent<M>>>,
-    mut repair_rx: mpsc::Receiver<oneshot::Sender<Result<bool, RepairError>>>,
+    mut repair_rx: mpsc::Receiver<(RepairStrategy, oneshot::Sender<Result<bool, RepairError>>)>,
 ) -> JoinHandle<()>
 where
     M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
 {
     tokio::spawn(async move {
         loop {
-            let reply_tx = tokio::select! {
+            let args = tokio::select! {
                 // We received a signal to repair the space.
                 msg = repair_rx.recv() => {
                     match msg {
-                        Some(reply_tx) => Some(reply_tx),
+                        Some(args) => Some(args),
                         None => {
                             // If the repair_tx is dropped then we can exit this task.
                             return;
@@ -234,21 +273,39 @@ where
                 _ = sleep(Duration::from_secs(REPAIR_FREQUENCY_SECS)) => None,
             };
 
-            let result = repair_space(
-                topic.into(),
-                &manager,
-                &store,
-                &import_local_tx,
-                &to_output_tx,
-            )
-            .await;
+            match args {
+                Some((scope, reply_tx)) => {
+                    let result = repair_space(
+                        topic.into(),
+                        scope,
+                        &manager,
+                        &store,
+                        &import_local_tx,
+                        &to_output_tx,
+                    )
+                    .await;
 
-            if let Err(ref err) = result {
-                warn!("failed to repair spaces: {}", err);
-            }
+                    if let Err(ref err) = result {
+                        warn!("failed to repair spaces: {}", err);
+                    }
 
-            if let Some(reply_tx) = reply_tx {
-                let _ = reply_tx.send(result);
+                    let _ = reply_tx.send(result);
+                }
+                None => {
+                    let result = repair_space(
+                        topic.into(),
+                        RepairStrategy::Global,
+                        &manager,
+                        &store,
+                        &import_local_tx,
+                        &to_output_tx,
+                    )
+                    .await;
+
+                    if let Err(ref err) = result {
+                        warn!("failed to repair spaces: {}", err);
+                    }
+                }
             }
         }
     })

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -24,8 +24,8 @@ use tokio::sync::oneshot::error::RecvError;
 
 use crate::node::CreateStreamError;
 use crate::operation::Extensions;
-use crate::spaces::RepairError;
 use crate::spaces::types::{InnerSpace, InnerSpaceError, SpacesManagerError};
+use crate::spaces::{RepairError, RepairStrategy};
 use crate::streams::{
     ImportError, LocalStreamFuture, ProcessedOperation, Source, StreamEvent, StreamPublisher,
     StreamSubscription,
@@ -247,7 +247,11 @@ where
     /// published live into the space topic.
     pub(crate) async fn repair(&self) -> Result<bool, RepairSpaceError> {
         let (tx, rx) = oneshot::channel();
-        self.tx.repair_tx.send(tx).await?;
+
+        // @TODO: Currently we default to merging all groups into the space state, once we do this
+        // selectively we can specify the groups to be included (root group + added / removed)
+        // using the RepairStrategy::Partial variant.
+        self.tx.repair_tx.send((RepairStrategy::Global, tx)).await?;
         let repaired = rx.await??;
         Ok(repaired)
     }
@@ -427,10 +431,14 @@ pub enum PublishSpaceError {
 #[allow(clippy::large_enum_variant)] // TODO: Reduce size of spaces error types.
 pub enum RepairSpaceError {
     #[error(transparent)]
+    Space(#[from] InnerSpaceError),
+
+    #[error(transparent)]
     Repair(#[from] RepairError),
 
+    #[allow(clippy::type_complexity)]
     #[error("failed to send on space repair task channel")]
-    Send(#[from] SendError<oneshot::Sender<Result<bool, RepairError>>>),
+    Send(#[from] SendError<(RepairStrategy, oneshot::Sender<Result<bool, RepairError>>)>),
 
     #[error("couldn't receive reply from repair task due to broken channel")]
     Recv(#[from] RecvError),

--- a/p2panda/src/streams/publisher.rs
+++ b/p2panda/src/streams/publisher.rs
@@ -15,7 +15,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::forge::{Forge, ForgeError, OperationForge};
 use crate::operation::{Extensions, LogId, Operation};
-use crate::spaces::RepairError;
+use crate::spaces::{RepairError, RepairStrategy};
 use crate::streams::drop_guard::StreamDropGuard;
 use crate::streams::external_stream::ExternalStreamFuture;
 use crate::streams::local_stream::LocalStreamFuture;
@@ -31,7 +31,7 @@ type ImportLocalTx = mpsc::Sender<(
     oneshot::Sender<LocalStreamFuture>,
 )>;
 type ToOutputTx<M> = mpsc::Sender<Vec<StreamEvent<M>>>;
-type RepairTx = mpsc::Sender<oneshot::Sender<Result<bool, RepairError>>>;
+type RepairTx = mpsc::Sender<(RepairStrategy, oneshot::Sender<Result<bool, RepairError>>)>;
 
 /// Publish messages into a topic stream.
 ///


### PR DESCRIPTION
The shared auth state contains operations relating to all known groups. Until now by default they
were interleaved into one graph which resulted in potentially unnecessary cross-group operation
dependencies. This change makes the default behaviour in -spaces to be      
that group operations are only dependant on each other if one becomes a member of another. For
example, operations for group A and group B will be appended to their own unconnected graphs until
A becomes a member of B. From that point on, all operations of A will also become a dependency of
B. It does not mean however that B is a dependency of A, it is still possible to replicate
operations for group A without any knowledge of group B.

Example

```
           ADD A
     ______/ |
    /        v
 ADD ..    ADD ..
   |         |
   v         v
CREATE A  CREATE B
```

Additionally changes were required in p2panda Node to _optionally_ chose to prefer merging all
known groups into a space forcefully. This is required for improved group discovery until there is
an invite flow which accounts for manually registering a new group (and processing any required
operations) on a space.

Some minor related refactorings were done as well to move reusable graph queries onto the inner CRDT state.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
