### PR TITLE
Make group sendsync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rand = { version = "0.10.1" }
 rand_chacha = { version = "0.10.0" }
 serde = { version = "1.0.228" }
 serde_bytes = { version = "0.11.19" }
+static_assertions = { version = "1.1.0" }
 thiserror = { version = "2.0.18" }
 tokio = { version = "1.52.3", default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false }

--- a/p2panda/Cargo.toml
+++ b/p2panda/Cargo.toml
@@ -40,6 +40,7 @@ p2panda-sync = { workspace = true, default-features = true }
 pin-project = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+static_assertions.workspace = true
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = true, features = ["sync"] }
 tokio-stream = { workspace = true, features = ["sync"] }

--- a/p2panda/src/spaces/group.rs
+++ b/p2panda/src/spaces/group.rs
@@ -28,6 +28,8 @@ pub struct Group {
     event_stream_handle: AbortHandle,
 }
 
+static_assertions::assert_impl_all!(Group: Send, Sync);
+
 impl Drop for Group {
     fn drop(&mut self) {
         self.event_stream_handle.abort();

--- a/p2panda/src/spaces/group.rs
+++ b/p2panda/src/spaces/group.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::cell::RefCell;
 use std::pin::Pin;
+use std::sync::RwLock;
 use std::task::{Context, Poll};
 
 use futures_util::stream::StreamExt;
@@ -24,7 +24,7 @@ use crate::streams::{ExternalStreamFuture, ImportError, StreamPublisher, StreamS
 pub struct Group {
     inner: InnerGroup,
     tx: StreamPublisher<NoBody>,
-    event_stream_rx: RefCell<broadcast::Receiver<GroupEvent>>,
+    event_stream_rx: RwLock<broadcast::Receiver<GroupEvent>>,
     event_stream_handle: AbortHandle,
 }
 
@@ -64,7 +64,7 @@ impl Group {
         Self {
             inner,
             tx,
-            event_stream_rx: RefCell::new(event_stream_rx),
+            event_stream_rx: RwLock::new(event_stream_rx),
             event_stream_handle: event_stream_handle.abort_handle(),
         }
     }
@@ -76,9 +76,13 @@ impl Group {
     pub fn event_stream(&self) -> impl Stream<Item = GroupEvent> + Send + Unpin + 'static {
         // Make sure we're not re-subscribing and thus dropping all events which might be still in
         // the buffer of the first broadcast receiver instance.
-        let stream = self
-            .event_stream_rx
-            .replace_with(|stream| stream.resubscribe());
+        let stream = {
+            let write = self.event_stream_rx.write().unwrap();
+            let resubscribed = write.resubscribe();
+
+            let mut write = write;
+            std::mem::replace(&mut *write, resubscribed)
+        };
 
         // TODO: Check if we really want to silence broadcast "lagged" errors here?
         let stream = BroadcastStream::new(stream).filter_map(|event| async { event.ok() });


### PR DESCRIPTION
Ensure that the `Group` type is `Send + Sync`, so it can be used in multi-threaded environments.

I am not 100% sure on whether this alters functionality and I did not execute the testsuite for now.

## 📋 Checklist

- [x] Add tests that cover your changes
