### PR TITLE
Automatically renew expired key-bundles and publish member messages more efficiently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Highlights are marked with a pancake 🥞
 - stream: Move orderer processor from node to stream [#1312](https://github.com/p2panda/p2panda/pull/1312)
 - net: Introduce an `Authoriser` for maintaining and enforcing allowlists and blocklists [#1321](https://github.com/p2panda/p2panda/pull/1321)
 - node: Integrate the `Authoriser` into the `Node`[#1321](https://github.com/p2panda/p2panda/pull/1321)
+- node: Automatically renew expired key-bundles and publish member messages more efficiently [#1337](https://github.com/p2panda/p2panda/pull/1337)
 
 ### Changed
 

--- a/p2panda-encryption/src/key_bundle/lifetime.rs
+++ b/p2panda-encryption/src/key_bundle/lifetime.rs
@@ -135,6 +135,20 @@ mod tests {
     use super::Lifetime;
 
     #[test]
+    fn order() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("SystemTime before UNIX EPOCH!")
+            .as_secs();
+
+        let lifetime_1 = Lifetime::from_range(now - 60, now + 30);
+        let lifetime_2 = Lifetime::from_range(now - 30, now + 60);
+
+        assert!(lifetime_1 < lifetime_2);
+        assert!(lifetime_1 != lifetime_2);
+    }
+
+    #[test]
     fn verify() {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/p2panda-encryption/src/key_bundle/prekey.rs
+++ b/p2panda-encryption/src/key_bundle/prekey.rs
@@ -119,3 +119,36 @@ pub fn latest_prekey<'a>(prekeys: Vec<&'a PreKey>) -> Option<&'a PreKey> {
 
     latest
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::Rng;
+    use crate::crypto::x25519::SecretKey;
+    use crate::key_bundle::Lifetime;
+
+    use super::PreKey;
+
+    #[test]
+    fn latest_prekey() {
+        let rng = Rng::from_seed([1; 32]);
+        let public_key = SecretKey::from_rng(&rng).unwrap().verifying_key().unwrap();
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("SystemTime before UNIX EPOCH!")
+            .as_secs();
+
+        //      NOW
+        // ===|=== (1)
+        //   =|====== (2) <-- "latest"
+        //    |      === (3)
+        let prekey_1 = PreKey::new(public_key, Lifetime::from_range(now - 30, now + 30));
+        let prekey_2 = PreKey::new(public_key, Lifetime::from_range(now - 10, now + 60));
+        let prekey_3 = PreKey::new(public_key, Lifetime::from_range(now + 60, now + 90));
+
+        let result = super::latest_prekey(vec![&prekey_1, &prekey_2, &prekey_3]);
+        assert_eq!(result, Some(&prekey_2));
+    }
+}

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -93,7 +93,7 @@ where
         credentials: Credentials,
         rng: Rng,
     ) -> Result<Self, ManagerError<F, C>> {
-        Self::new_with_config(store, forge, credentials, &Config::default(), rng)
+        Self::new_with_config(store, forge, credentials, Config::default(), rng)
     }
 
     /// Instantiate a new manager with custom configuration.
@@ -102,12 +102,11 @@ where
         store: S,
         forge: F,
         credentials: Credentials,
-        config: &Config,
+        config: Config,
         rng: Rng,
     ) -> Result<Self, ManagerError<F, C>> {
         let actor_id: ActorId = credentials.verifying_key();
-        let identity =
-            IdentityManager::new(store.clone(), forge, credentials, config.clone(), &rng)?;
+        let identity = IdentityManager::new(store.clone(), forge, credentials, config, &rng)?;
         let inner = ManagerInner {
             store,
             identity,

--- a/p2panda-spaces/src/test_utils/mod.rs
+++ b/p2panda-spaces/src/test_utils/mod.rs
@@ -48,13 +48,13 @@ impl TestPeer {
         let rng = Rng::from_seed([peer_id; 32]);
         let credentials = Credentials::from_rng(&rng).unwrap();
         let config = Config::default();
-        Self::new_with_config(peer_id, credentials, &config, rng).await
+        Self::new_with_config(peer_id, credentials, config, rng).await
     }
 
     pub async fn new_with_config(
         peer_id: TestPeerId,
         credentials: Credentials,
-        config: &Config,
+        config: Config,
         rng: Rng,
     ) -> Self {
         let store = SqliteStore::temporary().await;

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -551,25 +551,6 @@ impl Node {
             .unwrap_or(InnerSpace::new(self.spaces_manager.clone(), space_id));
         let (tx, rx) = self.stream_from::<M>(topic, from).await?;
 
-        // Publish one key bundle whenever we subscribe to a space.
-        //
-        // @TODO: this is a rather naive approach, we likely want some (configurable?) service
-        // that periodically publishes key bundles.
-        let message = self.spaces_manager.key_bundle_message().await?;
-
-        let operation = message.into_operation();
-        let processed = tx
-            .import_local(futures_util::stream::once(async { operation }))
-            .await?;
-
-        // Wait until processing the events has finished.
-
-        // TODO: Would be good to get an error / report here if processing the imported operations
-        // failed. This error so far only tells us that the channel broke down.
-        if processed.await.is_err() {
-            panic!();
-        }
-
         // Spawn per-space repair background task.
         let repair_task = RepairTask::spawn(
             inner.id(),
@@ -619,9 +600,6 @@ impl Node {
         let (tx, rx) = self.stream::<M>(topic).await?;
 
         // Publish one key bundle whenever we create a space.
-        //
-        // @TODO: this is a rather naive approach, we likely want some service that periodically
-        // publishes key bundles.
         let key_bundle_message = self.spaces_manager.key_bundle_message().await?;
 
         // Issue the events to create a space.
@@ -635,18 +613,20 @@ impl Node {
         let (groups_y, space_y, create_space_messages, events) =
             self.spaces_manager.create_space(space_id, &[]).await?;
 
-        let permit = self.store.begin().await?;
+        // Persist the computed groups- and spaces-state to the stores.
+        {
+            let permit = self.store.begin().await?;
 
-        // Persist the computed groups and spaces state to the stores.
-        let spaces_store = SqliteSpacesStore::<Extensions>::new(self.store.clone());
-        spaces_store
-            .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
-            .await?;
-        spaces_store
-            .set_space_state_tx(&space_id, &SpacesStoreState::from(space_y))
-            .await?;
+            let spaces_store = SqliteSpacesStore::<Extensions>::new(self.store.clone());
+            spaces_store
+                .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
+                .await?;
+            spaces_store
+                .set_space_state_tx(&space_id, &SpacesStoreState::from(space_y))
+                .await?;
 
-        self.store.commit(permit).await?;
+            self.store.commit(permit).await?;
+        }
 
         // Process the -spaces events by importing them as an "external stream".
         let mut messages = vec![key_bundle_message];

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -31,10 +31,9 @@ use crate::spaces::types::{
     AuthCapabilities, InnerSpace, InnerSpaceError, NoBody, SpacesManager, SpacesManagerError,
 };
 use crate::spaces::{
-    AccessLevel, ActorId, DEFAULT_REPAIR_STRATEGY, Group, GroupError, KeyBundleTask,
-    MEMBER_CONTROL_MESSAGE, Member, MemberAssociationHook, MemberError, RepairTask, Space,
-    SpaceSubscription, actor_to_topic, group_log_id, spaces_manager, spaces_stream,
-    to_initial_members,
+    AccessLevel, ActorId, DEFAULT_REPAIR_STRATEGY, Group, GroupError, KeyBundleTask, Member,
+    MemberAssociationHook, MemberError, RepairTask, Space, SpaceSubscription, actor_to_topic,
+    group_log_id, member_log_id, spaces_manager, spaces_stream, to_initial_members,
 };
 use crate::streams::{
     EphemeralStreamPublisher, EphemeralStreamSubscription, Event, ImportError, Pipeline,
@@ -549,11 +548,7 @@ impl Node {
 
             // Associate the space topic with our own member / key bundle logs.
             self.store
-                .associate(
-                    &Topic::from(space_id),
-                    &self.id(),
-                    &Hash::digest(MEMBER_CONTROL_MESSAGE),
-                )
+                .associate(&Topic::from(space_id), &self.id(), &member_log_id())
                 .await?;
         });
 
@@ -617,11 +612,7 @@ impl Node {
         // Associate the space topic with our own member / key bundle log.
         tx!(&self.store, {
             self.store
-                .associate(
-                    &Topic::from(space_id),
-                    &self.id(),
-                    &Hash::digest(MEMBER_CONTROL_MESSAGE),
-                )
+                .associate(&Topic::from(space_id), &self.id(), &member_log_id())
                 .await
         })?;
 

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -119,7 +119,7 @@ impl Node {
         let tasks = TaskTracker::new();
 
         // Spawn background tasks which run for the duration of the whole program.
-        let key_bundle_task = KeyBundleTask::spawn(spaces_manager.clone());
+        let key_bundle_task = KeyBundleTask::spawn(spaces_manager.clone()).await;
 
         let (events_tx, events_rx) = broadcast::channel::<SystemEvent>(256);
 

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -15,7 +15,8 @@ use p2panda_store::groups::GroupsStore;
 use p2panda_store::spaces::{SpacesStore, SqliteSpacesStore};
 use p2panda_store::sqlite::{SqliteError, SqliteStore, SqliteStoreBuilder};
 use p2panda_store::topics::TopicStore;
-use p2panda_store::{Transaction, tx};
+use p2panda_store::tx;
+use p2panda_stream::hooks::ProcessorHooksList;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::broadcast;
@@ -30,14 +31,15 @@ use crate::spaces::types::{
     AuthCapabilities, InnerSpace, InnerSpaceError, NoBody, SpacesManager, SpacesManagerError,
 };
 use crate::spaces::{
-    AccessLevel, ActorId, DEFAULT_REPAIR_STRATEGY, Group, GroupError, MEMBER_CONTROL_MESSAGE,
-    Member, MemberError, RepairTask, Space, SpaceSubscription, actor_to_topic, group_log_id,
-    spaces_manager, spaces_stream, to_initial_members,
+    AccessLevel, ActorId, DEFAULT_REPAIR_STRATEGY, Group, GroupError, KeyBundleTask,
+    MEMBER_CONTROL_MESSAGE, Member, MemberAssociationHook, MemberError, RepairTask, Space,
+    SpaceSubscription, actor_to_topic, group_log_id, spaces_manager, spaces_stream,
+    to_initial_members,
 };
 use crate::streams::{
-    EphemeralStreamPublisher, EphemeralStreamSubscription, ImportError, Pipeline, StreamFrom,
-    StreamPublisher, StreamSubscription, SystemEvent, TaskTracker, ephemeral_stream, event_stream,
-    processed_stream, to_stream_event, to_system_event,
+    EphemeralStreamPublisher, EphemeralStreamSubscription, Event, ImportError, Pipeline,
+    StreamFrom, StreamPublisher, StreamSubscription, SystemEvent, TaskTracker, ephemeral_stream,
+    event_stream, processed_stream, to_stream_event, to_system_event,
 };
 
 static_assertions::assert_impl_all!(Node: Send, Sync);
@@ -52,6 +54,7 @@ pub struct Node {
     tasks: TaskTracker,
     network: Network,
     spaces_manager: SpacesManager,
+    key_bundle_task: KeyBundleTask,
     events_tx: broadcast::Sender<SystemEvent>,
     events_rx: Mutex<broadcast::Receiver<SystemEvent>>,
     connection_authoriser: ConnectionAuthoriser,
@@ -110,6 +113,9 @@ impl Node {
         // Prepare manager which orchestrates processing of incoming operations.
         let tasks = TaskTracker::new();
 
+        // Spawn background tasks which run for the duration of the whole program.
+        let key_bundle_task = KeyBundleTask::spawn(spaces_manager.clone());
+
         let (events_tx, events_rx) = broadcast::channel::<SystemEvent>(256);
 
         Ok(Node {
@@ -120,6 +126,7 @@ impl Node {
             tasks,
             network,
             spaces_manager,
+            key_bundle_task,
             events_tx,
             events_rx: Mutex::new(events_rx),
             connection_authoriser,
@@ -322,6 +329,20 @@ impl Node {
     where
         M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
     {
+        self.stream_from_inner(topic, from, ProcessorHooksList::new())
+            .await
+    }
+
+    // TODO: This should be a proper TopicStream-builder.
+    async fn stream_from_inner<M>(
+        &self,
+        topic: impl Into<Topic>,
+        from: StreamFrom,
+        post_pipeline_hooks: ProcessorHooksList<Event>,
+    ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
+    where
+        M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
+    {
         let live_mode = true;
         let topic = topic.into();
 
@@ -337,6 +358,7 @@ impl Node {
             self.store.clone(),
             self.tasks.clone(),
             self.spaces_manager.clone(),
+            post_pipeline_hooks,
         );
 
         let (tx, rx) = processed_stream(
@@ -497,47 +519,39 @@ impl Node {
     {
         let space_id = space_id.into();
 
-        let permit = self.store.begin().await?;
+        tx!(self.store, {
+            // Associate all group logs we have with the space topic, this handles the "first time
+            // subscription" case where we want to sync all groups logs up-front.
+            //
+            // TODO: This can be removed once we have a working orderer as then the repair task can
+            // be relied upon.
+            let y: AuthGroupState<AuthCapabilities> = self
+                .store
+                .get_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID))
+                .await?
+                .unwrap_or_default();
 
-        // Associate all group logs we have with the space topic, this handles the "first time
-        // subscription" case where we want to sync all groups logs up-front.
-        //
-        // @TODO: This can be removed once we have a working orderer as then the repair task can
-        // be relied upon.
-        let y: AuthGroupState<AuthCapabilities> = self
-            .store
-            .get_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID))
-            .await?
-            .unwrap_or_default();
+            for group_id in y.groups_global() {
+                debug!(
+                    group_id = group_id.fmt_short(),
+                    space_id = space_id.fmt_short(),
+                    "associate group log with space topic"
+                );
+                self.store
+                    .associate(&Topic::from(space_id), &self.id(), &group_log_id(group_id))
+                    .await?;
+            }
 
-        for group_id in y.groups_global() {
-            debug!(
-                group_id = group_id.fmt_short(),
-                space_id = space_id.fmt_short(),
-                "associate group log with space topic"
-            );
+            // Associate the space topic with our own member / key bundle logs.
             self.store
-                .associate(&Topic::from(space_id), &self.id(), &group_log_id(group_id))
+                .associate(
+                    &Topic::from(space_id),
+                    &self.id(),
+                    &Hash::digest(MEMBER_CONTROL_MESSAGE),
+                )
                 .await?;
-        }
+        });
 
-        // Associate the space topic with the key bundle logs.
-        //
-        // This does _not_ happen during ingest as at that point there is no topic which could be
-        // used to perform this association. The same key bundle log can be associated with many
-        // spaces. And it can't happen in the forge as a user may never actually publish into a
-        // space.
-        self.store
-            .associate(
-                &Topic::from(space_id),
-                &self.id(),
-                &Hash::digest(MEMBER_CONTROL_MESSAGE),
-            )
-            .await?;
-
-        self.store.commit(permit).await?;
-
-        let topic = space_id;
         let inner = self
             .spaces_manager
             .space(space_id)
@@ -549,7 +563,8 @@ impl Node {
             // the space topic but only to announce their key bundles and await receiving control
             // messages.
             .unwrap_or(InnerSpace::new(self.spaces_manager.clone(), space_id));
-        let (tx, rx) = self.stream_from::<M>(topic, from).await?;
+
+        let (tx, rx) = self.space_stream_from_inner(space_id, from).await?;
 
         // Spawn per-space repair background task.
         let repair_task = RepairTask::spawn(
@@ -565,9 +580,24 @@ impl Node {
             inner,
             self.store.clone(),
             repair_task,
+            self.key_bundle_task.command_handle(),
             tx,
             rx,
         ))
+    }
+
+    async fn space_stream_from_inner<M>(
+        &self,
+        topic: impl Into<Topic>,
+        from: StreamFrom,
+    ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
+    where
+        M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
+    {
+        let mut post_pipeline = ProcessorHooksList::new();
+        post_pipeline.push(MemberAssociationHook::new(self.id(), self.store.clone()));
+
+        self.stream_from_inner(topic, from, post_pipeline).await
     }
 
     pub async fn create_space<M>(
@@ -579,11 +609,7 @@ impl Node {
     {
         let space_id = space_id.into();
 
-        // Associate the space topic with the key bundle logs.
-        //
-        // This does _not_ happen during ingest as at that point there is no topic which could be
-        // used to perform this association. The same key bundle log can be associated with many
-        // spaces.
+        // Associate the space topic with our own member / key bundle log.
         tx!(&self.store, {
             self.store
                 .associate(
@@ -594,13 +620,10 @@ impl Node {
                 .await
         })?;
 
-        // Establish a topic pub/sub stream using the space id as a topic. This also associates
-        // the key bundle log with the space topic.
-        let topic = space_id;
-        let (tx, rx) = self.stream::<M>(topic).await?;
-
-        // Publish one key bundle whenever we create a space.
-        let key_bundle_message = self.spaces_manager.key_bundle_message().await?;
+        // Establish a topic pub/sub stream using the space id as a topic.
+        let (tx, rx) = self
+            .space_stream_from_inner(space_id, StreamFrom::Frontier)
+            .await?;
 
         // Issue the events to create a space.
         //
@@ -614,9 +637,7 @@ impl Node {
             self.spaces_manager.create_space(space_id, &[]).await?;
 
         // Persist the computed groups- and spaces-state to the stores.
-        {
-            let permit = self.store.begin().await?;
-
+        tx!(self.store, {
             let spaces_store = SqliteSpacesStore::<Extensions>::new(self.store.clone());
             spaces_store
                 .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
@@ -624,17 +645,13 @@ impl Node {
             spaces_store
                 .set_space_state_tx(&space_id, &SpacesStoreState::from(space_y))
                 .await?;
-
-            self.store.commit(permit).await?;
-        }
-
-        // Process the -spaces events by importing them as an "external stream".
-        let mut messages = vec![key_bundle_message];
-        messages.extend(create_space_messages);
+        });
 
         let processed = tx
             .import_local(futures_util::stream::iter(
-                messages.into_iter().map(|message| message.into_operation()),
+                create_space_messages
+                    .into_iter()
+                    .map(|message| message.into_operation()),
             ))
             .await?;
 
@@ -682,7 +699,15 @@ impl Node {
             tx.to_output_tx.clone(),
         );
 
-        let (space, rx) = spaces_stream::<M>(inner, self.store.clone(), repair_task, tx, rx);
+        let (space, rx) = spaces_stream::<M>(
+            inner,
+            self.store.clone(),
+            repair_task,
+            self.key_bundle_task.command_handle(),
+            tx,
+            rx,
+        );
+
         Ok((space, rx))
     }
 

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -10,7 +10,7 @@ use p2panda_net::connection_authoriser::ConnectionAuthoriser;
 use p2panda_net::iroh_endpoint::RelayUrl;
 use p2panda_net::{NetworkId, NodeId};
 use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
-use p2panda_spaces::{AuthGroupState, GroupId, SpaceId, SpacesStoreState};
+use p2panda_spaces::{AuthGroupState, Config as SpacesConfig, GroupId, SpaceId, SpacesStoreState};
 use p2panda_store::groups::GroupsStore;
 use p2panda_store::spaces::{SpacesStore, SqliteSpacesStore};
 use p2panda_store::sqlite::{SqliteError, SqliteStore, SqliteStoreBuilder};
@@ -107,8 +107,13 @@ impl Node {
         )
         .await?;
 
-        // TODO: Expose -spaces configuration to public API.
-        let spaces_manager = spaces_manager(forge.clone(), credentials.clone(), store.clone())?;
+        let spaces_manager = spaces_manager(
+            forge.clone(),
+            credentials.clone(),
+            store.clone(),
+            // TODO: Expose -spaces configuration to public API.
+            SpacesConfig::default(),
+        )?;
 
         // Prepare manager which orchestrates processing of incoming operations.
         let tasks = TaskTracker::new();

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -427,6 +427,7 @@ mod tests {
     use p2panda_core::test_utils::{TestLog, setup_logging};
     use p2panda_core::traits::Digest;
     use p2panda_core::{Hash, PruneFlag, SigningKey, Topic};
+    use p2panda_spaces::Config;
     use p2panda_store::SqliteStore;
     use p2panda_stream::hooks::ProcessorHooksList;
     use p2panda_stream::orderer::{OrdererArgs, OrdererResult};
@@ -448,7 +449,8 @@ mod tests {
         let tasks = TaskTracker::new();
         let credentials = Credentials::generate();
         let forge = OperationForge::new(credentials.clone(), store.clone());
-        let spaces_manager = spaces_manager(forge, credentials, store.clone()).unwrap();
+        let spaces_manager =
+            spaces_manager(forge, credentials, store.clone(), Config::default()).unwrap();
 
         let pipeline_id = Hash::from([0; 32]);
         let pipeline = Pipeline::<LogId, (), Topic>::new(
@@ -507,7 +509,8 @@ mod tests {
         let tasks = TaskTracker::new();
         let credentials = Credentials::generate();
         let forge = OperationForge::new(credentials.clone(), store.clone());
-        let spaces_manager = spaces_manager(forge, credentials, store.clone()).unwrap();
+        let spaces_manager =
+            spaces_manager(forge, credentials, store.clone(), Config::default()).unwrap();
 
         let pipeline_id = Hash::from([0; 32]);
         let pipeline = Pipeline::<LogId, (), Topic>::new(
@@ -567,7 +570,8 @@ mod tests {
         let tasks = TaskTracker::new();
         let credentials = Credentials::generate();
         let forge = OperationForge::new(credentials.clone(), store.clone());
-        let spaces_manager = spaces_manager(forge, credentials, store.clone()).unwrap();
+        let spaces_manager =
+            spaces_manager(forge, credentials, store.clone(), Config::default()).unwrap();
 
         let pipeline_id = Hash::from([0; 32]);
         let pipeline = Pipeline::<LogId, (), Topic>::new(

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -12,6 +12,7 @@ use p2panda_core::{Extensions, Hash, LogId};
 use p2panda_store::SqliteStore;
 use p2panda_store::spaces::SqliteSpacesStore;
 use p2panda_stream::StreamLayerExt;
+use p2panda_stream::hooks::{Hooks, ProcessorHooksList};
 use p2panda_stream::ingest::Ingest;
 use p2panda_stream::log_prune::LogPrune;
 use p2panda_stream::orderer::{Orderer, OrdererResult};
@@ -161,9 +162,9 @@ impl<L, E, TP> Pipeline<L, E, TP>
 where
     // NOTE: Unfortunately there's no scoped "spawn_local" yet (it's an experimental tokio feature)
     // and we need to require a Send + 'static trait bounds, even though it's not used anywhere.
-    L: LogId + Send + 'static,
-    E: Extensions + Send + 'static,
-    TP: Clone + Send + Serialize + for<'a> Deserialize<'a> + 'static,
+    L: LogId + Send + Sync + 'static,
+    E: Extensions + Send + Sync + 'static,
+    TP: Clone + Send + Sync + Serialize + for<'a> Deserialize<'a> + 'static,
 {
     /// Creates a new "event processor" pipeline.
     ///
@@ -176,6 +177,7 @@ where
         store: SqliteStore,
         tasks: TaskTracker<Event<L, E, TP>, PipelineTaskId>,
         spaces_manager: SpacesManager,
+        post_hooks: ProcessorHooksList<Event<L, E, TP>>,
     ) -> Self {
         let pipeline_id = id.into();
 
@@ -194,21 +196,24 @@ where
             let from_pipeline_queue = from_pipeline_queue.clone();
             let from_pipeline_notify = from_pipeline_notify.clone();
 
+            let post_pipeline_hook = Hooks::<Event<L, E, TP>>::from_list(post_hooks);
+
             thread::spawn(move || {
                 let local = LocalSet::new();
 
                 local.spawn_local(async move {
                     let me = spaces_manager.id();
+
                     // Prepare event processing pipeline.
                     let ingest =
                         Ingest::<SqliteStore, Event<L, E, TP>, L, E, TP>::new(store.clone());
                     let orderer = Orderer::<SqliteStore, Event<L, E, TP>, E>::new(store.clone());
                     let log_prune =
                         LogPrune::<SqliteStore, Event<L, E, TP>, L, E>::new(store.clone());
-
-                    let spaces_store = SqliteSpacesStore::new(store);
-                    let spaces =
-                        SpacesProcessor::<Event<L, E, TP>>::new(spaces_store, spaces_manager);
+                    let spaces = {
+                        let spaces_store = SqliteSpacesStore::new(store);
+                        SpacesProcessor::<Event<L, E, TP>>::new(spaces_store, spaces_manager)
+                    };
 
                     // Receive incoming events through mpsc channel.
                     let pipeline = ReceiverStream::new(to_pipeline_rx)
@@ -262,7 +267,9 @@ where
                                 event.spaces = ProcessorStatus::Failed(err);
                                 event.noop()
                             }
-                        });
+                        })
+                        .layer(post_pipeline_hook)
+                        .map(|result| result.expect("hook processor is infallible"));
 
                     pin!(pipeline);
 
@@ -421,6 +428,7 @@ mod tests {
     use p2panda_core::traits::Digest;
     use p2panda_core::{Hash, PruneFlag, SigningKey, Topic};
     use p2panda_store::SqliteStore;
+    use p2panda_stream::hooks::ProcessorHooksList;
     use p2panda_stream::orderer::{OrdererArgs, OrdererResult};
 
     use crate::credentials::Credentials;
@@ -443,7 +451,13 @@ mod tests {
         let spaces_manager = spaces_manager(forge, credentials, store.clone()).unwrap();
 
         let pipeline_id = Hash::from([0; 32]);
-        let pipeline = Pipeline::<LogId, (), Topic>::new(pipeline_id, store, tasks, spaces_manager);
+        let pipeline = Pipeline::<LogId, (), Topic>::new(
+            pipeline_id,
+            store,
+            tasks,
+            spaces_manager,
+            ProcessorHooksList::new(),
+        );
 
         let log = TestLog::new();
         let topic = Topic::random();
@@ -496,7 +510,13 @@ mod tests {
         let spaces_manager = spaces_manager(forge, credentials, store.clone()).unwrap();
 
         let pipeline_id = Hash::from([0; 32]);
-        let pipeline = Pipeline::<LogId, (), Topic>::new(pipeline_id, store, tasks, spaces_manager);
+        let pipeline = Pipeline::<LogId, (), Topic>::new(
+            pipeline_id,
+            store,
+            tasks,
+            spaces_manager,
+            ProcessorHooksList::new(),
+        );
 
         let mut events = Vec::new();
         let mut dependencies = Vec::new();
@@ -550,7 +570,13 @@ mod tests {
         let spaces_manager = spaces_manager(forge, credentials, store.clone()).unwrap();
 
         let pipeline_id = Hash::from([0; 32]);
-        let pipeline = Pipeline::<LogId, (), Topic>::new(pipeline_id, store, tasks, spaces_manager);
+        let pipeline = Pipeline::<LogId, (), Topic>::new(
+            pipeline_id,
+            store,
+            tasks,
+            spaces_manager,
+            ProcessorHooksList::new(),
+        );
 
         let log_icebear = TestLog::new();
         let log_panda = TestLog::new();

--- a/p2panda/src/spaces/forge.rs
+++ b/p2panda/src/spaces/forge.rs
@@ -108,7 +108,7 @@ impl p2panda_spaces::Forge<AuthCapabilities> for OperationForge {
                 // this is _one single log_ across all spaces.
                 //
                 // New member messages are created automatically by a background task.
-                let log_id = LogId::digest(MEMBER_CONTROL_MESSAGE);
+                let log_id = member_log_id();
 
                 // TODO: The key bundle itself should not be in the header to allow deleting it
                 // after a while (without breaking the whole key bundle log.
@@ -205,6 +205,10 @@ impl p2panda_spaces::Forge<AuthCapabilities> for OperationForge {
     }
 }
 
+pub(crate) fn member_log_id() -> LogId {
+    LogId::digest(MEMBER_CONTROL_MESSAGE)
+}
+
 fn space_log_id(space_id: SpaceId) -> LogId {
     LogId::digest(&{
         let mut bytes = Vec::new();
@@ -234,7 +238,8 @@ pub(crate) async fn make_space_group_log_associations(
     space_group_id: VerifyingKey,
     groups_message_id: Hash,
 ) -> Result<(), SpacesForgeError> {
-    let Some(groups_operation): Option<Operation> = store.get_operation(&groups_message_id).await?
+    let Some(groups_operation): Option<Operation> =
+        store.get_operation_tx(&groups_message_id).await?
     else {
         return Err(SpacesForgeError::MissingGroupsOperation(groups_message_id));
     };

--- a/p2panda/src/spaces/member.rs
+++ b/p2panda/src/spaces/member.rs
@@ -46,6 +46,8 @@ use std::time::Duration;
 use p2panda_auth::Access;
 use p2panda_core::VerifyingKey;
 use p2panda_core::traits::ShortFormat;
+use p2panda_encryption::key_bundle::{Lifetime, LongTermKeyBundle};
+use p2panda_encryption::traits::KeyBundle;
 use p2panda_net::NodeId;
 use p2panda_spaces::{ActorId, MemberId, SpaceId};
 use p2panda_store::topics::TopicStore;
@@ -69,6 +71,19 @@ pub struct Member {
 impl Member {
     pub fn id(&self) -> ActorId {
         self.inner.id()
+    }
+
+    pub fn key_bundle(&self) -> &LongTermKeyBundle {
+        self.inner.key_bundle()
+    }
+
+    pub fn lifetime(&self) -> &Lifetime {
+        self.inner.key_bundle().lifetime()
+    }
+
+    pub fn verify(&self) -> Result<(), p2panda_spaces::member::MemberError> {
+        self.inner.verify()?;
+        Ok(())
     }
 }
 

--- a/p2panda/src/spaces/member.rs
+++ b/p2panda/src/spaces/member.rs
@@ -40,6 +40,7 @@
 //! Since this log is maintained independent of a particular space we need to explicitly associate
 //! it when the space starts to depend on the member's key bundles.
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use p2panda_auth::Access;
@@ -51,7 +52,7 @@ use p2panda_store::topics::TopicStore;
 use p2panda_store::{SqliteError, SqliteStore, tx};
 use p2panda_stream::hooks::ProcessorHook;
 use thiserror::Error;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot};
 use tracing::{debug, error};
 
 use crate::operation::Operation;
@@ -59,8 +60,6 @@ use crate::spaces::Group;
 use crate::spaces::forge::member_log_id;
 use crate::spaces::types::{AuthCapabilities, InnerMember, SpacesManager, SpacesManagerError};
 use crate::streams::{Event, ImportLocalTx, LocalStreamFuture};
-
-const CHECK_KEY_BUNDLE_FREQUENCY: Duration = Duration::from_mins(15);
 
 #[derive(Debug)]
 pub struct Member {
@@ -149,21 +148,48 @@ pub struct KeyBundleTask {
 
 impl KeyBundleTask {
     /// Spawn key bundle background task.
-    pub fn spawn(manager: SpacesManager) -> Self {
+    ///
+    /// This method awaits until we can be sure at least one valid key bundle was published into the
+    /// member's log. This assures that all logic to subscribe to a space causes sync session to be
+    /// initialised _after_ the log was checked & populated.
+    pub async fn spawn(manager: SpacesManager) -> Self {
+        Self::spawn_inner(manager, CHECK_KEY_BUNDLE_FREQUENCY).await
+    }
+
+    #[cfg(test)]
+    pub async fn spawn_with_frequency(manager: SpacesManager, frequency: Duration) -> Self {
+        Self::spawn_inner(manager, frequency).await
+    }
+
+    async fn spawn_inner(manager: SpacesManager, frequency: Duration) -> Self {
         debug!("key bundle management task started");
 
         let (tx, rx) = mpsc::unbounded_channel();
+        let ready_signal = Arc::new(Notify::new());
 
-        tokio::spawn(async move {
-            let result = renew_expired_key_bundles(manager, rx).await;
+        {
+            let ready_signal = ready_signal.clone();
 
-            match result {
-                Ok(_) => debug!("key bundle management task ended"),
-                Err(ref err) => {
-                    error!("failed task to automatically renew key bundles: {}", err);
+            tokio::spawn(async move {
+                let result = renew_expired_key_bundles(manager, rx, ready_signal, frequency).await;
+
+                match result {
+                    Ok(_) => debug!("key bundle management task ended"),
+                    Err(ref err) => {
+                        error!("failed task to automatically renew key bundles: {}", err);
+                    }
                 }
-            }
-        });
+            });
+        }
+
+        // Wait until we've received a "ready" signal from the internal task. Like this we can
+        // assure to only return when we know that at least one valid key bundle is already in the
+        // member's log. This is especially important when the application starts for the first time
+        // or after a long time where the key bundle expired in the meantime.
+        //
+        // This should prevent potential race conditions of other tasks which assume that at least
+        // one valid key bundle should be available.
+        ready_signal.notified().await;
 
         Self { tx }
     }
@@ -191,9 +217,13 @@ pub enum KeyBundleTaskCommand {
     RemoveStream(SpaceId),
 }
 
+const CHECK_KEY_BUNDLE_FREQUENCY: Duration = Duration::from_mins(15);
+
 async fn renew_expired_key_bundles(
     manager: SpacesManager,
     mut rx: mpsc::UnboundedReceiver<KeyBundleTaskCommand>,
+    ready_signal: Arc<Notify>,
+    frequency: Duration,
 ) -> Result<(), SpacesManagerError> {
     // Keep a list of all spaces streams where we publish the new "member" message into when a key
     // bundle is about to expire.
@@ -205,13 +235,14 @@ async fn renew_expired_key_bundles(
 
     // The interval always fires at start, later in the given frequency. This assures that we always
     // check the current key bundle at least once on process start.
-    let mut interval = tokio::time::interval(CHECK_KEY_BUNDLE_FREQUENCY);
+    let mut interval = tokio::time::interval(frequency);
     loop {
         tokio::select! {
             biased;
 
             _ = interval.tick() => {
                 if !manager.key_bundle_expired().await? {
+                    ready_signal.notify_one();
                     continue;
                 }
 
@@ -242,6 +273,8 @@ async fn renew_expired_key_bundles(
                 for space_id in failed_sends.iter() {
                     spaces_streams.remove(space_id);
                 }
+
+                ready_signal.notify_one();
             }
 
             command = rx.recv() => {
@@ -270,8 +303,7 @@ async fn publish_member_message(
 ) -> bool {
     let stream = Box::pin(futures_util::stream::once(async { operation }));
 
-    // We don't need to await the result.
-    let (ready_tx, _) = oneshot::channel::<LocalStreamFuture>();
+    let (ready_tx, ready_rx) = oneshot::channel::<LocalStreamFuture>();
 
     if let Err(err) = import_local_tx.send((stream, ready_tx)).await {
         debug!(
@@ -281,6 +313,9 @@ async fn publish_member_message(
 
         return false;
     }
+
+    // Wait until this member message was properly ingested.
+    let _ = ready_rx.await;
 
     true
 }

--- a/p2panda/src/spaces/member.rs
+++ b/p2panda/src/spaces/member.rs
@@ -3,17 +3,23 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use p2panda_auth::Access;
+use p2panda_core::VerifyingKey;
 use p2panda_core::traits::ShortFormat;
-use p2panda_spaces::{ActorId, SpaceId};
+use p2panda_net::NodeId;
+use p2panda_spaces::{ActorId, MemberId, SpaceId};
+use p2panda_store::topics::TopicStore;
+use p2panda_store::{SqliteError, SqliteStore, tx};
+use p2panda_stream::hooks::ProcessorHook;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
-use tokio::task::JoinHandle;
 use tracing::{debug, error};
 
 use crate::operation::Operation;
 use crate::spaces::Group;
-use crate::spaces::types::{InnerMember, SpacesManager, SpacesManagerError};
-use crate::streams::{ImportLocalTx, LocalStreamFuture};
+use crate::spaces::forge::member_log_id;
+use crate::spaces::types::{AuthCapabilities, InnerMember, SpacesManager, SpacesManagerError};
+use crate::streams::{Event, ImportLocalTx, LocalStreamFuture};
 
 const CHECK_KEY_BUNDLE_FREQUENCY: Duration = Duration::from_mins(15);
 
@@ -95,11 +101,13 @@ pub enum MemberError {
     Manager(#[from] SpacesManagerError),
 }
 
+pub type KeyBundleTaskSender = mpsc::UnboundedSender<KeyBundleTaskCommand>;
+
 /// Background task to automatically publish a new member message into all registered space streams if
 /// the associated key bundle is about to expire.
+#[derive(Clone, Debug)]
 pub struct KeyBundleTask {
-    tx: mpsc::UnboundedSender<KeyBundleTaskCommand>,
-    handle: JoinHandle<()>,
+    tx: KeyBundleTaskSender,
 }
 
 impl KeyBundleTask {
@@ -109,7 +117,7 @@ impl KeyBundleTask {
 
         let (tx, rx) = mpsc::unbounded_channel();
 
-        let handle = tokio::spawn(async move {
+        tokio::spawn(async move {
             let result = renew_expired_key_bundles(manager, rx).await;
 
             match result {
@@ -120,11 +128,11 @@ impl KeyBundleTask {
             }
         });
 
-        Self { tx, handle }
+        Self { tx }
     }
 
     /// Use the returned sender to add and remove space streams.
-    pub fn command_handle(&self) -> mpsc::UnboundedSender<KeyBundleTaskCommand> {
+    pub fn command_handle(&self) -> KeyBundleTaskSender {
         self.tx.clone()
     }
 }
@@ -140,28 +148,6 @@ pub enum KeyBundleTaskCommand {
 
     /// Remove inactive / closed stream from the list.
     RemoveStream(SpaceId),
-}
-
-async fn publish_member_message(
-    operation: Operation,
-    space_id: &SpaceId,
-    import_local_tx: &ImportLocalTx,
-) -> bool {
-    let stream = Box::pin(futures_util::stream::once(async { operation }));
-
-    // We don't need to await the result.
-    let (ready_tx, _) = oneshot::channel::<LocalStreamFuture>();
-
-    if let Err(err) = import_local_tx.send((stream, ready_tx)).await {
-        debug!(
-            space_id = %space_id.fmt_short(),
-            "sending member message failed due to error: {err}"
-        );
-
-        return false;
-    }
-
-    true
 }
 
 async fn renew_expired_key_bundles(
@@ -188,12 +174,13 @@ async fn renew_expired_key_bundles(
                     continue;
                 }
 
-                debug!(
-                    spaces_streams_len = spaces_streams.len(),
-                    "key bundle expired, automatically generate new one"
-                );
-
                 let operation = manager.key_bundle_message().await?.into_operation();
+
+                debug!(
+                    active_streams = spaces_streams.len(),
+                    seq_num = operation.header.seq_num,
+                    "key bundle non-existent or expired, automatically generate new one"
+                );
 
                 let mut failed_sends = Vec::new();
 
@@ -235,29 +222,124 @@ async fn renew_expired_key_bundles(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use p2panda_core::test_utils::setup_logging;
-    use p2panda_store::SqliteStore;
+async fn publish_member_message(
+    operation: Operation,
+    space_id: &SpaceId,
+    import_local_tx: &ImportLocalTx,
+) -> bool {
+    let stream = Box::pin(futures_util::stream::once(async { operation }));
 
-    use crate::Credentials;
-    use crate::forge::OperationForge;
-    use crate::streams::TaskTracker;
+    // We don't need to await the result.
+    let (ready_tx, _) = oneshot::channel::<LocalStreamFuture>();
 
-    use super::KeyBundleTask;
+    if let Err(err) = import_local_tx.send((stream, ready_tx)).await {
+        debug!(
+            space_id = %space_id.fmt_short(),
+            "sending member message failed due to error: {err}"
+        );
 
-    #[tokio::test]
-    async fn inform_spaces_about_new_key_bundles() {
-        setup_logging();
+        return false;
+    }
 
-        let spaces_manager = {
-            let store = SqliteStore::temporary().await;
-            let tasks = TaskTracker::new();
-            let credentials = Credentials::generate();
-            let forge = OperationForge::new(credentials.clone(), store.clone());
-            crate::spaces::spaces_manager(forge, credentials, store.clone()).unwrap()
+    true
+}
+
+/// Associate member log's by observing spaces events.
+///
+/// This helps with the following problem:
+///
+/// ```text
+/// Peer A creates space S with B, C, D
+///   A associates their member log to S
+/// Peer B joins space S
+///   B associates their member log to S
+/// Peer B wants to remove C
+///
+/// --> Peer B needs to inform A & D about the new secret but doesn't have the member log of D yet.
+/// ```
+///
+/// If Peer B would already associate D's member log when they've observed the CREATE event they
+/// would have had a chance to receive it from A. This hook makes sure that the association takes
+/// place.
+pub async fn associate_members(
+    my_node_id: VerifyingKey,
+    store: &SqliteStore,
+    events: &[p2panda_spaces::Event<AuthCapabilities>],
+) -> Option<(SpaceId, Vec<MemberId>)> {
+    for event in events {
+        let p2panda_spaces::Event::Spaces(space_event) = event else {
+            continue;
         };
 
-        let task = KeyBundleTask::spawn(spaces_manager);
+        let (space_id, context) = match space_event {
+            p2panda_spaces::SpaceEvent::Created {
+                space_id, context, ..
+            } => (space_id, context),
+            p2panda_spaces::SpaceEvent::Added {
+                space_id, context, ..
+            } => (space_id, context),
+            _ => continue,
+        };
+
+        // We have to look at _current_ members instead of only the added ones since we might not
+        // process all events from the beginning, especially if we've been added later to the group.
+        let members = &context.members;
+
+        if let Err(err) = associate_members_inner(store, space_id, members).await {
+            error!(
+                my_node_id = %my_node_id.fmt_short(),
+                space_id = %space_id.fmt_short(),
+                "member association failed: {err}"
+            );
+        } else {
+            debug!(
+                my_node_id = %my_node_id.fmt_short(),
+                space_id = %space_id.fmt_short(),
+                "associate {} member logs", members.len()
+            );
+        }
+    }
+
+    None
+}
+
+async fn associate_members_inner(
+    store: &SqliteStore,
+    space_id: &SpaceId,
+    members: &[(VerifyingKey, Access)],
+) -> Result<(), SqliteError> {
+    tx!(store, {
+        for (id, _) in members {
+            store.associate(space_id, id, &member_log_id()).await?;
+        }
+    });
+
+    Ok(())
+}
+
+/// Pipeline hook to observe spaces events and automatically associate member logs to the space when
+/// someone new was added.
+pub struct MemberAssociationHook {
+    my_node_id: NodeId,
+    store: SqliteStore,
+}
+
+impl MemberAssociationHook {
+    pub fn new(my_node_id: NodeId, store: SqliteStore) -> Self {
+        Self { my_node_id, store }
+    }
+}
+
+impl ProcessorHook<Event> for MemberAssociationHook {
+    async fn on_input(&self, input: &Event) {
+        let crate::processor::ProcessorStatus::Completed(ref result) = input.spaces else {
+            return;
+        };
+
+        let p2panda_stream::spaces::SpacesResult::Processed { events } = result else {
+            return;
+        };
+
+        associate_members(self.my_node_id, &self.store, events).await;
     }
 }

--- a/p2panda/src/spaces/member.rs
+++ b/p2panda/src/spaces/member.rs
@@ -434,3 +434,128 @@ impl ProcessorHook<Event> for MemberAssociationHook {
         associate_members(self.my_node_id, &self.store, events).await;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use p2panda_core::test_utils::setup_logging;
+    use p2panda_core::{Topic, VerifyingKey};
+    use p2panda_spaces::Config;
+    use p2panda_store::SqliteStore;
+    use p2panda_store::logs::LogStore;
+    use tokio::sync::mpsc;
+    use tokio_stream::StreamExt;
+
+    use crate::Credentials;
+    use crate::forge::OperationForge;
+    use crate::operation::Operation;
+    use crate::spaces::forge::member_log_id;
+
+    use super::{KeyBundleTask, KeyBundleTaskCommand};
+
+    async fn get_op_count(store: &SqliteStore, verifying_key: VerifyingKey) -> u32 {
+        let result = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_log_size(
+            store,
+            &verifying_key,
+            &member_log_id(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        result.map(|(op_count, _)| op_count).unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn ensure_key_bundle_after_spawn() {
+        setup_logging();
+
+        let credentials = Credentials::generate();
+        let store = SqliteStore::temporary().await;
+
+        let spaces_manager = {
+            let forge = OperationForge::new(credentials.clone(), store.clone());
+            crate::spaces::spaces_manager(
+                forge,
+                credentials.clone(),
+                store.clone(),
+                Config::default(),
+            )
+            .unwrap()
+        };
+
+        // 1. At start the member's log is empty.
+        assert_eq!(get_op_count(&store, credentials.verifying_key()).await, 0);
+
+        // 2. We launch the background task and expect a first key bundle to be published
+        //    automatically in the member's log.
+        let _task = KeyBundleTask::spawn(spaces_manager.clone()).await;
+        assert_eq!(get_op_count(&store, credentials.verifying_key()).await, 1);
+
+        // 3. The key bundle exists and is valid. Calling "me" doesn't generate a new one.
+        let key_bundle = spaces_manager.me().await.unwrap();
+        assert!(key_bundle.verify().is_ok());
+        assert_eq!(get_op_count(&store, credentials.verifying_key()).await, 1);
+    }
+
+    #[tokio::test]
+    async fn inform_active_spaces_about_new_key_bundles() {
+        setup_logging();
+
+        let credentials = Credentials::generate();
+        let store = SqliteStore::temporary().await;
+
+        let spaces_manager = {
+            let forge = OperationForge::new(credentials.clone(), store.clone());
+            crate::spaces::spaces_manager(
+                forge,
+                credentials.clone(),
+                store.clone(),
+                // Key bundles should expire before our background task checks next.
+                Config {
+                    pre_key_lifetime: Duration::from_millis(2000),
+                    pre_key_rotate_after: Duration::from_millis(1000),
+                },
+            )
+            .unwrap()
+        };
+
+        // 1. Spawn background task and register a mock spaces stream to it. We don't expect this
+        //    stream to receive any key bundles yet as they were added _afterwards_.
+        let task =
+            KeyBundleTask::spawn_with_frequency(spaces_manager.clone(), Duration::from_millis(300))
+                .await;
+        let handle = task.command_handle();
+
+        let space_id = Topic::random();
+        let (import_tx, mut import_rx) = mpsc::channel(16);
+        let _ = handle.send(KeyBundleTaskCommand::AddStream(space_id.into(), import_tx));
+
+        assert!(import_rx.is_empty());
+        assert_eq!(get_op_count(&store, credentials.verifying_key()).await, 1);
+
+        // 2. Background task is going into next cycle which will cause generation of new key
+        //    bundle. We expect all currently active streams (in "live-mode") to be informed about
+        //    this update.
+        let (mut import_stream, _) = import_rx.recv().await.expect("import stream exists");
+        let operation = import_stream.next().await.expect("an operation was forged");
+
+        let member_msg = match operation
+            .header
+            .extensions
+            .spaces_args()
+            .expect("spaces args in header")
+        {
+            p2panda_spaces::SpacesArgs::Member(member) => member,
+            _ => panic!("expected spaces args to be of type 'member'"),
+        };
+        assert!(member_msg.verify().is_ok());
+
+        let expected_member_msg = spaces_manager.me().await.unwrap();
+        // Compare key-bundles since every member instance will be generated with a new signature
+        // and is therefore not equal.
+        assert_eq!(expected_member_msg.key_bundle(), member_msg.key_bundle());
+        assert_eq!(get_op_count(&store, credentials.verifying_key()).await, 2);
+    }
+}

--- a/p2panda/src/spaces/member.rs
+++ b/p2panda/src/spaces/member.rs
@@ -1,13 +1,22 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use p2panda_spaces::ActorId;
+use std::collections::HashMap;
+use std::time::Duration;
+
+use p2panda_core::traits::ShortFormat;
+use p2panda_spaces::{ActorId, SpaceId};
 use thiserror::Error;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tracing::{debug, error};
 
+use crate::operation::Operation;
 use crate::spaces::Group;
-use crate::spaces::types::{InnerMember, SpacesManagerError};
+use crate::spaces::types::{InnerMember, SpacesManager, SpacesManagerError};
+use crate::streams::{ImportLocalTx, LocalStreamFuture};
 
-// TODO: Needs to provide safety methods to authenticate this member, check if the verifying key &
-// key bundle is authentic + that they belong together.
+const CHECK_KEY_BUNDLE_FREQUENCY: Duration = Duration::from_mins(15);
+
 #[derive(Debug)]
 pub struct Member {
     pub(crate) inner: InnerMember,
@@ -84,4 +93,171 @@ impl From<GroupActor> for ActorId {
 pub enum MemberError {
     #[error(transparent)]
     Manager(#[from] SpacesManagerError),
+}
+
+/// Background task to automatically publish a new member message into all registered space streams if
+/// the associated key bundle is about to expire.
+pub struct KeyBundleTask {
+    tx: mpsc::UnboundedSender<KeyBundleTaskCommand>,
+    handle: JoinHandle<()>,
+}
+
+impl KeyBundleTask {
+    /// Spawn key bundle background task.
+    pub fn spawn(manager: SpacesManager) -> Self {
+        debug!("key bundle management task started");
+
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        let handle = tokio::spawn(async move {
+            let result = renew_expired_key_bundles(manager, rx).await;
+
+            match result {
+                Ok(_) => debug!("key bundle management task ended"),
+                Err(ref err) => {
+                    error!("failed task to automatically renew key bundles: {}", err);
+                }
+            }
+        });
+
+        Self { tx, handle }
+    }
+
+    /// Use the returned sender to add and remove space streams.
+    pub fn command_handle(&self) -> mpsc::UnboundedSender<KeyBundleTaskCommand> {
+        self.tx.clone()
+    }
+}
+
+/// Command for key bundle management task.
+#[derive(Debug)]
+pub enum KeyBundleTaskCommand {
+    /// Add a new spaces stream to list.
+    ///
+    /// The task will automatically publish "member" messages with the newly generated key bundle
+    /// into each stream in the list when the current key bundle is about to expire.
+    AddStream(SpaceId, ImportLocalTx),
+
+    /// Remove inactive / closed stream from the list.
+    RemoveStream(SpaceId),
+}
+
+async fn publish_member_message(
+    operation: Operation,
+    space_id: &SpaceId,
+    import_local_tx: &ImportLocalTx,
+) -> bool {
+    let stream = Box::pin(futures_util::stream::once(async { operation }));
+
+    // We don't need to await the result.
+    let (ready_tx, _) = oneshot::channel::<LocalStreamFuture>();
+
+    if let Err(err) = import_local_tx.send((stream, ready_tx)).await {
+        debug!(
+            space_id = %space_id.fmt_short(),
+            "sending member message failed due to error: {err}"
+        );
+
+        return false;
+    }
+
+    true
+}
+
+async fn renew_expired_key_bundles(
+    manager: SpacesManager,
+    mut rx: mpsc::UnboundedReceiver<KeyBundleTaskCommand>,
+) -> Result<(), SpacesManagerError> {
+    // Keep a list of all spaces streams where we publish the new "member" message into when a key
+    // bundle is about to expire.
+    //
+    // TODO: Instead of this space id -> import stream association the whole thing should be it's
+    // own object (something like an "local import handle"), we should be able to create one
+    // directly from a stream object.
+    let mut spaces_streams: HashMap<SpaceId, ImportLocalTx> = HashMap::new();
+
+    // The interval always fires at start, later in the given frequency. This assures that we always
+    // check the current key bundle at least once on process start.
+    let mut interval = tokio::time::interval(CHECK_KEY_BUNDLE_FREQUENCY);
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = interval.tick() => {
+                if !manager.key_bundle_expired().await? {
+                    continue;
+                }
+
+                debug!(
+                    spaces_streams_len = spaces_streams.len(),
+                    "key bundle expired, automatically generate new one"
+                );
+
+                let operation = manager.key_bundle_message().await?.into_operation();
+
+                let mut failed_sends = Vec::new();
+
+                for (space_id, import_local_tx) in spaces_streams.iter() {
+                    let success = publish_member_message(
+                        operation.clone(),
+                        space_id,
+                        import_local_tx,
+                    )
+                    .await;
+
+                    if !success {
+                        failed_sends.push(*space_id);
+                    }
+                }
+
+                // Automatically remove streams from list where sending message failed.
+                for space_id in failed_sends.iter() {
+                    spaces_streams.remove(space_id);
+                }
+            }
+
+            command = rx.recv() => {
+                let Some(command) = command else {
+                    // Stop task when all senders were dropped.
+                    return Ok(());
+                };
+
+                match command {
+                    KeyBundleTaskCommand::AddStream(space_id, import_local_tx) => {
+                        spaces_streams.insert(space_id, import_local_tx);
+                    },
+                    KeyBundleTaskCommand::RemoveStream(space_id) => {
+                        spaces_streams.remove(&space_id);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p2panda_core::test_utils::setup_logging;
+    use p2panda_store::SqliteStore;
+
+    use crate::Credentials;
+    use crate::forge::OperationForge;
+    use crate::streams::TaskTracker;
+
+    use super::KeyBundleTask;
+
+    #[tokio::test]
+    async fn inform_spaces_about_new_key_bundles() {
+        setup_logging();
+
+        let spaces_manager = {
+            let store = SqliteStore::temporary().await;
+            let tasks = TaskTracker::new();
+            let credentials = Credentials::generate();
+            let forge = OperationForge::new(credentials.clone(), store.clone());
+            crate::spaces::spaces_manager(forge, credentials, store.clone()).unwrap()
+        };
+
+        let task = KeyBundleTask::spawn(spaces_manager);
+    }
 }

--- a/p2panda/src/spaces/member.rs
+++ b/p2panda/src/spaces/member.rs
@@ -1,5 +1,44 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Members who are part of an encrypted space.
+//!
+//! They are authors who can publish application messages into a space (when they have "write"
+//! access) and / or decrypt incoming ones (when they have "read" access).
+//!
+//! Every member is identified by its verification key (Ed25519). For initial key-agreement we
+//! internally use Signal's X3DH which requires an additional identity key (xEdDSA) and a pre-key
+//! (X25519).
+//!
+//! ## Key bundles
+//!
+//! Key bundles are used across all spaces to add a member or inform them about a new group secret
+//! for the first time. This means that _any_ current member of a group which introduces the first
+//! or a new group secret (via a CREATE, REMOVE or UPDATE) needs to have everyone else's key bundles
+//! available if these two members have never exchanged any secrets yet.
+//!
+//! NOTE: This rule currently applies to each space separately, we are currently looking into
+//! sharing this "two party" / X3DH key agreement state across all spaces, so we only need to do an
+//! initial key agreement with a key bundle _once_ per pair of members across all spaces.
+//!
+//! See related issue: <https://github.com/p2panda/p2panda/issues/1346>
+//!
+//! ## Exchanging key bundles
+//!
+//! The pre-key is published in form of a key bundle in the member's own log. This log is dedicated
+//! to only these kinds of messages.
+//!
+//! Alternatively they can also be shared "offchain" in a side-channel, for example via a QR code
+//! etc. to increase privacy.
+//!
+//! ## Expiring key bundles
+//!
+//! Key bundles expire after a configured number of days and need to be renewed for forward secrecy.
+//! All connected spaces have to be able to sync the new key bundles.
+//!
+//! ## Space association
+//!
+//! Since this log is maintained independent of a particular space we need to explicitly associate
+//! it when the space starts to depend on the member's key bundles.
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -96,15 +135,13 @@ impl From<GroupActor> for ActorId {
 }
 
 #[derive(Debug, Error)]
-pub enum MemberError {
-    #[error(transparent)]
-    Manager(#[from] SpacesManagerError),
-}
+#[error(transparent)]
+pub struct MemberError(#[from] SpacesManagerError);
 
 pub type KeyBundleTaskSender = mpsc::UnboundedSender<KeyBundleTaskCommand>;
 
-/// Background task to automatically publish a new member message into all registered space streams if
-/// the associated key bundle is about to expire.
+/// Background task to automatically publish a new member message into all currently active space
+/// streams if the associated key bundle is about to expire.
 #[derive(Clone, Debug)]
 pub struct KeyBundleTask {
     tx: KeyBundleTaskSender,
@@ -131,7 +168,7 @@ impl KeyBundleTask {
         Self { tx }
     }
 
-    /// Use the returned sender to add and remove space streams.
+    /// Use the returned sender to add and remove active space streams.
     pub fn command_handle(&self) -> KeyBundleTaskSender {
         self.tx.clone()
     }
@@ -144,6 +181,10 @@ pub enum KeyBundleTaskCommand {
     ///
     /// The task will automatically publish "member" messages with the newly generated key bundle
     /// into each stream in the list when the current key bundle is about to expire.
+    ///
+    /// This allows currently connected nodes to directly receive these messages in "live-mode" as
+    /// they get eagerly pushed towards them. Offline nodes will pick them up later as part of the
+    /// regular sync protocol.
     AddStream(SpaceId, ImportLocalTx),
 
     /// Remove inactive / closed stream from the list.

--- a/p2panda/src/spaces/mod.rs
+++ b/p2panda/src/spaces/mod.rs
@@ -22,6 +22,9 @@ pub use group::{
     AddGroupMemberError, Group, GroupError, GroupEvent, GroupFuture, RemoveGroupMemberError,
 };
 pub use member::{GroupActor, Member, MemberError};
+pub(crate) use member::{
+    KeyBundleTask, KeyBundleTaskCommand, KeyBundleTaskSender, MemberAssociationHook,
+};
 pub(crate) use repair::{DEFAULT_REPAIR_STRATEGY, RepairError, RepairTask};
 pub(crate) use space::spaces_stream;
 pub use space::{

--- a/p2panda/src/spaces/mod.rs
+++ b/p2panda/src/spaces/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod types;
 
 use p2panda_auth::Access;
 use p2panda_core::Topic;
+use p2panda_spaces::Config;
 use p2panda_store::SqliteStore;
 
 // Re-export useful types.
@@ -42,6 +43,7 @@ pub fn spaces_manager(
     forge: OperationForge,
     credentials: Credentials,
     store: SqliteStore,
+    config: Config,
 ) -> Result<SpacesManager, SpacesManagerError> {
     use p2panda_encryption::Rng;
 
@@ -50,7 +52,7 @@ pub fn spaces_manager(
     let rng = Rng::default();
     let spaces_store = SpacesStore::new(store.clone());
 
-    SpacesManager::new(spaces_store, forge, (&credentials).into(), rng)
+    SpacesManager::new_with_config(spaces_store, forge, (&credentials).into(), config, rng)
 }
 
 pub(crate) fn actor_to_topic(actor_id: impl Into<ActorId>) -> Topic {

--- a/p2panda/src/spaces/mod.rs
+++ b/p2panda/src/spaces/mod.rs
@@ -18,7 +18,7 @@ pub use p2panda_auth::AccessLevel;
 pub use p2panda_spaces::manager::ManagerError;
 pub use p2panda_spaces::{ActorId, GroupContext, GroupId, MemberId, SpaceContext, SpaceId};
 
-pub(crate) use forge::{MEMBER_CONTROL_MESSAGE, group_log_id};
+pub(crate) use forge::{group_log_id, member_log_id};
 pub use group::{
     AddGroupMemberError, Group, GroupError, GroupEvent, GroupFuture, RemoveGroupMemberError,
 };

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -51,9 +51,6 @@ pub(crate) fn spaces_stream<M>(
     )
 }
 
-// TODO: We need a way to automatically publish key bundles (if configured, it should also be an
-// option to _not_ do that to only allow initial key agreement through side channels which is more
-// private).
 #[derive(Debug)]
 pub struct Space<M> {
     inner: InnerSpace,
@@ -260,17 +257,19 @@ where
         messages: [SpacesMessage; 2],
         events: Vec<Event<AuthCapabilities>>,
     ) -> Result<(), ProcessError> {
-        let permit = self.store.begin().await?;
-
         // Persist the computed groups and spaces state to the stores.
-        self.store
-            .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
-            .await?;
-        self.store
-            .set_space_state_tx(&self.id(), &SpacesStoreState::from(space_y))
-            .await?;
+        {
+            let permit = self.store.begin().await?;
 
-        self.store.commit(permit).await?;
+            self.store
+                .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
+                .await?;
+            self.store
+                .set_space_state_tx(&self.id(), &SpacesStoreState::from(space_y))
+                .await?;
+
+            self.store.commit(permit).await?;
+        }
 
         let processed = self
             .tx

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -14,10 +14,10 @@ use p2panda_core::cbor::{EncodeError, encode_cbor};
 use p2panda_core::traits::ShortFormat;
 use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
 use p2panda_spaces::space::SpacesState;
-use p2panda_spaces::{ActorId, AuthGroupState, Event, MemberId, SpaceId, SpacesStoreState};
+use p2panda_spaces::{ActorId, AuthGroupState, MemberId, SpaceId, SpacesStoreState};
 use p2panda_store::groups::GroupsStore;
 use p2panda_store::spaces::{SpacesStore, SqliteSpacesStore};
-use p2panda_store::{SqliteError, SqliteStore, Transaction};
+use p2panda_store::{SqliteError, SqliteStore, tx};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::oneshot;
@@ -25,6 +25,7 @@ use tokio::sync::oneshot::error::RecvError;
 use tracing::error;
 
 use crate::operation::Extensions;
+use crate::spaces::member::associate_members;
 use crate::spaces::message::SpacesMessage;
 use crate::spaces::types::{AuthCapabilities, InnerSpace, InnerSpaceError, SpacesManagerError};
 use crate::spaces::{KeyBundleTaskCommand, KeyBundleTaskSender, RepairError, RepairTask};
@@ -55,7 +56,7 @@ where
     (
         Space {
             inner,
-            store: SqliteSpacesStore::new(store),
+            store,
             repair_task,
             key_bundle_task_tx,
             tx,
@@ -70,7 +71,7 @@ where
     M: Serialize,
 {
     inner: InnerSpace,
-    store: SqliteSpacesStore<Extensions>,
+    store: SqliteStore,
     repair_task: RepairTask,
     key_bundle_task_tx: KeyBundleTaskSender,
     tx: StreamPublisher<M>,
@@ -283,21 +284,24 @@ where
         groups_y: AuthGroupState<AuthCapabilities>,
         space_y: SpacesState<AuthCapabilities>,
         messages: [SpacesMessage; 2],
-        events: Vec<Event<AuthCapabilities>>,
+        events: Vec<p2panda_spaces::Event<AuthCapabilities>>,
     ) -> Result<(), ProcessError> {
-        // Persist the computed groups and spaces state to the stores.
-        {
-            let permit = self.store.begin().await?;
+        // Associate member logs with this space. This is equivalent to the member association hook
+        // which is registered on the event processing pipeline. Since locally issued events are not
+        // going through the pipeline, we have to repeat it here as well.
+        associate_members(self.inner.me(), &self.store, &events).await;
 
-            self.store
+        let spaces_store = SqliteSpacesStore::<Extensions>::new(self.store.clone());
+
+        tx!(spaces_store, {
+            // Persist the computed groups and spaces state to the stores.
+            spaces_store
                 .set_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID), &groups_y)
                 .await?;
-            self.store
+            spaces_store
                 .set_space_state_tx(&self.id(), &SpacesStoreState::from(space_y))
                 .await?;
-
-            self.store.commit(permit).await?;
-        }
+        });
 
         let processed = self
             .tx

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -22,11 +22,12 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::RecvError;
+use tracing::error;
 
 use crate::operation::Extensions;
 use crate::spaces::message::SpacesMessage;
 use crate::spaces::types::{AuthCapabilities, InnerSpace, InnerSpaceError, SpacesManagerError};
-use crate::spaces::{RepairError, RepairTask};
+use crate::spaces::{KeyBundleTaskCommand, KeyBundleTaskSender, RepairError, RepairTask};
 use crate::streams::{
     CloseError, ImportError, LocalStreamFuture, StreamEvent, StreamPublisher, StreamSubscription,
     to_stream_event, to_system_event,
@@ -37,14 +38,26 @@ pub(crate) fn spaces_stream<M>(
     inner: InnerSpace,
     store: SqliteStore,
     repair_task: RepairTask,
+    key_bundle_task_tx: KeyBundleTaskSender,
     tx: StreamPublisher<M>,
     rx: StreamSubscription<M>,
-) -> (Space<M>, SpaceSubscription<M>) {
+) -> (Space<M>, SpaceSubscription<M>)
+where
+    M: Serialize,
+{
+    if let Err(err) = key_bundle_task_tx.send(KeyBundleTaskCommand::AddStream(
+        inner.id(),
+        tx.import_local_tx.clone(),
+    )) {
+        error!(space_id = %inner.id(), "failed adding stream to key bundle task: {err}");
+    }
+
     (
         Space {
             inner,
             store: SqliteSpacesStore::new(store),
             repair_task,
+            key_bundle_task_tx,
             tx,
         },
         SpaceSubscription { rx },
@@ -52,11 +65,26 @@ pub(crate) fn spaces_stream<M>(
 }
 
 #[derive(Debug)]
-pub struct Space<M> {
+pub struct Space<M>
+where
+    M: Serialize,
+{
     inner: InnerSpace,
     store: SqliteSpacesStore<Extensions>,
     repair_task: RepairTask,
+    key_bundle_task_tx: KeyBundleTaskSender,
     tx: StreamPublisher<M>,
+}
+
+impl<M> Drop for Space<M>
+where
+    M: Serialize,
+{
+    fn drop(&mut self) {
+        let _ = self
+            .key_bundle_task_tx
+            .send(KeyBundleTaskCommand::RemoveStream(self.id()));
+    }
 }
 
 impl<M> Space<M>

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -446,6 +446,8 @@ pub(crate) async fn process_operation_in(
     let prune_flag = operation.header.extensions.prune_flag();
     let spaces_args = operation.header.extensions.spaces_args();
 
+    // TODO: Using the Source here to determine live-mode behaviour is not explicit enough and might
+    // lead to errors.
     match source {
         Source::ExternalStream { .. } | Source::LocalStore
             // Try pushing operation to other nodes if we have an active and "live" sync session

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -1124,3 +1124,108 @@ mod filtered_messages {
         }
     }
 }
+
+mod members {
+    use p2panda::Topic;
+    use p2panda::streams::StreamEvent;
+    use p2panda_auth::AccessLevel;
+    use p2panda_core::test_utils::setup_logging;
+    use tokio_stream::StreamExt;
+
+    // 1. Node A creates space S with {A, B, C, D} inside
+    // 2. Node B removes C from S
+    //
+    // Node B needs to inform A & D about the new secret after removing C and needs a key bundle of
+    // D to do that. If all member logs are correctly associated, B should have received it
+    // indirectly via A.
+    #[tokio::test]
+    async fn indirect_members_log_sync() {
+        setup_logging();
+
+        let topic = Topic::random();
+
+        let node_a = p2panda::spawn().await.unwrap();
+        let node_b = p2panda::spawn().await.unwrap();
+        let node_c = p2panda::spawn().await.unwrap();
+        let node_d = p2panda::spawn().await.unwrap();
+
+        let (node_a_space, mut node_a_rx) = node_a.create_space::<String>(topic).await.unwrap();
+
+        // Nodes C and D come online to sync their member logs with A. Node A will from now on
+        // "carry" their logs. We will shut down C and D directly afterwards to make sure this is
+        // ensured and A stays the only source of C or D's key bundle in the network.
+        let (node_c_space, node_c_rx) = node_c.space::<String>(topic).await.unwrap();
+        let (node_d_space, node_d_rx) = node_d.space::<String>(topic).await.unwrap();
+
+        let mut required_key_bundles = vec![node_c.id(), node_d.id()];
+
+        while let Some(event) = node_a_rx.next().await {
+            let StreamEvent::Member(member_id) = event else {
+                continue;
+            };
+
+            required_key_bundles.retain(|id| &member_id != id);
+
+            if required_key_bundles.is_empty() {
+                break;
+            }
+        }
+
+        drop(node_c_space);
+        drop(node_c_rx);
+
+        drop(node_d_space);
+        drop(node_d_rx);
+
+        // Node A brings everyone into the space. The space has the members {A, B, C, D} now.
+        node_a
+            .register_member(node_b.me().await.unwrap())
+            .await
+            .unwrap();
+
+        node_a_space
+            .add(node_b.id(), AccessLevel::Manage)
+            .await
+            .unwrap();
+
+        node_a_space
+            .add(node_c.id(), AccessLevel::Write)
+            .await
+            .unwrap();
+
+        node_a_space
+            .add(node_d.id(), AccessLevel::Write)
+            .await
+            .unwrap();
+
+        // Wait until B finished processing being added to the space and received all required
+        // key bundles AND got informed about all other members (C and D) being added.
+        let (node_b_space, mut node_b_rx) = node_b.space::<String>(topic).await.unwrap();
+
+        let mut required_key_bundles = vec![node_a.id(), node_d.id()];
+        let mut required_adds = vec![node_b.id(), node_c.id(), node_d.id()];
+
+        while let Some(event) = node_b_rx.next().await {
+            match event {
+                StreamEvent::Space { members, .. } => {
+                    for (member_id, _) in members {
+                        required_adds.retain(|id| &member_id != id);
+                    }
+                }
+                StreamEvent::Member(member_id) => {
+                    required_key_bundles.retain(|id| &member_id != id);
+                }
+                _ => continue,
+            }
+
+            if required_key_bundles.is_empty() && required_adds.is_empty() {
+                break;
+            }
+        }
+
+        // B wants to remove C and needs the key bundles of D to do this since they've never sent a
+        // direct message to D. Note that B doesn't need a key bundle for A because A already
+        // initiated a 2SM session with B when they've been added to the space.
+        node_b_space.remove(node_c.id()).await.unwrap();
+    }
+}


### PR DESCRIPTION
This PR improves the efficiency of published "member" messages which contain X3DH key bundles, used for initial key-agreement.

Messages are only published when key bundles expire or do not exist yet. We introduce a background task here which gets spawned on application start to assure that this is happening, even when the applications runs for many weeks.

Nodes who are offline will pick up the latest key bundles during sync. Online nodes receive them via "live-mode".

Another important aspect is the association of member logs with a space. This is done when a space is created or joined. Additionally we need to associate _other members_ logs by observing spaces events with a new processor hook, in particular CREATE and ADD events.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
