### PR TITLE
net: Update ractor to 0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
+### Changed
+
+- net: Update ractor to 0.16.2
+
 ### Fixed
 
 - encryption: Do not require pre-key bundle when initialising TwoParty state as a recipient [#1297](https://github.com/p2panda/p2panda/pull/1297)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Changed
 
-- net: Update ractor to 0.16.2
+- net: Update ractor to 0.16.2 [#1324](https://github.com/p2panda/p2panda/pull/1324)
 
 ### Fixed
 

--- a/p2panda-net/Cargo.toml
+++ b/p2panda-net/Cargo.toml
@@ -81,7 +81,7 @@ p2panda-discovery = { workspace = true, default-features = true, optional = true
 p2panda-store = { workspace = true }
 p2panda-sync = { workspace = true, default-features = true, optional = true }
 postcard = { version = "1.1.3", default-features = false, features = ["alloc", "use-std"] }
-ractor = "0.15.13"
+ractor = "0.16.2"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## Summary

- Update `p2panda-net` from ractor 0.15.13 to 0.16.2.
- Record the dependency update in the unreleased changelog.

This is dependency-only; no p2panda APIs or actor implementations need to change.

## Why

`p2panda-net` uses ractor throughout its discovery, gossip, endpoint, session, and supervision paths. Ractor 0.16 reduces hot-path actor overhead:

- Disabling unnecessary tracing-span work reduced the 100k-message benchmark median from 15.370 ms to 13.602 ms (11.5%) in [ractor#444](https://github.com/slawlor/ractor/pull/444).
- Boxing the actor loop once per actor instead of once per message reduced the no-span 100k-message median from 12.995 ms to 8.861 ms (31.8%) in [ractor#446](https://github.com/slawlor/ractor/pull/446).
- Process-group shutdown with 20k groups and 500 unrelated actors improved from 190.432 ms to 0.979 ms in [ractor#447](https://github.com/slawlor/ractor/pull/447).

The 0.16 series also introduces the optional `actor-macros` feature, including `#[ractor::actor]`, `#[ractor::message]`, `#[ractor::supervision]`, and `#[ractor::rpc]` attributes for reducing actor/message boilerplate. This PR does not enable or adopt those macros.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-features -- -D warnings --no-deps`
- `cargo test -p p2panda-net --all-features -- --skip iroh_mdns::tests::mdns_discovery` (46 tests/docs passed, 1 known flaky test ignored)

The mDNS test waits indefinitely because local multicast discovery is unavailable in this environment; it was skipped rather than changed.

## Checklist

- [x] Existing tests cover this dependency-only change
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] No issue is closed by this PR
- [x] No new files were added