### PR TITLE
Inform users of application messages "invalidated" by concurrent removal

### DIFF
--- a/p2panda-auth/src/graph.rs
+++ b/p2panda-auth/src/graph.rs
@@ -57,7 +57,7 @@ where
 ///
 /// Operations are considered concurrent if they are neither predecessors nor successors of the
 /// target operation.
-fn concurrent_operations<OP>(graph: &DiGraphMap<OP, ()>, target: OP) -> HashSet<OP>
+pub fn concurrent_operations<OP>(graph: &DiGraphMap<OP, ()>, target: OP) -> HashSet<OP>
 where
     OP: OperationId + Ord,
 {

--- a/p2panda-auth/src/group/crdt/mod.rs
+++ b/p2panda-auth/src/group/crdt/mod.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::access::Access;
+use crate::graph::concurrent_operations;
 use crate::group::{GroupAction, GroupMember, GroupMembersState, GroupMembershipError};
 use crate::traits::{Conditions, IdentityHandle, Operation, OperationId, Resolver};
 
@@ -388,6 +389,10 @@ where
         }
 
         false
+    }
+
+    pub fn concurrent_operations(&self, id: OP) -> HashSet<OP> {
+        concurrent_operations(&self.graph, id)
     }
 }
 

--- a/p2panda-spaces/src/encryption/orderer.rs
+++ b/p2panda-spaces/src/encryption/orderer.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::convert::Infallible;
 
+use p2panda_auth::graph::concurrent_operations;
 use p2panda_encryption::crypto::xchacha20::XAeadNonce;
 use p2panda_encryption::data_scheme::GroupSecretId;
 use p2panda_encryption::traits::GroupMessage;
@@ -99,6 +100,25 @@ impl EncryptionOrdererState {
     /// Has the orderer seen a certain message.
     pub fn has_seen(&self, id: OperationId) -> bool {
         self.graph.contains_node(id)
+    }
+
+    /// Returns ids of any application messages concurrent to the target operation.
+    pub fn concurrent_application_messages(&self, id: OperationId) -> Vec<OperationId> {
+        let concurrent = concurrent_operations(&self.graph, id);
+        concurrent
+            .into_iter()
+            .filter(|id| {
+                let message = self.messages.get(id).unwrap();
+                if let EncryptionMessage::Forged {
+                    args: EncryptionArgs::Application { .. },
+                    ..
+                } = message
+                {
+                    return true;
+                }
+                false
+            })
+            .collect()
     }
 }
 

--- a/p2panda-spaces/src/event.rs
+++ b/p2panda-spaces/src/event.rs
@@ -10,11 +10,12 @@ use p2panda_core::VerifyingKey;
 use crate::auth::message::AuthMessage;
 use crate::member::Member;
 use crate::message::SpaceMembershipMessage;
+use crate::space::SpacesState;
 use crate::types::{AuthGroupAction, AuthGroupState, EncryptionGroupOutput};
 use crate::utils::{
     added_members, demoted_members, promoted_members, removed_members, sort_members,
 };
-use crate::{ActorId, GroupId, MemberId, SpaceId};
+use crate::{ActorId, GroupId, MemberId, OperationId, SpaceId};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GroupActor {
@@ -286,6 +287,9 @@ pub enum SpaceEvent<C> {
 
         /// Additional event context and group state after any change occurred.
         groups_context: GroupContext<C>,
+
+        /// Effected concurrent application messages.
+        effected_application_messages: Vec<OperationId>,
     },
 
     /// One or many individuals were promoted in the space.
@@ -316,6 +320,11 @@ pub enum SpaceEvent<C> {
 
         /// Additional event context and group state after any change occurred.
         groups_context: GroupContext<C>,
+
+        /// Effected concurrent application messages.
+        ///
+        /// Will only ever be populated if member was demoted to below "write" access.
+        effected_application_messages: Vec<OperationId>,
     },
 
     /// Local actor was removed from the space.
@@ -388,9 +397,7 @@ where
 }
 
 pub(crate) fn to_space_event<C>(
-    space_id: SpaceId,
-    group_id: GroupId,
-    auth_y: &AuthGroupState<C>,
+    y: &SpacesState<C>,
     space_message: &SpaceMembershipMessage,
     auth_message: &AuthMessage<C>,
     previous_members: &[(MemberId, Access<C>)],
@@ -399,8 +406,11 @@ pub(crate) fn to_space_event<C>(
 where
     C: Conditions,
 {
-    let next_members = &auth_y.members(group_id);
-    let next_actors: Vec<_> = auth_y
+    let space_id = y.space_id;
+    let group_id = y.group_id;
+    let next_members = &y.groups_y.members(group_id);
+    let next_actors: Vec<_> = y
+        .groups_y
         .root_members(group_id)
         .into_iter()
         .map(|(member, access)| (GroupActor::from_group_member(member), access))
@@ -411,7 +421,7 @@ where
         members: next_members.to_vec(),
         actors: next_actors,
     };
-    let groups_context = groups_context(auth_y, auth_message, previous_ancestors);
+    let groups_context = groups_context(&y.groups_y, auth_message, previous_ancestors);
 
     let space_event = match auth_message.action() {
         AuthGroupAction::Create { .. } => SpaceEvent::Created {
@@ -431,11 +441,23 @@ where
         }
         AuthGroupAction::Remove { .. } => {
             let removed = removed_members(previous_members, next_members);
+            // If this is a remove message we need to collect any concurrent application messages
+            // which may be effected by the change.
+            let removed_authors: Vec<VerifyingKey> =
+                removed.iter().map(|(member, _)| *member).collect();
+            let effected_application_messages = detect_concurrent_app_messages(
+                y,
+                space_message.id,
+                auth_message.id(),
+                &removed_authors,
+            );
+
             SpaceEvent::Removed {
                 space_id,
                 removed,
                 context,
                 groups_context,
+                effected_application_messages,
             }
         }
         AuthGroupAction::Promote { .. } => {
@@ -449,16 +471,106 @@ where
         }
         AuthGroupAction::Demote { .. } => {
             let demoted = demoted_members(previous_members, next_members);
+            let non_write_demoted_members: Vec<_> = demoted
+                .iter()
+                .filter_map(|(member, access)| {
+                    if access < &Access::<C>::write() {
+                        Some(*member)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            let effected_application_messages = detect_concurrent_app_messages(
+                y,
+                space_message.id,
+                auth_message.id(),
+                &non_write_demoted_members,
+            );
+
             SpaceEvent::Demoted {
                 space_id,
                 demoted,
                 context,
                 groups_context,
+                effected_application_messages,
             }
         }
     };
 
     Event::Spaces(space_event)
+}
+
+/// Detect any application messages which were authored by a concurrently removed author.
+///
+/// There are two possible concurrency cases to detect, one can be inferred by inspecting the
+/// "proof" (a concrete point in the groups operation graph) an application message carries, the
+/// other by observing concurrency in the space operation graph itself.
+///
+/// Case 1: proof is concurrent
+///
+/// The application message is referring to a proof which is entirely concurrent to the target
+/// remove operation.
+///
+/// ```text
+///    Remove A                              ...          
+///       │                                   │           
+///       │                                   ▼           
+///       │   Add B ◄─────────────────────── App          
+///       │    │            proof             │           
+///       │    ▼                              ▼           
+///       └─► Add A                          ...          
+///            │                              │           
+///            ▼                              ▼           
+///          Group                          Space         
+///                                                                                                          
+/// ```  
+///
+/// Case 2: space operation is concurrent                                                    
+///                                     
+/// The application message is published concurrently to the membership message which incorporated
+/// the target remove into the space.
+///
+/// ```text
+///     Remove A ◄─────────────────────── Membership         
+///       │                                   │              
+///       │                                   ▼              
+///       │   Add B ◄──────────────────── Membership      App
+///       │    │                              │            │
+///       │    ▼                              ▼            │
+///       └─► Add A ◄───────────────────  Membership ◄─────┘
+///            │                              │              
+///            ▼                              ▼              
+///          Group                          Space      
+/// ```      
+fn detect_concurrent_app_messages<C: Conditions>(
+    y: &SpacesState<C>,
+    space_message_id: OperationId,
+    group_message_id: OperationId,
+    removed_authors: &[VerifyingKey],
+) -> Vec<OperationId> {
+    let concurrent_application_messages = y
+        .encryption_y
+        .orderer
+        .concurrent_application_messages(space_message_id);
+    let concurrent_groups_messages = y.groups_y.inner.concurrent_operations(group_message_id);
+    let mut effected_application_messages = vec![];
+    for (id, (author, proofs)) in y.proofs.iter() {
+        if !removed_authors.contains(author) {
+            // This operation author is not effected.
+            continue;
+        };
+
+        // If an application messages refers to _only_ concurrent branches in it's proof
+        // OR the application message was published concurrently to the space message
+        // which incorporated this group change then add it to the effected messages vec.
+        if concurrent_groups_messages.is_superset(proofs)
+            || concurrent_application_messages.contains(id)
+        {
+            effected_application_messages.push(*id);
+        }
+    }
+    effected_application_messages
 }
 
 /// Compute groups context.

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! API for managing members of a space and sending/receiving messages.
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 
 use p2panda_auth::Access;
 use p2panda_auth::group::GroupMember;
 use p2panda_auth::traits::{Conditions, Operation};
 use p2panda_auth::validation::{VerifyClaimedWriteError, verify_claimed_write_access};
-use p2panda_core::traits::{Digest, ShortFormat};
+use p2panda_core::traits::{Digest, Provenance, ShortFormat};
 use p2panda_core::{SigningKey, VerifyingKey};
 use p2panda_encryption::key_manager::KeyManagerState;
 use p2panda_encryption::key_registry::KeyRegistryState;
@@ -509,9 +509,7 @@ where
 
         // Construct space membership event.
         let space_event = to_space_event(
-            y.space_id,
-            y.group_id,
-            &y.groups_y,
+            y,
             space_message,
             auth_message,
             previous_members,
@@ -620,7 +618,15 @@ where
             .orderer
             .add_dependency(encryption_message.id(), &message.space_dependencies);
 
-        // Persist new state.
+        // Store the proof mapping.
+        //
+        // This is used for understanding which application messages are affected by concurrent
+        // member removals.
+        y.proofs.insert(
+            message.id,
+            (message.author, message.proof.iter().cloned().collect()),
+        );
+
         let events = encryption_output_to_space_events(&y.space_id, encryption_output);
 
         Ok(Some((y, events)))
@@ -778,6 +784,7 @@ where
                     group_id,
                     groups_y,
                     encryption_y,
+                    proofs: Default::default(),
                 }
             }
         };
@@ -836,7 +843,7 @@ where
         y.encryption_y = encryption_y;
 
         // Construct space args.
-        let (args, dependencies) = {
+        let (args, dependencies, proof) = {
             let EncryptionMessage::Args(encryption_args) = encryption_args else {
                 panic!("here we're only dealing with local operations");
             };
@@ -850,19 +857,29 @@ where
             else {
                 panic!("unexpected message type");
             };
+            let proof = y.groups_y.heads(&[y.group_id]);
             let args = SpacesArgs::Application {
                 space_id: y.space_id,
                 space_dependencies: dependencies.clone(),
-                proof: y.groups_y.heads(&[y.group_id]),
+                proof: proof.clone(),
                 group_secret_id,
                 nonce,
                 ciphertext,
             };
-            (args, dependencies)
+            (args, dependencies, proof)
         };
 
         // Forge message.
         let message = manager.identity.forge(args).await?;
+
+        // Store the proof mapping.
+        //
+        // This is used for understanding which application messages are affected by concurrent
+        // member removals.
+        y.proofs.insert(
+            message.hash(),
+            (message.author(), proof.into_iter().collect()),
+        );
 
         // Update dependencies.
         y.encryption_y
@@ -997,7 +1014,10 @@ pub struct SpacesState<C> {
     pub group_id: VerifyingKey,
     pub groups_y: AuthGroupState<C>,
     pub encryption_y: EncryptionGroupState,
+    pub proofs: ProofsMap,
 }
+
+pub(crate) type ProofsMap = HashMap<OperationId, (VerifyingKey, HashSet<OperationId>)>;
 
 impl<C> SpacesState<C>
 where
@@ -1010,7 +1030,7 @@ where
     ) -> Self {
         let space_id = space_y.space_id;
         let group_id = space_y.group_id;
-        let (groups_y, encryption_y) =
+        let (groups_y, encryption_y, proofs) =
             space_y.assemble_encryption_state(key_manager_y, key_registry_y);
 
         Self {
@@ -1018,6 +1038,7 @@ where
             group_id,
             groups_y,
             encryption_y,
+            proofs,
         }
     }
 }

--- a/p2panda-spaces/src/store.rs
+++ b/p2panda-spaces/src/store.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::encryption::dgm::EncryptionMembershipState;
 use crate::encryption::orderer::EncryptionOrdererState;
-use crate::space::SpacesState;
+use crate::space::{ProofsMap, SpacesState};
 use crate::types::{AuthGroupState, EncryptionGroupState};
 use crate::{GroupId, MemberId, SpaceId};
 
@@ -34,6 +34,7 @@ pub struct SpacesStoreState<C> {
     // TODO: Verify if this really required here? Maybe ordering is handled on another layer.
     pub orderer: EncryptionOrdererState,
     pub two_party: HashMap<MemberId, TwoPartyState<LongTermKeyBundle>>,
+    pub proofs: ProofsMap,
 }
 
 impl<C> SpacesStoreState<C> {
@@ -41,7 +42,7 @@ impl<C> SpacesStoreState<C> {
         self,
         my_keys: KeyManagerState,
         pki: KeyRegistryState<MemberId>,
-    ) -> (AuthGroupState<C>, EncryptionGroupState) {
+    ) -> (AuthGroupState<C>, EncryptionGroupState, ProofsMap) {
         let groups_y = self.groups_y;
 
         let encryption_y = EncryptionGroupState {
@@ -60,7 +61,7 @@ impl<C> SpacesStoreState<C> {
             is_welcomed: self.is_welcomed,
         };
 
-        (groups_y, encryption_y)
+        (groups_y, encryption_y, self.proofs)
     }
 }
 
@@ -71,6 +72,7 @@ impl<C> From<SpacesState<C>> for SpacesStoreState<C> {
             space_id: y.space_id,
             group_id: y.group_id,
             groups_y: y.groups_y,
+            proofs: y.proofs,
             is_welcomed: y.encryption_y.is_welcomed,
             secrets: y.encryption_y.secrets,
             orderer: y.encryption_y.orderer,

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -2098,3 +2098,196 @@ async fn promote_demote() {
 
     assert_eq!(all_bob_events.len(), 6);
 }
+
+#[tokio::test]
+async fn detect_affected_concurrent_application_messages() {
+    let alice = TestPeer::new(0).await;
+    let bob = <TestPeer>::new(1).await;
+    let claire = <TestPeer>::new(2).await;
+
+    let bob_id = bob.manager.id();
+    let claire_id = claire.manager.id();
+
+    let alice_manager = alice.manager.clone();
+    let bob_manager = bob.manager.clone();
+    let claire_manager = claire.manager.clone();
+
+    let alice_bundle = alice_manager.key_bundle_message().await.unwrap();
+    let bob_bundle = bob_manager.key_bundle_message().await.unwrap();
+    let claire_bundle = claire_manager.key_bundle_message().await.unwrap();
+
+    for bundle in [alice_bundle, bob_bundle, claire_bundle] {
+        alice_manager.process_persisted(&bundle).await.unwrap();
+        bob_manager.process_persisted(&bundle).await.unwrap();
+        claire_manager.process_persisted(&bundle).await.unwrap();
+    }
+
+    // Alice creates a Space with Bob as manager and Claire as "write" member
+    let space_id = SpaceId::digest(b"0");
+    let (_, messages, _) = alice_manager
+        .create_space_persisted(
+            space_id,
+            &[(bob_id, Access::manage()), (claire_id, Access::write())],
+        )
+        .await
+        .unwrap();
+
+    for message in messages.iter() {
+        bob.persist_operation(message).await.unwrap();
+        bob_manager.process_persisted(message).await.unwrap();
+        claire.persist_operation(message).await.unwrap();
+        claire_manager.process_persisted(message).await.unwrap();
+    }
+
+    let claire_space = claire_manager.space(space_id).await.unwrap().unwrap();
+    let (space_message, _) = claire_space
+        .publish_persisted(b"innocent message")
+        .await
+        .unwrap();
+
+    let claire_application_message_id = space_message.hash;
+
+    alice.persist_operation(&space_message).await.unwrap();
+    alice_manager
+        .process_persisted(&space_message)
+        .await
+        .unwrap();
+
+    let bob_space = bob_manager.space(space_id).await.unwrap().unwrap();
+    let (group_message, space_message, _) = bob_space.remove_persisted(claire_id).await.unwrap();
+
+    alice.persist_operation(&group_message).await.unwrap();
+    alice_manager
+        .process_persisted(&group_message)
+        .await
+        .unwrap();
+    alice.persist_operation(&space_message).await.unwrap();
+    let events = alice_manager
+        .process_persisted(&space_message)
+        .await
+        .unwrap();
+    let Event::Spaces(SpaceEvent::Removed {
+        effected_application_messages,
+        ..
+    }) = &events[0]
+    else {
+        panic!("unexpected message");
+    };
+
+    assert_eq!(effected_application_messages.len(), 1);
+    assert!(effected_application_messages.contains(&claire_application_message_id));
+}
+
+#[tokio::test]
+async fn detect_affected_concurrent_application_messages_by_proof() {
+    let alice = TestPeer::new(0).await;
+    let bob = <TestPeer>::new(1).await;
+    let claire = <TestPeer>::new(2).await;
+    let dave = <TestPeer>::new(3).await;
+
+    let bob_id = bob.manager.id();
+    let claire_id = claire.manager.id();
+    let dave_id = dave.manager.id();
+
+    let alice_manager = alice.manager.clone();
+    let bob_manager = bob.manager.clone();
+    let claire_manager = claire.manager.clone();
+    let dave_manager = dave.manager.clone();
+
+    let alice_bundle = alice_manager.key_bundle_message().await.unwrap();
+    let bob_bundle = bob_manager.key_bundle_message().await.unwrap();
+    let claire_bundle = claire_manager.key_bundle_message().await.unwrap();
+    let dave_bundle = dave_manager.key_bundle_message().await.unwrap();
+
+    for bundle in [alice_bundle, bob_bundle, claire_bundle, dave_bundle] {
+        alice_manager.process_persisted(&bundle).await.unwrap();
+        bob_manager.process_persisted(&bundle).await.unwrap();
+        claire_manager.process_persisted(&bundle).await.unwrap();
+        dave_manager.process_persisted(&bundle).await.unwrap();
+    }
+
+    // Alice creates a Space with Bob and Claire as managers.
+    let space_id = SpaceId::digest(b"0");
+    let (alice_space, messages, _) = alice_manager
+        .create_space_persisted(
+            space_id,
+            &[(bob_id, Access::manage()), (claire_id, Access::manage())],
+        )
+        .await
+        .unwrap();
+    let space_group_id = alice_space.group_id().await.unwrap();
+
+    for message in messages.iter() {
+        bob.persist_operation(message).await.unwrap();
+        bob_manager.process_persisted(message).await.unwrap();
+        claire.persist_operation(message).await.unwrap();
+        claire_manager.process_persisted(message).await.unwrap();
+        dave.persist_operation(message).await.unwrap();
+        dave_manager.process_persisted(message).await.unwrap();
+    }
+
+    // Bob adds Dave with "write" access.
+    let bob_space = bob_manager.space(space_id).await.unwrap().unwrap();
+    let (group_message, space_message, _) = bob_space
+        .add_persisted(dave_id, Access::write())
+        .await
+        .unwrap();
+
+    // Alice and Dave receive the "add" messages.
+    for message in [group_message, space_message] {
+        alice.persist_operation(&message).await.unwrap();
+        alice_manager.process_persisted(&message).await.unwrap();
+        dave.persist_operation(&message).await.unwrap();
+        dave_manager.process_persisted(&message).await.unwrap();
+    }
+
+    // Dave publishes a message, exercising their "write" access.
+    let dave_space = dave_manager.space(space_id).await.unwrap().unwrap();
+    let (space_message, _) = dave_space
+        .publish_persisted(b"innocent message")
+        .await
+        .unwrap();
+
+    let dave_application_message_id = space_message.hash;
+
+    // Alice processes the application message.
+    alice.persist_operation(&space_message).await.unwrap();
+    alice_manager
+        .process_persisted(&space_message)
+        .await
+        .unwrap();
+
+    // Concurrently to Dave being added to the group, Claire removes Bob (which transitively
+    // removes Dave).
+    let claire_space = claire_manager.space(space_id).await.unwrap().unwrap();
+    let (group_message, _, _) = claire_space.remove_persisted(bob_id).await.unwrap();
+
+    // Alice processes _only_ the group message. This simulates a group change occurring without a
+    // corresponding space message being issued.
+    alice.persist_operation(&group_message).await.unwrap();
+    alice_manager
+        .process_persisted(&group_message)
+        .await
+        .unwrap();
+
+    // Alice "repairs" the space. This forges a new space message which in the spaces dependency
+    // graph is _not_ concurrent to Dave's previously processed application message (because Alice
+    // already observed it). This is important for this test as we want to assert that application
+    // messages which refer to concurrent proofs, but are themselves not concurrent, are still
+    // detected as being effected by the remove.
+    let (_, events) = alice_space
+        .repair_persisted(&[space_group_id])
+        .await
+        .unwrap();
+
+    let Event::Spaces(SpaceEvent::Removed {
+        effected_application_messages,
+        ..
+    }) = &events[0]
+    else {
+        panic!("unexpected message");
+    };
+
+    assert_eq!(effected_application_messages.len(), 1);
+    assert!(effected_application_messages.contains(&dave_application_message_id));
+}


### PR DESCRIPTION
This change adds an `effected_application_messages` field to remove and demote events which
contains the ids of all application messages by the removed author which were published
concurrently to the remove message itself.

There are two possible concurrency cases to detect, one can be inferred by inspecting the "proof"
(a concrete point in the groups operation graph) an application message carries, the other by
observing concurrency in the space operation graph itself.

## Case 1: proof is concurrent

The application message is referring to a proof which is entirely concurrent to the target
remove operation.

```
   Remove A                              ...          
      │                                   │           
      │                                   ▼           
      │   Add B ◄─────────────────────── App          
      │    │            proof             │           
      │    ▼                              ▼           
      └─► Add A                          ...          
           │                              │           
           ▼                              ▼           
         Group                          Space         
                                                                                                         
```

## Case 2: space operation is concurrent                                                    
                                    
The application message is published concurrently to the membership message which incorporated
the target remove into the space.
```         
    Remove A ◄─────────────────────── Membership         
      │                                   │              
      │                                   ▼              
      │   Add B ◄──────────────────── Membership      App
      │    │                              │            │
      │    ▼                              ▼            │
      └─► Add A ◄───────────────────  Membership ◄─────┘
           │                              │              
           ▼                              ▼              
         Group                          Space      
```      


closes: #1344 

## 📋 Checklist

- [x] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
