### PR TITLE
Rewrite queries in p2panda-store to use safer QueryBuilder, update sqlx

### DIFF
--- a/p2panda-store/Cargo.toml
+++ b/p2panda-store/Cargo.toml
@@ -62,7 +62,7 @@ p2panda-encryption = { workspace = true, default-features = true, optional = tru
 rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite"], optional = true }
+sqlx = { version = "0.9.0", features = ["runtime-tokio", "sqlite"], optional = true }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, default-features = true, features = ["sync"], optional = true }
 

--- a/p2panda-store/src/address_book/sqlite.rs
+++ b/p2panda-store/src/address_book/sqlite.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::HashSet;
-use std::fmt::Display;
 use std::str::FromStr;
 use std::time::Duration;
 
 use p2panda_core::cbor::{decode_cbor, encode_cbor};
 use p2panda_core::{Topic, VerifyingKey};
 use serde::{Deserialize, Serialize};
-use sqlx::{query, query_as, query_scalar};
+use sqlx::{QueryBuilder, query, query_as, query_scalar};
 
 use crate::address_book::{AddressBookStore, NodeInfo};
 use crate::sqlite::{SqliteError, SqliteStore};
@@ -130,26 +129,33 @@ where
             })
             .await?;
 
-        let node_ids: Vec<&String> = result.iter().map(|item| &item.0).collect();
-
         // Remove associated topics for removed nodes.
         self.tx(async |tx| {
-            query(&format!(
-                "
+            let mut query_builder = QueryBuilder::new(
+                r#"
                 DELETE FROM
                     topics2node_infos_v1
                 WHERE
-                    node_id IN ({})
-                ",
-                in_op_str(&node_ids)
-            ))
-            .execute(&mut **tx)
-            .await
-            .map_err(SqliteError::Sqlite)
+                    node_id IN ( "#,
+            );
+
+            {
+                let mut separated = query_builder.separated(", ");
+                for item in result.iter() {
+                    separated.push_bind(&item.0);
+                }
+                separated.push_unseparated(") ");
+            }
+
+            query_builder
+                .build()
+                .execute(&mut **tx)
+                .await
+                .map_err(SqliteError::Sqlite)
         })
         .await?;
 
-        Ok(node_ids.len())
+        Ok(result.len())
     }
 
     async fn node_info(&self, id: &VerifyingKey) -> Result<Option<N>, Self::Error> {
@@ -274,20 +280,30 @@ where
     async fn selected_node_infos(&self, ids: &[VerifyingKey]) -> Result<Vec<N>, Self::Error> {
         let result = self
             .execute(async |pool| {
-                query_as::<_, (Vec<u8>,)>(&format!(
-                    "
+                let mut query_builder = QueryBuilder::new(
+                    r#"
                     SELECT
                         node_info
                     FROM
                         node_infos_v1
                     WHERE
-                        node_id IN ({})
-                    ",
-                    in_op_str(ids)
-                ))
-                .fetch_all(pool)
-                .await
-                .map_err(SqliteError::Sqlite)
+                        node_id IN (
+                "#,
+                );
+
+                {
+                    let mut separated = query_builder.separated(", ");
+                    for id in ids.iter() {
+                        separated.push_bind(id.to_string());
+                    }
+                    separated.push_unseparated(" ) ");
+                }
+
+                query_builder
+                    .build_query_as::<(Vec<u8>,)>()
+                    .fetch_all(pool)
+                    .await
+                    .map_err(SqliteError::Sqlite)
             })
             .await?;
 
@@ -346,8 +362,8 @@ where
     async fn node_infos_by_topics(&self, topics: &[Topic]) -> Result<Vec<N>, Self::Error> {
         let result = self
             .execute(async |pool| {
-                query_as::<_, (Vec<u8>,)>(&format!(
-                    "
+                let mut query_builder = QueryBuilder::new(
+                    r#"
                     SELECT
                         node_infos_v1.node_info
                     FROM
@@ -355,16 +371,31 @@ where
                     LEFT JOIN topics2node_infos_v1
                         ON node_infos_v1.node_id = topics2node_infos_v1.node_id
                     WHERE
-                        topics2node_infos_v1.topic_id IN ({})
+                        topics2node_infos_v1.topic_id IN (
+                "#,
+                );
+
+                {
+                    let mut separated = query_builder.separated(", ");
+                    for topic in topics {
+                        separated.push_bind(topic.to_string());
+                    }
+                    separated.push_unseparated(") ");
+                }
+
+                query_builder.push(
+                    r#"
                         AND node_infos_v1.stale = FALSE
                     GROUP BY
                         node_infos_v1.node_id
-                    ",
-                    in_op_str(topics)
-                ))
-                .fetch_all(pool)
-                .await
-                .map_err(SqliteError::Sqlite)
+                    "#,
+                );
+
+                query_builder
+                    .build_query_as::<(Vec<u8>,)>()
+                    .fetch_all(pool)
+                    .await
+                    .map_err(SqliteError::Sqlite)
             })
             .await?;
 
@@ -450,21 +481,6 @@ impl SqliteStore {
 
         Ok(())
     }
-}
-
-/// Takes a list of items implementing `Display` to turn it into an SQL "IN" operator where each
-/// item is represented as a string.
-///
-/// ```text
-/// SELECT * FROM users
-/// WHERE
-///     id IN ('1a', '2b', '3c');
-/// ```
-fn in_op_str<T: Display>(list: &[T]) -> String {
-    list.iter()
-        .map(|item| format!("'{item}'"))
-        .collect::<Vec<String>>()
-        .join(",")
 }
 
 /// Deserialize multiple rows containing encoded node info.

--- a/p2panda-store/src/logs/sqlite/mod.rs
+++ b/p2panda-store/src/logs/sqlite/mod.rs
@@ -159,10 +159,7 @@ where
         after: Option<SeqNum>,
         until: Option<SeqNum>,
     ) -> Result<Option<(u32, u32)>, Self::Error> {
-        // We need to use an inclusive greater-than to ensure our
-        // query includes the operation with sequence number 0.
-        let after_operator = if after.is_none() { ">=" } else { ">" };
-        let query_str = format!(
+        let log_meta: Option<LogMetaRow> = query_as::<_, LogMetaRow>(
             "
             SELECT
                 SUM(header_size) AS total_header_bytes,
@@ -171,24 +168,25 @@ where
             FROM
                 operations_v1
             WHERE
-                verifying_key = ?
-                AND log_id = ?
-                AND seq_num {} ?
-                AND seq_num <= ?
+                verifying_key = $1
+                AND log_id =$2
+                AND (
+                    ($3 == true AND seq_num >= $4)
+                    OR
+                    ($3 == false AND seq_num > $4)
+                )
+                AND seq_num <= $5
             ",
-            after_operator
-        );
-
-        let log_meta: Option<LogMetaRow> = query_as::<_, LogMetaRow>(&query_str)
-            .bind(author.to_string())
-            .bind(
-                encode_cbor(&log_id)
-                    .map_err(|err| SqliteError::Encode("log id".to_string(), err))?,
-            )
-            .bind(after.unwrap_or(0).to_string())
-            .bind(until.unwrap_or(SeqNum::MAX).to_string())
-            .fetch_optional(&self.pool)
-            .await?;
+        )
+        .bind(author.to_string())
+        .bind(encode_cbor(&log_id).map_err(|err| SqliteError::Encode("log id".to_string(), err))?)
+        // We need to use an inclusive greater-than to ensure our
+        // query includes the operation with sequence number 0.
+        .bind(after.is_none())
+        .bind(after.unwrap_or(0).to_string())
+        .bind(until.unwrap_or(SeqNum::MAX).to_string())
+        .fetch_optional(&self.pool)
+        .await?;
 
         let Some(row) = log_meta else {
             return Ok(None);
@@ -208,11 +206,7 @@ where
         after: Option<SeqNum>,
         until: Option<SeqNum>,
     ) -> Result<Option<Vec<(Operation<E>, Vec<u8>)>>, Self::Error> {
-        // We need to use an inclusive greater-than to ensure our
-        // query includes the operation with sequence number 0.
-        let after_operator = if after.is_none() { ">=" } else { ">" };
-
-        let operations = query_as::<_, OperationRow>(&format!(
+        let operations = query_as::<_, OperationRow>(
             "
             SELECT
                 hash,
@@ -223,15 +217,21 @@ where
             WHERE
                 verifying_key = $1
                 AND log_id = $2
-                AND seq_num {} $3
-                AND seq_num <= $4
+                AND (
+                    ($3 == true AND seq_num >= $4)
+                    OR
+                    ($3 == false AND seq_num > $4)
+                )
+                AND seq_num <= $5
             ORDER BY
                 seq_num
             ",
-            after_operator
-        ))
+        )
         .bind(author.to_string())
         .bind(encode_cbor(&log_id).map_err(|err| SqliteError::Encode("log id".to_string(), err))?)
+        // We need to use an inclusive greater-than to ensure our
+        // query includes the operation with sequence number 0.
+        .bind(after.is_none())
         .bind(after.unwrap_or(0).to_string())
         .bind(until.unwrap_or(SeqNum::MAX).to_string())
         .fetch_all(&self.pool)

--- a/p2panda-store/src/logs/sqlite/mod.rs
+++ b/p2panda-store/src/logs/sqlite/mod.rs
@@ -212,7 +212,7 @@ where
         // query includes the operation with sequence number 0.
         let after_operator = if after.is_none() { ">=" } else { ">" };
 
-        let query_str = format!(
+        let operations = query_as::<_, OperationRow>(&format!(
             "
             SELECT
                 hash,
@@ -221,26 +221,21 @@ where
             FROM
                 operations_v1
             WHERE
-                verifying_key = ?
-                AND log_id = ?
-                AND seq_num {} ?
-                AND seq_num <= ?
+                verifying_key = $1
+                AND log_id = $2
+                AND seq_num {} $3
+                AND seq_num <= $4
             ORDER BY
                 seq_num
             ",
             after_operator
-        );
-
-        let operations = query_as::<_, OperationRow>(&query_str)
-            .bind(author.to_string())
-            .bind(
-                encode_cbor(&log_id)
-                    .map_err(|err| SqliteError::Encode("log id".to_string(), err))?,
-            )
-            .bind(after.unwrap_or(0).to_string())
-            .bind(until.unwrap_or(SeqNum::MAX).to_string())
-            .fetch_all(&self.pool)
-            .await?;
+        ))
+        .bind(author.to_string())
+        .bind(encode_cbor(&log_id).map_err(|err| SqliteError::Encode("log id".to_string(), err))?)
+        .bind(after.unwrap_or(0).to_string())
+        .bind(until.unwrap_or(SeqNum::MAX).to_string())
+        .fetch_all(&self.pool)
+        .await?;
 
         let mut entries = Vec::new();
         for operation in operations {

--- a/p2panda-store/src/logs/sqlite/mod.rs
+++ b/p2panda-store/src/logs/sqlite/mod.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 
 use p2panda_core::cbor::encode_cbor;
 use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
-use sqlx::{query, query_as};
+use sqlx::{QueryBuilder, query, query_as};
 
 use crate::logs::LogStore;
 use crate::logs::sqlite::models::{LogHeightRow, LogMetaRow};
@@ -101,54 +101,43 @@ where
         author: &VerifyingKey,
         logs: &[L],
     ) -> Result<Option<BTreeMap<L, SeqNum>>, Self::Error> {
-        let mut encoded_log_ids = Vec::new();
-        for log in logs {
-            let encoded_log_id =
-                encode_cbor(&log).map_err(|err| SqliteError::Encode("log id".to_string(), err))?;
-            encoded_log_ids.push(encoded_log_id);
-        }
-
-        // This query formation approach is required since there is currently no
-        // way to directly bind arrays as comma-separated lists in sqlx.
-        let params = format!("?{}", ", ?".repeat(encoded_log_ids.len() - 1));
-        let query_str = format!(
-            "
-            SELECT
+        let mut query_builder = QueryBuilder::new(
+            r#"SELECT
                 log_id,
                 MAX(seq_num) as seq_num
             FROM
                 operations_v1
             WHERE
-                verifying_key = ?
-                AND log_id IN ( {} )
-            GROUP BY
-                log_id
-            ",
-            params
+                verifying_key = "#,
         );
 
-        let mut query = query_as::<_, LogHeightRow>(&query_str).bind(author.to_string());
+        query_builder.push_bind(author.to_string());
+        query_builder.push(" AND log_id IN ( ");
 
-        for log_id in encoded_log_ids {
-            query = query.bind(log_id)
-        }
-
-        let log_heights_query = query.fetch_all(&self.pool).await?;
-
-        let log_heights = if log_heights_query.is_empty() {
-            None
-        } else {
-            let mut log_heights = BTreeMap::new();
-
-            for row in log_heights_query {
-                let (log_id, seq_num) = row.try_into()?;
-                log_heights.insert(log_id, seq_num);
+        {
+            let mut separated = query_builder.separated(", ");
+            for log in logs {
+                let encoded_log_id = encode_cbor(&log)
+                    .map_err(|err| SqliteError::Encode("log id".to_string(), err))?;
+                separated.push_bind(encoded_log_id);
             }
 
-            Some(log_heights)
-        };
+            separated.push_unseparated(") GROUP BY log_id");
+        }
 
-        Ok(log_heights)
+        let log_heights = query_builder
+            .build_query_as::<LogHeightRow>()
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(|row| row.try_into())
+            .collect::<Result<BTreeMap<L, u32>, _>>()?;
+
+        if log_heights.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(log_heights))
+        }
     }
 
     /// Retrieve the count and total byte size of all operations in an author's log.

--- a/p2panda-store/src/orderer/sqlite.rs
+++ b/p2panda-store/src/orderer/sqlite.rs
@@ -6,7 +6,7 @@ use std::hash::Hash as StdHash;
 use std::str::FromStr;
 
 use p2panda_core::Hash;
-use sqlx::{query, query_as};
+use sqlx::{QueryBuilder, query, query_as};
 
 use crate::orderer::OrdererStore;
 #[cfg(any(test, feature = "test_utils"))]
@@ -328,23 +328,20 @@ where
     }
 
     async fn ready(&self, dependencies: &[ID]) -> Result<bool, Self::Error> {
-        self.tx(async |tx| {
-            let sql = format!(
-                "
-                SELECT
-                    COUNT(id)
-                FROM
-                    orderer_ready_v1
-                WHERE id IN ({})
-                ",
-                dependencies
-                    .iter()
-                    .map(|dep| format!("'{dep}'"))
-                    .collect::<Vec<String>>()
-                    .join(",")
-            );
+        let mut query_builder =
+            QueryBuilder::new("SELECT COUNT(id) FROM orderer_ready_v1 WHERE id IN (");
 
-            let result: (i64,) = query_as(&sql).fetch_one(&mut **tx).await?;
+        let mut separated = query_builder.separated(", ");
+        for dep in dependencies {
+            separated.push_bind(dep.to_string());
+        }
+
+        separated.push_unseparated(") ");
+
+        let query = query_builder.build_query_as::<(i64,)>();
+
+        self.tx(async |tx| {
+            let result = query.fetch_one(&mut **tx).await?;
             Ok(result.0 as usize == dependencies.len())
         })
         .await


### PR DESCRIPTION
Closes https://github.com/p2panda/p2panda/issues/1237

This patchset rewrites some of the queries in the `p2panda-store` crate to use the safe(r) `QueryBuilder` instead of doing unsafe string interpolation for building queries.

The patches run successfully through the tests, the patch for updating the dependency is added on top.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
