### PR TITLE
Expose InnerSpaceError

### DIFF
--- a/p2panda/src/spaces/mod.rs
+++ b/p2panda/src/spaces/mod.rs
@@ -34,7 +34,7 @@ pub use space::{
     AddSpaceMemberError, PublishSpaceError, RemoveSpaceMemberError, Space, SpaceFuture,
     SpaceSubscription,
 };
-pub use types::{InnerGroupEvent, SpacesManagerError};
+pub use types::{InnerGroupEvent, InnerSpaceError, SpacesManagerError};
 
 use crate::Credentials;
 use crate::forge::OperationForge;


### PR DESCRIPTION
The type is returned by Space::members() for example, so users of that function should be able to see the type.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
