### PR TITLE
Allow graceful closure of sync sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Highlights are marked with a pancake 🥞
 - node: Forward events resulting from local actions to app layer [#1290](https://github.com/p2panda/p2panda/pull/1290)
 - node: Cancel processed stream tasks on drop of stream handles [#1300](https://github.com/p2panda/p2panda/pull/1300)
 - spaces: Support partial merge of auth state into a space [#1299](https://github.com/p2panda/p2panda/pull/1299)
+- node: Allow graceful closure of sync sessions [#1307](https://github.com/p2panda/p2panda/pull/1307)
 
 ### Changed
 

--- a/p2panda-net/src/sync/actors/manager.rs
+++ b/p2panda-net/src/sync/actors/manager.rs
@@ -16,7 +16,7 @@ use p2panda_sync::protocols::{TopicHandshakeAcceptor, TopicHandshakeEvent, Topic
 use p2panda_sync::traits::{Manager as SyncManagerTrait, Protocol};
 use ractor::thread_local::{ThreadLocalActor, ThreadLocalActorSpawner};
 use ractor::{ActorId, ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent};
-use tokio::sync::{RwLock, broadcast};
+use tokio::sync::{RwLock, broadcast, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
@@ -55,7 +55,10 @@ pub enum ToSyncManager<M, E> {
     ),
 
     /// Close all streams for the given topic.
-    Close(Topic),
+    ///
+    /// A response can be awaited on the receiver of the provided oneshot channel to ensure that
+    /// state cleanup has been completed for any relevant sync sessions.
+    Close(Topic, oneshot::Sender<()>),
 
     /// Initiate sync session.
     InitiateSync(Topic, NodeId),
@@ -269,7 +272,9 @@ where
     ) -> Result<(), ActorProcessingErr> {
         // Close all active sync sessions.
         for (_, (actor, _)) in state.topic_managers.topic_manager_map.drain() {
-            actor.send_message(ToTopicManager::CloseAll)?;
+            let (reply, reply_rx) = oneshot::channel();
+            actor.send_message(ToTopicManager::CloseAll(reply))?;
+            let _ = reply_rx.await;
         }
 
         Ok(())
@@ -361,10 +366,14 @@ where
                     let _ = reply.send(None);
                 }
             }
-            ToSyncManager::Close(topic) => {
+            ToSyncManager::Close(topic, reply) => {
+                debug!(topic = topic.fmt_short(), "close sync in manager");
+
                 // Close all sync sessions running over this topic.
                 if let Some((actor, _)) = state.topic_managers.topic_manager_map.get(&topic) {
-                    actor.send_message(ToTopicManager::CloseAll)?;
+                    let (reply, reply_rx) = oneshot::channel();
+                    actor.send_message(ToTopicManager::CloseAll(reply))?;
+                    let _ = reply_rx.await;
                 }
 
                 // Drop the sync manager state for this topic.
@@ -384,7 +393,9 @@ where
                 // overlay will automatically remove the entry from the address book.
                 state.drop_topic_state(&topic);
 
-                debug!(topic = topic.fmt_short(), "close sync manager");
+                // Inform the caller that termination is complete for sync sessions over this
+                // topic.
+                let _ = reply.send(());
             }
             ToSyncManager::InitiateSync(topic, node_id) => {
                 if let Some((sync_manager_actor, live_mode)) =
@@ -431,7 +442,9 @@ where
                         "end sync session",
                     );
 
-                    sync_manager_actor.send_message(ToTopicManager::Close { node_id })?;
+                    // We don't wish to await termination so we ignore / drop the receiver.
+                    let (reply, _reply_rx) = oneshot::channel();
+                    sync_manager_actor.send_message(ToTopicManager::Close { node_id, reply })?;
                 }
             }
         }
@@ -481,7 +494,9 @@ where
                         "sync manager failed: {panic_msg:#?}",
                     );
 
-                    myself.send_message(ToSyncManager::Close(topic))?;
+                    let (reply, reply_rx) = oneshot::channel();
+                    myself.send_message(ToSyncManager::Close(topic, reply))?;
+                    let _ = reply_rx.await;
                 }
             }
             _ => (),

--- a/p2panda-net/src/sync/actors/topic_manager.rs
+++ b/p2panda-net/src/sync/actors/topic_manager.rs
@@ -1,5 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Topic manager actor.
+//!
+//! The topic manager holds state for all sync sessions associated with a single topic. It provides
+//! a means of initating new sync sessions, accepting inbound sync sessions and publishing messages
+//! to all active sync sessions for the associated topic.
+//!
+//! A separate topic manager actor is spawned by the sync manager for each topic of interest.
+
 use std::collections::{HashMap, HashSet};
 use std::error::Error as StdError;
 use std::fmt::Debug;
@@ -14,7 +22,7 @@ use p2panda_sync::traits::Manager as SyncManagerTrait;
 use p2panda_sync::{FromSync, SessionConfig, ToSync};
 use ractor::thread_local::{ThreadLocalActor, ThreadLocalActorSpawner};
 use ractor::{ActorId, ActorProcessingErr, ActorRef, SupervisionEvent};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, oneshot};
 use tokio::time::Duration;
 use tracing::{debug, warn};
 
@@ -60,10 +68,13 @@ pub enum ToTopicManager<T> {
 
     /// Close all active sync sessions running over the given topic. This essentially shuts down
     /// the whole manager.
-    CloseAll,
+    CloseAll(oneshot::Sender<()>),
 
     /// Close all active sync sessions running with the given node id.
-    Close { node_id: NodeId },
+    Close {
+        node_id: NodeId,
+        reply: oneshot::Sender<()>,
+    },
 }
 
 pub struct TopicManagerState<M>
@@ -311,7 +322,7 @@ where
                     let _ = handle.send(ToSync::Payload(data.clone())).await;
                 }
             }
-            ToTopicManager::CloseAll => {
+            ToTopicManager::CloseAll(reply) => {
                 // Get a handle onto any sync sessions running over the subscription topic and send
                 // a Close message. The session will send a close message to the remote then
                 // immediately drop the session.
@@ -332,8 +343,12 @@ where
                         node_id.fmt_short()
                     );
                 }
+
+                // The receiver may have been dropped immediately if the caller is not interested
+                // in awaiting the termination signal, so we ignore any potential error here.
+                let _ = reply.send(());
             }
-            ToTopicManager::Close { node_id } => {
+            ToTopicManager::Close { node_id, reply } => {
                 if state.active_sync_set.remove(&node_id) {
                     debug!(
                         topic = state.topic.fmt_short(),
@@ -363,6 +378,8 @@ where
                         let _ = handle.send(ToSync::Close).await;
                     }
                 };
+
+                let _ = reply.send(());
             }
         }
 

--- a/p2panda-net/src/sync/handle.rs
+++ b/p2panda-net/src/sync/handle.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use futures_util::{Stream, StreamExt};
 use p2panda_core::Topic;
 use p2panda_sync::FromSync;
 use ractor::{ActorRef, call};
 use thiserror::Error;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, oneshot};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
@@ -25,6 +26,7 @@ where
     topic: Topic,
     manager_ref: ActorRef<ToSyncManager<M, E>>,
     topic_manager_ref: ActorRef<ToTopicManager<M>>,
+    has_closed: AtomicBool,
 }
 
 impl<M, E> SyncHandle<M, E>
@@ -41,6 +43,7 @@ where
             topic,
             manager_ref,
             topic_manager_ref,
+            has_closed: AtomicBool::new(false),
         }
     }
 
@@ -84,6 +87,23 @@ where
             .send_message(ToSyncManager::InitiateSync(self.topic, node_id))
             .unwrap();
     }
+
+    /// Close the associated sync session gracefully.
+    ///
+    /// This method can be awaited to ensure that all sync-related state has been cleaned up.
+    pub async fn close(&self) -> Result<(), SyncHandleError<M, E>> {
+        let (reply, reply_rx) = oneshot::channel();
+
+        self.manager_ref
+            .send_message(ToSyncManager::Close(self.topic, reply))
+            .map_err(Box::new)?;
+
+        // Await the termination completion signal.
+        let _ = reply_rx.await;
+        self.has_closed.store(true, Ordering::Relaxed);
+
+        Ok(())
+    }
 }
 
 impl<M, E> Drop for SyncHandle<M, E>
@@ -92,10 +112,27 @@ where
     E: Clone + Send + 'static,
 {
     fn drop(&mut self) {
-        // Ignore error here as the actor might already be dropped.
-        let _ = self
-            .manager_ref
-            .send_message(ToSyncManager::Close(self.topic));
+        let (reply, _reply_rx) = oneshot::channel();
+
+        // Sending `ToSyncManager::Close` twice for the same topic in quick succession can cause
+        // an error in the `TopicManager` actor; this occurs if a new topic stream is created
+        // immediately after sending the `Close` instruction.
+        //
+        // The error case is clearer if we consider this example of the TopicManager queue:
+        //
+        // Close     -> cleans up all state for the topic
+        // Create    -> sets up state for the topic
+        // Close     -> cleans up all state for the topic
+        // Subscribe -> returns an error because the expected state doesn't exist
+        //
+        // Only send the message here if a graceful closure has not been initiated from a higher
+        // level.
+        if !self.has_closed.load(Ordering::Relaxed) {
+            // Ignore error here as the actor might already be dropped.
+            let _ = self
+                .manager_ref
+                .send_message(ToSyncManager::Close(self.topic, reply));
+        }
     }
 }
 
@@ -150,4 +187,7 @@ pub enum SyncHandleError<M, E> {
 
     #[error("no stream exists for the given topic")]
     StreamNotFound,
+
+    #[error(transparent)]
+    Close(#[from] Box<ractor::MessagingErr<ToSyncManager<M, E>>>),
 }

--- a/p2panda/src/streams/publisher.rs
+++ b/p2panda/src/streams/publisher.rs
@@ -3,12 +3,16 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures_util::stream::BoxStream;
 use futures_util::{FutureExt, Stream};
 use p2panda_core::cbor::{EncodeError, encode_cbor};
 use p2panda_core::{Hash, Topic};
+use p2panda_net::sync::SyncHandle;
+use p2panda_net::utils::ShortFormat;
+use p2panda_sync::protocols::TopicLogSyncEvent;
 use serde::Serialize;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
@@ -100,6 +104,7 @@ type RepairTx = mpsc::Sender<(RepairStrategy, oneshot::Sender<Result<bool, Repai
 pub struct StreamPublisher<M> {
     topic: Topic,
     forge: OperationForge,
+    sync_handle: Arc<SyncHandle<Operation, TopicLogSyncEvent<Extensions>>>,
     #[allow(clippy::type_complexity)]
     pub(crate) publish_tx: PublishTx<M>,
     import_external_tx: ImportExternalTx,
@@ -120,6 +125,7 @@ where
     pub fn new(
         topic: Topic,
         forge: OperationForge,
+        sync_handle: Arc<SyncHandle<Operation, TopicLogSyncEvent<Extensions>>>,
         publish_tx: PublishTx<M>,
         import_external_tx: ImportExternalTx,
         import_local_tx: ImportLocalTx,
@@ -130,6 +136,7 @@ where
         Self {
             topic,
             forge,
+            sync_handle,
             publish_tx,
             import_external_tx,
             import_local_tx,
@@ -152,6 +159,43 @@ where
     /// applications if they want to block UI components etc.
     pub async fn publish(&self, message: M) -> Result<PublishFuture, PublishError> {
         self.publish_inner(Some(message), false).await
+    }
+
+    async fn publish_inner(
+        &self,
+        message: Option<M>,
+        prune_flag: bool,
+    ) -> Result<PublishFuture, PublishError> {
+        // Create, sign and persist operation with given payload.
+        let extensions = Extensions::builder(LogId::from_topic(self.topic()))
+            .prune_flag(prune_flag)
+            .build();
+
+        let body_bytes = match message {
+            Some(ref message) => Some(encode_cbor(&message)?),
+            None => None,
+        };
+
+        let operation = self
+            .forge
+            .create_operation(
+                Some(self.topic()),
+                extensions.log_id(),
+                body_bytes,
+                extensions,
+            )
+            .await?;
+        let hash = operation.hash;
+
+        // Start processing operation in pipeline. Keep a oneshot receiver around to allow users to
+        // optionally await & get informed when processing has finished.
+        let (processed_tx, processed_rx) = oneshot::channel();
+        self.publish_tx
+            .send((operation.clone(), message, processed_tx))
+            .await
+            .map_err(|err| PublishError::SendToProcessor(err.to_string()))?;
+
+        Ok(PublishFuture { hash, processed_rx })
     }
 
     /// Deletes all our previously published messages in this topic stream.
@@ -217,43 +261,26 @@ where
             .map_err(|err| ImportError::ReceiveFromProcessor(err.to_string()))
     }
 
-    async fn publish_inner(
-        &self,
-        message: Option<M>,
-        prune_flag: bool,
-    ) -> Result<PublishFuture, PublishError> {
-        // Create, sign and persist operation with given payload.
-        let extensions = Extensions::builder(LogId::from_topic(self.topic()))
-            .prune_flag(prune_flag)
-            .build();
-
-        let body_bytes = match message {
-            Some(ref message) => Some(encode_cbor(&message)?),
-            None => None,
-        };
-
-        let operation = self
-            .forge
-            .create_operation(
-                Some(self.topic()),
-                extensions.log_id(),
-                body_bytes,
-                extensions,
-            )
-            .await?;
-        let hash = operation.hash;
-
-        // Start processing operation in pipeline. Keep a oneshot receiver around to allow users to
-        // optionally await & get informed when processing has finished.
-        let (processed_tx, processed_rx) = oneshot::channel();
-        self.publish_tx
-            .send((operation.clone(), message, processed_tx))
+    /// Close the associated sync session gracefully.
+    ///
+    /// This method can be awaited to ensure that all sync-related state has been cleaned up
+    /// internally.
+    ///
+    /// Call `close()` if you wish to drop a `StreamPublisher` and then immediately create a new
+    /// stream for the same topic.
+    pub async fn close(&self) -> Result<(), CloseError> {
+        self.sync_handle
+            .close()
             .await
-            .map_err(|err| PublishError::SendToProcessor(err.to_string()))?;
+            .map_err(|_| CloseError(self.topic.fmt_short()))?;
 
-        Ok(PublishFuture { hash, processed_rx })
+        Ok(())
     }
 }
+
+#[derive(Debug, Error)]
+#[error("an error occurred while closing a stream publisher sync handle for topic {0}")]
+pub struct CloseError(String);
 
 /// Future which can be awaited to find out when a locally published operation has finished
 /// processing.

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -428,6 +428,7 @@ where
     let tx = StreamPublisher::new(
         topic,
         forge,
+        sync_handle,
         publish_tx,
         import_external_tx,
         import_local_tx,

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -247,13 +247,11 @@ async fn automatic_acking() {
     assert_message_id(&rx.next().await.unwrap(), message_id_1);
     assert_message_id(&rx.next().await.unwrap(), message_id_2);
 
+    // Await graceful termination of the sync session.
+    let _ = tx.close().await;
+
     drop(tx);
     drop(rx);
-
-    // TODO: Remove this once we're able to close the (tx, rx) gracefully.
-    //
-    // Sleep briefly to wait for sync session clean-up to complete.
-    sleep(Duration::from_millis(50)).await;
 
     // Create a new subscription.
     let (tx, mut rx) = node.stream::<String>(topic).await.unwrap();
@@ -302,13 +300,11 @@ async fn explicit_acking() {
     // Acknowledge first message.
     rx.ack(message_id_1).await.unwrap();
 
+    // Await graceful termination of the sync session.
+    let _ = tx.close().await;
+
     drop(tx);
     drop(rx);
-
-    // TODO: Remove this once we're able to close the (tx, rx) gracefully.
-    //
-    // Sleep briefly to wait for sync session clean-up to complete.
-    sleep(Duration::from_millis(50)).await;
 
     // Create a new subscription, streaming from "acked frontier".
     let (_tx, mut rx) = node.stream::<String>(topic).await.unwrap();
@@ -332,12 +328,8 @@ async fn replay_stream_from_start() {
     {
         let (panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
         panda_tx.publish("Hello, Icebear!".into()).await.unwrap();
+        let _ = panda_tx.close().await;
     }
-
-    // TODO: Remove this once we're able to close the (tx, rx) gracefully.
-    //
-    // Sleep briefly to wait for sync session clean-up to complete.
-    sleep(Duration::from_millis(50)).await;
 
     // Panda subscribes again, this time asking to replay all messages from start.
     let (_panda_tx, mut panda_rx) = panda
@@ -397,13 +389,11 @@ async fn replay_stream_from_cursor() {
         id
     };
 
+    // Await graceful termination of the sync session.
+    let _ = tx.close().await;
+
     drop(tx);
     drop(rx);
-
-    // TODO: Remove this once we're able to close the (tx, rx) gracefully.
-    //
-    // Sleep briefly to wait for sync session clean-up to complete.
-    sleep(Duration::from_millis(50)).await;
 
     let mut cursor = Cursor::new(topic.to_string(), LogHeights::default());
     cursor.advance(node.id(), LogId::from_topic(topic), 0); // seq_num = 0, the first message
@@ -587,14 +577,12 @@ async fn sync_is_closed_on_drop() {
     }
     assert!(sync_started);
 
+    // Await graceful termination of the sync session.
+    let _ = _icebear_tx.close().await;
+
     // Sync session should be terminated once both stream handles have been dropped.
     drop(_icebear_tx);
     drop(icebear_rx);
-
-    // TODO: Remove this once we're able to close the (tx, rx) gracefully.
-    //
-    // Sleep briefly to wait for sync session clean-up to complete.
-    sleep(Duration::from_millis(50)).await;
 
     // Resubscribe to the same topic.
     let (_icebear_tx, mut icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
@@ -612,4 +600,54 @@ async fn sync_is_closed_on_drop() {
         }
     }
     assert!(sync_started_again);
+}
+
+#[tokio::test]
+async fn graceful_closure_of_publisher() {
+    setup_logging();
+
+    let chat_id = Topic::random();
+
+    let panda = p2panda::builder().spawn().await.unwrap();
+    let icebear = p2panda::builder().spawn().await.unwrap();
+
+    let (panda_tx, _panda_rx) = panda.stream::<String>(chat_id).await.unwrap();
+    panda_tx.publish("Hello, Icebear!".into()).await.unwrap();
+
+    let (icebear_tx, icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
+
+    // Sync session should be terminated once both stream handles have been dropped.
+    drop(icebear_tx);
+    drop(icebear_rx);
+
+    // Attempting to create a new stream for the same topic will return an error because the
+    // cleanup initated by dropping the publisher and subscriber has not yet completed.
+    assert!(icebear.stream::<String>(chat_id).await.is_err());
+
+    // Briefly sleep to await cleanup.
+    sleep(Duration::from_millis(50)).await;
+
+    let (icebear_tx, icebear_rx) = icebear.stream::<String>(chat_id).await.unwrap();
+
+    // Gracefully close the publisher, awaiting termination.
+    let _ = icebear_tx.close().await;
+
+    drop(icebear_tx);
+    drop(icebear_rx);
+
+    // The stream can now be successfully created immediately after drop.
+    //
+    // This serves to illustrate that there is nothing problematic about explicitly closing the
+    // publisher and then dropping the stream; the underlying sync handle implementation
+    // deduplicates the `Close` message that is sent to the sync session actor.
+    let stream_result = icebear.stream::<String>(chat_id).await;
+    assert!(stream_result.is_ok());
+
+    let (icebear_tx, _icebear_rx) = stream_result.unwrap();
+
+    // Gracefully close the publisher, awaiting termination.
+    let _ = icebear_tx.close().await;
+
+    // The stream can now be successfully created immediately after calling close.
+    assert!(icebear.stream::<String>(chat_id).await.is_ok());
 }


### PR DESCRIPTION
In this PR we introduce the ability to close a topic sync session and await cleanup. This complements the previous fire-and-forget approach to closing / dropping sync sessions.

Changes have been made to the sync manager and topic sync manager; a oneshot sender is supplied along with the `ToSyncManager::Close` and `ToTopicManger::Close` actor messages. A reply can be awaited on the oneshot receiver. The termination signal is sent once all state cleanup has been completed.

The new graceful termination functionality is exposed at the high-level API via the `StreamPublisher::close()` method.

Deduplication logic was necessary to ensure that unexpected behaviour doesn't occur as a result of two `Close` messages being sent: one by an explicit call to `StreamPublisher::close()` and one via the implicit `Drop` behaviour of the internal `SyncHandle`.

Addresses: https://github.com/p2panda/p2panda/issues/1274

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
