### PR TITLE
Enforce strict, canonical CBOR when decoding headers and their extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Highlights are marked with a pancake 🥞
 ### Changed
 
 - core: New forwards-compatible, safer and faster API to create, encode and decode operations [#1200](https://github.com/p2panda/p2panda/pull/1200)
+- core: Enforce strict, canonical CBOR when decoding headers and their extensions [#1374](https://github.com/p2panda/p2panda/pull/1374)
 - core: Remove `Extension` trait [#1370](https://github.com/p2panda/p2panda/pull/1370)
 - sync: Use Borrow<GroupsArgs> in groups processor instead [#1370](https://github.com/p2panda/p2panda/pull/1370)
 - net: Update ractor to 0.16.2 [#1324](https://github.com/p2panda/p2panda/pull/1324)

--- a/p2panda-core/src/operation/any.rs
+++ b/p2panda-core/src/operation/any.rs
@@ -183,22 +183,11 @@ impl AnyHeader {
         // The bytes are decoded in a zero-copy manner, only reading from the given byte slice.
         let cbor = {
             let codec = cbor_core::DecodeOptions::new()
-                // Reduce strictness as we can't enforce it for all possible ways users will encode
-                // their extensions. On top we want to uphold the robustness principle: "be
-                // conservative in what you do, be liberal in what you accept from others"
-                .strictness(cbor_core::Strictness {
-                    // We're fine with non-canonical encodings.
-                    allow_non_shortest_integers: true,
-                    allow_non_shortest_floats: true,
-                    allow_oversized_bigints: true,
-                    allow_unsorted_map_keys: true,
-                    // Can lead to undefined behaviour and is simply wrong.
-                    allow_duplicate_map_keys: false,
-                    // Respect length limit right from the beginning.
-                    allow_indefinite_length: false,
-                })
-                // Still, we want to make sure some attacks are mitigated and set rather low
-                // / pessimistic thresholds.
+                // Enforce a strict, canonical CBOR encoding, otherwise integrity checks would fail
+                // when decoding & encoding the headers again on our end. See `encode_header` for
+                // details.
+                .strictness(cbor_core::Strictness::STRICT)
+                // Make sure some attacks are mitigated and set rather low / pessimistic thresholds.
                 .recursion_limit(64)
                 .length_limit(512) // 0.5kb
                 .oom_mitigation(64);

--- a/p2panda-core/src/operation/header.rs
+++ b/p2panda-core/src/operation/header.rs
@@ -254,18 +254,15 @@ pub(crate) fn encode_header(
         cbor.append(backlink.as_bytes());
     }
 
-    // TODO: We're currently serializing from the AST using cbor_core. If decoding an extension from
-    // another code-base (which was generated using another CBOR encoder with different rules) and
-    // encoding it here again, we might end up with a different byte sequence and thus hash digest.
+    // We're serializing from the AST using cbor_core. If decoding an extension from another
+    // code-base (which was generated using another CBOR encoder with different rules) and encoding
+    // it here again, we might end up with a different byte sequence and thus hash digest.
     //
     // This can for example happen if the given extension uses non-canonical CBOR encoding,
     // ambigious map ordering etc.
     //
-    // Since there is no other p2panda implementation around right now this is not broken (yet) but
-    // we want to change this in the future to manually append the original extension bytes to the
-    // CBOR result.
-    //
-    // See related issue: <https://github.com/p2panda/p2panda/issues/1373>
+    // To mitigate this from happening we're enforcing a strict, canonical CBOR encoding when
+    // decoding the extensions bytes.
     if let Some(extensions) = extensions {
         cbor.append(extensions.to_owned());
     }

--- a/p2panda-core/src/operation/tests.rs
+++ b/p2panda-core/src/operation/tests.rs
@@ -287,5 +287,10 @@ fn non_canonical_extensions() {
     // Decoding the non-canonical version should fail on CBOR decoder level (and _not_ when we check
     // the integrity of the header since the signature is technically correct).
     let result = Header::<MyExtensions>::decode(&non_canonical_bytes);
-    std::assert_matches!(result, Err(HeaderError::DecodingExtensions(_)));
+    std::assert_matches!(
+        result,
+        Err(HeaderError::DecodingHeader(
+            cbor_core::Error::NonDeterministic
+        ))
+    );
 }

--- a/p2panda-core/src/operation/tests.rs
+++ b/p2panda-core/src/operation/tests.rs
@@ -246,3 +246,46 @@ fn forwards_compatible_checks() {
     assert_eq!(header.extensions.timestamp, 1780572316919.into());
     assert_eq!(header.extensions.prune_flag, false.into()); // set to default when not given
 }
+
+#[test]
+fn non_canonical_extensions() {
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct MyExtensions {
+        field_a: u8,
+        field_b: u8,
+    }
+
+    // [
+    //   1,
+    //   h'...',
+    //   h'...',
+    //   0,
+    //   0,
+    //   {
+    //      "field_a": 12,
+    //      "field_b": 17,
+    //   }
+    // ]
+    let bytes = hex::decode("860158208b8a1a22ce4d22984c5eca66cb55d5a2679f42b7667e9b7838a15d0049b2bcea58409053796ef0724b493d2ddf0c240504ca7a8d3b80af5cd7eaf633622d7dea0469949cc4252017341171d8cdbaad2829aa27754425e041d198027a7c48150d2b0e0000a2676669656c645f610c676669656c645f6211").unwrap();
+
+    // [
+    //   1,
+    //   h'...',
+    //   h'...',
+    //   0,
+    //   0,
+    //   {
+    //      "field_b": 17, <-- the order of fields changed
+    //      "field_a": 12,
+    //   }
+    // ]
+    let non_canonical_bytes = hex::decode("860158208b8a1a22ce4d22984c5eca66cb55d5a2679f42b7667e9b7838a15d0049b2bcea58409053796ef0724b493d2ddf0c240504ca7a8d3b80af5cd7eaf633622d7dea0469949cc4252017341171d8cdbaad2829aa27754425e041d198027a7c48150d2b0e0000a2676669656c645f6211676669656c645f6111").unwrap();
+
+    let result = Header::<MyExtensions>::decode(&bytes);
+    assert!(result.is_ok(), "decoding canonical representation works");
+
+    // Decoding the non-canonical version should fail on CBOR decoder level (and _not_ when we check
+    // the integrity of the header since the signature is technically correct).
+    let result = Header::<MyExtensions>::decode(&non_canonical_bytes);
+    std::assert_matches!(result, Err(HeaderError::DecodingExtensions(_)));
+}


### PR DESCRIPTION
Closes: #1373 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
