### PR TITLE
p2panda-net: support bearer authentication for iroh relays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
-- net: Support bearer authentication for iroh relays
+- net: Support bearer authentication for iroh relays [#1361](https://github.com/p2panda/p2panda/pull/1361)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Highlights are marked with a pancake 🥞
 
 ## [Unreleased]
 
+### Added
+
+- net: Support bearer authentication for iroh relays
+
 ### Changed
 
 - net: Update ractor to 0.16.2 [#1324](https://github.com/p2panda/p2panda/pull/1324)

--- a/p2panda-net/src/iroh_endpoint/builder.rs
+++ b/p2panda-net/src/iroh_endpoint/builder.rs
@@ -16,6 +16,7 @@ pub struct Builder {
     signing_key: Option<SigningKey>,
     config: Option<IrohConfig>,
     relay_urls: HashSet<iroh::RelayUrl>,
+    relay_auth_token: Option<String>,
     address_book: AddressBook,
 }
 
@@ -27,6 +28,7 @@ impl Builder {
             config: None,
             address_book,
             relay_urls: HashSet::new(),
+            relay_auth_token: None,
         }
     }
 
@@ -68,11 +70,20 @@ impl Builder {
         self
     }
 
+    pub fn relay_auth_token(mut self, token: impl Into<String>) -> Self {
+        self.relay_auth_token = Some(token.into());
+        self
+    }
+
     pub(crate) fn build_args(self) -> IrohEndpointArgs {
         let network_id = self.network_id.unwrap_or(DEFAULT_NETWORK_ID);
         let signing_key = self.signing_key.unwrap_or_default();
         let config = self.config.unwrap_or_default();
         let relay_map = iroh::RelayMap::from_iter(self.relay_urls);
+        let relay_map = match self.relay_auth_token {
+            Some(token) => relay_map.with_auth_token(token),
+            None => relay_map,
+        };
         (
             network_id,
             signing_key,

--- a/p2panda-net/src/iroh_endpoint/builder.rs
+++ b/p2panda-net/src/iroh_endpoint/builder.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use p2panda_core::SigningKey;
 use ractor::thread_local::{ThreadLocalActor, ThreadLocalActorSpawner};
@@ -15,8 +15,7 @@ pub struct Builder {
     network_id: Option<NetworkId>,
     signing_key: Option<SigningKey>,
     config: Option<IrohConfig>,
-    relay_urls: HashSet<iroh::RelayUrl>,
-    relay_auth_token: Option<String>,
+    relays: HashMap<iroh::RelayUrl, Option<String>>,
     address_book: AddressBook,
 }
 
@@ -27,8 +26,7 @@ impl Builder {
             signing_key: None,
             config: None,
             address_book,
-            relay_urls: HashSet::new(),
-            relay_auth_token: None,
+            relays: HashMap::new(),
         }
     }
 
@@ -66,12 +64,12 @@ impl Builder {
     /// If no relay is given other nodes can only connect to us if a directly reachable IP address
     /// is available and known to them.
     pub fn relay_url(mut self, url: iroh::RelayUrl) -> Self {
-        self.relay_urls.insert(url);
+        self.relays.insert(url, None);
         self
     }
 
-    pub fn relay_auth_token(mut self, token: impl Into<String>) -> Self {
-        self.relay_auth_token = Some(token.into());
+    pub fn relay_url_with_token(mut self, url: iroh::RelayUrl, token: impl Into<String>) -> Self {
+        self.relays.insert(url, Some(token.into()));
         self
     }
 
@@ -79,11 +77,14 @@ impl Builder {
         let network_id = self.network_id.unwrap_or(DEFAULT_NETWORK_ID);
         let signing_key = self.signing_key.unwrap_or_default();
         let config = self.config.unwrap_or_default();
-        let relay_map = iroh::RelayMap::from_iter(self.relay_urls);
-        let relay_map = match self.relay_auth_token {
-            Some(token) => relay_map.with_auth_token(token),
-            None => relay_map,
-        };
+        let relay_map = self
+            .relays
+            .into_iter()
+            .map(|(url, token)| match token {
+                Some(token) => iroh::RelayConfig::from(url).with_auth_token(token),
+                None => iroh::RelayConfig::from(url),
+            })
+            .collect();
         (
             network_id,
             signing_key,

--- a/p2panda-net/src/iroh_endpoint/tests.rs
+++ b/p2panda-net/src/iroh_endpoint/tests.rs
@@ -4,13 +4,40 @@ use iroh::protocol::ProtocolHandler;
 use p2panda_core::test_utils::setup_logging;
 
 use crate::address_book::AddressBook;
-use crate::iroh_endpoint::Endpoint;
+use crate::iroh_endpoint::{Builder, Endpoint};
 use crate::test_utils::test_args;
 
 const ECHO_PROTOCOL_ID: &[u8] = b"test/echo/v1";
 
 #[derive(Debug)]
 struct EchoProtocol;
+
+#[tokio::test]
+async fn configure_relay_authentication() {
+    const AUTH_TOKEN: &str = "very-secret-token";
+
+    let relay_url: iroh::RelayUrl = "https://relay.example.com".parse().unwrap();
+    let address_book = AddressBook::builder().spawn().await.unwrap();
+    let (_, _, _, relay_map, _) = Builder::new(address_book)
+        .relay_url(relay_url.clone())
+        .relay_auth_token(AUTH_TOKEN)
+        .build_args();
+
+    let relay_config = relay_map.get(&relay_url).unwrap();
+    assert_eq!(relay_config.auth_token.as_deref(), Some(AUTH_TOKEN));
+}
+
+#[tokio::test]
+async fn relay_authentication_is_optional() {
+    let relay_url: iroh::RelayUrl = "https://relay.example.com".parse().unwrap();
+    let address_book = AddressBook::builder().spawn().await.unwrap();
+    let (_, _, _, relay_map, _) = Builder::new(address_book)
+        .relay_url(relay_url.clone())
+        .build_args();
+
+    let relay_config = relay_map.get(&relay_url).unwrap();
+    assert_eq!(relay_config.auth_token, None);
+}
 
 impl ProtocolHandler for EchoProtocol {
     async fn accept(

--- a/p2panda-net/src/iroh_endpoint/tests.rs
+++ b/p2panda-net/src/iroh_endpoint/tests.rs
@@ -13,18 +13,34 @@ const ECHO_PROTOCOL_ID: &[u8] = b"test/echo/v1";
 struct EchoProtocol;
 
 #[tokio::test]
-async fn configure_relay_authentication() {
-    const AUTH_TOKEN: &str = "very-secret-token";
+async fn configure_authentication_per_relay() {
+    const FIRST_AUTH_TOKEN: &str = "first-secret-token";
+    const SECOND_AUTH_TOKEN: &str = "second-secret-token";
 
-    let relay_url: iroh::RelayUrl = "https://relay.example.com".parse().unwrap();
+    let first_relay_url: iroh::RelayUrl = "https://first-relay.example.com".parse().unwrap();
+    let second_relay_url: iroh::RelayUrl = "https://second-relay.example.com".parse().unwrap();
+    let public_relay_url: iroh::RelayUrl = "https://public-relay.example.com".parse().unwrap();
     let address_book = AddressBook::builder().spawn().await.unwrap();
     let (_, _, _, relay_map, _) = Builder::new(address_book)
-        .relay_url(relay_url.clone())
-        .relay_auth_token(AUTH_TOKEN)
+        .relay_url_with_token(first_relay_url.clone(), FIRST_AUTH_TOKEN)
+        .relay_url_with_token(second_relay_url.clone(), SECOND_AUTH_TOKEN)
+        .relay_url(public_relay_url.clone())
         .build_args();
 
-    let relay_config = relay_map.get(&relay_url).unwrap();
-    assert_eq!(relay_config.auth_token.as_deref(), Some(AUTH_TOKEN));
+    let first_relay_config = relay_map.get(&first_relay_url).unwrap();
+    assert_eq!(
+        first_relay_config.auth_token.as_deref(),
+        Some(FIRST_AUTH_TOKEN)
+    );
+
+    let second_relay_config = relay_map.get(&second_relay_url).unwrap();
+    assert_eq!(
+        second_relay_config.auth_token.as_deref(),
+        Some(SECOND_AUTH_TOKEN)
+    );
+
+    let public_relay_config = relay_map.get(&public_relay_url).unwrap();
+    assert_eq!(public_relay_config.auth_token, None);
 }
 
 #[tokio::test]


### PR DESCRIPTION
`p2panda-net` does not currently support passing in `auth_token` when connecting to iroh relays. This PR adds a `relay_url_with_token` method to the iroh_endpoint builder to configure an optional auth token per relay.

Also added tests to verify each relay gets it's own token in relay_config and that the old `relay_url` method still works. I've verified this works on a private relay.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
