### PR TITLE
Pipeline hook managing per-space allow- and block-lists 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Highlights are marked with a pancake 🥞
 - stream: Filter out spaces application messages from concurrently removed members [#1291](https://github.com/p2panda/p2panda/pull/1291)
 - stream: Hooks processor to register event callbacks in streaming pipeline [#1339](https://github.com/p2panda/p2panda/pull/1339)
 - stream: Move orderer processor from node to stream [#1312](https://github.com/p2panda/p2panda/pull/1312)
+- node: ConnectionAuthoriserHook updating authoriser based on space membership [#1359](https://github.com/p2panda/p2panda/pull/1359)
 
 ### Changed
 

--- a/p2panda-net/src/sync/actors/manager.rs
+++ b/p2panda-net/src/sync/actors/manager.rs
@@ -595,12 +595,23 @@ where
             .can_connect_on_topic(node_id, topic)
             .await;
 
-        if !allow {
-            warn!(
-                "rejected sync with blocked node {} on topic {}",
-                node_id.fmt_short(),
-                topic.fmt_short()
-            );
+        // Authorise that we should be connecting on this topic with the remote node.
+        if allow {
+            self.connection_authoriser
+                .send_event(ConnectionAuthoriserEvent::TopicAllowed {
+                    topic,
+                    node: node_id,
+                })
+                .await;
+        } else {
+            let event = ConnectionAuthoriserEvent::TopicBlocked {
+                topic,
+                node: node_id,
+            };
+            warn!("{}", event);
+            self.connection_authoriser.send_event(event).await;
+
+            // Do not accept a sync session with a blocked topic-node combination.
             connection.close(VarInt::from_u32(0), b"not authorised");
             return Err(iroh::protocol::AcceptError::from_err(
                 ConnectionAuthoriserError::NotAuthorised,

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -38,7 +38,8 @@ use crate::types::{
     EncryptionGroup, EncryptionGroupError, EncryptionGroupState,
 };
 use crate::utils::{
-    added_secret_members, removed_secret_members, secret_members, sort_members, typed_members,
+    added_secret_members, removed_members, removed_secret_members, secret_members, sort_members,
+    typed_members,
 };
 use crate::{ActorId, GroupId, MemberId, OperationId, SpaceEvent, SpaceId, StrongRemoveResolver};
 
@@ -473,6 +474,16 @@ where
             &current_ancestors,
         );
 
+        // Record any individuals that were removed from the space.
+        for event in events.iter() {
+            if let Event::Spaces(SpaceEvent::Removed { context, .. }) = &event {
+                let removed = removed_members(&current_members, &context.members)
+                    .into_iter()
+                    .map(|(member, _)| member);
+                y.removed.extend(removed);
+            }
+        }
+
         events.extend(application_events);
 
         Ok(Some((y, events)))
@@ -778,6 +789,7 @@ where
                     group_id,
                     groups_y,
                     encryption_y,
+                    removed: Default::default(),
                 }
             }
         };
@@ -802,6 +814,18 @@ where
         let mut members = y.groups_y.members(y.group_id);
         sort_members(&mut members);
         Ok(members)
+    }
+
+    /// Returns all members who were removed from, and not re-admitted to, this space.
+    pub async fn removed(&self) -> Result<Vec<MemberId>, SpaceError<F, C>> {
+        let y = self.state().await?;
+        let mut members = y.groups_y.members(y.group_id).into_iter();
+        let removed = y
+            .removed
+            .iter()
+            .filter(|removed| members.any(|(member, _)| member != **removed))
+            .cloned();
+        Ok(removed.collect())
     }
 
     /// All actors (both groups and individuals) in the space.
@@ -997,6 +1021,10 @@ pub struct SpacesState<C> {
     pub group_id: VerifyingKey,
     pub groups_y: AuthGroupState<C>,
     pub encryption_y: EncryptionGroupState,
+
+    /// The set of all individuals who have ever been removed from the space, either via. direct
+    /// removal, or transitively as a member of a removed group.
+    pub removed: HashSet<MemberId>,
 }
 
 impl<C> SpacesState<C>
@@ -1010,6 +1038,7 @@ where
     ) -> Self {
         let space_id = space_y.space_id;
         let group_id = space_y.group_id;
+        let removed = space_y.removed.clone();
         let (groups_y, encryption_y) =
             space_y.assemble_encryption_state(key_manager_y, key_registry_y);
 
@@ -1018,6 +1047,7 @@ where
             group_id,
             groups_y,
             encryption_y,
+            removed,
         }
     }
 }

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -477,6 +477,11 @@ where
         // Record any individuals that were removed from the space.
         for event in events.iter() {
             if let Event::Spaces(SpaceEvent::Removed { context, .. }) = &event {
+                // We accumulate all members who were ever removed from a space here. If only the
+                // diff was used, it would be harder for consumers to implement block patterns
+                // based on this field as information about historic removals would be lost. To
+                // account for re-adds the current membership of the group can be compared against
+                // the remove list.
                 let removed = removed_members(&current_members, &context.members)
                     .into_iter()
                     .map(|(member, _)| member);
@@ -1022,7 +1027,7 @@ pub struct SpacesState<C> {
     pub groups_y: AuthGroupState<C>,
     pub encryption_y: EncryptionGroupState,
 
-    /// The set of all individuals who have ever been removed from the space, either via. direct
+    /// The set of all individuals who have ever been removed from the space, either via direct
     /// removal, or transitively as a member of a removed group.
     pub removed: HashSet<MemberId>,
 }

--- a/p2panda-spaces/src/store.rs
+++ b/p2panda-spaces/src/store.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use p2panda_encryption::data_scheme::SecretBundleState;
 use p2panda_encryption::data_scheme::dcgka::DcgkaState;
@@ -34,6 +34,7 @@ pub struct SpacesStoreState<C> {
     // TODO: Verify if this really required here? Maybe ordering is handled on another layer.
     pub orderer: EncryptionOrdererState,
     pub two_party: HashMap<MemberId, TwoPartyState<LongTermKeyBundle>>,
+    pub removed: HashSet<MemberId>,
 }
 
 impl<C> SpacesStoreState<C> {
@@ -75,6 +76,7 @@ impl<C> From<SpacesState<C>> for SpacesStoreState<C> {
             secrets: y.encryption_y.secrets,
             orderer: y.encryption_y.orderer,
             two_party: y.encryption_y.dcgka.two_party,
+            removed: y.removed,
         }
     }
 }

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -31,9 +31,10 @@ use crate::spaces::types::{
     AuthCapabilities, InnerSpace, InnerSpaceError, NoBody, SpacesManager, SpacesManagerError,
 };
 use crate::spaces::{
-    AccessLevel, ActorId, DEFAULT_REPAIR_STRATEGY, Group, GroupError, KeyBundleTask, Member,
-    MemberAssociationHook, MemberError, RepairTask, Space, SpaceSubscription, actor_to_topic,
-    group_log_id, member_log_id, spaces_manager, spaces_stream, to_initial_members,
+    AccessLevel, ActorId, ConnectionAuthoriserHook, DEFAULT_REPAIR_STRATEGY, Group, GroupError,
+    KeyBundleTask, Member, MemberAssociationHook, MemberError, RepairTask, Space,
+    SpaceSubscription, actor_to_topic, group_log_id, member_log_id, spaces_manager, spaces_stream,
+    to_initial_members,
 };
 use crate::streams::{
     EphemeralStreamPublisher, EphemeralStreamSubscription, Event, ImportError, Pipeline,
@@ -564,6 +565,16 @@ impl Node {
             // messages.
             .unwrap_or(InnerSpace::new(self.spaces_manager.clone(), space_id));
 
+        // Populate the connection authoriser block-list based on members who were removed from,
+        // and not later re-admitted to, the space. It is possible this is the first time
+        // subscribing to the space in which case there is no state to query yet. For this reason
+        // we ignore errors and fallback to a default empty vec.
+        let removed = inner.removed().await.ok().unwrap_or_default();
+        for node in removed {
+            self.connection_authoriser
+                .topic_block(node, space_id.into())
+                .await;
+        }
         let (tx, rx) = self.space_stream_from_inner(space_id, from).await?;
 
         // Spawn per-space repair background task.
@@ -574,6 +585,7 @@ impl Node {
             DEFAULT_REPAIR_STRATEGY,
             tx.import_local_tx.clone(),
             tx.to_output_tx.clone(),
+            self.connection_authoriser.clone(),
         );
 
         Ok(spaces_stream::<M>(
@@ -583,6 +595,7 @@ impl Node {
             self.key_bundle_task.command_handle(),
             tx,
             rx,
+            self.connection_authoriser.clone(),
         ))
     }
 
@@ -595,6 +608,9 @@ impl Node {
         M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
     {
         let mut post_pipeline = ProcessorHooksList::new();
+        post_pipeline.push(ConnectionAuthoriserHook::new(
+            self.connection_authoriser.clone(),
+        ));
         post_pipeline.push(MemberAssociationHook::new(self.id(), self.store.clone()));
 
         self.stream_from_inner(topic, from, post_pipeline).await
@@ -693,6 +709,7 @@ impl Node {
             DEFAULT_REPAIR_STRATEGY,
             tx.import_local_tx.clone(),
             tx.to_output_tx.clone(),
+            self.connection_authoriser.clone(),
         );
 
         let (space, rx) = spaces_stream::<M>(
@@ -702,6 +719,7 @@ impl Node {
             self.key_bundle_task.command_handle(),
             tx,
             rx,
+            self.connection_authoriser.clone(),
         );
 
         Ok((space, rx))

--- a/p2panda/src/spaces/authoriser.rs
+++ b/p2panda/src/spaces/authoriser.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use p2panda_net::connection_authoriser::ConnectionAuthoriser;
+use p2panda_spaces::SpaceEvent;
+use p2panda_stream::hooks::ProcessorHook;
+use p2panda_stream::spaces::SpacesResult;
+
+use crate::processor::ProcessorStatus;
+use crate::spaces::types::AuthCapabilities;
+use crate::streams::Event;
+
+/// Pipeline hook to observe spaces events and add any members we observe being removed to the
+/// connection block-list for the space topic.
+///
+/// NOTE: State for the connection authoriser is not persisted so it's important that it be
+/// populated with initial state on startup if required.
+pub struct ConnectionAuthoriserHook {
+    inner: ConnectionAuthoriser,
+}
+
+impl ConnectionAuthoriserHook {
+    pub fn new(inner: ConnectionAuthoriser) -> Self {
+        Self { inner }
+    }
+}
+
+impl ProcessorHook<Event> for ConnectionAuthoriserHook {
+    async fn on_input(&self, input: &Event) {
+        let ProcessorStatus::Completed(ref result) = input.spaces else {
+            return;
+        };
+
+        let SpacesResult::Processed { events } = result else {
+            return;
+        };
+
+        update_authoriser(&self.inner, events).await;
+    }
+}
+
+pub(crate) async fn update_authoriser(
+    connection_authoriser: &ConnectionAuthoriser,
+    events: &Vec<p2panda_spaces::Event<AuthCapabilities>>,
+) {
+    for event in events {
+        let p2panda_spaces::Event::Spaces(space_event) = event else {
+            continue;
+        };
+        let (space_id, members) = match space_event {
+            SpaceEvent::Created {
+                space_id, context, ..
+            } => (space_id, &context.members),
+            SpaceEvent::Added {
+                space_id, context, ..
+            } => (space_id, &context.members),
+            SpaceEvent::Removed {
+                space_id,
+                removed,
+                context,
+                ..
+            } => {
+                // For remove events add removed members to the topic block-list.
+                for (member, _) in removed {
+                    connection_authoriser
+                        .topic_block(*member, { *space_id }.into())
+                        .await;
+                }
+
+                (space_id, &context.members)
+            }
+            _ => return,
+        };
+
+        // For all events add current members to the topic allow-list.
+        //
+        // This catches the case where a previously removed member has been re-added.
+        for (member, _) in members {
+            connection_authoriser
+                .topic_allow(*member, { *space_id }.into())
+                .await;
+        }
+    }
+}

--- a/p2panda/src/spaces/mod.rs
+++ b/p2panda/src/spaces/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+mod authoriser;
 mod forge;
 mod group;
 mod member;
@@ -18,6 +19,7 @@ pub use p2panda_auth::AccessLevel;
 pub use p2panda_spaces::manager::ManagerError;
 pub use p2panda_spaces::{ActorId, GroupContext, GroupId, MemberId, SpaceContext, SpaceId};
 
+pub(crate) use authoriser::ConnectionAuthoriserHook;
 pub(crate) use forge::{group_log_id, member_log_id};
 pub use group::{
     AddGroupMemberError, Group, GroupError, GroupEvent, GroupFuture, RemoveGroupMemberError,

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use p2panda_core::traits::{Provenance, ShortFormat};
 use p2panda_core::{Hash, Topic};
+use p2panda_net::connection_authoriser::ConnectionAuthoriser;
 use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
 use p2panda_spaces::{AuthGroupState, GroupId, SpaceId, SpacesStoreState};
 use p2panda_store::groups::GroupsStore;
@@ -19,6 +20,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, trace, warn};
 
 use crate::operation::Operation;
+use crate::spaces::authoriser::update_authoriser;
 use crate::spaces::types::{AuthCapabilities, SpacesArgs, SpacesManager, SpacesStore};
 use crate::spaces::{SpacesManagerError, group_log_id};
 use crate::streams::{
@@ -79,6 +81,8 @@ pub(crate) async fn repair_space<M>(
     store: &SqliteStore,
     import_local_tx: &ImportLocalTx,
     to_output_tx: &ToOutputTx<M>,
+    // TODO: Only required until https://github.com/p2panda/p2panda/issues/1362 is resolved.
+    connection_authoriser: &ConnectionAuthoriser,
 ) -> Result<bool, RepairError> {
     let spaces_store = SpacesStore::new(store.clone());
 
@@ -212,6 +216,9 @@ pub(crate) async fn repair_space<M>(
     // Await processing of operations to be complete.
     ready_rx.await?;
 
+    // TODO: Only required until https://github.com/p2panda/p2panda/issues/1362 is resolved.
+    update_authoriser(connection_authoriser, &events).await;
+
     let events = events
         .into_iter()
         .filter_map(|event| match event {
@@ -253,6 +260,8 @@ impl RepairTask {
         strategy: RepairStrategy,
         import_tx: ImportLocalTx,
         to_output_tx: ToOutputTx<M>,
+        // TODO: Only required until https://github.com/p2panda/p2panda/issues/1362 is resolved.
+        connection_authoriser: ConnectionAuthoriser,
     ) -> Self
     where
         M: Send + 'static,
@@ -275,6 +284,7 @@ impl RepairTask {
                             &store,
                             &import_tx,
                             &to_output_tx,
+                            &connection_authoriser
                         )
                         .await;
 
@@ -299,6 +309,7 @@ impl RepairTask {
                                     &store,
                                     &import_tx,
                                     &to_output_tx,
+                                    &connection_authoriser
                                 )
                                 .await;
 

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -12,6 +12,7 @@ use p2panda_auth::{Access, AccessLevel};
 use p2panda_core::Hash;
 use p2panda_core::cbor::{EncodeError, encode_cbor};
 use p2panda_core::traits::ShortFormat;
+use p2panda_net::connection_authoriser::ConnectionAuthoriser;
 use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
 use p2panda_spaces::space::SpacesState;
 use p2panda_spaces::{ActorId, AuthGroupState, MemberId, SpaceId, SpacesStoreState};
@@ -25,6 +26,7 @@ use tokio::sync::oneshot::error::RecvError;
 use tracing::error;
 
 use crate::operation::Extensions;
+use crate::spaces::authoriser::update_authoriser;
 use crate::spaces::member::associate_members;
 use crate::spaces::message::SpacesMessage;
 use crate::spaces::types::{AuthCapabilities, InnerSpace, InnerSpaceError, SpacesManagerError};
@@ -42,6 +44,8 @@ pub(crate) fn spaces_stream<M>(
     key_bundle_task_tx: KeyBundleTaskSender,
     tx: StreamPublisher<M>,
     rx: StreamSubscription<M>,
+    // TODO: Only required until https://github.com/p2panda/p2panda/issues/1362 is resolved.
+    connection_authoriser: ConnectionAuthoriser,
 ) -> (Space<M>, SpaceSubscription<M>)
 where
     M: Serialize,
@@ -60,6 +64,7 @@ where
             repair_task,
             key_bundle_task_tx,
             tx,
+            connection_authoriser,
         },
         SpaceSubscription { rx },
     )
@@ -75,6 +80,7 @@ where
     repair_task: RepairTask,
     key_bundle_task_tx: KeyBundleTaskSender,
     tx: StreamPublisher<M>,
+    connection_authoriser: ConnectionAuthoriser,
 }
 
 impl<M> Drop for Space<M>
@@ -167,6 +173,9 @@ where
             )
             .await?;
 
+        // TODO: Only required until https://github.com/p2panda/p2panda/issues/1362 is resolved.
+        update_authoriser(&self.connection_authoriser, &events).await;
+
         self.process_change(groups_y, space_y, [auth_message, space_message], events)
             .await?;
 
@@ -192,6 +201,9 @@ where
 
         let (groups_y, space_y, auth_message, space_message, events) =
             self.inner.remove(actor).await?;
+
+        // TODO: Only required until https://github.com/p2panda/p2panda/issues/1362 is resolved.
+        update_authoriser(&self.connection_authoriser, &events).await;
 
         self.process_change(groups_y, space_y, [auth_message, space_message], events)
             .await?;

--- a/p2panda/tests/spaces.rs
+++ b/p2panda/tests/spaces.rs
@@ -1018,6 +1018,10 @@ mod filtered_messages {
         // Panda subscribes again.
         let (_panda_space, mut panda_rx) = panda.space::<SecretData>(topic).await.unwrap();
 
+        // And manually adds penguin to the allow-list as removed members are automatically
+        // blocked.
+        panda.topic_allow(penguin_id, topic).await;
+
         // Panda will be sent the second message from penguin, however it will not be forwarded to
         // the app layer as they know penguin has been removed (concurrent to the application
         // message being published).
@@ -1249,5 +1253,110 @@ mod members {
         // direct message to D. Note that B doesn't need a key bundle for A because A already
         // initiated a 2SM session with B when they've been added to the space.
         node_b_space.remove(node_c.id()).await.unwrap();
+    }
+}
+
+mod connection_authorisation {
+
+    use p2panda::streams::{StreamEvent, SystemEvent};
+    use p2panda_core::test_utils::setup_logging;
+    use p2panda_net::connection_authoriser::ConnectionAuthoriserEvent;
+    use tokio_stream::StreamExt;
+
+    use super::{SecretData, spawn_node};
+
+    #[tokio::test]
+    async fn member_allow_and_block() {
+        setup_logging();
+
+        use p2panda::Topic;
+        use p2panda_auth::AccessLevel;
+
+        let network_id = Topic::random().into();
+        let topic = Topic::random();
+
+        let panda = spawn_node(network_id).await;
+        let mut panda_system_rx = panda.event_stream().await.unwrap();
+        let penguin = spawn_node(network_id).await;
+
+        // Panda creates a space.
+        let (panda_space, mut panda_rx) = panda.create_space::<SecretData>(topic).await.unwrap();
+
+        // Penguin subscribes to the space.
+        let (penguin_space, mut penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
+
+        while let Some(event) = panda_rx.next().await {
+            if let StreamEvent::Member(member) = event {
+                if member == penguin.id() {
+                    break;
+                }
+            };
+        }
+
+        // Panda adds Penguin as a member of the space.
+        let penguin_id = penguin.id();
+        panda_space
+            .add(penguin_id, AccessLevel::Write)
+            .await
+            .unwrap();
+
+        while let Some(event) = penguin_rx.next().await {
+            let StreamEvent::Space { members, .. } = event else {
+                continue;
+            };
+
+            if members.iter().any(|(member, _)| *member == penguin.id()) {
+                break;
+            }
+        }
+
+        // Penguin unsubscribes from the space.
+        penguin_space.close().await.unwrap();
+
+        // Panda removes Penguin.
+        panda_space
+            .remove(penguin_id)
+            .await
+            .expect("panda removes penguin");
+
+        let (penguin_space, _penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
+
+        while let Some(event) = panda_system_rx.next().await {
+            let SystemEvent::ConnectionAuthoriser(ConnectionAuthoriserEvent::TopicBlocked {
+                topic: topic_inner,
+                node,
+            }) = event
+            else {
+                continue;
+            };
+
+            assert_eq!(node, penguin_id);
+            assert_eq!(topic_inner, topic);
+            break;
+        }
+
+        penguin_space.close().await.unwrap();
+
+        // Panda adds Penguin again.
+        panda_space
+            .add(penguin_id, AccessLevel::Read)
+            .await
+            .expect("panda removes penguin");
+
+        let (_penguin_space, _penguin_rx) = penguin.space::<SecretData>(topic).await.unwrap();
+
+        while let Some(event) = panda_system_rx.next().await {
+            let SystemEvent::ConnectionAuthoriser(ConnectionAuthoriserEvent::TopicAllowed {
+                topic: topic_inner,
+                node,
+            }) = event
+            else {
+                continue;
+            };
+
+            assert_eq!(node, penguin_id);
+            assert_eq!(topic_inner, topic);
+            break;
+        }
     }
 }


### PR DESCRIPTION
This changes introduces a ConnectionAuthoriserHook which holds the global ConnectionAuthoriser. It
watches the event stream and reacts to membership change events ("create", "add" and "remove").
Current members are always added to the allow-list for the space topic, removed members are added
to the block-list. The former handles re-admitting a previously removed member.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
