### PR TITLE
Register hooks on Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Highlights are marked with a pancake 🥞
 - spaces: Support partial merge of auth state into a space [#1299](https://github.com/p2panda/p2panda/pull/1299)
 - node: Allow graceful closure of sync sessions [#1307](https://github.com/p2panda/p2panda/pull/1307)
 - node: API for promoting and demoting space members [#1311](https://github.com/p2panda/p2panda/pull/1311)
+- net: Register hooks on Endpoint [#1319](https://github.com/p2panda/p2panda/pull/1319)
 
 ### Changed
 

--- a/p2panda-net/src/iroh_endpoint/actors/endpoint.rs
+++ b/p2panda-net/src/iroh_endpoint/actors/endpoint.rs
@@ -25,6 +25,7 @@ use crate::iroh_endpoint::actors::connection::{
 use crate::iroh_endpoint::actors::is_globally_reachable_endpoint;
 use crate::iroh_endpoint::config::IrohConfig;
 use crate::iroh_endpoint::discovery::AddressBookDiscovery;
+use crate::iroh_endpoint::hooks::EndpointHooksList;
 use crate::utils::{ShortFormat, from_signing_key};
 use crate::{NetworkId, NodeId, ProtocolId, hash_protocol_id_with_network_id};
 
@@ -86,6 +87,7 @@ pub struct IrohState {
     config: IrohConfig,
     relay_map: iroh::RelayMap,
     address_book: AddressBook,
+    hooks: EndpointHooksList,
     endpoint: Option<iroh::Endpoint>,
     protocols: ProtocolMap,
     accept_handle: Option<JoinHandle<()>>,
@@ -99,6 +101,7 @@ pub type IrohEndpointArgs = (
     IrohConfig,
     iroh::RelayMap,
     AddressBook,
+    EndpointHooksList,
 );
 
 #[derive(Default)]
@@ -116,7 +119,7 @@ impl ThreadLocalActor for IrohEndpoint {
         myself: ActorRef<Self::Msg>,
         args: Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
-        let (network_id, signing_key, config, relay_map, address_book) = args;
+        let (network_id, signing_key, config, relay_map, address_book, hooks) = args;
 
         // Automatically bind iroh endpoint after actor start.
         myself.send_message(ToIrohEndpoint::Bind)?;
@@ -127,6 +130,7 @@ impl ThreadLocalActor for IrohEndpoint {
             config,
             relay_map,
             address_book,
+            hooks,
             endpoint: None,
             protocols: Arc::default(),
             accept_handle: None,
@@ -198,6 +202,7 @@ impl ThreadLocalActor for IrohEndpoint {
                     .address_lookup(address_book_discovery)
                     .secret_key(from_signing_key(state.signing_key.clone()))
                     .transport_config(quic_transport_config)
+                    .hooks(state.hooks.clone())
                     .bind_addr(socket_address_v4)?
                     .bind_addr(socket_address_v6)?
                     .bind()

--- a/p2panda-net/src/iroh_endpoint/builder.rs
+++ b/p2panda-net/src/iroh_endpoint/builder.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 
+use iroh::endpoint::EndpointHooks;
 use p2panda_core::SigningKey;
 use ractor::thread_local::{ThreadLocalActor, ThreadLocalActorSpawner};
 
@@ -9,6 +10,7 @@ use crate::address_book::AddressBook;
 use crate::iroh_endpoint::actors::{IrohEndpoint, IrohEndpointArgs};
 use crate::iroh_endpoint::api::{Endpoint, EndpointError};
 use crate::iroh_endpoint::config::IrohConfig;
+use crate::iroh_endpoint::hooks::EndpointHooksList;
 use crate::{DEFAULT_NETWORK_ID, NetworkId};
 
 pub struct Builder {
@@ -17,6 +19,7 @@ pub struct Builder {
     config: Option<IrohConfig>,
     relay_urls: HashSet<iroh::RelayUrl>,
     address_book: AddressBook,
+    hooks: EndpointHooksList,
 }
 
 impl Builder {
@@ -27,6 +30,7 @@ impl Builder {
             config: None,
             address_book,
             relay_urls: HashSet::new(),
+            hooks: EndpointHooksList::new(),
         }
     }
 
@@ -68,17 +72,35 @@ impl Builder {
         self
     }
 
+    /// Register custom hooks with the endpoint.
+    ///
+    /// Endpoint hooks intercept the connection establishment process of an iroh `Endpoint`.
+    ///
+    /// Multiple hooks can be registered with the `Endpoint` and will be called in their order of
+    /// registration. If any of the hooks result in a connection rejection, all further processing
+    /// is aborted and subsequent hooks will not be called.
+    ///
+    /// See iroh's [`EndpointHooks`] documentation for further details.
+    ///
+    /// [`EndpointHooks`]: https://docs.rs/iroh/latest/iroh/endpoint/trait.EndpointHooks.html
+    pub fn hooks(mut self, hook: impl EndpointHooks + 'static + Clone) -> Self {
+        self.hooks.push(hook);
+        self
+    }
+
     pub(crate) fn build_args(self) -> IrohEndpointArgs {
         let network_id = self.network_id.unwrap_or(DEFAULT_NETWORK_ID);
         let signing_key = self.signing_key.unwrap_or_default();
         let config = self.config.unwrap_or_default();
         let relay_map = iroh::RelayMap::from_iter(self.relay_urls);
+
         (
             network_id,
             signing_key,
             config,
             relay_map,
             self.address_book,
+            self.hooks,
         )
     }
 

--- a/p2panda-net/src/iroh_endpoint/hooks.rs
+++ b/p2panda-net/src/iroh_endpoint/hooks.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Endpoint hooks traits and types.
+use std::pin::Pin;
+
+use iroh::EndpointAddr;
+use iroh::endpoint::{AfterHandshakeOutcome, BeforeConnectOutcome, Connection, EndpointHooks};
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+pub trait DynEndpointHooks: std::fmt::Debug + Send + Sync {
+    fn before_connect<'a>(
+        &'a self,
+        remote_addr: &'a EndpointAddr,
+        alpn: &'a [u8],
+    ) -> BoxFuture<'a, BeforeConnectOutcome>;
+
+    fn after_handshake<'a>(&'a self, conn: &'a Connection) -> BoxFuture<'a, AfterHandshakeOutcome>;
+
+    fn clone_dyn(&self) -> Box<dyn DynEndpointHooks>;
+}
+
+impl<T: EndpointHooks + Clone + 'static> DynEndpointHooks for T {
+    fn before_connect<'a>(
+        &'a self,
+        remote_addr: &'a EndpointAddr,
+        alpn: &'a [u8],
+    ) -> BoxFuture<'a, BeforeConnectOutcome> {
+        Box::pin(EndpointHooks::before_connect(self, remote_addr, alpn))
+    }
+
+    fn after_handshake<'a>(&'a self, conn: &'a Connection) -> BoxFuture<'a, AfterHandshakeOutcome> {
+        Box::pin(EndpointHooks::after_handshake(self, conn))
+    }
+
+    fn clone_dyn(&self) -> Box<dyn DynEndpointHooks> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn DynEndpointHooks> {
+    fn clone(&self) -> Self {
+        self.clone_dyn()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct EndpointHooksList {
+    pub inner: Vec<Box<dyn DynEndpointHooks>>,
+}
+
+impl EndpointHooksList {
+    pub(crate) fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+
+    pub(crate) fn push(&mut self, hook: impl EndpointHooks + 'static + Clone) {
+        let hook = Box::new(hook);
+        self.inner.push(hook);
+    }
+}
+
+impl EndpointHooks for EndpointHooksList {
+    async fn before_connect(
+        &self,
+        remote_addr: &EndpointAddr,
+        alpn: &[u8],
+    ) -> BeforeConnectOutcome {
+        for hook in self.inner.iter() {
+            match hook.before_connect(remote_addr, alpn).await {
+                BeforeConnectOutcome::Accept => continue,
+                reject @ BeforeConnectOutcome::Reject => {
+                    return reject;
+                }
+            }
+        }
+        BeforeConnectOutcome::Accept
+    }
+
+    async fn after_handshake(&self, conn: &Connection) -> AfterHandshakeOutcome {
+        for hook in self.inner.iter() {
+            match hook.after_handshake(conn).await {
+                AfterHandshakeOutcome::Accept => continue,
+                reject @ AfterHandshakeOutcome::Reject { .. } => {
+                    return reject;
+                }
+            }
+        }
+        AfterHandshakeOutcome::Accept
+    }
+}

--- a/p2panda-net/src/iroh_endpoint/mod.rs
+++ b/p2panda-net/src/iroh_endpoint/mod.rs
@@ -6,6 +6,7 @@ mod api;
 mod builder;
 mod config;
 mod discovery;
+mod hooks;
 #[cfg(feature = "supervisor")]
 mod supervisor;
 #[cfg(test)]

--- a/p2panda-net/src/iroh_endpoint/tests.rs
+++ b/p2panda-net/src/iroh_endpoint/tests.rs
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use iroh::EndpointAddr;
+use iroh::endpoint::{AfterHandshakeOutcome, BeforeConnectOutcome, Connection, EndpointHooks};
 use iroh::protocol::ProtocolHandler;
+use p2panda_core::VerifyingKey;
 use p2panda_core::test_utils::setup_logging;
+use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 
 use crate::address_book::AddressBook;
 use crate::iroh_endpoint::Endpoint;
 use crate::test_utils::test_args;
+use crate::utils::to_verifying_key;
 
 const ECHO_PROTOCOL_ID: &[u8] = b"test/echo/v1";
 
@@ -29,6 +34,51 @@ impl ProtocolHandler for EchoProtocol {
     }
 }
 
+/// Test hook instance to report on outbound and inbound connections.
+#[derive(Debug, Clone)]
+struct TestHook {
+    tx: UnboundedSender<MonitoredConnection>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum MonitoredConnection {
+    Outbound { remote: VerifyingKey },
+    Inbound { remote: VerifyingKey },
+}
+
+/// Test implementation of the `EndpointHooks` trait.
+///
+/// This is a super minimal single connection reporting implementation.
+impl EndpointHooks for TestHook {
+    // Runs before an outgoing connection begins.
+    async fn before_connect(
+        &self,
+        remote_addr: &EndpointAddr,
+        _alpn: &[u8],
+    ) -> BeforeConnectOutcome {
+        self.tx
+            .send(MonitoredConnection::Outbound {
+                remote: to_verifying_key(remote_addr.id),
+            })
+            .ok();
+
+        BeforeConnectOutcome::Accept
+    }
+
+    // Runs after the handshake for both incoming and outgoing connections.
+    async fn after_handshake(&self, conn: &Connection) -> AfterHandshakeOutcome {
+        if conn.side().is_server() {
+            self.tx
+                .send(MonitoredConnection::Inbound {
+                    remote: to_verifying_key(conn.remote_id()),
+                })
+                .ok();
+        }
+
+        AfterHandshakeOutcome::Accept
+    }
+}
+
 #[tokio::test]
 async fn establish_connection() {
     setup_logging();
@@ -40,10 +90,17 @@ async fn establish_connection() {
     let alice_address_book = AddressBook::builder().spawn().await.unwrap();
     let bob_address_book = AddressBook::builder().spawn().await.unwrap();
 
+    // Instantiate endpoint hooks for both.
+    let (alice_hook_tx, mut alice_hook_rx) = unbounded_channel();
+    let (bob_hook_tx, mut bob_hook_rx) = unbounded_channel();
+    let alice_hook = TestHook { tx: alice_hook_tx };
+    let bob_hook = TestHook { tx: bob_hook_tx };
+
     // Spawn both endpoint actors.
     let alice_endpoint = Endpoint::builder(alice_address_book)
         .config(alice_args.iroh_config.clone())
         .signing_key(alice_args.signing_key.clone())
+        .hooks(alice_hook)
         .spawn()
         .await
         .unwrap();
@@ -51,6 +108,7 @@ async fn establish_connection() {
     let bob_endpoint = Endpoint::builder(bob_address_book.clone())
         .config(bob_args.iroh_config.clone())
         .signing_key(bob_args.signing_key.clone())
+        .hooks(bob_hook)
         .spawn()
         .await
         .unwrap();
@@ -81,6 +139,26 @@ async fn establish_connection() {
     // Receive the echo.
     let response = rx.read_to_end(1000).await.unwrap();
     assert_eq!(&response, b"i feel so");
+
+    // Bob should receive a notification of the outbound connection.
+    if let Some(event) = bob_hook_rx.recv().await {
+        assert_eq!(
+            event,
+            MonitoredConnection::Outbound {
+                remote: alice_args.verifying_key
+            }
+        );
+    }
+
+    // Alice should receive a notification of the inbound connection.
+    if let Some(event) = alice_hook_rx.recv().await {
+        assert_eq!(
+            event,
+            MonitoredConnection::Inbound {
+                remote: bob_args.verifying_key
+            }
+        );
+    }
 
     // Shut down connection and actors.
     connection.close(0u32.into(), b"bye!");


### PR DESCRIPTION
Here we add a `hooks()` method on the `Builder` which allows the user to register custom hooks on the endpoint (for example, to monitor connections or reject them based on access control lists).

We also introduce a custom trait to make iroh's `EndpointHooks` trait `Dyn` compatible.

A minimal connection monitor hook is implemented and used in the `establish_connection()` test.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- ~~[ ] Link this PR to any issues it closes~~
- [x] New files contain a SPDX license header