### PR TITLE
Safe key bundle registration by cross-signing X3DH identity- and verifying-keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Highlights are marked with a pancake 🥞
 - node: API for promoting and demoting space members [#1311](https://github.com/p2panda/p2panda/pull/1311)
 - node: Emit per-group and global groups events [#1313](https://github.com/p2panda/p2panda/pull/1313)
 - stream: Hooks processor to register event callbacks in streaming pipeline [#1339](https://github.com/p2panda/p2panda/pull/1339)
+- spaces: Safe key bundle registration by cross-signing X3DH identity- and verifying-keys [#1332](https://github.com/p2panda/p2panda/pull/1332)
 
 ### Changed
 

--- a/p2panda-spaces/src/config.rs
+++ b/p2panda-spaces/src/config.rs
@@ -14,8 +14,8 @@ pub struct Config {
     /// When a key bundle should be considered expired and thus invalid.
     pub pre_key_lifetime: Duration,
 
-    /// Rotate our own pre keys after this duration, to allow some time between peers receiving
-    /// our new one and the old one expiring.
+    /// Rotate our own pre-keys after this duration, to allow some time between peers receiving our
+    /// new one and the old one expiring.
     pub pre_key_rotate_after: Duration,
 }
 

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -2,12 +2,10 @@
 
 use std::collections::{HashMap, HashSet};
 
-use p2panda_core::VerifyingKey;
-use serde::{Deserialize, Serialize};
-
 use p2panda_auth::Access;
 use p2panda_auth::group::GroupMember;
 use p2panda_auth::traits::{Conditions, Operation};
+use p2panda_core::VerifyingKey;
 
 use crate::auth::message::AuthMessage;
 use crate::message::SpaceMembershipMessage;
@@ -17,7 +15,7 @@ use crate::utils::{
 };
 use crate::{ActorId, GroupId, MemberId, SpaceId};
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GroupActor {
     id: ActorId,
     is_group: bool,
@@ -52,7 +50,7 @@ impl GroupActor {
 }
 
 /// Events emitted when system state changes or application messages are processed.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]
 pub enum Event<C> {
     /// A group membership change occurred in the shared groups state.
@@ -80,7 +78,7 @@ pub enum Event<C> {
 }
 
 /// Additional context attached to group events.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GroupContext<C> {
     /// The actor who authored the associated group action.
     pub author: ActorId,
@@ -102,7 +100,7 @@ pub struct GroupContext<C> {
 }
 
 /// Additional context attached to space events.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SpaceContext<C> {
     /// The actor who applied this action to the spaces state.
     ///
@@ -121,7 +119,7 @@ pub struct SpaceContext<C> {
 }
 
 /// Events emitted when global auth state changes.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GroupEvent<C> {
     /// A group was created.
     Created {
@@ -243,7 +241,7 @@ impl<C> GroupEvent<C> {
 }
 
 /// Events emitted when space membership changes.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SpaceEvent<C> {
     /// A space was created.
     Created {

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -8,6 +8,7 @@ use p2panda_auth::traits::{Conditions, Operation};
 use p2panda_core::VerifyingKey;
 
 use crate::auth::message::AuthMessage;
+use crate::member::Member;
 use crate::message::SpaceMembershipMessage;
 use crate::types::{AuthGroupAction, AuthGroupState, EncryptionGroupOutput};
 use crate::utils::{
@@ -53,6 +54,9 @@ impl GroupActor {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]
 pub enum Event<C> {
+    /// A member's info with associated key-bundle has been received.
+    Member(Member),
+
     /// A group membership change occurred in the shared groups state.
     ///
     /// This event does _not_ signify that any space has incorporated this change yet. The
@@ -64,10 +68,6 @@ pub enum Event<C> {
     /// Encrypted application messages are buffered until the local member is welcomed into a
     /// space with a "create" or "add" message.
     Application { space_id: SpaceId, data: Vec<u8> },
-
-    // @TODO: Could maybe add field to show when the bundle is valid until?
-    /// An actors' pre-key bundle has been received.
-    KeyBundle { author: MemberId },
 
     /// A membership change occurred on a space.
     ///

--- a/p2panda-spaces/src/group.rs
+++ b/p2panda-spaces/src/group.rs
@@ -183,7 +183,7 @@ where
         // the ancestor group itself.
         let dependencies = AuthGroup::heads(&y, group_id, &action);
 
-        let args = SpacesArgs::Auth {
+        let args = SpacesArgs::Group {
             group_id,
             auth_dependencies: dependencies,
             group_action: action,

--- a/p2panda-spaces/src/identity.rs
+++ b/p2panda-spaces/src/identity.rs
@@ -171,7 +171,10 @@ where
     /// Register a member with long-term key bundle material.
     ///
     /// Throws an error if provided key bundle has an invalid signature or expired.
-    pub async fn register_member(&mut self, member: &Member) -> Result<(), IdentityError<F, C>> {
+    pub async fn process(&mut self, member: &Member) -> Result<Event<C>, IdentityError<F, C>> {
+        // 1. Claimed member id belongs to the associated key bundle and it's X3DH identity key.
+        // 2. Key bundle's pre-key belongs to identity key.
+        // 3. Key bundle has not expired.
         member.verify()?;
 
         let pki = {
@@ -197,14 +200,7 @@ where
                 .map_err(|err| StoreError::Transaction(err.to_string()))?;
         }
 
-        Ok(())
-    }
-
-    /// Process member information with associated key bundle received from the network.
-    pub async fn process(&mut self, member: Member) -> Result<Event<C>, IdentityError<F, C>> {
-        member.verify()?;
-        self.register_member(&member).await?;
-        Ok(Event::Member(member))
+        Ok(Event::Member(member.clone()))
     }
 
     pub async fn forge(&mut self, args: SpacesArgs<C>) -> Result<F::Message, IdentityError<F, C>> {
@@ -373,7 +369,7 @@ mod tests {
         let bob_id = bob_credentials.verifying_key().into();
 
         let bob_member = bob_identity_manager.me().await.unwrap();
-        alice_identity_manager.process(bob_member).await.unwrap();
+        alice_identity_manager.process(&bob_member).await.unwrap();
 
         let key_registry_y = alice_identity_manager.key_registry().await.unwrap();
         let (_, bundle): (_, Option<LongTermKeyBundle>) =

--- a/p2panda-spaces/src/identity.rs
+++ b/p2panda-spaces/src/identity.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 use crate::event::Event;
 use crate::forge::Forge;
 use crate::manager::StoreError;
-use crate::member::Member;
+use crate::member::{Member, MemberError};
 use crate::message::SpacesArgs;
 use crate::{Config, Credentials, MemberId};
 
@@ -76,7 +76,11 @@ where
     ///
     /// Note: Key bundle will be rotated if the latest is reaching it's configured expiry date.
     pub(crate) async fn me(&self) -> Result<Member, IdentityError<F, C>> {
-        Ok(Member::new(self.id(), self.key_bundle().await?))
+        Ok(Member::new(
+            &self.rng,
+            &self.credentials,
+            self.key_bundle().await?,
+        )?)
     }
 
     /// Returns "latest", publishable key bundle of us or automatically generates a new one if
@@ -98,7 +102,7 @@ where
             return Ok(bundle);
         }
 
-        // Automatically rotate pre key.
+        // Automatically rotate pre-key.
         let key_manager_y_i = KeyManager::rotate_prekey(
             key_manager_y,
             Lifetime::new(self.config.pre_key_lifetime.as_secs()),
@@ -159,9 +163,7 @@ where
     ///
     /// Note: Key bundle will be rotated if the latest is reaching it's configured expiry date.
     pub async fn key_bundle_message(&mut self) -> Result<F::Message, IdentityError<F, C>> {
-        let args = SpacesArgs::KeyBundle {
-            key_bundle: self.key_bundle().await?,
-        };
+        let args = SpacesArgs::Member(self.me().await?);
         let message = self.forge.forge(args).await.map_err(IdentityError::Forge)?;
         Ok(message)
     }
@@ -201,16 +203,11 @@ where
         Ok(())
     }
 
-    /// Process a key bundle received from the network.
-    pub async fn process_key_bundle(
-        &mut self,
-        author: MemberId,
-        key_bundle: &LongTermKeyBundle,
-    ) -> Result<Event<C>, IdentityError<F, C>> {
-        key_bundle.verify()?;
-        let member = Member::new(author, key_bundle.clone());
+    /// Process member information with associated key bundle received from the network.
+    pub async fn process(&mut self, member: Member) -> Result<Event<C>, IdentityError<F, C>> {
+        member.verify()?;
         self.register_member(&member).await?;
-        Ok(Event::KeyBundle { author })
+        Ok(Event::Member(member))
     }
 
     pub async fn forge(&mut self, args: SpacesArgs<C>) -> Result<F::Message, IdentityError<F, C>> {
@@ -268,6 +265,9 @@ where
 
     #[error(transparent)]
     KeyBundle(#[from] KeyBundleError),
+
+    #[error(transparent)]
+    Member(#[from] MemberError),
 
     #[error("received long-term key bundle for {0} on message signed by unexpected author {1}")]
     KeyBundleAuthor(VerifyingKey, VerifyingKey),
@@ -333,8 +333,8 @@ mod tests {
         let actor_id = credentials.signing_key().verifying_key();
         assert_eq!(msg.author(), actor_id);
         match msg.borrow() {
-            SpacesArgs::KeyBundle { key_bundle } => {
-                assert!(key_bundle.verify().is_ok());
+            SpacesArgs::Member(member) => {
+                assert!(member.verify().is_ok());
             }
             _ => panic!("expected key bundle message"),
         }
@@ -376,18 +376,13 @@ mod tests {
         let bob_id = bob_credentials.verifying_key().into();
 
         let bob_member = bob_identity_manager.me().await.unwrap();
-        let bob_bundle = bob_member.key_bundle();
-        alice_identity_manager
-            .process_key_bundle(bob_id, bob_bundle)
-            .await
-            .unwrap();
+        alice_identity_manager.process(bob_member).await.unwrap();
 
         let key_registry_y = alice_identity_manager.key_registry().await.unwrap();
         let (_, bundle): (_, Option<LongTermKeyBundle>) =
             KeyRegistry::key_bundle(key_registry_y, &bob_id).unwrap();
         assert!(bundle.is_some());
         let bundle_identity_key = bundle.unwrap().identity_key().to_owned();
-        assert_eq!(bundle_identity_key, *bob_bundle.identity_key());
         assert_eq!(
             bundle_identity_key,
             bob_credentials.identity_secret().verifying_key().unwrap()

--- a/p2panda-spaces/src/identity.rs
+++ b/p2panda-spaces/src/identity.rs
@@ -171,12 +171,9 @@ where
     /// Register a member with long-term key bundle material.
     ///
     /// Throws an error if provided key bundle has an invalid signature or expired.
-    //
-    // NOTE: **Security:** This method does _only_ validate if the pre-key signature maps to the
-    // given identity key but **not** if the member's handle / id is authentic. Applications need to
-    // provide an authentication scheme and validate `Member` before calling this method to prevent
-    // impersonation attacks.
     pub async fn register_member(&mut self, member: &Member) -> Result<(), IdentityError<F, C>> {
+        member.verify()?;
+
         let pki = {
             let y = self.key_registry().await?;
             KeyRegistry::add_longterm_bundle(y, member.id(), member.key_bundle().clone())?

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -259,7 +259,7 @@ where
                 let mut manager = self.inner.write().await;
                 let event = manager
                     .identity
-                    .process(member.clone())
+                    .process(member)
                     .await
                     .map_err(ManagerError::IdentityManager)?;
 
@@ -333,11 +333,12 @@ where
     /// channel (QR code scan etc.).
     pub async fn register_member(&self, member: &Member) -> Result<(), ManagerError<F, C>> {
         let mut manager = self.inner.write().await;
-        manager
+        let _event = manager
             .identity
-            .register_member(member)
+            .process(member)
             .await
-            .map_err(ManagerError::IdentityManager)
+            .map_err(ManagerError::IdentityManager);
+        Ok(())
     }
 
     /// Check if my latest key bundle has expired.

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -255,11 +255,11 @@ where
         // Route message to the regarding member-, group- or space processor.
         let result = match args {
             // Received key bundle from a member.
-            SpacesArgs::KeyBundle { key_bundle } => {
+            SpacesArgs::Member(member) => {
                 let mut manager = self.inner.write().await;
                 let event = manager
                     .identity
-                    .process_key_bundle(message.author(), key_bundle)
+                    .process(member.clone())
                     .await
                     .map_err(ManagerError::IdentityManager)?;
 

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -265,7 +265,7 @@ where
 
                 (None, None, vec![event])
             }
-            SpacesArgs::Auth { .. } => {
+            SpacesArgs::Group { .. } => {
                 let event = Group::process(self.clone(), &SpacesMessage::auth(message))
                     .await
                     .map_err(ManagerError::Group)?;
@@ -520,7 +520,7 @@ where
             };
 
             match message.borrow() {
-                SpacesArgs::Auth { .. } => SpacesMessage::auth(&message),
+                SpacesArgs::Group { .. } => SpacesMessage::auth(&message),
                 _ => {
                     return Err(ManagerError::IncorrectMessageVariant(auth_message_id));
                 }

--- a/p2panda-spaces/src/member.rs
+++ b/p2panda-spaces/src/member.rs
@@ -1,27 +1,81 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use p2panda_core::Signature;
+use p2panda_core::cbor::encode_cbor;
+use p2panda_encryption::Rng;
+use p2panda_encryption::crypto::xeddsa::{XSignature, xeddsa_sign, xeddsa_verify};
 use p2panda_encryption::key_bundle::{KeyBundleError, LongTermKeyBundle};
 use p2panda_encryption::traits::KeyBundle;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-use crate::MemberId;
+use crate::{Credentials, MemberId};
 
-/// A group member and their long-term key bundle.
-#[derive(Debug)]
+/// A group member and their associated long-term key bundle.
+///
+/// Authenticity between the verifying key and X3DH identity key is assured through cross-signing.
+/// Through this we assure that the associated key bundle belongs to the verifying key as well.
+/// Additional checks are performed against the key bundle's pre-key and it's lifetime.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Member {
+    /// Verifying key of this space member, used as an identifier.
     id: MemberId,
+
+    /// Associated X3DH key bundle with used identity key and pre-key.
+    ///
+    /// The pre-key's integrity and authenticity is assured by an xEdDSA signature inside the key
+    /// bundle.
+    ///
+    /// ```text
+    /// [Identity Key] --> [Pre-Key]
+    /// ```
     key_bundle: LongTermKeyBundle,
+
+    /// Signature proves that the member id is authenticted by the X3DH identity key and this
+    /// particular key bundle (identified by the pre-key).
+    ///
+    /// ```text
+    /// [Identity Key] --> [Pre-Key + Member-Id]
+    /// ```
+    cross_signature_1: XSignature,
+
+    /// Signature proves that the X3DH identity key and associated key-bundle is authentic (cross
+    /// signed).
+    ///
+    /// ```text
+    /// [Verifying Key] --> [Pre-Key + Identity Key]
+    /// ```
+    cross_signature_2: Signature,
 }
 
 impl Member {
-    // @NOTE(adz) **Security:** This struct does _not_ guarantee if the member's handle / id is
-    // authentic. We or applications will need to provide an authentication scheme and validate
-    // `Member` before using it anywhere to prevent impersonation attacks.
-    //
-    // Since we're currently not allowing to construct `Member` from "the outside" (all instances
-    // are provided by our API which derived everything from signed messages) I don't see an issue
-    // yet, but care will be required as soon as `Member` gets constructable, serializable etc.
-    pub(crate) fn new(id: MemberId, key_bundle: LongTermKeyBundle) -> Self {
-        Self { id, key_bundle }
+    pub(crate) fn new(
+        rng: &Rng,
+        credentials: &Credentials,
+        key_bundle: LongTermKeyBundle,
+    ) -> Result<Self, MemberError> {
+        let id = credentials.verifying_key();
+
+        let cross_signature_1 = {
+            let mut bytes = id.as_bytes().to_vec();
+            // Include pre-key as a nonce to prevent re-play attacks across key bundles.
+            bytes.extend_from_slice(key_bundle.signed_prekey().as_bytes());
+            // XEdDSA scheme uses a random entropy source, this gives us something like a nonce /
+            // unique signature across member instances even if the inputs were the same.
+            xeddsa_sign(&bytes, &credentials.identity_secret, rng)?
+        };
+
+        let cross_signature_2 = {
+            let bytes = encode_cbor(&key_bundle)?;
+            credentials.signing_key.sign(&bytes)
+        };
+
+        Ok(Self {
+            id,
+            key_bundle,
+            cross_signature_1,
+            cross_signature_2,
+        })
     }
 
     /// Identifier for this member.
@@ -29,13 +83,145 @@ impl Member {
         self.id
     }
 
-    /// Long-term key bundle for this member.
+    /// Associated long-term key bundle for this member.
     pub fn key_bundle(&self) -> &LongTermKeyBundle {
         &self.key_bundle
     }
 
-    /// Verify the key bundle.
-    pub fn verify(&self) -> Result<(), KeyBundleError> {
-        self.key_bundle.verify()
+    /// Verify the key bundle and associated member id.
+    pub fn verify(&self) -> Result<(), MemberError> {
+        // Identity Key -> Pre-Key + Verifying Key.
+        {
+            let mut bytes = self.id.as_bytes().to_vec();
+            bytes.extend_from_slice(self.key_bundle.signed_prekey().as_bytes());
+
+            xeddsa_verify(
+                &bytes,
+                self.key_bundle.identity_key(),
+                &self.cross_signature_1,
+            )?;
+        }
+
+        // Verifying Key -> Identity Key.
+        {
+            let bytes = encode_cbor(&self.key_bundle)?;
+            if !self.id.verify(&bytes, &self.cross_signature_2) {
+                return Err(MemberError::MemberSignature);
+            }
+        }
+
+        // Identity Key -> Pre-Key in key bundle & lifetime check.
+        self.key_bundle.verify()?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum MemberError {
+    #[error("failed encoding key bundle to compute or verify signature")]
+    EncodeKeyBundle(#[from] p2panda_core::cbor::EncodeError),
+
+    #[error("X3DH identity key could not prove that the member id is authentic")]
+    IdentitySignature(#[from] p2panda_encryption::crypto::xeddsa::XEdDSAError),
+
+    #[error("member could not prove that the X3DH identity key is authentic")]
+    MemberSignature,
+
+    #[error("key bundle is either expired or pre-key integrity invalid")]
+    InvalidKeyBundle(#[from] KeyBundleError),
+}
+
+#[cfg(test)]
+mod tests {
+    use p2panda_encryption::Rng;
+    use p2panda_encryption::key_bundle::{Lifetime, LongTermKeyBundle, PreKey};
+
+    use crate::Credentials;
+
+    use super::Member;
+
+    #[test]
+    fn verify_integrity() {
+        let rng = Rng::from_seed([1; 32]);
+        let credentials = Credentials::from_rng(&rng).unwrap();
+
+        let key_bundle = {
+            let prekey = PreKey::new(
+                credentials.identity_secret().verifying_key().unwrap(),
+                Lifetime::default(),
+            );
+            let signature = prekey.sign(&credentials.identity_secret(), &rng).unwrap();
+
+            LongTermKeyBundle::new(
+                credentials.identity_secret.verifying_key().unwrap(),
+                prekey,
+                signature,
+            )
+        };
+
+        let member = Member::new(&rng, &credentials, key_bundle).unwrap();
+        assert!(member.verify().is_ok());
+
+        // Member id / verifying key is not matching signatures.
+        let mut invalid_member = member.clone();
+        invalid_member.id = {
+            let credentials = Credentials::from_rng(&rng).unwrap();
+            credentials.verifying_key()
+        };
+        assert!(invalid_member.verify().is_err());
+    }
+
+    #[test]
+    fn replay_key_bundles() {
+        let rng = Rng::from_seed([1; 32]);
+        let credentials = Credentials::from_rng(&rng).unwrap();
+
+        let key_bundle_1 = {
+            let prekey = PreKey::new(
+                credentials.identity_secret().verifying_key().unwrap(),
+                Lifetime::default(),
+            );
+            let signature = prekey.sign(&credentials.identity_secret(), &rng).unwrap();
+
+            LongTermKeyBundle::new(
+                credentials.identity_secret.verifying_key().unwrap(),
+                prekey,
+                signature,
+            )
+        };
+
+        let member_1 = Member::new(&rng, &credentials, key_bundle_1.clone()).unwrap();
+        assert!(member_1.verify().is_ok());
+
+        // Re-signing of the same key bundle using same credentials is okay, but will lead to
+        // different signature (XEdDSA uses a random entropy source).
+        let member_2 = Member::new(&rng, &credentials, key_bundle_1).unwrap();
+        assert!(member_2.verify().is_ok());
+        assert_ne!(member_1, member_2);
+
+        // Re-use of the same signatures across key bundles is not permitted.
+        let key_bundle_2 = {
+            let prekey = PreKey::new(
+                credentials.identity_secret().verifying_key().unwrap(),
+                Lifetime::default(),
+            );
+            let signature = prekey.sign(&credentials.identity_secret(), &rng).unwrap();
+
+            LongTermKeyBundle::new(
+                credentials.identity_secret.verifying_key().unwrap(),
+                prekey,
+                signature,
+            )
+        };
+
+        let member_3 = Member {
+            id: member_1.id,
+            key_bundle: key_bundle_2.clone(), // <--
+            cross_signature_1: member_1.cross_signature_1,
+            cross_signature_2: member_1.cross_signature_2,
+        };
+        assert!(member_3.verify().is_err());
+        assert_eq!(member_1.id, member_2.id);
     }
 }

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -103,7 +103,7 @@ where
     where
         M: Provenance<VerifyingKey> + Digest<Hash> + Borrow<SpacesArgs<C>>,
     {
-        let SpacesArgs::Auth {
+        let SpacesArgs::Group {
             group_id,
             group_action,
             auth_dependencies,
@@ -157,8 +157,8 @@ pub enum SpacesArgs<C> {
     /// Note: Applications should check if the key bundle was authored by the sender.
     KeyBundle { key_bundle: LongTermKeyBundle },
 
-    /// System message containing an auth control message.
-    Auth {
+    /// System message containing group control message.
+    Group {
         /// id of the group this message applies to.
         group_id: GroupId,
 
@@ -169,7 +169,7 @@ pub enum SpacesArgs<C> {
         auth_dependencies: Vec<OperationId>,
     },
 
-    /// System message containing a reference to an `SpacesArgs::Auth` message and additional
+    /// System message containing a reference to an `SpacesArgs::Group` message and additional
     /// fields for applying the resulting membership change to a specific space.
     SpaceMembership {
         /// Space this message should be applied to.
@@ -236,7 +236,7 @@ impl<C> SpacesArgs<C> {
     pub fn dependencies(&self) -> Vec<Hash> {
         match self {
             SpacesArgs::KeyBundle { .. } => vec![],
-            SpacesArgs::Auth {
+            SpacesArgs::Group {
                 auth_dependencies, ..
             } => auth_dependencies.to_owned(),
             SpacesArgs::SpaceMembership {
@@ -260,7 +260,7 @@ impl<C> SpacesArgs<C> {
     pub fn variant_str(&self) -> String {
         match self {
             SpacesArgs::KeyBundle { .. } => "key bundle".to_string(),
-            SpacesArgs::Auth { .. } => "auth group".to_string(),
+            SpacesArgs::Group { .. } => "auth group".to_string(),
             SpacesArgs::SpaceMembership { .. } => "space membership".to_string(),
             SpacesArgs::SpaceUpdate { .. } => "space update".to_string(),
             SpacesArgs::Application { .. } => "application".to_string(),

--- a/p2panda-spaces/src/message.rs
+++ b/p2panda-spaces/src/message.rs
@@ -7,11 +7,12 @@ use p2panda_auth::group::GroupAction;
 use p2panda_auth::traits::Conditions;
 use p2panda_core::traits::{Digest, Provenance};
 use p2panda_core::{Hash, VerifyingKey};
+use p2panda_encryption::crypto::xchacha20::XAeadNonce;
 use p2panda_encryption::data_scheme::GroupSecretId;
-use p2panda_encryption::{crypto::xchacha20::XAeadNonce, key_bundle::LongTermKeyBundle};
 use serde::{Deserialize, Serialize};
 
 use crate::auth::message::AuthMessage;
+use crate::member::Member;
 use crate::types::EncryptionDirectMessage;
 use crate::{ActorId, GroupId, OperationId, SpaceId};
 
@@ -152,10 +153,8 @@ where
 /// Enum representing all possible message types.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum SpacesArgs<C> {
-    /// System message, contains key bundle of the given author.
-    ///
-    /// Note: Applications should check if the key bundle was authored by the sender.
-    KeyBundle { key_bundle: LongTermKeyBundle },
+    /// System message, contains key bundle of the given member.
+    Member(Member),
 
     /// System message containing group control message.
     Group {
@@ -235,7 +234,7 @@ impl<C> SpacesArgs<C> {
     /// themselves been processed.
     pub fn dependencies(&self) -> Vec<Hash> {
         match self {
-            SpacesArgs::KeyBundle { .. } => vec![],
+            SpacesArgs::Member { .. } => vec![],
             SpacesArgs::Group {
                 auth_dependencies, ..
             } => auth_dependencies.to_owned(),
@@ -259,7 +258,7 @@ impl<C> SpacesArgs<C> {
 
     pub fn variant_str(&self) -> String {
         match self {
-            SpacesArgs::KeyBundle { .. } => "key bundle".to_string(),
+            SpacesArgs::Member { .. } => "key bundle".to_string(),
             SpacesArgs::Group { .. } => "auth group".to_string(),
             SpacesArgs::SpaceMembership { .. } => "space membership".to_string(),
             SpacesArgs::SpaceUpdate { .. } => "space update".to_string(),

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -1803,7 +1803,7 @@ async fn add_expired_member_to_group() {
             signature,
         );
 
-        Member::new(bob.manager.id(), bundle)
+        Member::new(&rng, &bob.credentials, bundle).unwrap()
     };
 
     // Alice adds Bob's key bundle. At this point it is still valid.
@@ -1856,7 +1856,7 @@ async fn process_operation_from_expired_member() {
             signature,
         );
 
-        Member::new(bob.manager.id(), bundle)
+        Member::new(&rng, &bob.credentials, bundle).unwrap()
     };
 
     // Alice adds Bob's key bundle. At this point it is still valid.

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -56,7 +56,7 @@ async fn create_space() {
     let message_01 = messages[0].clone();
     let message_02 = messages[1].clone();
 
-    let SpacesArgs::Auth {
+    let SpacesArgs::Group {
         group_id: auth_group_id,
         group_action,
         auth_dependencies,
@@ -228,7 +228,7 @@ async fn add_member_to_space() {
     let members = space.members().await.unwrap();
     drop(space);
 
-    let SpacesArgs::Auth {
+    let SpacesArgs::Group {
         group_id: auth_group_id,
         group_action,
         auth_dependencies,
@@ -410,7 +410,7 @@ async fn add_pull_member_to_space() {
         .unwrap();
     let members = space.members().await.unwrap();
 
-    let SpacesArgs::Auth {
+    let SpacesArgs::Group {
         group_id: auth_group_id,
         group_action,
         auth_dependencies,
@@ -653,7 +653,7 @@ async fn remove_member() {
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
     let (message_03, message_04, _) = space.remove_persisted(bob_id).await.unwrap();
 
-    let SpacesArgs::Auth { group_action, .. } = message_03.borrow() else {
+    let SpacesArgs::Group { group_action, .. } = message_03.borrow() else {
         panic!("expected auth message");
     };
 
@@ -776,7 +776,7 @@ async fn concurrent_removal_conflict() {
     let space = alice_manager.space(space_id).await.unwrap().unwrap();
     let (message_05, message_06, _) = space.add_persisted(dave_id, Access::read()).await.unwrap();
 
-    let SpacesArgs::Auth { group_action, .. } = message_05.borrow() else {
+    let SpacesArgs::Group { group_action, .. } = message_05.borrow() else {
         panic!("expected auth message");
     };
 
@@ -864,7 +864,7 @@ async fn space_from_existing_auth_state() {
     let message_03 = messages[1].clone();
     let message_04 = messages[2].clone();
 
-    let SpacesArgs::Auth { group_action, .. } = message_02.borrow() else {
+    let SpacesArgs::Group { group_action, .. } = message_02.borrow() else {
         panic!("expected auth message");
     };
 
@@ -957,7 +957,7 @@ async fn create_group() {
     );
 
     // There is one auth message.
-    let SpacesArgs::Auth {
+    let SpacesArgs::Group {
         group_id,
         group_action,
         ..
@@ -1024,7 +1024,7 @@ async fn add_member_to_group() {
     );
 
     // There is one auth message.
-    let SpacesArgs::Auth {
+    let SpacesArgs::Group {
         group_id,
         group_action,
         auth_dependencies,
@@ -1078,7 +1078,7 @@ async fn remove_member_from_group() {
     assert_eq!(members, vec![(alice_id, Access::manage()),]);
 
     // There is one auth message.
-    let SpacesArgs::Auth {
+    let SpacesArgs::Group {
         group_id,
         group_action,
         auth_dependencies,

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -36,7 +36,7 @@ use crate::spaces::{
 use crate::streams::{
     EphemeralStreamPublisher, EphemeralStreamSubscription, ImportError, Pipeline, StreamFrom,
     StreamPublisher, StreamSubscription, SystemEvent, TaskTracker, ephemeral_stream, event_stream,
-    processed_stream, to_stream_event, to_system_event,
+    group_to_system_event, processed_stream, to_stream_event,
 };
 
 /// Node API with methods to establish ephemeral and eventually consistent topic streams.
@@ -650,7 +650,7 @@ impl Node {
                     Some(to_stream_event(space_event).into())
                 }
                 p2panda_spaces::Event::Groups(group_event) => {
-                    Some(to_system_event(group_event).into())
+                    Some(group_to_system_event(group_event).into())
                 }
                 _ => None,
             })

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -29,7 +29,7 @@ use crate::spaces::types::{
     AuthCapabilities, InnerSpace, InnerSpaceError, NoBody, SpacesManager, SpacesManagerError,
 };
 use crate::spaces::{
-    AccessLevel, ActorId, Group, GroupError, KEY_BUNDLE_LOG_ID, Member, MemberError, Space,
+    AccessLevel, ActorId, Group, GroupError, MEMBER_CONTROL_MESSAGE, Member, MemberError, Space,
     SpaceSubscription, actor_to_topic, group_log_id, spaces_manager, spaces_stream,
     to_initial_members,
 };
@@ -522,7 +522,7 @@ impl Node {
             .associate(
                 &Topic::from(space_id),
                 &self.id(),
-                &Hash::digest(KEY_BUNDLE_LOG_ID),
+                &Hash::digest(MEMBER_CONTROL_MESSAGE),
             )
             .await?;
 
@@ -583,7 +583,7 @@ impl Node {
                 .associate(
                     &Topic::from(space_id),
                     &self.id(),
-                    &Hash::digest(KEY_BUNDLE_LOG_ID),
+                    &Hash::digest(MEMBER_CONTROL_MESSAGE),
                 )
                 .await
         })?;

--- a/p2panda/src/spaces/forge.rs
+++ b/p2panda/src/spaces/forge.rs
@@ -15,7 +15,7 @@ use crate::operation::{Extensions, LogId, Operation};
 use crate::spaces::message::SpacesMessage;
 use crate::spaces::types::{AuthCapabilities, SpacesArgs};
 
-pub(crate) const KEY_BUNDLE_LOG_ID: &[u8] = b"key_bundle/v1";
+pub(crate) const MEMBER_CONTROL_MESSAGE: &[u8] = b"member_control/v1";
 
 const GROUP_CONTROL_MESSAGE: &[u8] = b"group_control/v1";
 
@@ -98,13 +98,12 @@ impl p2panda_spaces::Forge<AuthCapabilities> for OperationForge {
         // by -spaces? If yes, are declaring _all_ dependencies really it's concern or only the ones
         // which are relevant to the spaces protocol?
         let operation = match args {
-            // 1. Key Bundle logs.
-            p2panda_spaces::SpacesArgs::KeyBundle { ref key_bundle } => {
-                // TODO: Check actual encoding format of key bundle. Will require versioning.
-                let bytes = encode_cbor(&key_bundle).expect("serialisation of key bundle to CBOR");
+            // 1. Member logs (with associated key bundles).
+            p2panda_spaces::SpacesArgs::Member(ref member) => {
+                let bytes = encode_cbor(&member).expect("serialisation of key bundle to CBOR");
 
-                // Every author maintains their own key bundle log.
-                let log_id = LogId::digest(KEY_BUNDLE_LOG_ID);
+                // Every member maintains their own log with key bundles inside.
+                let log_id = LogId::digest(MEMBER_CONTROL_MESSAGE);
 
                 // TODO: The key bundle itself should not be in the header to allow deleting it
                 // after a while (without breaking the whole key bundle log.

--- a/p2panda/src/spaces/forge.rs
+++ b/p2panda/src/spaces/forge.rs
@@ -115,7 +115,7 @@ impl p2panda_spaces::Forge<AuthCapabilities> for OperationForge {
             }
 
             // 2. Group logs.
-            p2panda_spaces::SpacesArgs::Auth { group_id, .. } => {
+            p2panda_spaces::SpacesArgs::Group { group_id, .. } => {
                 // Every author maintains their own log of control messages _per_ group.
                 let log_id = group_log_id(group_id);
 
@@ -235,7 +235,7 @@ pub(crate) async fn make_space_group_log_associations(
     };
 
     // Associate all group logs for members introduced by this operation.
-    if let Some(SpacesArgs::Auth {
+    if let Some(SpacesArgs::Group {
         group_id,
         group_action: GroupAction::Create { .. },
         ..

--- a/p2panda/src/spaces/mod.rs
+++ b/p2panda/src/spaces/mod.rs
@@ -17,7 +17,7 @@ pub use p2panda_auth::AccessLevel;
 pub use p2panda_spaces::manager::ManagerError;
 pub use p2panda_spaces::{ActorId, GroupContext, GroupId, MemberId, SpaceContext, SpaceId};
 
-pub(crate) use forge::{KEY_BUNDLE_LOG_ID, group_log_id};
+pub(crate) use forge::{MEMBER_CONTROL_MESSAGE, group_log_id};
 pub use group::{Group, GroupError, GroupEvent, GroupFuture};
 pub use member::{GroupActor, Member, MemberError};
 pub(crate) use repair::{RepairError, RepairStrategy, spawn_repair_task};

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -142,7 +142,7 @@ pub(crate) async fn repair_space<M>(
         };
 
         // Ignore non-groups operations.
-        let Some(SpacesArgs::Auth {
+        let Some(SpacesArgs::Group {
             group_id,
             group_action,
             ..

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -25,7 +25,7 @@ use crate::operation::Operation;
 use crate::spaces::group_log_id;
 use crate::spaces::types::{AuthCapabilities, SpacesArgs, SpacesStore};
 use crate::spaces::{SpacesManagerError, types::SpacesManager};
-use crate::streams::{ForwardEvent, LocalStreamFuture, to_stream_event, to_system_event};
+use crate::streams::{ForwardEvent, LocalStreamFuture, group_to_system_event, to_stream_event};
 
 const REPAIR_FREQUENCY_SECS: u64 = 1;
 
@@ -220,7 +220,9 @@ pub(crate) async fn repair_space<M>(
         .into_iter()
         .filter_map(|event| match event {
             p2panda_spaces::Event::Spaces(space_event) => Some(to_stream_event(space_event).into()),
-            p2panda_spaces::Event::Groups(group_event) => Some(to_system_event(group_event).into()),
+            p2panda_spaces::Event::Groups(group_event) => {
+                Some(group_to_system_event(group_event).into())
+            }
             _ => None,
         })
         .collect();

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -30,7 +30,7 @@ use crate::spaces::types::{AuthCapabilities, InnerSpace, InnerSpaceError, Spaces
 use crate::spaces::{RepairError, RepairStrategy};
 use crate::streams::{
     ImportError, LocalStreamFuture, StreamEvent, StreamPublisher, StreamSubscription,
-    to_stream_event, to_system_event,
+    group_to_system_event, to_stream_event,
 };
 
 /// Wraps topic stream and returns the pub/sub pair of a more specialised spaces stream.
@@ -282,7 +282,7 @@ where
                     Some(to_stream_event(space_event).into())
                 }
                 p2panda_spaces::Event::Groups(group_event) => {
-                    Some(to_system_event(group_event).into())
+                    Some(group_to_system_event(group_event).into())
                 }
                 _ => None,
             })

--- a/p2panda/src/streams/event_stream.rs
+++ b/p2panda/src/streams/event_stream.rs
@@ -6,7 +6,7 @@ use futures_util::Stream;
 use futures_util::stream::{SelectAll, StreamExt};
 use p2panda_auth::AccessLevel;
 use p2panda_net::discovery::DiscoveryEvent;
-use p2panda_spaces::{ActorId, GroupId};
+use p2panda_spaces::{ActorId, GroupId, MemberId};
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 
@@ -20,7 +20,13 @@ use crate::spaces::types::InnerGroupEvent;
 #[derive(Clone, Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum SystemEvent {
+    /// Events of the discovery protocol.
     Discovery(DiscoveryEvent),
+
+    /// Received member info with associated key-bundle.
+    MemberInfoReceived { member_id: MemberId },
+
+    /// Group change occurred.
     Groups {
         /// Id of the group this event originated from.
         group_id: GroupId,

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -32,7 +32,7 @@ pub(crate) use local_stream::LocalStreamFuture;
 pub use publisher::{ImportError, PublishError, PublishFuture, StreamPublisher};
 pub use replay::{ReplayError, StreamFrom};
 pub use stream::{ForwardEvent, ProcessedOperation, Source, StreamEvent};
-pub(crate) use stream::{processed_stream, to_stream_event, to_system_event};
+pub(crate) use stream::{group_to_system_event, processed_stream, to_stream_event};
 pub use subscription::StreamSubscription;
 pub use sync_metrics::{SessionPhase, SyncError};
 

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -576,9 +576,8 @@ where
                     }
                 }
 
-                p2panda_spaces::Event::KeyBundle { author } => {
-                    forward_events.push(ForwardEvent::topic_stream(StreamEvent::KeyBundle(*author)))
-                }
+                p2panda_spaces::Event::Member(member) => forward_events
+                    .push(ForwardEvent::topic_stream(StreamEvent::Member(member.id()))),
 
                 p2panda_spaces::Event::Groups(group_event) => forward_events.push(
                     ForwardEvent::system(to_system_event(group_event.to_owned())),
@@ -787,7 +786,7 @@ pub enum StreamEvent<M> {
     },
 
     /// Key bundle has been processed.
-    KeyBundle(VerifyingKey),
+    Member(VerifyingKey),
 }
 
 pub(crate) fn to_stream_event<M>(event: InnerSpaceEvent) -> StreamEvent<M> {

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -576,11 +576,14 @@ where
                     }
                 }
 
-                p2panda_spaces::Event::Member(member) => forward_events
-                    .push(ForwardEvent::topic_stream(StreamEvent::Member(member.id()))),
+                p2panda_spaces::Event::Member(member) => {
+                    forward_events.push(ForwardEvent::system(SystemEvent::MemberInfoReceived {
+                        member_id: member.id(),
+                    }))
+                }
 
                 p2panda_spaces::Event::Groups(group_event) => forward_events.push(
-                    ForwardEvent::system(to_system_event(group_event.to_owned())),
+                    ForwardEvent::system(group_to_system_event(group_event.to_owned())),
                 ),
 
                 p2panda_spaces::Event::Spaces(space_event) => forward_events.push(
@@ -840,7 +843,7 @@ pub(crate) fn to_stream_event<M>(event: InnerSpaceEvent) -> StreamEvent<M> {
     }
 }
 
-pub(crate) fn to_system_event(event: InnerGroupEvent) -> SystemEvent {
+pub(crate) fn group_to_system_event(event: InnerGroupEvent) -> SystemEvent {
     let members = event
         .context()
         .members

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -63,7 +63,7 @@ async fn spaces_api() -> Result<(), Box<dyn std::error::Error>> {
     // Panda receives both penguins key bundles.
     let mut expected = HashSet::from([penguin_laptop.id(), penguin_mobile.id()]);
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::KeyBundle(verifying_key) = event {
+        if let StreamEvent::Member(verifying_key) = event {
             expected.remove(&verifying_key);
             if expected.is_empty() {
                 break;
@@ -304,7 +304,7 @@ async fn spaces_sync() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::KeyBundle(..) = event {
+        if let StreamEvent::Member(..) = event {
             break;
         };
     }
@@ -588,7 +588,7 @@ async fn api_validation() -> Result<(), Box<dyn std::error::Error>> {
     let (tiger_space, mut tiger_rx) = tiger.space::<String>(topic).await?;
 
     while let Some(event) = panda_rx.next().await {
-        if let StreamEvent::KeyBundle(verifying_key) = event {
+        if let StreamEvent::Member(verifying_key) = event {
             if verifying_key == tiger.id() {
                 break;
             }


### PR DESCRIPTION
This PR changes the notion from key-bundles towards "members" objects (tbd if this is still a good name).

Member objects contain all information required to identify a member and verify that the associated X3DH key-bundle is checked and was authored / claimed by that member. The latter is now provided through a cross-signing process.

Some additional naming changes have been made on the more public methods, using the Member naming instead of KeyBundle.

Closes: https://github.com/p2panda/p2panda/issues/1210

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
