### PR TITLE
Cancel processed stream tasks on drop of stream handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Highlights are marked with a pancake 🥞
 - spaces: Introduce local stream import [#1296](https://github.com/p2panda/p2panda/pull/1296)
 - spaces: Compute and return events from local methods [#1290](https://github.com/p2panda/p2panda/pull/1290)
 - node: Forward events resulting from local actions to app layer [#1290](https://github.com/p2panda/p2panda/pull/1290)
+- node: Cancel processed stream tasks on drop of stream handles [#1300](https://github.com/p2panda/p2panda/pull/1300)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde_bytes = { version = "0.11.19" }
 thiserror = { version = "2.0.18" }
 tokio = { version = "1.52.3", default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false }
+tokio-util = { version = "0.7.18" }
 tracing = { version = "0.1.44" }
 tracing-subscriber = { version = "0.3.23" }
 

--- a/p2panda/Cargo.toml
+++ b/p2panda/Cargo.toml
@@ -43,6 +43,7 @@ serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = true, features = ["sync"] }
 tokio-stream = { workspace = true, features = ["sync"] }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"], optional = true }
 

--- a/p2panda/src/streams/drop_guard.rs
+++ b/p2panda/src/streams/drop_guard.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+
+use p2panda_core::Topic;
+use p2panda_net::utils::ShortFormat;
+use tokio_util::sync::CancellationToken;
+use tracing::trace;
+
+/// Helper maintaining a counter of references to the same stream topic.
+///
+/// This is used to break out of relevant stream processing loops once all publisher and
+/// subscription handles have been dropped.
+#[derive(Debug)]
+pub struct StreamDropGuard {
+    topic: Topic,
+    counter: Arc<AtomicUsize>,
+    token: CancellationToken,
+    ignore_drop: bool,
+}
+
+/// Initial value the reference counter starts with.
+const INITIAL_COUNTER: usize = 1;
+
+impl StreamDropGuard {
+    pub(crate) fn new(topic: Topic, token: CancellationToken) -> Self {
+        trace!(
+            topic = topic.fmt_short(),
+            counter = INITIAL_COUNTER,
+            "new stream drop guard"
+        );
+
+        Self {
+            topic,
+            counter: Arc::new(AtomicUsize::new(INITIAL_COUNTER)),
+            token,
+            ignore_drop: false,
+        }
+    }
+
+    /// Returns current number of references to this topic.
+    #[allow(unused)]
+    fn counter(&self) -> usize {
+        self.counter.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Returns true if there's still one or more references for this topic used.
+    #[allow(unused)]
+    fn has_subscriptions(&self) -> bool {
+        self.counter() >= INITIAL_COUNTER
+    }
+
+    /// Clone guard, but don't increment reference counter.
+    ///
+    /// This is useful if we need to keep it around somewhere for further use without affecting the
+    /// drop logic.
+    #[allow(unused)]
+    fn clone_without_increment(&self) -> Self {
+        Self {
+            topic: self.topic,
+            counter: self.counter.clone(),
+            token: self.token.clone(),
+            ignore_drop: true,
+        }
+    }
+}
+
+impl Clone for StreamDropGuard {
+    fn clone(&self) -> Self {
+        let value = self
+            .counter
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        trace!(
+            topic = self.topic.fmt_short(),
+            counter = value + 1,
+            "clone stream drop guard +1"
+        );
+
+        Self {
+            topic: self.topic,
+            counter: self.counter.clone(),
+            token: self.token.clone(),
+            ignore_drop: false,
+        }
+    }
+}
+
+impl Drop for StreamDropGuard {
+    fn drop(&mut self) {
+        // This instance is not used to count references, we drop it without taking any action.
+        if self.ignore_drop {
+            return;
+        }
+
+        // Check if we can cancel the stream processing token if all publishers and subscriptions
+        // have been dropped for it.
+        let previous_counter = self
+            .counter
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+
+        trace!(
+            topic = self.topic.fmt_short(),
+            counter = previous_counter - 1,
+            "drop stream drop guard -1"
+        );
+
+        // If the previous value is equal the initial value, the last instance of the guard was
+        // dropped and the counter has no references to the topic anymore.
+        let no_references_left = previous_counter == INITIAL_COUNTER;
+
+        if no_references_left {
+            trace!(
+                topic = self.topic.fmt_short(),
+                "cancel processed_stream token"
+            );
+
+            self.token.cancel();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio_util::sync::CancellationToken;
+
+    use super::StreamDropGuard;
+
+    #[tokio::test]
+    async fn stream_drop_guard() {
+        let token = CancellationToken::new();
+
+        let guard_1 = StreamDropGuard::new([1; 32].into(), token.clone());
+        assert_eq!(guard_1.counter(), 1);
+
+        let guard_2 = guard_1.clone();
+        assert_eq!(guard_1.counter(), 2);
+
+        let guard_3 = guard_1.clone();
+        assert_eq!(guard_1.counter(), 3);
+
+        drop(guard_3);
+        assert_eq!(guard_1.counter(), 2);
+        assert!(!token.is_cancelled());
+
+        drop(guard_2);
+        assert_eq!(guard_1.counter(), 1);
+        assert!(!token.is_cancelled());
+
+        drop(guard_1);
+        assert!(token.is_cancelled());
+    }
+}

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod acked;
+mod drop_guard;
 mod ephemeral_stream;
 mod event_stream;
 mod external_stream;

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -5,8 +5,10 @@ mod ephemeral_stream;
 mod event_stream;
 mod external_stream;
 mod local_stream;
+mod publisher;
 mod replay;
 mod stream;
+mod subscription;
 mod sync_metrics;
 
 use p2panda_core::Topic;
@@ -26,12 +28,11 @@ pub use event_stream::SystemEvent;
 pub(crate) use event_stream::event_stream;
 pub use external_stream::ExternalStreamFuture;
 pub(crate) use local_stream::LocalStreamFuture;
+pub use publisher::{ImportError, PublishError, PublishFuture, StreamPublisher};
 pub use replay::{ReplayError, StreamFrom};
 pub(crate) use stream::processed_stream;
-pub use stream::{
-    ImportError, ProcessedOperation, PublishError, PublishFuture, Source, StreamEvent,
-    StreamPublisher, StreamSubscription,
-};
+pub use stream::{ProcessedOperation, Source, StreamEvent};
+pub use subscription::StreamSubscription;
 pub use sync_metrics::{SessionPhase, SyncError};
 
 pub(crate) type Event = crate::processor::Event<LogId, Extensions, Topic>;

--- a/p2panda/src/streams/publisher.rs
+++ b/p2panda/src/streams/publisher.rs
@@ -16,6 +16,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::forge::{Forge, ForgeError, OperationForge};
 use crate::operation::{Extensions, LogId, Operation};
 use crate::spaces::RepairError;
+use crate::streams::drop_guard::StreamDropGuard;
 use crate::streams::external_stream::ExternalStreamFuture;
 use crate::streams::local_stream::LocalStreamFuture;
 use crate::streams::{Event, StreamEvent};
@@ -106,6 +107,7 @@ pub struct StreamPublisher<M> {
     import_local_tx: ImportLocalTx,
     pub(crate) to_output_tx: ToOutputTx<M>,
     pub(crate) repair_tx: RepairTx,
+    _guard: StreamDropGuard,
     _marker: PhantomData<M>,
 }
 
@@ -123,6 +125,7 @@ where
         import_local_tx: ImportLocalTx,
         repair_tx: RepairTx,
         to_output_tx: ToOutputTx<M>,
+        _guard: StreamDropGuard,
     ) -> Self {
         Self {
             topic,
@@ -132,6 +135,7 @@ where
             import_local_tx,
             repair_tx,
             to_output_tx,
+            _guard,
             _marker: PhantomData,
         }
     }

--- a/p2panda/src/streams/publisher.rs
+++ b/p2panda/src/streams/publisher.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::stream::BoxStream;
+use futures_util::{FutureExt, Stream};
+use p2panda_core::cbor::{EncodeError, encode_cbor};
+use p2panda_core::{Hash, Topic};
+use serde::Serialize;
+use thiserror::Error;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::forge::{Forge, ForgeError, OperationForge};
+use crate::operation::{Extensions, LogId, Operation};
+use crate::spaces::RepairError;
+use crate::streams::external_stream::ExternalStreamFuture;
+use crate::streams::local_stream::LocalStreamFuture;
+use crate::streams::{Event, StreamEvent};
+
+type PublishTx<M> = mpsc::Sender<(Operation, Option<M>, oneshot::Sender<Event>)>;
+type ImportExternalTx = mpsc::Sender<(
+    BoxStream<'static, Operation>,
+    oneshot::Sender<ExternalStreamFuture>,
+)>;
+type ImportLocalTx = mpsc::Sender<(
+    BoxStream<'static, Operation>,
+    oneshot::Sender<LocalStreamFuture>,
+)>;
+type ToOutputTx<M> = mpsc::Sender<Vec<StreamEvent<M>>>;
+type RepairTx = mpsc::Sender<oneshot::Sender<Result<bool, RepairError>>>;
+
+/// Publish messages into a topic stream.
+///
+/// Any message type `M` can be published as long as it can be encoded into bytes by implementing
+/// serde's [`Serialize`] and [`Deserialize`] traits.
+///
+/// ## Example
+///
+/// ```rust
+/// # use p2panda_core::Topic;
+/// # use serde::{Serialize, Deserialize};
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let node = p2panda::builder().spawn().await?;
+/// #
+/// let our_trees = Topic::random();
+///
+/// #[derive(Clone, Debug, Serialize, Deserialize)]
+/// struct Tree {
+///     leafy: bool,
+///     latin_name: String,
+/// }
+///
+/// let (tx, _rx) = node.stream::<Tree>(our_trees).await?;
+///
+/// tx.publish(Tree {
+///     leafy: true,
+///     latin_name: "Acer pseudoplatanus".into(),
+/// }).await?;
+/// #
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Append-only log
+///
+/// The Node API internally maintains an append-only log data-type for published application
+/// messages in a topic stream.
+///
+/// Publishing a message creates and signs an [`Operation`] which gets automatically appended to
+/// the author's log for the given topic. The message itself is the payload of the created
+/// operation.
+///
+/// ```plain
+/// Author "Panda"
+/// Topic "Trees" Log: [ Header ] <-- [ Header ] <-- [ Header ] ...
+///                         |             |              |
+///                         v            ...            ...
+///                     [ Body ]
+///               "Acer pseudoplatanus"
+///
+/// Author "Icebear"
+/// Topic "Trees" Log: [ Header ] <-- [ Header ] ...
+///                         |             |
+///                         v            ...
+///                     [ Body ]
+///                 "Pinus halepensis"
+/// ```
+///
+/// ## External sources
+///
+/// Operations can be imported from external sources into the processing pipeline by calling
+/// [`StreamPublisher::import`]. This allows transporting data via sneakernets (USB stick, etc.) or
+/// other sync solutions.
+#[derive(Clone, Debug)]
+pub struct StreamPublisher<M> {
+    topic: Topic,
+    forge: OperationForge,
+    #[allow(clippy::type_complexity)]
+    pub(crate) publish_tx: PublishTx<M>,
+    import_external_tx: ImportExternalTx,
+    #[allow(clippy::type_complexity)]
+    import_local_tx: ImportLocalTx,
+    pub(crate) to_output_tx: ToOutputTx<M>,
+    pub(crate) repair_tx: RepairTx,
+    _marker: PhantomData<M>,
+}
+
+impl<M> StreamPublisher<M>
+where
+    M: Serialize,
+{
+    /// Create a new `StreamPublisher`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        topic: Topic,
+        forge: OperationForge,
+        publish_tx: PublishTx<M>,
+        import_external_tx: ImportExternalTx,
+        import_local_tx: ImportLocalTx,
+        repair_tx: RepairTx,
+        to_output_tx: ToOutputTx<M>,
+    ) -> Self {
+        Self {
+            topic,
+            forge,
+            publish_tx,
+            import_external_tx,
+            import_local_tx,
+            repair_tx,
+            to_output_tx,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Associated topic.
+    pub fn topic(&self) -> Topic {
+        self.topic
+    }
+
+    /// Publish a message into a topic stream.
+    ///
+    /// Locally created operations are processed by the same pipeline as remotely received
+    /// operations. It is possible to await the processing result which can be useful for some
+    /// applications if they want to block UI components etc.
+    pub async fn publish(&self, message: M) -> Result<PublishFuture, PublishError> {
+        self.publish_inner(Some(message), false).await
+    }
+
+    /// Deletes all our previously published messages in this topic stream.
+    ///
+    /// This signals to all other nodes that they should remove them as well.
+    ///
+    /// A message can be optionally added when pruning, allowing to publish a "snapshot" /
+    /// state-based CRDT of the current state, so nodes can still consistently re-create all state,
+    /// even if previous messages are gone.
+    ///
+    /// Internally we're applying append-only log prefix deletion, meaning that the log's prefix
+    /// gets pruned. The prefix is the set of operations in the log's sequence which are causally
+    /// "older" / before the point where the prune flag was set.
+    pub async fn prune(&self, message: Option<M>) -> Result<PublishFuture, PublishError> {
+        self.publish_inner(message, true).await
+    }
+
+    /// Import an external source of operations.
+    ///
+    /// Please note: Operations do not contain any information by themselves about to which topic
+    /// they belong. By importing operations into a topic stream, they will be assigned to this
+    /// topic. Make sure you accordingly routed operations into the correct topic before.
+    pub async fn import(
+        &self,
+        stream: impl Stream<Item = Operation> + Send + 'static,
+    ) -> Result<ExternalStreamFuture, ImportError> {
+        // Send stream to processor.
+        let stream = Box::pin(stream);
+        let (ready_tx, ready_rx) = oneshot::channel::<ExternalStreamFuture>();
+        self.import_external_tx
+            .send((stream, ready_tx))
+            .await
+            .map_err(|err| ImportError::SendToProcessor(err.to_string()))?;
+
+        // Await receiving the session id and future which will complete when the external stream
+        // closes and all operations have been processed.
+        ready_rx
+            .await
+            .map_err(|err| ImportError::ReceiveFromProcessor(err.to_string()))
+    }
+
+    /// Import a local source of operations.
+    ///
+    /// This method can be used for importing some locally forged operations in a batch. The user
+    /// will receive no "import" events on the stream, only events resulting from publishing the
+    /// operations themselves.
+    pub(crate) async fn import_local(
+        &self,
+        stream: impl Stream<Item = Operation> + Send + 'static,
+    ) -> Result<LocalStreamFuture, ImportError> {
+        // Send stream to processor.
+        let stream = Box::pin(stream);
+        let (ready_tx, ready_rx) = oneshot::channel::<LocalStreamFuture>();
+        self.import_local_tx
+            .send((stream, ready_tx))
+            .await
+            .map_err(|err| ImportError::SendToProcessor(err.to_string()))?;
+
+        // Await receiving the future which will complete when the stream
+        // closes and all operations have been processed.
+        ready_rx
+            .await
+            .map_err(|err| ImportError::ReceiveFromProcessor(err.to_string()))
+    }
+
+    async fn publish_inner(
+        &self,
+        message: Option<M>,
+        prune_flag: bool,
+    ) -> Result<PublishFuture, PublishError> {
+        // Create, sign and persist operation with given payload.
+        let extensions = Extensions::builder(LogId::from_topic(self.topic()))
+            .prune_flag(prune_flag)
+            .build();
+
+        let body_bytes = match message {
+            Some(ref message) => Some(encode_cbor(&message)?),
+            None => None,
+        };
+
+        let operation = self
+            .forge
+            .create_operation(
+                Some(self.topic()),
+                extensions.log_id(),
+                body_bytes,
+                extensions,
+            )
+            .await?;
+        let hash = operation.hash;
+
+        // Start processing operation in pipeline. Keep a oneshot receiver around to allow users to
+        // optionally await & get informed when processing has finished.
+        let (processed_tx, processed_rx) = oneshot::channel();
+        self.publish_tx
+            .send((operation.clone(), message, processed_tx))
+            .await
+            .map_err(|err| PublishError::SendToProcessor(err.to_string()))?;
+
+        Ok(PublishFuture { hash, processed_rx })
+    }
+}
+
+/// Future which can be awaited to find out when a locally published operation has finished
+/// processing.
+#[derive(Debug)]
+pub struct PublishFuture {
+    hash: Hash,
+    processed_rx: oneshot::Receiver<Event>,
+}
+
+impl PublishFuture {
+    /// Returns hash of the published operation.
+    pub fn hash(&self) -> Hash {
+        self.hash
+    }
+}
+
+impl Future for PublishFuture {
+    type Output = Result<Event, oneshot::error::RecvError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.processed_rx.poll_unpin(cx)
+    }
+}
+
+/// Error occurred when creating operation and publishing it to topic stream.
+#[derive(Debug, Error)]
+pub enum PublishError {
+    #[error("an error occurred while serializing the message for publication: {0}")]
+    MessageEncoding(#[from] EncodeError),
+
+    #[error("an error occurred while creating an operation in the forge: {0}")]
+    Forge(#[from] ForgeError),
+
+    #[error("an error occurred while publishing an operation to the log sync stream: {0}")]
+    SyncHandle(String),
+
+    #[error("could not send to processor pipeline: {0}")]
+    SendToProcessor(String),
+}
+
+#[derive(Debug, Error)]
+pub enum ImportError {
+    #[error("could not send to processor pipeline: {0}")]
+    SendToProcessor(String),
+
+    #[error("an error occurred awaiting message from processor: {0}")]
+    ReceiveFromProcessor(String),
+}

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -2,14 +2,11 @@
 
 use std::borrow::Borrow;
 use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
+use futures_util::StreamExt;
 use futures_util::stream::BoxStream;
-use futures_util::{FutureExt, Stream, StreamExt};
-use p2panda_core::cbor::{DecodeError, EncodeError, decode_cbor, encode_cbor};
+use p2panda_core::cbor::{DecodeError, decode_cbor};
 use p2panda_core::traits::Digest;
 use p2panda_core::{Hash, Topic, VerifyingKey};
 use p2panda_net::NodeId;
@@ -19,27 +16,27 @@ use p2panda_net::sync::SyncHandle;
 use p2panda_net::utils::ShortFormat;
 use p2panda_spaces::SpaceEvent;
 use p2panda_store::SqliteStore;
-use p2panda_store::operations::OperationStore;
 use p2panda_stream::spaces::SpacesResult;
 use p2panda_sync::protocols::TopicLogSyncEvent;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, warn};
 
-use crate::forge::{Forge, ForgeError, OperationForge};
+use crate::forge::OperationForge;
 use crate::node::{AckPolicy, CreateStreamError};
-use crate::operation::{Extensions, Header, LogId, Operation};
+use crate::operation::{Extensions, Header, Operation};
 use crate::processor::{ProcessorError, ProcessorStatus};
+use crate::spaces::spawn_repair_task;
 use crate::spaces::types::SpacesManager;
-use crate::spaces::{RepairError, spawn_repair_task};
 use crate::streams::acked::{Acked, AckedError};
 use crate::streams::external_stream::{
     ExternalStream, ExternalStreamEvent, ExternalStreamFuture, SessionId,
 };
 use crate::streams::local_stream::{LocalStream, LocalStreamEvent, LocalStreamFuture};
+use crate::streams::publisher::StreamPublisher;
 use crate::streams::replay::{ReplayError, StreamFrom, replay_log_ranges};
+use crate::streams::subscription::StreamSubscription;
 use crate::streams::sync_metrics::{self, Aggregator, SessionPhase, SyncError};
 use crate::streams::{Event, Pipeline};
 
@@ -404,7 +401,7 @@ where
         });
     }
 
-    let tx = StreamPublisher {
+    let tx = StreamPublisher::new(
         topic,
         forge,
         publish_tx,
@@ -412,15 +409,9 @@ where
         import_local_tx,
         repair_tx,
         to_output_tx,
-        _marker: PhantomData,
-    };
+    );
 
-    let rx = StreamSubscription {
-        topic,
-        store,
-        acked,
-        stream: ReceiverStream::new(app_rx),
-    };
+    let rx = StreamSubscription::new(topic, store, acked, ReceiverStream::new(app_rx));
 
     Ok((tx, rx))
 }
@@ -610,303 +601,6 @@ where
     }
 
     Some(forward_events)
-}
-
-/// Publish messages into a topic stream.
-///
-/// Any message type `M` can be published as long as it can be encoded into bytes by implementing
-/// serde's [`Serialize`] and [`Deserialize`] traits.
-///
-/// ## Example
-///
-/// ```rust
-/// # use p2panda_core::Topic;
-/// # use serde::{Serialize, Deserialize};
-/// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # let node = p2panda::builder().spawn().await?;
-/// #
-/// let our_trees = Topic::random();
-///
-/// #[derive(Clone, Debug, Serialize, Deserialize)]
-/// struct Tree {
-///     leafy: bool,
-///     latin_name: String,
-/// }
-///
-/// let (tx, _rx) = node.stream::<Tree>(our_trees).await?;
-///
-/// tx.publish(Tree {
-///     leafy: true,
-///     latin_name: "Acer pseudoplatanus".into(),
-/// }).await?;
-/// #
-/// # Ok(())
-/// # }
-/// ```
-///
-/// ## Append-only log
-///
-/// The Node API internally maintains an append-only log data-type for published application
-/// messages in a topic stream.
-///
-/// Publishing a message creates and signs an [`Operation`] which gets automatically appended to
-/// the author's log for the given topic. The message itself is the payload of the created
-/// operation.
-///
-/// ```plain
-/// Author "Panda"
-/// Topic "Trees" Log: [ Header ] <-- [ Header ] <-- [ Header ] ...
-///                         |             |              |
-///                         v            ...            ...
-///                     [ Body ]
-///               "Acer pseudoplatanus"
-///
-/// Author "Icebear"
-/// Topic "Trees" Log: [ Header ] <-- [ Header ] ...
-///                         |             |
-///                         v            ...
-///                     [ Body ]
-///                 "Pinus halepensis"
-/// ```
-///
-/// ## External sources
-///
-/// Operations can be imported from external sources into the processing pipeline by calling
-/// [`StreamPublisher::import`]. This allows transporting data via sneakernets (USB stick, etc.) or
-/// other sync solutions.
-#[derive(Clone, Debug)]
-pub struct StreamPublisher<M> {
-    topic: Topic,
-    forge: OperationForge,
-    #[allow(clippy::type_complexity)]
-    pub(crate) publish_tx: mpsc::Sender<(Operation, Option<M>, oneshot::Sender<Event>)>,
-    import_external_tx: mpsc::Sender<(
-        BoxStream<'static, Operation>,
-        oneshot::Sender<ExternalStreamFuture>,
-    )>,
-    #[allow(clippy::type_complexity)]
-    import_local_tx: mpsc::Sender<(
-        BoxStream<'static, Operation>,
-        oneshot::Sender<LocalStreamFuture>,
-    )>,
-    pub(crate) to_output_tx: mpsc::Sender<Vec<StreamEvent<M>>>,
-    pub(crate) repair_tx: mpsc::Sender<oneshot::Sender<Result<bool, RepairError>>>,
-    _marker: PhantomData<M>,
-}
-
-impl<M> StreamPublisher<M>
-where
-    M: Serialize,
-{
-    /// Associated topic.
-    pub fn topic(&self) -> Topic {
-        self.topic
-    }
-
-    /// Publish a message into a topic stream.
-    ///
-    /// Locally created operations are processed by the same pipeline as remotely received
-    /// operations. It is possible to await the processing result which can be useful for some
-    /// applications if they want to block UI components etc.
-    pub async fn publish(&self, message: M) -> Result<PublishFuture, PublishError> {
-        self.publish_inner(Some(message), false).await
-    }
-
-    /// Deletes all our previously published messages in this topic stream.
-    ///
-    /// This signals to all other nodes that they should remove them as well.
-    ///
-    /// A message can be optionally added when pruning, allowing to publish a "snapshot" /
-    /// state-based CRDT of the current state, so nodes can still consistently re-create all state,
-    /// even if previous messages are gone.
-    ///
-    /// Internally we're applying append-only log prefix deletion, meaning that the log's prefix
-    /// gets pruned. The prefix is the set of operations in the log's sequence which are causally
-    /// "older" / before the point where the prune flag was set.
-    pub async fn prune(&self, message: Option<M>) -> Result<PublishFuture, PublishError> {
-        self.publish_inner(message, true).await
-    }
-
-    /// Import an external source of operations.
-    ///
-    /// Please note: Operations do not contain any information by themselves about to which topic
-    /// they belong. By importing operations into a topic stream, they will be assigned to this
-    /// topic. Make sure you accordingly routed operations into the correct topic before.
-    pub async fn import(
-        &self,
-        stream: impl Stream<Item = Operation> + Send + 'static,
-    ) -> Result<ExternalStreamFuture, ImportError> {
-        // Send stream to processor.
-        let stream = Box::pin(stream);
-        let (ready_tx, ready_rx) = oneshot::channel::<ExternalStreamFuture>();
-        self.import_external_tx
-            .send((stream, ready_tx))
-            .await
-            .map_err(|err| ImportError::SendToProcessor(err.to_string()))?;
-
-        // Await receiving the session id and future which will complete when the external stream
-        // closes and all operations have been processed.
-        ready_rx
-            .await
-            .map_err(|err| ImportError::ReceiveFromProcessor(err.to_string()))
-    }
-
-    /// Import a local source of operations.
-    ///
-    /// This method can be used for importing some locally forged operations in a batch. The user
-    /// will receive no "import" events on the stream, only events resulting from publishing the
-    /// operations themselves.
-    pub(crate) async fn import_local(
-        &self,
-        stream: impl Stream<Item = Operation> + Send + 'static,
-    ) -> Result<LocalStreamFuture, ImportError> {
-        // Send stream to processor.
-        let stream = Box::pin(stream);
-        let (ready_tx, ready_rx) = oneshot::channel::<LocalStreamFuture>();
-        self.import_local_tx
-            .send((stream, ready_tx))
-            .await
-            .map_err(|err| ImportError::SendToProcessor(err.to_string()))?;
-
-        // Await receiving the future which will complete when the stream
-        // closes and all operations have been processed.
-        ready_rx
-            .await
-            .map_err(|err| ImportError::ReceiveFromProcessor(err.to_string()))
-    }
-
-    async fn publish_inner(
-        &self,
-        message: Option<M>,
-        prune_flag: bool,
-    ) -> Result<PublishFuture, PublishError> {
-        // Create, sign and persist operation with given payload.
-        let extensions = Extensions::builder(LogId::from_topic(self.topic()))
-            .prune_flag(prune_flag)
-            .build();
-
-        let body_bytes = match message {
-            Some(ref message) => Some(encode_cbor(&message)?),
-            None => None,
-        };
-
-        let operation = self
-            .forge
-            .create_operation(
-                Some(self.topic()),
-                extensions.log_id(),
-                body_bytes,
-                extensions,
-            )
-            .await?;
-        let hash = operation.hash;
-
-        // Start processing operation in pipeline. Keep a oneshot receiver around to allow users to
-        // optionally await & get informed when processing has finished.
-        let (processed_tx, processed_rx) = oneshot::channel();
-        self.publish_tx
-            .send((operation.clone(), message, processed_tx))
-            .await
-            .map_err(|err| PublishError::SendToProcessor(err.to_string()))?;
-
-        Ok(PublishFuture { hash, processed_rx })
-    }
-}
-
-/// Future which can be awaited to find out when a locally published operation has finished
-/// processing.
-#[derive(Debug)]
-pub struct PublishFuture {
-    hash: Hash,
-    processed_rx: oneshot::Receiver<Event>,
-}
-
-impl PublishFuture {
-    /// Returns hash of the published operation.
-    pub fn hash(&self) -> Hash {
-        self.hash
-    }
-}
-
-impl Future for PublishFuture {
-    type Output = Result<Event, oneshot::error::RecvError>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.processed_rx.poll_unpin(cx)
-    }
-}
-
-/// Subscription to events arriving from a topic stream.
-///
-/// A topic stream emits:
-///
-/// - Locally created or remotely synced [`ProcessedOperation`] with application messages inside
-/// - Topic-scoped system-events, for example if a sync session has begun and how much will be sent
-/// - Critical errors such as [`AckedError`] coming from the processing pipeline
-///
-/// ## Example
-///
-/// ```no_run
-/// use futures_util::StreamExt;
-/// use p2panda_core::Topic;
-/// # #[tokio::main]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # let node = p2panda::spawn().await?;
-/// let topic = Topic::random();
-///
-/// let (_tx, mut rx) = node.stream::<String>(topic).await?;
-///
-/// while let Some(stream_event) = rx.next().await {
-///     // .. react to topic stream events
-/// }
-/// #
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug)]
-pub struct StreamSubscription<M> {
-    topic: Topic,
-    store: SqliteStore,
-    acked: Acked,
-    stream: ReceiverStream<StreamEvent<M>>,
-}
-
-impl<M> StreamSubscription<M> {
-    /// Associated topic.
-    pub fn topic(&self) -> Topic {
-        self.topic
-    }
-
-    /// Explicitly acknowledge operation.
-    ///
-    /// Fails silently if operation is not known (it might have been pruned, etc.).
-    ///
-    /// If the [`AckPolicy`] is set to "explicit", users want to call this method _after_
-    /// applicaton-level processing has successfully finished. See high-level description in
-    /// [`Node::stream`](crate::node::Node::stream) for more details.
-    pub async fn ack(&self, id: Hash) -> Result<(), AckedError> {
-        if let Some(operation) = OperationStore::<_, _>::get_operation(&self.store, &id).await? {
-            self.acked.ack(&operation.header).await?;
-        }
-
-        Ok(())
-    }
-}
-
-impl<M> Stream for StreamSubscription<M>
-where
-    M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
-{
-    type Item = StreamEvent<M>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.stream.poll_next_unpin(cx)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.stream.size_hint()
-    }
 }
 
 /// Operations with application messages, system events and errors coming from a topic stream
@@ -1183,29 +877,4 @@ pub enum Source {
 
     /// Source when an operation was published locally or replayed.
     LocalStore,
-}
-
-/// Error occurred when creating operation and publishing it to topic stream.
-#[derive(Debug, Error)]
-pub enum PublishError {
-    #[error("an error occurred while serializing the message for publication: {0}")]
-    MessageEncoding(#[from] EncodeError),
-
-    #[error("an error occurred while creating an operation in the forge: {0}")]
-    Forge(#[from] ForgeError),
-
-    #[error("an error occurred while publishing an operation to the log sync stream: {0}")]
-    SyncHandle(String),
-
-    #[error("could not send to processor pipeline: {0}")]
-    SendToProcessor(String),
-}
-
-#[derive(Debug, Error)]
-pub enum ImportError {
-    #[error("could not send to processor pipeline: {0}")]
-    SendToProcessor(String),
-
-    #[error("an error occurred awaiting message from processor: {0}")]
-    ReceiveFromProcessor(String),
 }

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -21,6 +21,7 @@ use p2panda_sync::protocols::TopicLogSyncEvent;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 use crate::forge::OperationForge;
@@ -30,6 +31,7 @@ use crate::processor::{ProcessorError, ProcessorStatus};
 use crate::spaces::spawn_repair_task;
 use crate::spaces::types::SpacesManager;
 use crate::streams::acked::{Acked, AckedError};
+use crate::streams::drop_guard::StreamDropGuard;
 use crate::streams::external_stream::{
     ExternalStream, ExternalStreamEvent, ExternalStreamFuture, SessionId,
 };
@@ -168,10 +170,13 @@ where
         repair_rx,
     );
 
-    // FIXME: Both tasks need to be gracefully shut down when the tx / rx halves got dropped,
-    // otherwise the sync session keeps running.
+    // Create a cancellation token which is used to break out of the input and output event
+    // processing tasks once all instances of the `StreamPublisher` and `StreamSubscription` have
+    // been dropped.
     //
-    // See related issue: https://github.com/p2panda/p2panda/issues/1272
+    // The spawn repair task doesn't require a cancellation token; it is aborted via the handle
+    // during the wind-down of the input event task.
+    let cancellation_token = CancellationToken::new();
 
     // Spawn first task which receives processed "output events" from the processing pipeline, the
     // result is handled (acking, decoding, conversion to `StreamEvent`, etc.) and then finally
@@ -179,6 +184,8 @@ where
     {
         let pipeline = pipeline.clone();
         let acked = acked.clone();
+
+        let cancellation_token_child = cancellation_token.child_token();
 
         tokio::spawn(async move {
             loop {
@@ -211,6 +218,13 @@ where
                     Some(stream_events) = to_output_rx.recv() => {
                         stream_events
                     }
+
+                    // Break out of the loop, thereby ending the task, when both the
+                    // `StreamPublisher` and `StreamSubscription` have been dropped.
+                    _ = cancellation_token_child.cancelled() => {
+                            debug!(topic = %topic.to_hex(), "aborting output event processing task");
+                        break
+                    }
                 };
 
                 // Send processing result to application layer.
@@ -233,6 +247,8 @@ where
         let store = store.clone();
         let sync_handle = sync_handle.clone();
         let to_output_tx = to_output_tx.clone();
+
+        let cancellation_token_child = cancellation_token.child_token();
 
         tokio::spawn(async move {
             // =======================
@@ -391,6 +407,13 @@ where
                             ,
                         }
                     },
+
+                    // Break out of the loop, thereby ending the task, when both the
+                    // `StreamPublisher` and `StreamSubscription` have been dropped.
+                    _ = cancellation_token_child.cancelled() => {
+                            debug!(topic = %topic.to_hex(), "aborting input event processing task");
+                        break
+                    }
                 };
 
                 let _ = to_output_tx.send(stream_events).await;
@@ -401,6 +424,7 @@ where
         });
     }
 
+    let drop_guard = StreamDropGuard::new(topic, cancellation_token.clone());
     let tx = StreamPublisher::new(
         topic,
         forge,
@@ -409,9 +433,9 @@ where
         import_local_tx,
         repair_tx,
         to_output_tx,
+        drop_guard.clone(),
     );
-
-    let rx = StreamSubscription::new(topic, store, acked, ReceiverStream::new(app_rx));
+    let rx = StreamSubscription::new(topic, store, acked, ReceiverStream::new(app_rx), drop_guard);
 
     Ok((tx, rx))
 }

--- a/p2panda/src/streams/subscription.rs
+++ b/p2panda/src/streams/subscription.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt::Debug;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::{Stream, StreamExt};
+use p2panda_core::{Hash, Topic};
+use p2panda_store::SqliteStore;
+use p2panda_store::operations::OperationStore;
+use serde::{Deserialize, Serialize};
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::streams::StreamEvent;
+use crate::streams::acked::{Acked, AckedError};
+
+/// Subscription to events arriving from a topic stream.
+///
+/// A topic stream emits:
+///
+/// - Locally created or remotely synced [`ProcessedOperation`] with application messages inside
+/// - Topic-scoped system-events, for example if a sync session has begun and how much will be sent
+/// - Critical errors such as [`AckedError`] coming from the processing pipeline
+///
+/// ## Example
+///
+/// ```no_run
+/// use futures_util::StreamExt;
+/// use p2panda_core::Topic;
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let node = p2panda::spawn().await?;
+/// let topic = Topic::random();
+///
+/// let (_tx, mut rx) = node.stream::<String>(topic).await?;
+///
+/// while let Some(stream_event) = rx.next().await {
+///     // .. react to topic stream events
+/// }
+/// #
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct StreamSubscription<M> {
+    topic: Topic,
+    store: SqliteStore,
+    acked: Acked,
+    stream: ReceiverStream<StreamEvent<M>>,
+}
+
+impl<M> StreamSubscription<M> {
+    /// Create a new `StreamSubscription`.
+    pub fn new(
+        topic: Topic,
+        store: SqliteStore,
+        acked: Acked,
+        stream: ReceiverStream<StreamEvent<M>>,
+    ) -> Self {
+        Self {
+            topic,
+            store,
+            acked,
+            stream,
+        }
+    }
+
+    /// Associated topic.
+    pub fn topic(&self) -> Topic {
+        self.topic
+    }
+
+    /// Explicitly acknowledge operation.
+    ///
+    /// Fails silently if operation is not known (it might have been pruned, etc.).
+    ///
+    /// If the [`AckPolicy`] is set to "explicit", users want to call this method _after_
+    /// applicaton-level processing has successfully finished. See high-level description in
+    /// [`Node::stream`](crate::node::Node::stream) for more details.
+    pub async fn ack(&self, id: Hash) -> Result<(), AckedError> {
+        if let Some(operation) = OperationStore::<_, _>::get_operation(&self.store, &id).await? {
+            self.acked.ack(&operation.header).await?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<M> Stream for StreamSubscription<M>
+where
+    M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
+{
+    type Item = StreamEvent<M>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.stream.poll_next_unpin(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+}

--- a/p2panda/src/streams/subscription.rs
+++ b/p2panda/src/streams/subscription.rs
@@ -13,6 +13,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use crate::streams::StreamEvent;
 use crate::streams::acked::{Acked, AckedError};
+use crate::streams::drop_guard::StreamDropGuard;
 
 /// Subscription to events arriving from a topic stream.
 ///
@@ -47,6 +48,7 @@ pub struct StreamSubscription<M> {
     store: SqliteStore,
     acked: Acked,
     stream: ReceiverStream<StreamEvent<M>>,
+    _guard: StreamDropGuard,
 }
 
 impl<M> StreamSubscription<M> {
@@ -56,12 +58,14 @@ impl<M> StreamSubscription<M> {
         store: SqliteStore,
         acked: Acked,
         stream: ReceiverStream<StreamEvent<M>>,
+        _guard: StreamDropGuard,
     ) -> Self {
         Self {
             topic,
             store,
             acked,
             stream,
+            _guard,
         }
     }
 

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::time::Duration;
-
 use futures_util::StreamExt;
 use mock_instant::thread_local::MockClock;
 use p2panda::Credentials;
@@ -17,6 +15,7 @@ use p2panda_core::{Cursor, Hash, Topic};
 use p2panda_net::discovery::DiscoveryEvent;
 use p2panda_store::logs::LogStore;
 use tokio::task::JoinHandle;
+use tokio::time::{Duration, sleep};
 
 fn assert_replay_started<M>(event: &StreamEvent<M>, expected_total_operations: u32) {
     let StreamEvent::ReplayStarted { total_operations } = event else {
@@ -248,10 +247,15 @@ async fn automatic_acking() {
     assert_message_id(&rx.next().await.unwrap(), message_id_1);
     assert_message_id(&rx.next().await.unwrap(), message_id_2);
 
-    // Create a new subscription.
     drop(tx);
     drop(rx);
 
+    // TODO: Remove this once we're able to close the (tx, rx) gracefully.
+    //
+    // Sleep briefly to wait for sync session clean-up to complete.
+    sleep(Duration::from_millis(50)).await;
+
+    // Create a new subscription.
     let (tx, mut rx) = node.stream::<String>(topic).await.unwrap();
 
     // Publish one more message.
@@ -298,10 +302,15 @@ async fn explicit_acking() {
     // Acknowledge first message.
     rx.ack(message_id_1).await.unwrap();
 
-    // Create a new subscription, streaming from "acked frontier".
     drop(tx);
     drop(rx);
 
+    // TODO: Remove this once we're able to close the (tx, rx) gracefully.
+    //
+    // Sleep briefly to wait for sync session clean-up to complete.
+    sleep(Duration::from_millis(50)).await;
+
+    // Create a new subscription, streaming from "acked frontier".
     let (_tx, mut rx) = node.stream::<String>(topic).await.unwrap();
 
     // We except to receive only the un-acked messages from the subscription stream.
@@ -324,6 +333,11 @@ async fn replay_stream_from_start() {
         let (panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
         panda_tx.publish("Hello, Icebear!".into()).await.unwrap();
     }
+
+    // TODO: Remove this once we're able to close the (tx, rx) gracefully.
+    //
+    // Sleep briefly to wait for sync session clean-up to complete.
+    sleep(Duration::from_millis(50)).await;
 
     // Panda subscribes again, this time asking to replay all messages from start.
     let (_panda_tx, mut panda_rx) = panda
@@ -383,13 +397,18 @@ async fn replay_stream_from_cursor() {
         id
     };
 
-    // Force re-playing from custom cursor position with new stream subscription.
     drop(tx);
     drop(rx);
+
+    // TODO: Remove this once we're able to close the (tx, rx) gracefully.
+    //
+    // Sleep briefly to wait for sync session clean-up to complete.
+    sleep(Duration::from_millis(50)).await;
 
     let mut cursor = Cursor::new(topic.to_string(), LogHeights::default());
     cursor.advance(node.id(), LogId::from_topic(topic), 0); // seq_num = 0, the first message
 
+    // Force re-playing from custom cursor position with new stream subscription.
     let (_tx, mut rx) = node
         .stream_from::<String>(topic, StreamFrom::Cursor(cursor))
         .await
@@ -535,11 +554,62 @@ async fn deduplicate_events() {
                     received.push(operation);
                 }
             }
-            _ = tokio::time::sleep(Duration::from_secs(2)) => {
+            _ = sleep(Duration::from_secs(2)) => {
                 break;
             }
         }
     }
 
     assert_eq!(received.len(), 3);
+}
+
+#[tokio::test]
+async fn sync_is_closed_on_drop() {
+    setup_logging();
+
+    let chat_id = Topic::random();
+
+    let panda = p2panda::builder().spawn().await.unwrap();
+    let icebear = p2panda::builder().spawn().await.unwrap();
+
+    let (panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
+    panda_tx.publish("Hello, Icebear!".into()).await.unwrap();
+
+    let (_icebear_tx, mut icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
+
+    let mut sync_started = false;
+
+    while let Some(event) = icebear_rx.next().await {
+        if let StreamEvent::SyncStarted { .. } = event {
+            sync_started = true;
+            break;
+        }
+    }
+    assert!(sync_started);
+
+    // Sync session should be terminated once both stream handles have been dropped.
+    drop(_icebear_tx);
+    drop(icebear_rx);
+
+    // TODO: Remove this once we're able to close the (tx, rx) gracefully.
+    //
+    // Sleep briefly to wait for sync session clean-up to complete.
+    sleep(Duration::from_millis(50)).await;
+
+    // Resubscribe to the same topic.
+    let (_icebear_tx, mut icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
+
+    let mut sync_started_again = false;
+
+    // Assert that a new sync session has started.
+    //
+    // This serves to ensure that the initial sync session for this topic was terminated once
+    // icebear's stream handles were dropped.
+    while let Some(event) = icebear_rx.next().await {
+        if let StreamEvent::SyncStarted { .. } = event {
+            sync_started_again = true;
+            break;
+        }
+    }
+    assert!(sync_started_again);
 }


### PR DESCRIPTION
Here we introduce a `StreamDropGuard` to ensure that the input and output event processing tasks in `processed_stream()` are broken out of when all instances of a topic stream handle are dropped.

The commit messages tell the detailed story.

Addresses: https://github.com/p2panda/p2panda/issues/1272

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header