### PR TITLE
Bump hpke-rs to version v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Highlights are marked with a pancake 🥞
 ### Fixed
 
 - encryption: Do not require pre-key bundle when initialising TwoParty state as a recipient [#1297](https://github.com/p2panda/p2panda/pull/1297)
+- encryption: Update hpke-rs to v0.7.0 [#1309](https://github.com/p2panda/p2panda/pull/1309)
 
 ## [0.7.0] - 07/07/2026
 

--- a/p2panda-encryption/Cargo.toml
+++ b/p2panda-encryption/Cargo.toml
@@ -35,9 +35,9 @@ chacha20poly1305 = { version = "0.10.1", features = ["alloc"], default-features 
 curve25519-dalek = "4.1.3"
 hex = { workspace = true }
 hkdf = "0.12.4"
-hpke-rs = "0.6.1"
-hpke-rs-crypto = "0.6.1"
-hpke-rs-rust-crypto = "0.6.1"
+hpke-rs = "0.7.0"
+hpke-rs-crypto = "0.7.0"
+hpke-rs-rust-crypto = "0.7.0"
 p2panda-core = { workspace = true }
 rand_chacha = { version = "0.9.0", features = ["os_rng"] }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Due to this security issue in earlier versions: https://rustsec.org/advisories/RUSTSEC-2026-0212

closes: #1308 

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes

