### PR TITLE
Emit per-group and global groups events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Highlights are marked with a pancake 🥞
 - spaces: Support partial merge of auth state into a space [#1299](https://github.com/p2panda/p2panda/pull/1299)
 - node: Allow graceful closure of sync sessions [#1307](https://github.com/p2panda/p2panda/pull/1307)
 - node: API for promoting and demoting space members [#1311](https://github.com/p2panda/p2panda/pull/1311)
-- net: Register hooks on Endpoint [#1319](https://github.com/p2panda/p2panda/pull/1319)
+- node: Emit per-group and global groups events [#1313](https://github.com/p2panda/p2panda/pull/1313)
 
 ### Changed
 

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -303,6 +303,22 @@ where
         }
     }
 
+    /// Get all ancestor groups of the passed target group.
+    ///
+    /// A ancestor group is any group that the target group is a transitive child of. Said another
+    /// way, if the membership of the target group changed, a ancestor is any group which would be
+    /// effected by this change.
+    pub fn ancestors(&self, target: ID) -> Vec<ID> {
+        let mut ancestors = vec![];
+        for (id, _) in self.current_state() {
+            let children = self.groups(id);
+            if children.iter().any(|(id, _)| id == &target) {
+                ancestors.push(id)
+            }
+        }
+        ancestors
+    }
+
     /// Get all current individual members of a group.
     pub fn members(&self, group_id: ID) -> Vec<(ID, Access<C>)> {
         self.traverse_members(group_id, 0)

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::{HashMap, HashSet};
+
+use p2panda_core::VerifyingKey;
 use serde::{Deserialize, Serialize};
 
 use p2panda_auth::Access;
@@ -52,24 +55,50 @@ impl GroupActor {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum Event<C> {
-    Group(GroupEvent<C>),
+    /// A group membership change occurred in the shared groups state.
+    ///
+    /// This event does _not_ signify that any space has incorporated this change yet. The
+    /// Event::Spaces variant is emitted on space membership changes.
+    Groups(GroupEvent<C>),
+
+    /// An application message was decrypted.
+    ///
+    /// Encrypted application messages are buffered until the local member is welcomed into a
+    /// space with a "create" or "add" message.
     Application { space_id: SpaceId, data: Vec<u8> },
+
     // @TODO: Could maybe add field to show when the bundle is valid until?
+    /// An actors' pre-key bundle has been received.
     KeyBundle { author: MemberId },
-    Space(SpaceEvent<C>),
+
+    /// A membership change occurred on a space.
+    ///
+    /// This event is emitted every time the membership of a space changes. Events are silently
+    /// dropped if the local member is not (yet) a member of the space. For every Event::Groups
+    /// event a Event::Spaces event will be emitted for every effected space.
+    Spaces(SpaceEvent<C>),
 }
 
 /// Additional context attached to group events.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct GroupsContext<C> {
-    /// The actor who authored this action.
+pub struct GroupContext<C> {
+    /// The actor who authored the associated group action.
     pub author: ActorId,
 
     /// Root group actors, can be individuals or groups.
-    pub group_actors: Vec<(GroupActor, Access<C>)>,
+    pub actors: Vec<(GroupActor, Access<C>)>,
 
-    /// Members of this group.
+    /// Members of the group.
     pub members: Vec<(ActorId, Access<C>)>,
+
+    /// All groups for which the group is a child (direct or transitive).
+    pub ancestors: Vec<ActorId>,
+
+    /// All groups effected by the associated group change and their members.
+    pub effected_group_members: HashMap<ActorId, Vec<(ActorId, Access<C>)>>,
+
+    /// All groups effected by the associated group change and their direct actor members.
+    pub effected_group_actors: HashMap<ActorId, Vec<(GroupActor, Access<C>)>>,
 }
 
 /// Additional context attached to space events.
@@ -81,13 +110,13 @@ pub struct SpaceContext<C> {
     /// auth changes which effect a space are applied later by other members.
     pub author: MemberId,
 
-    /// Id of the group associated with this space.
+    /// Id of the group associated with the space.
     pub group_id: GroupId,
 
-    /// Members in the spaces' space.
+    /// Current members of the space.
     pub members: Vec<(MemberId, Access<C>)>,
 
-    /// Members in the spaces' space.
+    /// Current direct actor members of the space.
     pub actors: Vec<(GroupActor, Access<C>)>,
 }
 
@@ -103,7 +132,7 @@ pub enum GroupEvent<C> {
         initial_members: Vec<(GroupActor, Access<C>)>,
 
         /// Additional event context and group state after any change occurred.
-        context: GroupsContext<C>,
+        context: GroupContext<C>,
     },
 
     /// A member was added to a group.
@@ -118,7 +147,7 @@ pub enum GroupEvent<C> {
         access: Access<C>,
 
         /// Additional event context and group state after any change occurred.
-        context: GroupsContext<C>,
+        context: GroupContext<C>,
     },
 
     /// A member was removed from a group.
@@ -130,7 +159,7 @@ pub enum GroupEvent<C> {
         removed: GroupActor,
 
         /// Additional event context and group state after any change occurred.
-        context: GroupsContext<C>,
+        context: GroupContext<C>,
     },
 
     /// An existing group member was promoted.
@@ -145,7 +174,7 @@ pub enum GroupEvent<C> {
         access: Access<C>,
 
         /// Additional event context and group state after any change occurred.
-        context: GroupsContext<C>,
+        context: GroupContext<C>,
     },
 
     /// An existing group member was demoted.
@@ -160,11 +189,12 @@ pub enum GroupEvent<C> {
         access: Access<C>,
 
         /// Additional event context and group state after any change occurred.
-        context: GroupsContext<C>,
+        context: GroupContext<C>,
     },
 }
 
 impl<C> GroupEvent<C> {
+    /// The target group of this event.
     pub fn group_id(&self) -> GroupId {
         match self {
             GroupEvent::Created { group_id, .. } => *group_id,
@@ -174,9 +204,45 @@ impl<C> GroupEvent<C> {
             GroupEvent::Demoted { group_id, .. } => *group_id,
         }
     }
+
+    /// The groups context attached to this event.
+    pub fn context(&self) -> &GroupContext<C> {
+        match self {
+            GroupEvent::Created { context, .. }
+            | GroupEvent::Added { context, .. }
+            | GroupEvent::Removed { context, .. }
+            | GroupEvent::Promoted { context, .. }
+            | GroupEvent::Demoted { context, .. } => context,
+        }
+    }
+
+    /// Returns true if the passed group was effected by the action which triggered this event.
+    ///
+    /// An effected group is one whose membership changes as a result of the events' action,
+    /// including ancestor groups who transitively contain the actions target group as member. A
+    /// change could be if a member was added, removed, promoted or demoted.
+    ///
+    ///
+    /// ```text
+    ///    [group A]   [group B]   [group C]
+    ///           |     |
+    ///           v     v
+    ///          [group D]
+    /// ```
+    ///
+    /// In the above example, group D is effected by events for group A & B but not C.
+    pub fn effected_group(&self, group_id: GroupId) -> bool {
+        let mut effected_group = self.context().effected_group_actors.keys();
+
+        if effected_group.any(|id| *id == group_id) {
+            return true;
+        }
+
+        false
+    }
 }
 
-/// Events emitted when space encryption group membership changes.
+/// Events emitted when space membership changes.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SpaceEvent<C> {
     /// A space was created.
@@ -191,7 +257,7 @@ pub enum SpaceEvent<C> {
         context: SpaceContext<C>,
 
         /// Additional event context and group state after any change occurred.
-        groups_context: GroupsContext<C>,
+        groups_context: GroupContext<C>,
     },
 
     /// One or many individuals were added to the space.
@@ -206,7 +272,7 @@ pub enum SpaceEvent<C> {
         context: SpaceContext<C>,
 
         /// Additional event context and group state after any change occurred.
-        groups_context: GroupsContext<C>,
+        groups_context: GroupContext<C>,
     },
 
     /// One or many individuals were removed from the space.
@@ -221,7 +287,7 @@ pub enum SpaceEvent<C> {
         context: SpaceContext<C>,
 
         /// Additional event context and group state after any change occurred.
-        groups_context: GroupsContext<C>,
+        groups_context: GroupContext<C>,
     },
 
     /// One or many individuals were promoted in the space.
@@ -236,7 +302,7 @@ pub enum SpaceEvent<C> {
         context: SpaceContext<C>,
 
         /// Additional event context and group state after any change occurred.
-        groups_context: GroupsContext<C>,
+        groups_context: GroupContext<C>,
     },
 
     /// One or many individuals were demoted in the space.
@@ -251,7 +317,7 @@ pub enum SpaceEvent<C> {
         context: SpaceContext<C>,
 
         /// Additional event context and group state after any change occurred.
-        groups_context: GroupsContext<C>,
+        groups_context: GroupContext<C>,
     },
 
     /// Local actor was removed from the space.
@@ -280,19 +346,20 @@ where
         .collect()
 }
 
-pub(crate) fn auth_message_to_group_event<C>(
+pub(crate) fn to_groups_event<C>(
     auth_y: &AuthGroupState<C>,
     auth_message: &AuthMessage<C>,
-) -> GroupEvent<C>
+    previous_ancestors: &[MemberId],
+) -> Event<C>
 where
     C: Conditions,
 {
     let group_id = auth_message.group_id();
-    let context = groups_context(auth_y, auth_message);
-    match auth_message.action() {
+    let context = groups_context(auth_y, auth_message, previous_ancestors);
+    let group_event = match auth_message.action() {
         AuthGroupAction::Create { .. } => GroupEvent::Created {
             group_id,
-            initial_members: context.group_actors.clone(),
+            initial_members: context.actors.clone(),
             context,
         },
         AuthGroupAction::Add { member, access } => GroupEvent::Added {
@@ -318,27 +385,18 @@ where
             access,
             context,
         },
-    }
+    };
+    Event::Groups(group_event)
 }
 
-pub(crate) fn group_message_to_auth_event<C>(
-    auth_y: &AuthGroupState<C>,
-    auth_message: &AuthMessage<C>,
-) -> Event<C>
-where
-    C: Conditions,
-{
-    let group_event = auth_message_to_group_event(auth_y, auth_message);
-    Event::Group(group_event)
-}
-
-pub(crate) fn space_message_to_space_event<C>(
+pub(crate) fn to_space_event<C>(
     space_id: SpaceId,
     group_id: GroupId,
     auth_y: &AuthGroupState<C>,
     space_message: &SpaceMembershipMessage,
     auth_message: &AuthMessage<C>,
     previous_members: &[(MemberId, Access<C>)],
+    previous_ancestors: &[MemberId],
 ) -> Event<C>
 where
     C: Conditions,
@@ -355,7 +413,7 @@ where
         members: next_members.to_vec(),
         actors: next_actors,
     };
-    let groups_context = groups_context(auth_y, auth_message);
+    let groups_context = groups_context(auth_y, auth_message, previous_ancestors);
 
     let space_event = match auth_message.action() {
         AuthGroupAction::Create { .. } => SpaceEvent::Created {
@@ -402,28 +460,60 @@ where
         }
     };
 
-    Event::Space(space_event)
+    Event::Spaces(space_event)
 }
 
-fn groups_context<C>(auth_y: &AuthGroupState<C>, auth_message: &AuthMessage<C>) -> GroupsContext<C>
+/// Compute groups context.
+fn groups_context<C>(
+    auth_y: &AuthGroupState<C>,
+    auth_message: &AuthMessage<C>,
+    previous_ancestors: &[MemberId],
+) -> GroupContext<C>
 where
     C: Conditions,
 {
     let group_id = auth_message.group_id();
 
-    let mut group_actors: Vec<_> = auth_y
+    let mut actors: Vec<_> = auth_y
         .root_members(group_id)
         .into_iter()
         .map(|(member, access)| (GroupActor::from_group_member(member), access))
         .collect();
-    sort_members(&mut group_actors);
+    sort_members(&mut actors);
 
     let mut members = auth_y.members(group_id);
     sort_members(&mut members);
 
-    GroupsContext {
+    let mut ancestors = auth_y.inner.ancestors(group_id);
+    ancestors.sort();
+
+    // Retrieve members of all effected groups.
+    let effected: HashSet<&VerifyingKey> =
+        HashSet::from_iter(ancestors.iter().chain(previous_ancestors.iter()));
+    let effected_group_members: HashMap<ActorId, Vec<(ActorId, Access<C>)>> = effected
+        .iter()
+        .map(|id| (**id, auth_y.members(**id)))
+        .collect();
+    let effected_group_actors: HashMap<ActorId, Vec<(GroupActor, Access<C>)>> = effected
+        .into_iter()
+        .map(|id| {
+            (
+                *id,
+                auth_y
+                    .root_members(*id)
+                    .into_iter()
+                    .map(|(member, access)| (GroupActor::from_group_member(member), access))
+                    .collect(),
+            )
+        })
+        .collect();
+
+    GroupContext {
         author: auth_message.author(),
         members,
-        group_actors,
+        actors,
+        effected_group_members,
+        effected_group_actors,
+        ancestors,
     }
 }

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use tracing::debug;
 
 use crate::auth::message::AuthMessage;
-use crate::event::{Event, group_message_to_auth_event};
+use crate::event::{Event, to_groups_event};
 use crate::forge::Forge;
 use crate::identity::IdentityError;
 use crate::manager::{Manager, StoreError};
@@ -35,7 +35,7 @@ use crate::{ActorId, GroupId, MemberId};
 /// layers outside of p2panda-spaces to enforce access control rules.
 ///
 /// A group can be a member of many spaces, or indeed other groups, and any changes effect all
-/// parents.
+/// ancestors.
 ///
 /// Only members with Manage access level are allowed to manage the groups members.
 #[derive(Debug)]
@@ -164,9 +164,10 @@ where
             return Ok(None);
         }
 
+        let previous_ancestors = groups_y.inner.ancestors(auth_message.group_id());
         groups_y =
             AuthGroup::<C>::process(groups_y, auth_message).map_err(GroupError::AuthGroup)?;
-        let events = group_message_to_auth_event(&groups_y, auth_message);
+        let events = to_groups_event(&groups_y, auth_message, &previous_ancestors);
         Ok(Some((groups_y, events)))
     }
 
@@ -179,7 +180,7 @@ where
     ) -> Result<(AuthGroupState<C>, F::Message, Event<C>), GroupError<F, C>> {
         // Compute the auth graph heads to include as dependencies based on the groups included in
         // this action. This means any groups being added / removed in the action, plus the id of
-        // the parent group itself.
+        // the ancestor group itself.
         let dependencies = AuthGroup::heads(&y, group_id, &action);
 
         let args = SpacesArgs::Auth {
@@ -194,9 +195,10 @@ where
         };
 
         let auth_message = SpacesMessage::auth(&message);
+        let previous_ancestors = y.inner.ancestors(auth_message.group_id());
         let y = AuthGroup::<C>::process(y, &auth_message).map_err(GroupError::AuthGroup)?;
 
-        let event = group_message_to_auth_event(&y, &auth_message);
+        let event = to_groups_event(&y, &auth_message, &previous_ancestors);
 
         Ok((y, message, event))
     }

--- a/p2panda-spaces/src/lib.rs
+++ b/p2panda-spaces/src/lib.rs
@@ -27,7 +27,7 @@ use p2panda_core::{Hash, VerifyingKey};
 pub use auth::message::AuthMessage;
 pub use config::Config;
 pub use credentials::Credentials;
-pub use event::{Event, GroupActor, GroupEvent, GroupsContext, SpaceContext, SpaceEvent};
+pub use event::{Event, GroupActor, GroupContext, GroupEvent, SpaceContext, SpaceEvent};
 pub use forge::Forge;
 pub use message::{SpacesArgs, SpacesMessage};
 pub use store::SpacesStoreState;

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -26,7 +26,7 @@ use crate::auth::message::AuthMessage;
 use crate::encryption::dgm::EncryptionMembershipState;
 use crate::encryption::message::{EncryptionArgs, EncryptionMessage};
 use crate::encryption::orderer::EncryptionOrdererState;
-use crate::event::{Event, encryption_output_to_space_events, space_message_to_space_event};
+use crate::event::{Event, encryption_output_to_space_events, to_space_event};
 use crate::forge::Forge;
 use crate::group::{Group, GroupError};
 use crate::identity::IdentityError;
@@ -327,6 +327,7 @@ where
 
         // Get next space members.
         let next_members = y.groups_y.members(y.group_id);
+        let current_ancestors = y.groups_y.inner.ancestors(y.group_id);
         let next_secret_members = secret_members(&next_members);
 
         // Process the change of membership on encryption the context.
@@ -373,6 +374,7 @@ where
             auth_message,
             &SpacesMessage::space_membership(&space_message),
             &current_members,
+            &current_ancestors,
         );
 
         Ok((y, space_message, events))
@@ -409,6 +411,7 @@ where
         let duplicate_pointer = y.groups_y.inner.operations.contains_key(&auth_message.id());
 
         let current_members = y.groups_y.members(y.group_id);
+        let current_ancestors = y.groups_y.inner.ancestors(y.group_id);
         let current_secret_members = secret_members(&current_members);
 
         // Process auth message on space auth state.
@@ -461,8 +464,14 @@ where
             .orderer
             .add_dependency(*id, space_dependencies);
 
-        let mut events =
-            Self::generate_space_events(me, &y, auth_message, space_message, &current_members);
+        let mut events = Self::generate_space_events(
+            me,
+            &y,
+            auth_message,
+            space_message,
+            &current_members,
+            &current_ancestors,
+        );
 
         events.extend(application_events);
 
@@ -476,6 +485,7 @@ where
         auth_message: &AuthMessage<C>,
         space_message: &SpaceMembershipMessage,
         previous_members: &[(ActorId, Access<C>)],
+        previous_ancestors: &[ActorId],
     ) -> Vec<Event<C>> {
         let mut events = vec![];
         // If current and next member sets are equal it indicates that the space is not affected
@@ -498,19 +508,20 @@ where
         }
 
         // Construct space membership event.
-        let space_event = space_message_to_space_event(
+        let space_event = to_space_event(
             y.space_id,
             y.group_id,
             &y.groups_y,
             space_message,
             auth_message,
             previous_members,
+            previous_ancestors,
         );
 
         events.push(space_event);
 
         if ejected {
-            events.push(Event::Space(SpaceEvent::Ejected {
+            events.push(Event::Spaces(SpaceEvent::Ejected {
                 space_id: y.space_id,
             }))
         }

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -16,7 +16,7 @@ use p2panda_encryption::data_scheme::DirectMessage;
 use p2panda_encryption::key_bundle::{Lifetime, LongTermKeyBundle, PreKey};
 
 use crate::SpaceId;
-use crate::event::{Event, GroupActor, GroupEvent, GroupsContext, SpaceContext, SpaceEvent};
+use crate::event::{Event, GroupActor, GroupContext, GroupEvent, SpaceContext, SpaceEvent};
 use crate::manager::ManagerError;
 use crate::member::Member;
 use crate::message::SpacesArgs;
@@ -686,11 +686,11 @@ async fn remove_member() {
     assert_eq!(events.len(), 2);
     assert!(matches!(
         events[0],
-        Event::Space(SpaceEvent::Removed { .. })
+        Event::Spaces(SpaceEvent::Removed { .. })
     ));
     assert!(matches!(
         events[1],
-        Event::Space(SpaceEvent::Ejected { .. })
+        Event::Spaces(SpaceEvent::Ejected { .. })
     ));
 }
 
@@ -1367,76 +1367,76 @@ async fn events() {
             // Member auth group created.
             0 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Created { group_id, .. }) if group_id == group.id());
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Created { context: GroupsContext{ author, .. }, .. }) if author == alice_id);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Created { context: GroupsContext{ members, .. }, .. }) if members.len() == 2);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Created { group_id, .. }) if group_id == group.id());
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Created { context: GroupContext{ author, .. }, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Created { context: GroupContext{ members, .. }, .. }) if members.len() == 2);
             }
             // Space auth group created.
             1 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Created { group_id, .. }) if group_id == space_group_id);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Created { context: GroupsContext{ author, .. }, .. }) if author == alice_id);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Created { context: GroupsContext{ members, .. }, .. }) if members.len() == 3);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Created { group_id, .. }) if group_id == space_group_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Created { context: GroupContext{ author, .. }, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Created { context: GroupContext{ members, .. }, .. }) if members.len() == 3);
             }
             // Both previous auth messages published to newly created space, initial members added
             // to encryption context.
             2 => assert_eq!(bob_events.len(), 0),
             3 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Created { space_id, context: SpaceContext{group_id, ..}, .. }) if space_id == space.id() && group_id == space_group_id);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Created { initial_members, ..}) if initial_members.len() == 3);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Created { context: SpaceContext{ author, ..}, .. }) if author == alice_id);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Created { context: SpaceContext{ members, ..}, .. }) if members.len() == 3);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Created { groups_context: GroupsContext{ author, .. }, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Created { space_id, context: SpaceContext{group_id, ..}, .. }) if space_id == space.id() && group_id == space_group_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Created { initial_members, ..}) if initial_members.len() == 3);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Created { context: SpaceContext{ author, ..}, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Created { context: SpaceContext{ members, ..}, .. }) if members.len() == 3);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Created { groups_context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             // Dave added to space auth group and encryption context.
             4 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Added { added, group_id, .. }) if added == GroupActor::individual(dave_id) && group_id == space_group_id);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Added { context: GroupsContext{ author, .. }, .. }) if author == alice_id);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Added { context: GroupsContext{ members, .. }, .. }) if members.len() == 4);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Added { added, group_id, .. }) if added == GroupActor::individual(dave_id) && group_id == space_group_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Added { context: GroupContext{ author, .. }, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Added { context: GroupContext{ members, .. }, .. }) if members.len() == 4);
             }
             5 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Added { groups_context: GroupsContext{ author, .. }, .. }) if author == alice_id);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Added { added, .. }) if added == vec![(dave_id, Access::read())]);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Added { context: SpaceContext{ author, ..}, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Added { groups_context: GroupContext{ author, .. }, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Added { added, .. }) if added == vec![(dave_id, Access::read())]);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Added { context: SpaceContext{ author, ..}, .. }) if author == alice_id);
             }
             // Dave removed from space auth group and encryption context.
             6 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Removed { removed, .. }) if removed == GroupActor::individual(dave_id));
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Removed { context: GroupsContext{ author, .. }, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Removed { removed, .. }) if removed == GroupActor::individual(dave_id));
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Removed { context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             7 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Removed { groups_context: GroupsContext{ author, .. }, .. }) if author == alice_id);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Removed { removed, .. }) if removed == vec![(dave_id, Access::read())]);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Removed { context: SpaceContext{ author, ..}, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Removed { groups_context: GroupContext{ author, .. }, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Removed { removed, .. }) if removed == vec![(dave_id, Access::read())]);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Removed { context: SpaceContext{ author, ..}, .. }) if author == alice_id);
             }
             // Dave added to auth group with pull access.
             8 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Added { added, .. }) if added == GroupActor::individual(dave_id));
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Added { context: GroupsContext{ author, .. }, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Added { added, .. }) if added == GroupActor::individual(dave_id));
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Added { context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             9 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Added { added, .. }) if added == vec![(dave_id, Access::pull())]);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Added { groups_context: GroupsContext{ author, .. }, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Added { added, .. }) if added == vec![(dave_id, Access::pull())]);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Added { groups_context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             // Remove member group from space auth group, both bob and claire removed..
             10 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Removed { removed, .. }) if removed == GroupActor::group(group.id()));
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Removed { context: GroupsContext{ author, .. }, .. }) if author == alice_id);
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Removed { removed, .. }) if removed == GroupActor::group(group.id()));
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Removed { context: GroupContext{ author, .. }, .. }) if author == alice_id);
             }
             11 => {
                 assert_eq!(bob_events.len(), 2);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Removed { removed, .. }) if removed.len() == 2);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Removed { removed, .. }) if removed.len() == 2);
                 std::assert_matches!(
                     bob_events[1].clone(),
-                    Event::Space(SpaceEvent::Ejected { .. })
+                    Event::Spaces(SpaceEvent::Ejected { .. })
                 );
             }
             _ => panic!(),
@@ -1956,7 +1956,7 @@ async fn ejected_event() {
 
     // The last event is an "ejected".
     let ejected_event = events.last().unwrap();
-    assert_matches!(ejected_event, Event::Space(SpaceEvent::Ejected { .. }))
+    assert_matches!(ejected_event, Event::Spaces(SpaceEvent::Ejected { .. }))
 }
 
 #[tokio::test]
@@ -2034,8 +2034,8 @@ async fn promote_demote() {
     assert_eq!(events.len(), 2);
 
     // Expect create group and create space events to be emitted.
-    std::assert_matches!(events.remove(0), Event::Group(GroupEvent::Created { .. }));
-    std::assert_matches!(events.remove(0), Event::Space(SpaceEvent::Created { .. }));
+    std::assert_matches!(events.remove(0), Event::Groups(GroupEvent::Created { .. }));
+    std::assert_matches!(events.remove(0), Event::Spaces(SpaceEvent::Created { .. }));
 
     // Promote bob to "manage" access
     let (auth_operation, space_operation, mut events) = space
@@ -2046,8 +2046,8 @@ async fn promote_demote() {
 
     // One group event and no space events emitted, bob was already a member of the space so no event required.
     assert_eq!(events.len(), 2);
-    std::assert_matches!(events.remove(0), Event::Group(GroupEvent::Promoted { promoted, access, .. }) if promoted.id() == bob_id && access.is_manage());
-    std::assert_matches!(events.remove(0), Event::Space(SpaceEvent::Promoted { promoted, .. }) if promoted == vec![(bob_id, Access::manage())]);
+    std::assert_matches!(events.remove(0), Event::Groups(GroupEvent::Promoted { promoted, access, .. }) if promoted.id() == bob_id && access.is_manage());
+    std::assert_matches!(events.remove(0), Event::Spaces(SpaceEvent::Promoted { promoted, .. }) if promoted == vec![(bob_id, Access::manage())]);
 
     // Demote bob to "pull" access.
     let (auth_operation, space_operation, mut events) = space
@@ -2056,14 +2056,12 @@ async fn promote_demote() {
         .unwrap();
     alice_messages.extend([auth_operation, space_operation]);
 
-    // Expect a "demoted" group event and "removed" space event as losing "read" access means bob
-    // has effectively been removed from the space.
+    // Expect a "demoted" group and space event.
     assert_eq!(events.len(), 2);
-    std::assert_matches!(events.remove(0), Event::Group(GroupEvent::Demoted { demoted, access, .. }) if demoted.id() == bob_id && access.is_pull());
-    std::assert_matches!(events.remove(0), Event::Space(SpaceEvent::Demoted { demoted, .. }) if demoted[0] == (bob_id, Access::pull()));
+    std::assert_matches!(events.remove(0), Event::Groups(GroupEvent::Demoted { demoted, access, .. }) if demoted.id() == bob_id && access.is_pull());
+    std::assert_matches!(events.remove(0), Event::Spaces(SpaceEvent::Demoted { demoted, .. }) if demoted[0] == (bob_id, Access::pull()));
 
-    // Bob receives the same events (with the addition of the "ejected" when they got demoted to
-    // "pull" access).
+    // Bob receives the same events.
     let mut all_bob_events = vec![];
     for (idx, message) in alice_messages.iter().enumerate() {
         bob.persist_operation(&message).await.unwrap();
@@ -2072,27 +2070,27 @@ async fn promote_demote() {
         match idx {
             0 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0], Event::Group(GroupEvent::Created { .. }));
+                std::assert_matches!(bob_events[0], Event::Groups(GroupEvent::Created { .. }));
             }
             1 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0], Event::Space(SpaceEvent::Created { .. }));
+                std::assert_matches!(bob_events[0], Event::Spaces(SpaceEvent::Created { .. }));
             }
             2 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Promoted { promoted, access, .. }) if promoted.id() == bob_id && access.is_manage());
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Promoted { promoted, access, .. }) if promoted.id() == bob_id && access.is_manage());
             }
             3 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Promoted { promoted, .. }) if promoted == vec![(bob_id, Access::manage())]);
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Promoted { promoted, .. }) if promoted == vec![(bob_id, Access::manage())]);
             }
             4 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Group(GroupEvent::Demoted { demoted, access, .. }) if demoted.id() == bob_id && access.is_pull());
+                std::assert_matches!(bob_events[0].clone(), Event::Groups(GroupEvent::Demoted { demoted, access, .. }) if demoted.id() == bob_id && access.is_pull());
             }
             5 => {
                 assert_eq!(bob_events.len(), 1);
-                std::assert_matches!(bob_events[0].clone(), Event::Space(SpaceEvent::Demoted { demoted, .. }) if demoted[0] == (bob_id, Access::pull()));
+                std::assert_matches!(bob_events[0].clone(), Event::Spaces(SpaceEvent::Demoted { demoted, .. }) if demoted[0] == (bob_id, Access::pull()));
             }
             _ => panic!(),
         }

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::fmt::Debug;
+use std::sync::RwLock;
 
 use futures_util::Stream;
 use p2panda_core::traits::ShortFormat;
@@ -16,6 +17,7 @@ use p2panda_store::topics::TopicStore;
 use p2panda_store::{Transaction, tx};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio::sync::broadcast;
 use tracing::debug;
 
 pub use crate::builder::NodeBuilder;
@@ -32,9 +34,9 @@ use crate::spaces::{
     to_initial_members,
 };
 use crate::streams::{
-    EphemeralStreamPublisher, EphemeralStreamSubscription, ImportError, Pipeline, StreamEvent,
-    StreamFrom, StreamPublisher, StreamSubscription, SystemEvent, TaskTracker, ephemeral_stream,
-    event_stream, processed_stream,
+    EphemeralStreamPublisher, EphemeralStreamSubscription, ImportError, Pipeline, StreamFrom,
+    StreamPublisher, StreamSubscription, SystemEvent, TaskTracker, ephemeral_stream, event_stream,
+    processed_stream, to_stream_event, to_system_event,
 };
 
 /// Node API with methods to establish ephemeral and eventually consistent topic streams.
@@ -47,6 +49,8 @@ pub struct Node {
     tasks: TaskTracker,
     network: Network,
     spaces_manager: SpacesManager,
+    events_tx: broadcast::Sender<SystemEvent>,
+    events_rx: RwLock<broadcast::Receiver<SystemEvent>>,
 }
 
 impl Node {
@@ -93,6 +97,8 @@ impl Node {
         // Prepare manager which orchestrates processing of incoming operations.
         let tasks = TaskTracker::new();
 
+        let (events_tx, events_rx) = broadcast::channel::<SystemEvent>(256);
+
         Ok(Node {
             config,
             store,
@@ -101,6 +107,8 @@ impl Node {
             tasks,
             network,
             spaces_manager,
+            events_tx,
+            events_rx: RwLock::new(events_rx),
         })
     }
 
@@ -325,6 +333,7 @@ impl Node {
             self.forge.clone(),
             self.spaces_manager.clone(),
             pipeline,
+            self.events_tx.clone(),
             from,
         )
         .await
@@ -361,8 +370,8 @@ impl Node {
 
     /// Returns a stream of system events.
     ///
-    /// System events include all network-related events, such as discovery events, which are not
-    /// associated with a specific topic.
+    /// System events include all system or network-related events, such as space membership
+    /// changes or discovery events, which are not associated with a specific topic.
     ///
     /// Any events generated before this method is called will _not_ be emitted. Therefore, it's
     /// recommended to call `event_stream()` right after the `Node` is spawned if you wish to
@@ -377,7 +386,15 @@ impl Node {
             .await
             .map_err(|err| CreateStreamError(err.to_string()))?;
 
-        Ok(event_stream(discovery_events))
+        let events_rx = {
+            let write = self.events_rx.write().unwrap();
+            let resubscribed = write.resubscribe();
+
+            let mut write = write;
+            std::mem::replace(&mut *write, resubscribed)
+        };
+
+        Ok(event_stream(events_rx, discovery_events))
     }
 
     pub async fn register_member(&self, member: Member) -> Result<(), MemberError> {
@@ -392,8 +409,15 @@ impl Node {
             Some(inner) => {
                 let topic = actor_to_topic(inner.id());
                 let (tx, rx) = self.stream::<NoBody>(topic).await?;
+                let events_rx = {
+                    let write = self.events_rx.write().unwrap();
+                    let resubscribed = write.resubscribe();
 
-                Ok(Some(Group::new(inner, tx, rx)))
+                    let mut write = write;
+                    std::mem::replace(&mut *write, resubscribed)
+                };
+
+                Ok(Some(Group::new(inner, tx, rx, events_rx)))
             }
             None => Ok(None),
         }
@@ -410,14 +434,11 @@ impl Node {
         // and therefore not emit any events.
         let initial_members = to_initial_members(initial_members);
 
-        // @TODO: Group events are currently not forwarded to the user. It's not clear which
-        // channel these should be sent on, the spaces stream, a stream for the specific group, or
-        // a global groups stream.
         let (_, group_id, message, _events) =
             self.spaces_manager.create_group(&initial_members).await?;
 
         let topic = actor_to_topic(group_id);
-        let (tx, _rx) = self.stream::<NoBody>(topic).await?;
+        let (tx, rx) = self.stream::<NoBody>(topic).await?;
 
         let processed = tx
             .import_local(futures_util::stream::once(async {
@@ -431,12 +452,20 @@ impl Node {
             panic!();
         }
 
-        let group = self
+        let events_rx = {
+            let write = self.events_rx.write().unwrap();
+            let resubscribed = write.resubscribe();
+
+            let mut write = write;
+            std::mem::replace(&mut *write, resubscribed)
+        };
+
+        let inner = self
+            .spaces_manager
             .group(group_id)
             .await?
-            .expect("materialised group after processing operations");
-
-        Ok(group)
+            .expect("newly created group exists");
+        Ok(Group::new(inner, tx, rx, events_rx))
     }
 
     pub async fn space<M>(
@@ -617,7 +646,12 @@ impl Node {
         let events = events
             .into_iter()
             .filter_map(|event| match event {
-                p2panda_spaces::Event::Space(space_event) => Some(StreamEvent::Space(space_event)),
+                p2panda_spaces::Event::Spaces(space_event) => {
+                    Some(to_stream_event(space_event).into())
+                }
+                p2panda_spaces::Event::Groups(group_event) => {
+                    Some(to_system_event(group_event).into())
+                }
                 _ => None,
             })
             .collect();

--- a/p2panda/src/spaces/group.rs
+++ b/p2panda/src/spaces/group.rs
@@ -4,26 +4,32 @@ use std::pin::Pin;
 use std::sync::RwLock;
 use std::task::{Context, Poll};
 
-use futures_util::stream::StreamExt;
 use futures_util::{FutureExt, Stream};
 use p2panda_auth::{Access, AccessLevel};
 use p2panda_core::VerifyingKey;
-use p2panda_spaces::{ActorId, GroupsContext, MemberId};
+use p2panda_spaces::{ActorId, GroupContext, GroupId, MemberId};
 use thiserror::Error;
 use tokio::sync::{broadcast, oneshot};
 use tokio::task::AbortHandle;
+use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::node::CreateStreamError;
 use crate::processor::ProcessorError;
 use crate::spaces::GroupActor;
-use crate::spaces::types::{InnerGroup, InnerGroupError, NoBody, SpacesManagerError};
-use crate::streams::{ExternalStreamFuture, ImportError, StreamPublisher, StreamSubscription};
+use crate::spaces::types::{
+    AuthCapabilities, InnerGroup, InnerGroupError, InnerGroupEvent, NoBody, SpacesManagerError,
+};
+use crate::streams::{
+    ImportError, LocalStreamFuture, StreamPublisher, StreamSubscription, SystemEvent,
+};
 
 #[derive(Debug)]
 pub struct Group {
     inner: InnerGroup,
     tx: StreamPublisher<NoBody>,
+    #[allow(unused)]
+    rx: StreamSubscription<NoBody>,
     event_stream_rx: RwLock<broadcast::Receiver<GroupEvent>>,
     event_stream_handle: AbortHandle,
 }
@@ -40,33 +46,39 @@ impl Group {
     pub(crate) fn new(
         inner: InnerGroup,
         tx: StreamPublisher<NoBody>,
-        mut rx: StreamSubscription<NoBody>,
+        rx: StreamSubscription<NoBody>,
+        mut in_event_stream_rx: broadcast::Receiver<SystemEvent>,
     ) -> Self {
-        let (event_stream_tx, event_stream_rx) = broadcast::channel::<GroupEvent>(256);
+        let (out_event_stream_tx, out_event_stream_rx) = broadcast::channel::<GroupEvent>(256);
 
+        let group_id = inner.id();
         let event_stream_handle = tokio::spawn(async move {
-            // TODO: Convert events.
-            while let Some(_event) = rx.next().await {
-                let event = GroupEvent::Added {
-                    added: GroupActor {
-                        id: ActorId::from(VerifyingKey::default()),
-                        group: false,
-                    },
-                    context: GroupsContext {
-                        author: VerifyingKey::default(),
-                        group_actors: vec![],
-                        members: vec![],
-                    },
+            while let Ok(event) = in_event_stream_rx.recv().await {
+                let SystemEvent::Groups {
+                    inner: group_event, ..
+                } = event
+                else {
+                    continue;
                 };
 
-                let _ = event_stream_tx.send(event);
+                // If this group is not effected by the action which triggered this event then
+                // don't forward it. This includes checking if the group is a parent effected by a
+                // childs membership change. We actually want to forward events for all children
+                // groups so here we only filter out events which are completely unrelated to the
+                // current group.
+                if !group_event.effected_group(group_id) && group_id != group_event.group_id() {
+                    continue;
+                }
+
+                let _ = out_event_stream_tx.send(to_group_event(group_id, group_event));
             }
         });
 
         Self {
             inner,
             tx,
-            event_stream_rx: RwLock::new(event_stream_rx),
+            rx,
+            event_stream_rx: RwLock::new(out_event_stream_rx),
             event_stream_handle: event_stream_handle.abort_handle(),
         }
     }
@@ -87,7 +99,7 @@ impl Group {
         };
 
         // TODO: Check if we really want to silence broadcast "lagged" errors here?
-        let stream = BroadcastStream::new(stream).filter_map(|event| async { event.ok() });
+        let stream = BroadcastStream::new(stream).filter_map(|event| event.ok());
 
         Box::pin(stream)
     }
@@ -97,9 +109,6 @@ impl Group {
         actor: impl Into<ActorId>,
         access: AccessLevel,
     ) -> Result<GroupFuture, GroupError> {
-        // @TODO: Group events are currently not forwarded to the user. It's not clear which
-        // channel these should be sent on, the spaces stream, a stream for the specific group, or
-        // a global groups stream.
         let (_, message, _events) = self
             .inner
             .add(
@@ -113,7 +122,7 @@ impl Group {
 
         let processed = self
             .tx
-            .import(futures_util::stream::once(async {
+            .import_local(futures_util::stream::once(async {
                 message.into_operation()
             }))
             .await?;
@@ -125,14 +134,11 @@ impl Group {
     }
 
     pub async fn remove(&self, actor: impl Into<ActorId>) -> Result<GroupFuture, GroupError> {
-        // @TODO: Group events are currently not forwarded to the user. It's not clear which
-        // channel these should be sent on, the spaces stream, a stream for the specific group, or
-        // a global groups stream.
         let (_, message, _events) = self.inner.remove(actor.into()).await?;
 
         let processed = self
             .tx
-            .import(futures_util::stream::once(async {
+            .import_local(futures_util::stream::once(async {
                 message.into_operation()
             }))
             .await?;
@@ -165,25 +171,9 @@ impl Into<ActorId> for Group {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum GroupEvent {
-    Created {
-        initial_members: Vec<(GroupActor, AccessLevel)>,
-        context: GroupsContext<()>,
-    },
-    Added {
-        added: GroupActor,
-        context: GroupsContext<()>,
-    },
-    Removed {
-        removed: GroupActor,
-        context: GroupsContext<()>,
-    },
-}
-
 pub struct GroupFuture {
     pub(crate) group_id: ActorId,
-    pub(crate) processed: ExternalStreamFuture,
+    pub(crate) processed: LocalStreamFuture,
 }
 
 impl GroupFuture {
@@ -206,6 +196,73 @@ impl Into<ActorId> for GroupFuture {
     fn into(self) -> ActorId {
         self.group_id
     }
+}
+
+/// Event emitted from the group event stream.
+///
+/// Events are emitted when membership of the group changes due to an action directly changing the root
+/// members, or as a result of any child group membership changing.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GroupEvent {
+    /// The current group members.
+    pub members: Vec<(ActorId, AccessLevel)>,
+
+    /// The current actor members (can contain individuals and groups).
+    pub actors: Vec<(GroupActor, AccessLevel)>,
+
+    /// The inner group event.
+    ///
+    /// This event may be targeting a child group and contains additionally meta information
+    /// regarding the exact change that occurred.
+    pub inner: InnerGroupEvent,
+}
+
+/// Convert a p2panda_spaces::GroupEvent into p2panda::GroupEvent.
+pub fn to_group_event(group_id: GroupId, event: InnerGroupEvent) -> GroupEvent {
+    let (members, actors) = if group_id == event.group_id() {
+        (
+            event.context().members.clone(),
+            event.context().actors.clone(),
+        )
+    } else {
+        let GroupContext {
+            effected_group_members,
+            effected_group_actors,
+            ..
+        } = event.context();
+        let members = effected_group_members
+            .get(&group_id)
+            .cloned()
+            .unwrap_or_default();
+
+        let actors = effected_group_actors
+            .get(&group_id)
+            .cloned()
+            .unwrap_or_default();
+        (members, actors)
+    };
+
+    GroupEvent {
+        members: members.iter().map(to_member).collect(),
+        actors: actors.iter().map(to_actor).collect(),
+        inner: event,
+    }
+}
+
+fn to_member(member: &(VerifyingKey, Access<AuthCapabilities>)) -> (VerifyingKey, AccessLevel) {
+    (member.0, member.1.level)
+}
+
+fn to_actor(
+    member: &(p2panda_spaces::GroupActor, Access<AuthCapabilities>),
+) -> (GroupActor, AccessLevel) {
+    (
+        GroupActor {
+            id: member.0.id(),
+            group: member.0.is_group(),
+        },
+        member.1.level,
+    )
 }
 
 #[derive(Debug, Error)]

--- a/p2panda/src/spaces/mod.rs
+++ b/p2panda/src/spaces/mod.rs
@@ -15,7 +15,7 @@ use p2panda_store::SqliteStore;
 // Re-export useful types.
 pub use p2panda_auth::AccessLevel;
 pub use p2panda_spaces::manager::ManagerError;
-pub use p2panda_spaces::{ActorId, GroupId, GroupsContext, MemberId, SpaceContext, SpaceId};
+pub use p2panda_spaces::{ActorId, GroupContext, GroupId, MemberId, SpaceContext, SpaceId};
 
 pub(crate) use forge::{KEY_BUNDLE_LOG_ID, group_log_id};
 pub use group::{Group, GroupError, GroupEvent, GroupFuture};
@@ -26,7 +26,7 @@ pub use space::{
     AddSpaceMemberError, PublishSpaceError, RemoveSpaceMemberError, Space, SpaceFuture,
     SpaceSubscription,
 };
-pub use types::SpacesManagerError;
+pub use types::{InnerGroupEvent, SpacesManagerError};
 
 use crate::Credentials;
 use crate::forge::OperationForge;
@@ -66,5 +66,23 @@ pub(crate) fn to_initial_members(
                 },
             )
         })
+        .collect()
+}
+
+pub(crate) fn to_members(
+    members: &[(ActorId, Access<AuthCapabilities>)],
+) -> Vec<(ActorId, AccessLevel)> {
+    members
+        .iter()
+        .map(|(actor, access)| (*actor, access.level))
+        .collect()
+}
+
+pub(crate) fn to_actors(
+    actors: &[(p2panda_spaces::GroupActor, Access<AuthCapabilities>)],
+) -> Vec<(GroupActor, AccessLevel)> {
+    actors
+        .iter()
+        .map(|(actor, access)| (actor.clone().into(), access.level))
         .collect()
 }

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -25,7 +25,7 @@ use crate::operation::Operation;
 use crate::spaces::group_log_id;
 use crate::spaces::types::{AuthCapabilities, SpacesArgs, SpacesStore};
 use crate::spaces::{SpacesManagerError, types::SpacesManager};
-use crate::streams::{LocalStreamFuture, StreamEvent};
+use crate::streams::{ForwardEvent, LocalStreamFuture, to_stream_event, to_system_event};
 
 const REPAIR_FREQUENCY_SECS: u64 = 1;
 
@@ -80,7 +80,7 @@ pub(crate) async fn repair_space<M>(
         BoxStream<'static, Operation>,
         oneshot::Sender<LocalStreamFuture>,
     )>,
-    to_output_tx: &mpsc::Sender<Vec<StreamEvent<M>>>,
+    to_output_tx: &mpsc::Sender<Vec<ForwardEvent<M>>>,
 ) -> Result<bool, RepairError> {
     let spaces_store = SpacesStore::new(store.clone());
 
@@ -219,7 +219,8 @@ pub(crate) async fn repair_space<M>(
     let events = events
         .into_iter()
         .filter_map(|event| match event {
-            p2panda_spaces::Event::Space(space_event) => Some(StreamEvent::Space(space_event)),
+            p2panda_spaces::Event::Spaces(space_event) => Some(to_stream_event(space_event).into()),
+            p2panda_spaces::Event::Groups(group_event) => Some(to_system_event(group_event).into()),
             _ => None,
         })
         .collect();
@@ -250,7 +251,7 @@ pub(crate) fn spawn_repair_task<M>(
         BoxStream<'static, Operation>,
         oneshot::Sender<LocalStreamFuture>,
     )>,
-    to_output_tx: mpsc::Sender<Vec<StreamEvent<M>>>,
+    to_output_tx: mpsc::Sender<Vec<ForwardEvent<M>>>,
     mut repair_rx: mpsc::Receiver<(RepairStrategy, oneshot::Sender<Result<bool, RepairError>>)>,
 ) -> JoinHandle<()>
 where

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -30,6 +30,7 @@ use crate::spaces::types::{AuthCapabilities, InnerSpace, InnerSpaceError, Spaces
 use crate::spaces::{RepairError, RepairStrategy};
 use crate::streams::{
     ImportError, LocalStreamFuture, StreamEvent, StreamPublisher, StreamSubscription,
+    to_stream_event, to_system_event,
 };
 
 /// Wraps topic stream and returns the pub/sub pair of a more specialised spaces stream.
@@ -277,7 +278,12 @@ where
         let events = events
             .into_iter()
             .filter_map(|event| match event {
-                p2panda_spaces::Event::Space(space_event) => Some(StreamEvent::Space(space_event)),
+                p2panda_spaces::Event::Spaces(space_event) => {
+                    Some(to_stream_event(space_event).into())
+                }
+                p2panda_spaces::Event::Groups(group_event) => {
+                    Some(to_system_event(group_event).into())
+                }
                 _ => None,
             })
             .collect();

--- a/p2panda/src/spaces/types.rs
+++ b/p2panda/src/spaces/types.rs
@@ -11,7 +11,9 @@ pub type NoBody = ();
 /// In the high-level API we don't do anything with auth capabilities (yet).
 pub type AuthCapabilities = ();
 
-pub type SpaceEvent = p2panda_spaces::SpaceEvent<AuthCapabilities>;
+pub type InnerGroupEvent = p2panda_spaces::GroupEvent<AuthCapabilities>;
+
+pub type InnerSpaceEvent = p2panda_spaces::SpaceEvent<AuthCapabilities>;
 
 pub type SpacesArgs = p2panda_spaces::SpacesArgs<AuthCapabilities>;
 

--- a/p2panda/src/streams/event_stream.rs
+++ b/p2panda/src/streams/event_stream.rs
@@ -1,33 +1,63 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::pin::Pin;
+
 use futures_util::Stream;
 use futures_util::stream::{SelectAll, StreamExt};
+use p2panda_auth::AccessLevel;
 use p2panda_net::discovery::DiscoveryEvent;
+use p2panda_spaces::{ActorId, GroupId};
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
+
+use crate::spaces::GroupActor;
+use crate::spaces::types::InnerGroupEvent;
 
 /// System event.
 ///
 /// System events encompass all network-related events which are not directly associated with a
 /// topic.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum SystemEvent {
     Discovery(DiscoveryEvent),
+    Groups {
+        /// Id of the group this event originated from.
+        group_id: GroupId,
+
+        /// Current group members.
+        members: Vec<(ActorId, AccessLevel)>,
+
+        /// Current actor members (can contain individuals and groups).
+        actors: Vec<(GroupActor, AccessLevel)>,
+
+        /// Inner group event.
+        ///
+        /// Contains additionally meta information regarding the exact change that occurred.
+        inner: InnerGroupEvent,
+    },
 }
 
 /// Merge the provided event streams into a single, unified system event stream.
 pub(crate) fn event_stream(
+    events_stream: broadcast::Receiver<SystemEvent>,
     discovery_events: broadcast::Receiver<DiscoveryEvent>,
 ) -> impl Stream<Item = SystemEvent> + Send + Unpin + 'static {
     let discovery_broadcast_stream = BroadcastStream::new(discovery_events);
 
-    let discovery_stream = Box::pin(
+    let discovery_stream: Pin<Box<dyn Stream<Item = SystemEvent> + Send>> = Box::pin(
         discovery_broadcast_stream
             .filter_map(|event| async { event.ok().map(SystemEvent::Discovery) }),
     );
 
+    let events_broadcast_stream = BroadcastStream::new(events_stream);
+
+    let events_stream: Pin<Box<dyn Stream<Item = SystemEvent> + Send>> =
+        Box::pin(events_broadcast_stream.filter_map(|event| async { event.ok() }));
+
     let mut stream_set = SelectAll::new();
     stream_set.push(discovery_stream);
+    stream_set.push(events_stream);
 
     Box::pin(stream_set)
 }

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -31,8 +31,8 @@ pub use external_stream::ExternalStreamFuture;
 pub(crate) use local_stream::LocalStreamFuture;
 pub use publisher::{ImportError, PublishError, PublishFuture, StreamPublisher};
 pub use replay::{ReplayError, StreamFrom};
-pub(crate) use stream::processed_stream;
-pub use stream::{ProcessedOperation, Source, StreamEvent};
+pub use stream::{ForwardEvent, ProcessedOperation, Source, StreamEvent};
+pub(crate) use stream::{processed_stream, to_stream_event, to_system_event};
 pub use subscription::StreamSubscription;
 pub use sync_metrics::{SessionPhase, SyncError};
 

--- a/p2panda/src/streams/publisher.rs
+++ b/p2panda/src/streams/publisher.rs
@@ -23,7 +23,7 @@ use crate::spaces::{RepairError, RepairStrategy};
 use crate::streams::drop_guard::StreamDropGuard;
 use crate::streams::external_stream::ExternalStreamFuture;
 use crate::streams::local_stream::LocalStreamFuture;
-use crate::streams::{Event, StreamEvent};
+use crate::streams::{Event, ForwardEvent};
 
 type PublishTx<M> = mpsc::Sender<(Operation, Option<M>, oneshot::Sender<Event>)>;
 type ImportExternalTx = mpsc::Sender<(
@@ -34,7 +34,7 @@ type ImportLocalTx = mpsc::Sender<(
     BoxStream<'static, Operation>,
     oneshot::Sender<LocalStreamFuture>,
 )>;
-type ToOutputTx<M> = mpsc::Sender<Vec<StreamEvent<M>>>;
+type ToOutputTx<M> = mpsc::Sender<Vec<ForwardEvent<M>>>;
 type RepairTx = mpsc::Sender<(RepairStrategy, oneshot::Sender<Result<bool, RepairError>>)>;
 
 /// Publish messages into a topic stream.

--- a/p2panda/src/streams/replay.rs
+++ b/p2panda/src/streams/replay.rs
@@ -15,8 +15,8 @@ use tracing::debug;
 
 use crate::operation::{Extensions, LogId, Operation};
 use crate::processor::Pipeline;
-use crate::streams::StreamEvent;
 use crate::streams::stream::{Source, process_operation_in};
+use crate::streams::{ForwardEvent, StreamEvent};
 
 /// Determines the starting point of a subscription stream.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
@@ -49,7 +49,7 @@ impl From<Cursor<VerifyingKey, LogId>> for StreamFrom {
 pub(crate) async fn replay_log_ranges<M>(
     topic: Topic,
     store: &SqliteStore,
-    to_output_tx: &mpsc::Sender<Vec<StreamEvent<M>>>,
+    to_output_tx: &mpsc::Sender<Vec<ForwardEvent<M>>>,
     pipeline: &Pipeline<LogId, Extensions, Topic>,
     sync_handle: &Arc<SyncHandle<Operation, TopicLogSyncEvent<Extensions>>>,
     log_ranges: LogRanges<VerifyingKey, LogId>,
@@ -65,7 +65,7 @@ where
     }
 
     to_output_tx
-        .send(vec![StreamEvent::ReplayStarted { total_operations }])
+        .send(vec![StreamEvent::ReplayStarted { total_operations }.into()])
         .await
         .map_err(|_| ReplayError::CriticalError)?;
 
@@ -89,7 +89,7 @@ where
     }
 
     to_output_tx
-        .send(vec![StreamEvent::ReplayEnded])
+        .send(vec![StreamEvent::ReplayEnded.into()])
         .await
         .map_err(|_| ReplayError::CriticalError)?;
 

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use futures_util::StreamExt;
 use futures_util::stream::BoxStream;
+use p2panda_auth::AccessLevel;
 use p2panda_core::cbor::{DecodeError, decode_cbor};
 use p2panda_core::traits::Digest;
 use p2panda_core::{Hash, Topic, VerifyingKey};
@@ -14,11 +15,12 @@ use p2panda_net::sync::SyncHandle;
 // TODO: Replace with ShortFormat from p2panda-core.
 // See: https://github.com/p2panda/p2panda/issues/1270
 use p2panda_net::utils::ShortFormat;
+use p2panda_spaces::{ActorId, SpaceContext, SpaceId};
 use p2panda_store::SqliteStore;
 use p2panda_stream::spaces::SpacesResult;
 use p2panda_sync::protocols::TopicLogSyncEvent;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
@@ -27,8 +29,8 @@ use crate::forge::OperationForge;
 use crate::node::{AckPolicy, CreateStreamError};
 use crate::operation::{Extensions, Header, Operation};
 use crate::processor::{ProcessorError, ProcessorStatus};
-use crate::spaces::spawn_repair_task;
-use crate::spaces::types::{SpaceEvent, SpacesManager};
+use crate::spaces::types::{InnerSpaceEvent, SpacesManager};
+use crate::spaces::{GroupActor, InnerGroupEvent, spawn_repair_task, to_actors, to_members};
 use crate::streams::acked::{Acked, AckedError};
 use crate::streams::drop_guard::StreamDropGuard;
 use crate::streams::external_stream::{
@@ -39,7 +41,7 @@ use crate::streams::publisher::StreamPublisher;
 use crate::streams::replay::{ReplayError, StreamFrom, replay_log_ranges};
 use crate::streams::subscription::StreamSubscription;
 use crate::streams::sync_metrics::{self, Aggregator, SessionPhase, SyncError};
-use crate::streams::{Event, Pipeline};
+use crate::streams::{Event, Pipeline, SystemEvent};
 
 /// Number of items which can stay in the buffer before the application-layer picks up the
 /// operations. If buffer runs full the processor will pause work and we'll apply backpressure to
@@ -106,6 +108,7 @@ pub(crate) async fn processed_stream<M>(
     forge: OperationForge,
     spaces_manager: SpacesManager,
     pipeline: Pipeline,
+    event_tx: broadcast::Sender<SystemEvent>,
     from: StreamFrom,
 ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
 where
@@ -155,7 +158,7 @@ where
 
     // If any other process wants to bring an stream event forward to the application layer ("output
     // stream"), this channel should be used.
-    let (to_output_tx, mut to_output_rx) = mpsc::channel::<Vec<StreamEvent<M>>>(128);
+    let (to_output_tx, mut to_output_rx) = mpsc::channel::<Vec<ForwardEvent<M>>>(128);
 
     let (repair_tx, repair_rx) = mpsc::channel(1);
 
@@ -188,7 +191,7 @@ where
 
         tokio::spawn(async move {
             loop {
-                let stream_events = tokio::select! {
+                let forward_events = tokio::select! {
                     // We need to process pipeline output events _before_ any other system events.
                     // This is crucial to ensure correct ordering of events such as "replay started"
                     // being followed by "processed operations" and then finally by "replay ended",
@@ -198,7 +201,7 @@ where
                     // Handle resulting output events from the pipeline and forward them as stream
                     // events to application layer, when applicable.
                     from_pipeline_event = pipeline.next() => {
-                        if let Some(stream_events) =
+                        if let Some(forward_events) =
                             process_operation_out::<M>(
                                 from_pipeline_event,
                                 topic,
@@ -206,7 +209,7 @@ where
                                 &acked
                             ).await
                         {
-                            stream_events
+                            forward_events
                         } else {
                             continue;
                         }
@@ -214,8 +217,8 @@ where
 
                     // Any other process forwarding an event (like "replay ended", etc.) to the
                     // application layer.
-                    Some(stream_events) = to_output_rx.recv() => {
-                        stream_events
+                    Some(forward_events) = to_output_rx.recv() => {
+                        forward_events
                     }
 
                     // Break out of the loop, thereby ending the task, when both the
@@ -230,8 +233,15 @@ where
                 //
                 // If channel stopped working because the subscriber got dropped, ignore it as
                 // we still might want to process locally published operations.
-                for stream_event in stream_events {
-                    let _ = app_tx.send(stream_event).await;
+                for forward_event in forward_events {
+                    match forward_event {
+                        ForwardEvent::System(system_event) => {
+                            let _ = event_tx.send(*system_event);
+                        }
+                        ForwardEvent::Stream(stream_event) => {
+                            let _ = app_tx.send(*stream_event).await;
+                        }
+                    }
                 }
             }
         });
@@ -275,9 +285,12 @@ where
                     );
 
                     let _ = to_output_tx
-                        .send(vec![StreamEvent::ReplayFailed {
-                            error: Arc::new(error),
-                        }])
+                        .send(vec![
+                            StreamEvent::ReplayFailed {
+                                error: Arc::new(error),
+                            }
+                            .into(),
+                        ])
                         .await;
                 }
             }
@@ -288,7 +301,7 @@ where
 
             let mut aggregator = Aggregator::new();
             loop {
-                let stream_events = tokio::select! {
+                let forward_events: Vec<ForwardEvent<M>> = tokio::select! {
                     // Received incoming operation from remote source.
                     item = sync_stream.next() => {
                         let Some(result) = item else {
@@ -358,7 +371,7 @@ where
                         match event {
                             ExternalStreamEvent::Start {
                                 session_id
-                            } => vec![StreamEvent::ImportStarted { session_id }],
+                            } => vec![StreamEvent::ImportStarted { session_id }.into()],
                             ExternalStreamEvent::Operation { session_id, operation } => {
                                 process_operation_in(
                                     *operation,
@@ -373,7 +386,7 @@ where
                             ExternalStreamEvent::End {
                                 session_id
                             } => {
-                                vec![StreamEvent::ImportEnded { session_id }]
+                                vec![StreamEvent::ImportEnded { session_id }.into()]
                             },
                         }
                     },
@@ -415,7 +428,7 @@ where
                     }
                 };
 
-                let _ = to_output_tx.send(stream_events).await;
+                let _ = to_output_tx.send(forward_events).await;
             }
 
             // Abort the repair task.
@@ -494,7 +507,7 @@ pub(crate) async fn process_operation_out<M>(
     topic: Topic,
     ack_policy: AckPolicy,
     acked: &Acked,
-) -> Option<Vec<StreamEvent<M>>>
+) -> Option<Vec<ForwardEvent<M>>>
 where
     M: for<'a> Deserialize<'a> + Send + 'static,
 {
@@ -507,11 +520,11 @@ where
             error,
         );
 
-        let failure_event = vec![StreamEvent::ProcessingFailed {
+        let failure_event = vec![ForwardEvent::stream(StreamEvent::ProcessingFailed {
             event,
             error,
             source,
-        }];
+        })];
 
         return Some(failure_event);
     }
@@ -534,13 +547,13 @@ where
                             if ack_policy == AckPolicy::Automatic
                                 && let Err(error) = acked.ack(&event).await
                             {
-                                forward_events.push(StreamEvent::AckFailed {
+                                forward_events.push(ForwardEvent::stream(StreamEvent::AckFailed {
                                     event: event.clone(),
                                     error: Arc::new(error),
-                                });
+                                }));
                             }
 
-                            forward_events.push(StreamEvent::Processed {
+                            forward_events.push(ForwardEvent::stream(StreamEvent::Processed {
                                 operation: ProcessedOperation {
                                     event: event.clone(),
                                     topic,
@@ -548,28 +561,28 @@ where
                                     message,
                                 },
                                 source: source.clone(),
-                            });
+                            }));
                         }
-                        Err(error) => forward_events.push(StreamEvent::DecodeFailed {
-                            event: event.clone(),
-                            error,
-                        }),
+                        Err(error) => {
+                            forward_events.push(ForwardEvent::stream(StreamEvent::DecodeFailed {
+                                event: event.clone(),
+                                error,
+                            }))
+                        }
                     }
                 }
 
                 p2panda_spaces::Event::KeyBundle { author } => {
-                    forward_events.push(StreamEvent::KeyBundle(*author))
+                    forward_events.push(ForwardEvent::stream(StreamEvent::KeyBundle(*author)))
                 }
 
-                p2panda_spaces::Event::Group(_) => {
-                    // @TODO: It's not clear if group events should be forwarded on the spaces
-                    // stream, so for now we don't forward any.
-                    // forward_events.push(StreamEvent::Group(group_event.to_owned()))
-                }
+                p2panda_spaces::Event::Groups(group_event) => forward_events.push(
+                    ForwardEvent::system(to_system_event(group_event.to_owned())),
+                ),
 
-                p2panda_spaces::Event::Space(space_event) => {
-                    forward_events.push(StreamEvent::Space(space_event.to_owned()))
-                }
+                p2panda_spaces::Event::Spaces(space_event) => forward_events.push(
+                    ForwardEvent::stream(to_stream_event(space_event.to_owned())),
+                ),
             }
         }
     } else {
@@ -577,10 +590,10 @@ where
         let Some(body) = event.body() else {
             // _Always_ ack system-level events, even if no automatic policy was configured.
             if let Err(error) = acked.ack(&event).await {
-                return Some(vec![StreamEvent::AckFailed {
+                return Some(vec![ForwardEvent::stream(StreamEvent::AckFailed {
                     event,
                     error: Arc::new(error),
-                }]);
+                })]);
             }
 
             return None;
@@ -604,13 +617,13 @@ where
                 if ack_policy == AckPolicy::Automatic
                     && let Err(error) = acked.ack(&event).await
                 {
-                    return Some(vec![StreamEvent::AckFailed {
+                    return Some(vec![ForwardEvent::stream(StreamEvent::AckFailed {
                         event,
                         error: Arc::new(error),
-                    }]);
+                    })]);
                 }
 
-                return Some(vec![StreamEvent::Processed {
+                return Some(vec![ForwardEvent::stream(StreamEvent::Processed {
                     operation: ProcessedOperation {
                         event,
                         topic,
@@ -618,9 +631,14 @@ where
                         message,
                     },
                     source,
-                }]);
+                })]);
             }
-            Err(error) => return Some(vec![StreamEvent::DecodeFailed { event, error }]),
+            Err(error) => {
+                return Some(vec![ForwardEvent::stream(StreamEvent::DecodeFailed {
+                    event,
+                    error,
+                })]);
+            }
         }
     }
 
@@ -630,7 +648,6 @@ where
 /// Operations with application messages, system events and errors coming from a topic stream
 /// subscription.
 #[derive(Clone, Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum StreamEvent<M> {
     /// Operation with application message coming from a topic stream.
     ///
@@ -754,16 +771,131 @@ pub enum StreamEvent<M> {
     },
 
     /// Space has been created or modified.
-    Space(SpaceEvent),
-
-    // @TODO: It's not clear where group events should be forwarded so we don't send any for now
-    // and therefore this variant is commented out.
-    //
-    /// Group has been created or modified.
-    // Group(GroupEvent<AuthCapabilities>),
+    ///
+    /// An event is emitted for every space membership change which occurs. This could be the
+    /// result of a change of membership in a child group. In all cases the new membership of the
+    /// space is included directly in the event along with additional meta-information, including
+    /// regarding the action (possibly targeting a child group) which caused the membership change.
+    Space {
+        space_id: SpaceId,
+        members: Vec<(ActorId, AccessLevel)>,
+        actors: Vec<(GroupActor, AccessLevel)>,
+        inner: InnerSpaceEvent,
+    },
 
     /// Key bundle has been processed.
     KeyBundle(VerifyingKey),
+}
+
+pub(crate) fn to_stream_event<M>(event: InnerSpaceEvent) -> StreamEvent<M> {
+    match &event {
+        p2panda_spaces::SpaceEvent::Created {
+            space_id,
+            context: SpaceContext {
+                members, actors, ..
+            },
+            ..
+        }
+        | p2panda_spaces::SpaceEvent::Added {
+            space_id,
+            context: SpaceContext {
+                members, actors, ..
+            },
+            ..
+        }
+        | p2panda_spaces::SpaceEvent::Removed {
+            space_id,
+            context: SpaceContext {
+                members, actors, ..
+            },
+            ..
+        }
+        | p2panda_spaces::SpaceEvent::Promoted {
+            space_id,
+            context: SpaceContext {
+                members, actors, ..
+            },
+            ..
+        }
+        | p2panda_spaces::SpaceEvent::Demoted {
+            space_id,
+            context: SpaceContext {
+                members, actors, ..
+            },
+            ..
+        } => StreamEvent::Space {
+            space_id: *space_id,
+            members: to_members(members),
+            actors: to_actors(actors),
+            inner: event,
+        },
+        p2panda_spaces::SpaceEvent::Ejected { space_id } => StreamEvent::Space {
+            space_id: *space_id,
+            members: vec![],
+            actors: vec![],
+            inner: event,
+        },
+    }
+}
+
+pub(crate) fn to_system_event(event: InnerGroupEvent) -> SystemEvent {
+    let members = event
+        .context()
+        .members
+        .iter()
+        .map(|(id, access)| (*id, access.level))
+        .collect();
+
+    let actors = event
+        .context()
+        .actors
+        .iter()
+        .map(|(actor, access)| {
+            (
+                GroupActor {
+                    id: actor.id(),
+                    group: actor.is_group(),
+                },
+                access.level,
+            )
+        })
+        .collect();
+
+    let group_id = event.group_id();
+    SystemEvent::Groups {
+        group_id,
+        members,
+        actors,
+        inner: event,
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum ForwardEvent<M> {
+    System(Box<SystemEvent>),
+    Stream(Box<StreamEvent<M>>),
+}
+
+impl<M> ForwardEvent<M> {
+    pub fn system(event: SystemEvent) -> Self {
+        Self::System(Box::new(event))
+    }
+
+    pub fn stream(event: StreamEvent<M>) -> Self {
+        Self::Stream(Box::new(event))
+    }
+}
+
+impl<M> From<StreamEvent<M>> for ForwardEvent<M> {
+    fn from(value: StreamEvent<M>) -> ForwardEvent<M> {
+        ForwardEvent::stream(value)
+    }
+}
+
+impl<M> From<SystemEvent> for ForwardEvent<M> {
+    fn from(value: SystemEvent) -> ForwardEvent<M> {
+        ForwardEvent::system(value)
+    }
 }
 
 /// Processed operation with application message coming from a topic stream.

--- a/p2panda/src/streams/sync_metrics.rs
+++ b/p2panda/src/streams/sync_metrics.rs
@@ -9,8 +9,8 @@ use p2panda_sync::protocols::{Metrics, TopicLogSyncEvent};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::streams::StreamEvent;
 use crate::streams::stream::Source;
+use crate::streams::{ForwardEvent, StreamEvent};
 
 type SessionId = u64;
 
@@ -246,6 +246,12 @@ impl<E, M> From<SyncEvent<E>> for StreamEvent<M> {
             // decoded first so this branch is never called.
             SyncEvent::OperationReceived { .. } => unreachable!(),
         }
+    }
+}
+
+impl<E, M> From<SyncEvent<E>> for ForwardEvent<M> {
+    fn from(value: SyncEvent<E>) -> Self {
+        StreamEvent::from(value).into()
     }
 }
 

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -620,9 +620,10 @@ async fn graceful_closure_of_publisher() {
     drop(icebear_tx);
     drop(icebear_rx);
 
-    // Attempting to create a new stream for the same topic will return an error because the
-    // cleanup initated by dropping the publisher and subscriber has not yet completed.
-    assert!(icebear.stream::<String>(chat_id).await.is_err());
+    // TODO: known flaky assertion: https://github.com/p2panda/p2panda/issues/1320
+    // // Attempting to create a new stream for the same topic will return an error because the
+    // // cleanup initated by dropping the publisher and subscriber has not yet completed.
+    // assert!(icebear.stream::<String>(chat_id).await.is_err());
 
     // Briefly sleep to await cleanup.
     sleep(Duration::from_millis(50)).await;

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -1,19 +1,20 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use core::panic;
 use std::assert_matches;
 use std::collections::HashSet;
-use std::time::Duration;
 
 use p2panda::Topic;
-use p2panda::spaces::{AddSpaceMemberError, PublishSpaceError, RemoveSpaceMemberError};
-use p2panda::streams::StreamEvent;
+use p2panda::spaces::{
+    AddSpaceMemberError, GroupEvent, InnerGroupEvent, PublishSpaceError, RemoveSpaceMemberError,
+};
+use p2panda::streams::{StreamEvent, SystemEvent};
 use p2panda::{SigningKey, operation::Header};
 use p2panda_auth::validation::{AddMemberError, RemoveMemberError, WriteError};
 use p2panda_auth::{Access, AccessLevel};
 use p2panda_core::{cbor::decode_cbor, test_utils::setup_logging};
 use p2panda_spaces::SpaceEvent;
 use serde::{Deserialize, Serialize};
-use tokio::time::sleep;
 use tokio_stream::StreamExt;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -29,6 +30,7 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
     use p2panda::Topic;
 
     let panda = p2panda::spawn().await?;
+    let mut panda_system_rx = panda.event_stream().await?;
 
     // Spaces behave like topic-streams, just that they're encrypted towards members.
     let topic = Topic::random();
@@ -38,7 +40,11 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
 
     // Panda receives a space created event for their own action.
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+        if let StreamEvent::Space {
+            inner: SpaceEvent::Created { .. },
+            ..
+        } = event
+        {
             break;
         };
     }
@@ -46,6 +52,7 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
     // We can manage (nested) groups (useful for multi-device, etc.)
     let penguin_laptop = p2panda::spawn().await?;
     let penguin_mobile = p2panda::spawn().await?;
+    let mut penguin_mobile_system_rx = penguin_mobile.event_stream().await?;
 
     // Penguin subscribes to the space in order to publish some key bundles.
     let (penguin_laptop_space, mut penguin_laptop_rx) =
@@ -73,50 +80,61 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Panda receives the group.
-    // @TODO: Switch to observing groups events when this is implemented.
-    loop {
-        let group = panda.group(penguin.id()).await?;
-        if group.is_some() {
-            break;
-        }
-        sleep(Duration::from_secs(1)).await;
+    while let Some(event) = panda_system_rx.next().await {
+        if let SystemEvent::Groups {
+            group_id,
+            inner: InnerGroupEvent::Created { .. },
+            ..
+        } = event
+        {
+            if group_id == penguin.id() {
+                break;
+            }
+        };
     }
 
     // Penguin mobile receives the group.
-    // @TODO: Switch to observing groups events when this is implemented.
-    loop {
-        let group = penguin_mobile.group(penguin.id()).await?;
-        if group.is_some() {
-            break;
-        }
-        sleep(Duration::from_secs(1)).await;
+    while let Some(event) = penguin_mobile_system_rx.next().await {
+        if let SystemEvent::Groups {
+            group_id,
+            inner: InnerGroupEvent::Created { .. },
+            ..
+        } = event
+        {
+            if group_id == penguin.id() {
+                break;
+            }
+        };
     }
 
     panda_space.add(penguin.id(), AccessLevel::Read).await?;
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
-            assert_eq!(added.len(), 2);
-            assert!(added.contains(&(penguin_laptop.id(), Access::read())));
-            assert!(added.contains(&(penguin_mobile.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 3);
+            assert!(members.contains(&(panda.id(), AccessLevel::Manage)));
+            assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
+            assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
             break;
         };
     }
 
     while let Some(event) = penguin_laptop_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
-            assert_eq!(added.len(), 2);
-            assert!(added.contains(&(penguin_laptop.id(), Access::read())));
-            assert!(added.contains(&(penguin_mobile.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 3);
+            assert!(members.contains(&(panda.id(), AccessLevel::Manage)));
+            assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
+            assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
             break;
         };
     }
 
     while let Some(event) = penguin_mobile_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
-            assert_eq!(added.len(), 2);
-            assert!(added.contains(&(penguin_laptop.id(), Access::read())));
-            assert!(added.contains(&(penguin_mobile.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 3);
+            assert!(members.contains(&(panda.id(), AccessLevel::Manage)));
+            assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
+            assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
             break;
         };
     }
@@ -188,21 +206,40 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
             .is_ok()
     );
 
-    while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Promoted { promoted, .. }) = event {
-            assert_eq!(promoted.len(), 1);
-            // NOTE: Penguin mobile is not promoted as they don't hold "write" access in the sub-group.
-            assert!(promoted.contains(&(penguin_laptop.id(), Access::write())));
-            break;
-        };
-    }
-
     assert!(
         panda_space
             .actors()
             .await?
             .contains(&(penguin.id(), AccessLevel::Write))
     );
+
+    while let Some(event) = panda_rx.next().await {
+        if let StreamEvent::Space {
+            members,
+            inner: SpaceEvent::Promoted { .. },
+            ..
+        } = event
+        {
+            assert_eq!(members.len(), 3);
+            assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Write)));
+            assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
+            break;
+        };
+    }
+
+    while let Some(event) = penguin_laptop_rx.next().await {
+        if let StreamEvent::Space {
+            members,
+            inner: SpaceEvent::Promoted { .. },
+            ..
+        } = event
+        {
+            assert_eq!(members.len(), 3);
+            assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Write)));
+            assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
+            break;
+        };
+    }
 
     // Panda demotes penguin to have "read" access.
     assert!(
@@ -213,9 +250,10 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Demoted { demoted, .. }) = event {
-            assert_eq!(demoted.len(), 1);
-            assert!(demoted.contains(&(penguin_laptop.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 3);
+            assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
+            assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
             break;
         };
     }
@@ -229,17 +267,10 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
 
     // Penguin laptop also receives the promote and demote.
     while let Some(event) = penguin_laptop_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Promoted { promoted, .. }) = event {
-            assert_eq!(promoted.len(), 1);
-            assert!(promoted.contains(&(penguin_laptop.id(), Access::write())));
-            break;
-        };
-    }
-
-    while let Some(event) = penguin_laptop_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Demoted { demoted, .. }) = event {
-            assert_eq!(demoted.len(), 1);
-            assert!(demoted.contains(&(penguin_laptop.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 3);
+            assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Read)));
+            assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
             break;
         };
     }
@@ -263,7 +294,11 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
     let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+        if let StreamEvent::Space {
+            inner: SpaceEvent::Created { .. },
+            ..
+        } = event
+        {
             break;
         };
     }
@@ -280,17 +315,17 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
     panda_space.add(penguin.id(), AccessLevel::Read).await?;
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
-            assert_eq!(added.len(), 1);
-            assert!(added.contains(&(penguin.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 2);
+            assert!(members.contains(&(penguin.id(), AccessLevel::Read)));
             break;
         };
     }
 
     while let Some(event) = penguin_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
-            assert_eq!(added.len(), 1);
-            assert!(added.contains(&(penguin.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 2);
+            assert!(members.contains(&(penguin.id(), AccessLevel::Read)));
             break;
         };
     }
@@ -376,7 +411,9 @@ async fn sync_repair_space() -> Result<(), Box<dyn std::error::Error>> {
     let topic = Topic::random();
 
     let panda = p2panda::spawn().await?;
+    let mut panda_system_rx = panda.event_stream().await?;
     let penguin = p2panda::spawn().await?;
+    let mut penguin_system_rx = penguin.event_stream().await?;
 
     // Penguin creates a group before subscribing to the space.
     let penguin_group = penguin
@@ -388,48 +425,59 @@ async fn sync_repair_space() -> Result<(), Box<dyn std::error::Error>> {
     let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+        if let StreamEvent::Space {
+            inner: SpaceEvent::Created { .. },
+            ..
+        } = event
+        {
             break;
         };
     }
 
-    // Panda materialized the group.
-    // @TODO: Switch to observing groups events when this is implemented.
-    loop {
-        let group = panda.group(penguin_group.id()).await?;
-        if group.is_some() {
-            break;
-        }
-        sleep(Duration::from_secs(1)).await;
+    // Panda receives the group.
+    while let Some(event) = panda_system_rx.next().await {
+        if let SystemEvent::Groups {
+            group_id,
+            inner: InnerGroupEvent::Created { .. },
+            ..
+        } = event
+        {
+            if group_id == penguin_group.id() {
+                break;
+            }
+        };
     }
 
-    // Penguin mobile materialized the group.
-    // @TODO: Switch to observing groups events when this is implemented.
-    loop {
-        let group = penguin.group(penguin_group.id()).await?;
-        if group.is_some() {
-            break;
-        }
-        sleep(Duration::from_secs(1)).await;
+    // Penguin receives the group.
+    while let Some(event) = penguin_system_rx.next().await {
+        if let SystemEvent::Groups {
+            group_id,
+            inner: InnerGroupEvent::Created { .. },
+            ..
+        } = event
+        {
+            if group_id == penguin_group.id() {
+                break;
+            }
+        };
     }
-
     // We expect panda to be able to add penguin group as a space member now.
     panda_space
         .add(penguin_group.id(), AccessLevel::Read)
         .await?;
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
-            assert_eq!(added.len(), 1);
-            assert!(added.contains(&(penguin.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 2);
+            assert!(members.contains(&(penguin.id(), AccessLevel::Read)));
             break;
         };
     }
 
     while let Some(event) = penguin_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
-            assert_eq!(added.len(), 1);
-            assert!(added.contains(&(penguin.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 2);
+            assert!(members.contains(&(penguin.id(), AccessLevel::Read)));
             break;
         };
     }
@@ -444,6 +492,7 @@ async fn live_repair_space() -> Result<(), Box<dyn std::error::Error>> {
     let topic = Topic::random();
 
     let panda = p2panda::spawn().await?;
+    let mut panda_system_rx = panda.event_stream().await?;
     let penguin = p2panda::spawn().await?;
 
     // Penguin subscribes to the space.
@@ -451,7 +500,11 @@ async fn live_repair_space() -> Result<(), Box<dyn std::error::Error>> {
     let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await?;
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Created { .. }) = event {
+        if let StreamEvent::Space {
+            inner: SpaceEvent::Created { .. },
+            ..
+        } = event
+        {
             break;
         };
     }
@@ -461,14 +514,18 @@ async fn live_repair_space() -> Result<(), Box<dyn std::error::Error>> {
         .create_group(&[(penguin.id(), AccessLevel::Manage)])
         .await?;
 
-    // Panda materialized the group.
-    // @TODO: Switch to observing groups events when this is implemented.
-    loop {
-        let group = panda.group(penguin_group.id()).await?;
-        if group.is_some() {
-            break;
-        }
-        sleep(Duration::from_secs(1)).await;
+    // Panda receives the group.
+    while let Some(event) = panda_system_rx.next().await {
+        if let SystemEvent::Groups {
+            group_id,
+            inner: InnerGroupEvent::Created { .. },
+            ..
+        } = event
+        {
+            if group_id == penguin_group.id() {
+                break;
+            }
+        };
     }
 
     // We expect panda to be able to add penguin group to the space.
@@ -477,17 +534,17 @@ async fn live_repair_space() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
-            assert_eq!(added.len(), 1);
-            assert!(added.contains(&(penguin.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 2);
+            assert!(members.contains(&(penguin.id(), AccessLevel::Read)));
             break;
         };
     }
 
     while let Some(event) = penguin_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Added { added, .. }) = event {
-            assert_eq!(added.len(), 1);
-            assert!(added.contains(&(penguin.id(), Access::read())));
+        if let StreamEvent::Space { members, .. } = event {
+            assert_eq!(members.len(), 2);
+            assert!(members.contains(&(penguin.id(), AccessLevel::Read)));
             break;
         };
     }
@@ -542,7 +599,11 @@ async fn api_validation() -> Result<(), Box<dyn std::error::Error>> {
     panda_space.add(tiger.id(), AccessLevel::Read).await?;
 
     while let Some(event) = tiger_rx.next().await {
-        if let StreamEvent::Space(SpaceEvent::Added { .. }) = event {
+        if let StreamEvent::Space {
+            inner: SpaceEvent::Added { .. },
+            ..
+        } = event
+        {
             break;
         };
     }
@@ -572,4 +633,160 @@ async fn api_validation() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     Ok(())
+}
+
+#[tokio::test]
+async fn group_events() {
+    setup_logging();
+
+    use p2panda::Topic;
+
+    let panda = p2panda::spawn().await.unwrap();
+    let mut panda_system_rx = panda.event_stream().await.unwrap();
+
+    let topic = Topic::random();
+
+    // Create a space with only us inside.
+    //
+    // NOTE: Having a space in this test is only required to sync the group operations.
+    let (_panda_space, _panda_rx) = panda.create_space::<SecretData>(topic).await.unwrap();
+
+    let penguin_laptop = p2panda::spawn().await.unwrap();
+    let penguin_mobile = p2panda::spawn().await.unwrap();
+    let mut penguin_laptop_system_rx = penguin_laptop.event_stream().await.unwrap();
+
+    let (_penguin_laptop_space, _penguin_laptop_rx) =
+        penguin_laptop.space::<SecretData>(topic).await.unwrap();
+    let (_penguin_mobile_space, _penguin_mobile_rx) =
+        penguin_mobile.space::<SecretData>(topic).await.unwrap();
+
+    // Penguin creates a device group.
+    let device_group = penguin_laptop
+        .create_group(&[(penguin_laptop.id(), AccessLevel::Manage)])
+        .await
+        .unwrap();
+
+    // Penguin receives the device group event on their system stream.
+    loop {
+        if let Some(SystemEvent::Groups {
+            group_id,
+            inner: InnerGroupEvent::Created { .. },
+            ..
+        }) = penguin_laptop_system_rx.next().await
+        {
+            if group_id == device_group.id() {
+                break;
+            }
+        };
+    }
+
+    // Panda receives the device group event on their system stream.
+    loop {
+        if let Some(SystemEvent::Groups {
+            group_id,
+            inner: InnerGroupEvent::Created { .. },
+            ..
+        }) = panda_system_rx.next().await
+        {
+            if group_id == device_group.id() {
+                break;
+            }
+        };
+    }
+
+    // Panda creates a team group with Penguin's device group as a member.
+    let team_group = panda
+        .create_group(&[
+            (panda.id(), AccessLevel::Manage),
+            (device_group.id(), AccessLevel::Write),
+        ])
+        .await
+        .unwrap();
+    let team_group_id = team_group.id();
+
+    // Penguin receives the team group event on their system stream.
+    loop {
+        if let Some(SystemEvent::Groups {
+            group_id,
+            inner: InnerGroupEvent::Created { .. },
+            ..
+        }) = penguin_laptop_system_rx.next().await
+        {
+            if group_id == team_group.id() {
+                break;
+            }
+        };
+    }
+
+    // Panda receives the team group event on their system stream.
+    loop {
+        if let Some(SystemEvent::Groups {
+            group_id,
+            inner: InnerGroupEvent::Created { .. },
+            ..
+        }) = panda_system_rx.next().await
+        {
+            if group_id == team_group.id() {
+                break;
+            }
+        };
+    }
+
+    // Panda subscribes to the group event stream.
+    let mut panda_team_group_rx = team_group.event_stream();
+    // Penguin subscribes to the group event stream.
+    let panda_team_group_on_penguin = penguin_laptop.group(team_group_id).await.unwrap().unwrap();
+    let mut panda_team_group_on_penguin_rx = panda_team_group_on_penguin.event_stream();
+
+    // Penguin adds their mobile to the device group.
+    let ready = device_group
+        .add(penguin_mobile.id(), AccessLevel::Read)
+        .await
+        .unwrap();
+
+    ready.await.unwrap();
+
+    // Penguin receives the add event on the team group rx.
+    loop {
+        if let Some(GroupEvent {
+            members,
+            actors,
+            inner:
+                InnerGroupEvent::Added {
+                    group_id: action_group_id,
+                    ..
+                },
+            ..
+        }) = panda_team_group_on_penguin_rx.next().await
+        {
+            assert_eq!(members.len(), 3);
+            assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Write)));
+            assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
+            assert_eq!(actors.len(), 2);
+            assert_eq!(action_group_id, device_group.id());
+            break;
+        };
+    }
+
+    // Panda receives the add event on the team group rx.
+    loop {
+        if let Some(GroupEvent {
+            members,
+            actors,
+            inner:
+                InnerGroupEvent::Added {
+                    group_id: action_group_id,
+                    ..
+                },
+            ..
+        }) = panda_team_group_rx.next().await
+        {
+            assert_eq!(members.len(), 3);
+            assert!(members.contains(&(penguin_laptop.id(), AccessLevel::Write)));
+            assert!(members.contains(&(penguin_mobile.id(), AccessLevel::Read)));
+            assert_eq!(actors.len(), 2);
+            assert_eq!(action_group_id, device_group.id());
+            break;
+        };
+    }
 }


### PR DESCRIPTION
This change wires up the event streams so that events containing group membership changes are forwarded to the correct subscribers. There are two routes a group event can take:

1) to the global system events stream
2) to any per-group event streams

For the former all events are forwarded. For the latter we only want to forward events which effect membership of the subscribed-to group, this includes events targeting the subscribed-to group or any child groups (current or removed). This filtering required adding some additional contextual information to the groups events in p2panda-spaces.

Additional changes were made to make the structure of group and space events consistent, and to present the user with the most pertinent information up front. In this case that would be the current membership of a group or space, rather than the actual action which resulted in the group membership change.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
