### PR TITLE
Only emit space membership change events when user is member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Highlights are marked with a pancake 🥞
 
 - Use `Signer` trait instead of `SigningKey` in `p2panda-core` [#1202](https://github.com/p2panda/p2panda/pull/1202)
 - spaces: Remove auth resolver generic parameter [#1298](https://github.com/p2panda/p2panda/pull/1298)
+- spaces: Only emit membership change events if local user is space member [#1304](https://github.com/p2panda/p2panda/pull/1304)
 
 ### Fixed
 

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -467,6 +467,12 @@ where
                 return Ok(Some((y, events)));
             };
 
+            // If we are not a member of the space anymore/yet, then don't forward any membership
+            // change events.
+            if !next_members.contains(&self.manager.id()) {
+                return Ok(Some((y, events)));
+            }
+
             // Construct space membership event.
             let membership_event = space_message_to_space_event(
                 self.id(),

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -668,9 +668,9 @@ async fn remove_member() {
     assert_eq!(events.len(), 1);
     bob.persist_operation(&message_04).await.unwrap();
     let events = bob_manager.process_persisted(&message_04).await.unwrap();
-    assert_eq!(events.len(), 2);
+    assert_eq!(events.len(), 1);
     assert!(matches!(
-        events[1],
+        events[0],
         Event::Space(SpaceEvent::Ejected { .. })
     ));
 }
@@ -1400,11 +1400,9 @@ async fn events() {
                 std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Removed { context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             11 => {
-                assert_eq!(bob_events.len(), 2);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Removed { removed, .. }) if removed == vec![bob_id, claire_id]);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Removed { context: SpaceContext{ auth_author, spaces_author, ..}, .. }) if auth_author == alice_id && spaces_author == alice_id);
+                assert_eq!(bob_events.len(), 1);
                 std::assert_matches!(
-                    bob_events[1].clone(),
+                    bob_events[0].clone(),
                     Event::Space(SpaceEvent::Ejected { .. })
                 );
             }
@@ -1412,7 +1410,7 @@ async fn events() {
         }
     }
 
-    assert_eq!(all_bob_events.len(), 11);
+    assert_eq!(all_bob_events.len(), 10);
 }
 
 #[tokio::test]

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -64,20 +64,6 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
         };
     }
 
-    // Penguin laptop receives space created event.
-    while let Some(event) = penguin_laptop_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
-            break;
-        };
-    }
-
-    // Penguin mobile receives space created event.
-    while let Some(event) = penguin_mobile_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
-            break;
-        };
-    }
-
     // Penguin creates a device group (on their laptop).
     let penguin = penguin_laptop
         .create_group(&[
@@ -212,14 +198,14 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
     // Panda creates and subscribes to a space.
     let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
 
-    while let Some(event) = penguin_rx.next().await {
+    while let Some(event) = panda_rx.next().await {
         if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
             break;
         };
     }
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+        if let StreamEvent::KeyBundle(..) = event {
             break;
         };
     }
@@ -337,12 +323,6 @@ async fn sync_repair_space() -> Result<(), Box<dyn std::error::Error>> {
     let (_penguin_space, mut penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
     let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
 
-    while let Some(event) = penguin_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
-            break;
-        };
-    }
-
     while let Some(event) = panda_rx.next().await {
         if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
             break;
@@ -405,12 +385,6 @@ async fn live_repair_space() -> Result<(), Box<dyn std::error::Error>> {
     // Penguin subscribes to the space.
     let (_penguin_space, mut penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
     let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
-
-    while let Some(event) = penguin_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
-            break;
-        };
-    }
 
     while let Some(event) = panda_rx.next().await {
         if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {


### PR DESCRIPTION
When a member joins a space for the first time they process all past control messages which results in events for membership history _before_ the member joined being emitted on the stream. This is unexpected, if a user is added, then events should only be emitted from that add onwards.

This commit introduces a check in p2panda-spaces results in membership change events only being emitted if the local user is becoming, or already is, a member of the space.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
