### PR TITLE
Refactor RepairTask, move some logic into p2panda-spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Highlights are marked with a pancake 🥞
 - node: Move repair task out of stream [#1347](https://github.com/p2panda/p2panda/pull/1347)
 - node: Increase stream buffer size [#1360](https://github.com/p2panda/p2panda/pull/1360)
 - node: Use random network ids in tests [#1360](https://github.com/p2panda/p2panda/pull/1360)
+- node: Refactor RepairTask into clear functions [#1377](https://github.com/p2panda/p2panda/pull/1377)
+- spaces: Introduce Space::missing_group_messages method [#1377](https://github.com/p2panda/p2panda/pull/1377)
 
 ### Fixed
 

--- a/p2panda-spaces/src/manager.rs
+++ b/p2panda-spaces/src/manager.rs
@@ -27,7 +27,7 @@ use crate::group::{Group, GroupError};
 use crate::identity::{IdentityError, IdentityManager};
 use crate::member::Member;
 use crate::message::{SpaceMembershipMessage, SpacesArgs, SpacesMessage};
-use crate::space::{Space, SpaceError, SpacesState};
+use crate::space::{GroupsScope, Space, SpaceError, SpacesState};
 use crate::store::SpacesStoreState;
 use crate::types::AuthGroupState;
 use crate::{ActorId, Config, Credentials, GroupId, SpaceId};
@@ -414,88 +414,28 @@ where
         Ok(y)
     }
 
-    /// Return `true` if the space is missing operations from the passed groups.
+    /// Return `true` if the space is missing operations from the global groups state filtered to
+    /// the passed [`GroupsScope`].
     pub async fn space_repair_required(
         &self,
         space_id: SpaceId,
-        groups: &[GroupId],
+        scope: &GroupsScope,
     ) -> Result<bool, ManagerError<F, C>> {
+        let Some(space_y) = self.get_space_state(&space_id).await? else {
+            return Ok(false);
+        };
         let groups_y = self.get_groups_state().await?;
 
-        let Some(space_y) = self.get_space_state(&space_id).await? else {
-            return Err(ManagerError::SpaceNotFound(space_id));
+        let group_ids = match scope {
+            GroupsScope::Global => groups_y.groups_global(),
+            GroupsScope::Group(id) => vec![*id],
+            GroupsScope::Space => vec![space_y.group_id],
         };
 
-        let space_heads = space_y.groups_y.inner.heads(groups);
-        let global_heads = groups_y.inner.heads(groups);
+        let space_heads = space_y.groups_y.inner.heads(&group_ids);
+        let global_heads = groups_y.inner.heads(&group_ids);
 
         Ok(space_heads != global_heads)
-    }
-
-    /// Publish a reference to any auth messages missing from a space.
-    ///
-    /// Each space holds a copy of the shared auth state by publishing a reference to each auth
-    /// control message it witnesses. A space can get out-of-sync with this shared state if auth
-    /// messages were published without the local peer knowing about a space, either because they
-    /// are not a member or because they were yet to learn about it.
-    ///
-    /// ## Out-of-sync Space
-    ///
-    /// ```text
-    /// Shared Auth State     Space State
-    ///
-    ///       [x]
-    ///       [x] <-------------- [z]
-    ///       [x] <-------------- [z]
-    ///       [x] <-------------- [z]
-    /// ```
-    ///
-    /// On identifying that a space needs "repairing" by calling space_repair_required(), _any_
-    /// current space member can publish a message into the space referencing the missing auth
-    /// message.
-    ///
-    /// It is recommended that repair does not occur after every call to process() as this would
-    /// cause peers to publish redundant pointers into the spaces graph. Although these duplicates do not
-    /// introduce any buggy or unexpected behavior, repairing after every processed message would
-    /// introduce an undesirable level of redundancy.
-    ///
-    /// ## Redundant pointers
-    ///
-    /// ```text
-    /// Shared Auth State     Space State
-    ///
-    ///       [x] <-----------[z1][z2][z3]
-    ///       [x] <-------------- [z]
-    ///       [x] <-------------- [z]
-    ///       [x] <-------------- [z]
-    /// ```
-    ///
-    /// A sensible approach to detecting and repairing spaces will involve processing messages in
-    /// logical batches and only detecting and repairing any out-of-sync spaces after a batch has
-    /// been processed. Alternatively some scheduling or throttling logic could be employed.
-    pub async fn repair_space(
-        &self,
-        space_id: SpaceId,
-        groups: &[GroupId],
-    ) -> Result<(SpacesState<C>, Vec<F::Message>, Vec<Event<C>>), ManagerError<F, C>> {
-        let Some(space) = self.space(space_id).await? else {
-            return Err(ManagerError::SpaceNotFound(space_id));
-        };
-
-        if !space
-            .members()
-            .await?
-            .iter()
-            .any(|(id, access)| *id == self.id() && *access >= Access::<C>::read())
-        {
-            // Only members with Read or greater access can repair spaces.
-            let space_y = space.state().await?;
-            return Ok((space_y, vec![], vec![]));
-        }
-
-        let result = space.repair(groups).await.map_err(ManagerError::Space)?;
-
-        Ok(result)
     }
 
     async fn handle_space_membership_message(
@@ -673,55 +613,6 @@ where
         };
 
         Ok(events)
-    }
-
-    pub async fn repair_spaces(
-        &self,
-        space_ids: &[SpaceId],
-    ) -> Result<Vec<(SpacesState<C>, Vec<F::Message>, Vec<Event<C>>)>, ManagerError<F, C>> {
-        let mut results = vec![];
-
-        for id in space_ids {
-            let Some(space) = self.space(*id).await? else {
-                continue;
-            };
-
-            if !space
-                .members()
-                .await?
-                .iter()
-                .any(|(id, access)| *id == self.id() && *access >= Access::<C>::read())
-            {
-                // Only members with Read or greater access can repair spaces.
-                let space_y = space.state().await?;
-                results.push((space_y, vec![], vec![]));
-                continue;
-            }
-
-            let result = space
-                .repair(&[space.group_id().await?])
-                .await
-                .map_err(ManagerError::Space)?;
-            results.push(result);
-        }
-
-        Ok(results)
-    }
-
-    pub async fn repair_spaces_persisted(
-        &self,
-        space_ids: &[SpaceId],
-    ) -> Result<Vec<F::Message>, ManagerError<F, C>> {
-        let results = self.repair_spaces(space_ids).await?;
-
-        let mut messages = vec![];
-        for (space_y, messages_inner, _) in results {
-            let space_id = space_y.space_id;
-            self.set_space_state(&space_id, &space_y.into()).await?;
-            messages.extend(messages_inner);
-        }
-
-        Ok(messages)
     }
 }
 

--- a/p2panda-spaces/src/space.rs
+++ b/p2panda-spaces/src/space.rs
@@ -642,28 +642,149 @@ where
         Ok(Some((y, events)))
     }
 
+    /// Returns group messages (in topological order) which are present on the global groups state
+    /// but not yet incorporated into the space. This is useful when we want to merge these
+    /// messages into the space and forward them to other space subscribers.
+    ///
+    /// This would be required in the following scenarios 1) messages for a member group were
+    /// created concurrently to the space creation 2) we want to add a "not-yet-incorporated"
+    /// group to the space as a member 3) we want to pro-actively "push" groups into a space in
+    /// order to aid group discovery.
+    ///
+    /// The query can be filtered to a sub-set of all groups based on a [`GroupsScope`]. This
+    /// method can be used by any coordination layer to understand which messages already on our
+    /// global groups state should be merged into a space.
+    ///
+    /// When managing a space the following requirements should be considered:
+    ///
+    /// 1) For a current member group: all known group messages must be incorporated
+    /// 2) For a to-be-added member group: all known group messages must be incorporated
+    /// 3) For a non-member group: all known group messages can optionally be incorporated to aid
+    ///    group discovery
+    ///
+    /// These statements assume that all transitive group member's messages are first
+    /// incorporated.
+    ///
+    /// With above statements in mind, one can see how the this method can be useful in several
+    /// cases.
+    ///
+    /// ## 1) keep the space up-to-date with known group changes.
+    ///
+    /// ```text
+    /// Global Groups   : [A, B]
+    /// Space 1 Members : [A, B]
+    ///
+    /// ==== Group C was created and added to Group B concurrently ====
+    ///
+    /// Global Groups : [A, B, C]
+    /// Space Members : [A, B] <- now missing group C operations
+    ///
+    /// Any group member aware of these concurrent changes should send the group messages to
+    /// subscribers and incorporate them into the space.
+    /// ```
+    ///
+    /// ## 2) add a new group to the space.
+    ///
+    /// ```text
+    /// Global Groups : [A, B]
+    /// Space Members : [A] <- doesn't need group B operations yet
+    ///
+    /// ==== Group B to be added to Space ====
+    ///
+    /// Before adding B then all it's messages must be incorporated into the space.
+    /// ```
+    ///
+    /// ## 3) highly-discoverable groups
+    ///
+    /// ```text
+    /// Global Groups : [A, B, C, D, E]
+    /// Space Members : [A] <- doesn't need other group operations except for discovery
+    ///  
+    /// ==== Any group may be added to a space by any member ====
+    ///
+    /// In order to make groups automatically discoverable their messages should be proactively
+    /// forwarded and incorporated into a space.
+    /// ```
+    pub async fn missing_group_messages(
+        &self,
+        scope: &GroupsScope,
+    ) -> Result<Vec<OperationId>, SpaceError<F, C>> {
+        let y = self.state().await?;
+        let groups_y = self.manager.get_groups_state().await?;
+
+        let group_ids = match scope {
+            GroupsScope::Global => groups_y.groups_global(),
+            GroupsScope::Group(id) => vec![*id],
+            GroupsScope::Space => vec![y.group_id],
+        };
+
+        let mut groups_operations = vec![];
+        for id in groups_y.inner.toposort(&group_ids) {
+            if y.groups_y.inner.operations.contains_key(&id) {
+                continue;
+            }
+            groups_operations.push(id)
+        }
+
+        Ok(groups_operations)
+    }
+
+    /// Publish a reference to any global groups messages missing from a space.
+    ///
+    /// Each space holds a copy of the shared groups state by publishing a reference to each group
+    /// control message it witnesses. A space can get out-of-sync with this shared state if group
+    /// messages were published without the local peer knowing about a space, either because they
+    /// are not a member or because they were yet to learn about it. Group membership changes will
+    /// not be reflected in the space until this reference message is published.
+    ///
+    /// ## Out-of-sync Space
+    ///
+    /// ```text
+    /// Shared Groups State   Space State
+    ///
+    ///       [x]
+    ///       [x] <-------------- [z]
+    ///       [x] <-------------- [z]
+    ///       [x] <-------------- [z]
+    /// ```
+    ///
+    /// On identifying that a space needs "repairing" by calling space_repair_required(), _any_
+    /// current space member can publish a message into the space referencing the missing group
+    /// message.
+    ///
+    /// It is recommended that repair does not occur after every call to process() as this would
+    /// cause peers to publish redundant pointers into the spaces graph. Although these duplicates
+    /// do not introduce any buggy or unexpected behavior, repairing after every processed message
+    /// would introduce an undesirable level of redundancy.
+    ///
+    /// ## Redundant pointers
+    ///
+    /// ```text
+    /// Shared Groups State   Space State
+    ///
+    ///       [x] <-----------[z1][z2][z3]
+    ///       [x] <-------------- [z]
+    ///       [x] <-------------- [z]
+    ///       [x] <-------------- [z]
+    /// ```
+    ///
+    /// A sensible approach to detecting and repairing spaces will involve processing messages in
+    /// logical batches and only detecting and repairing any out-of-sync spaces after a batch has
+    /// been processed. Alternatively some scheduling or throttling logic could be employed.
     pub async fn repair(
         &self,
-        groups: &[GroupId],
+        scope: &GroupsScope,
     ) -> Result<(SpacesState<C>, Vec<F::Message>, Vec<Event<C>>), SpaceError<F, C>> {
+        let missing_group_messages = self.missing_group_messages(scope).await?;
         let groups_y = self.manager.get_groups_state().await?;
         let mut space_y = self.state().await?;
 
         let mut messages = vec![];
         let mut events = vec![];
-        // @TODO: we can optimize here by calculating the diff between the current space auth
-        // graph tips and the global auth graph tips. Then we could apply only the diff, rather
-        // than processing all operations as we do here.
-        let sorted = groups_y.inner.toposort(groups);
-        for id in sorted {
-            // This auth message has already been processed by the space.
-            if space_y.groups_y.inner.operations.contains_key(&id) {
-                continue;
-            };
-
-            let operation = groups_y.inner.operations.get(&id).unwrap();
+        for id in missing_group_messages.iter() {
+            let group_message = groups_y.inner.operations.get(id).unwrap();
             let (space_y_i, space_message, space_events) =
-                Space::process_auth_message(self.manager.clone(), space_y, operation).await?;
+                Space::process_auth_message(self.manager.clone(), space_y, group_message).await?;
 
             space_y = space_y_i;
 
@@ -907,6 +1028,18 @@ where
     }
 }
 
+/// Enum used for specifying the scope which can be used to filter operations in the groups graph.
+pub enum GroupsScope {
+    /// All groups in the global state.
+    Global,
+
+    /// A single group.
+    Group(GroupId),
+
+    /// The space group.
+    Space,
+}
+
 #[cfg(any(test, feature = "test_utils"))]
 impl<S, F, C> Space<S, F, C>
 where
@@ -1008,9 +1141,9 @@ where
 
     pub async fn repair_persisted(
         &self,
-        groups: &[GroupId],
+        scope: &GroupsScope,
     ) -> Result<(Vec<F::Message>, Vec<Event<C>>), SpaceError<F, C>> {
-        let (space_y, messages, events) = self.repair(groups).await?;
+        let (space_y, messages, events) = self.repair(scope).await?;
         self.manager
             .set_space_state(&self.id(), &space_y.into())
             .await?;

--- a/p2panda-spaces/src/tests.rs
+++ b/p2panda-spaces/src/tests.rs
@@ -20,7 +20,7 @@ use crate::event::{Event, GroupActor, GroupContext, GroupEvent, SpaceContext, Sp
 use crate::manager::ManagerError;
 use crate::member::Member;
 use crate::message::SpacesArgs;
-use crate::space::{Space, SpaceError};
+use crate::space::{GroupsScope, Space, SpaceError};
 use crate::test_utils::{TestPeer, TestSpaceError};
 use crate::types::AuthGroupAction;
 
@@ -1223,10 +1223,11 @@ async fn shared_auth_state() {
         .unwrap();
 
     // Make Space 0 and Space 1 aware of this change.
-    let (messages, events) = space_0.repair_persisted(&[group.id()]).await.unwrap();
+    let scope = GroupsScope::Group(group.id());
+    let (messages, events) = space_0.repair_persisted(&scope).await.unwrap();
     assert_eq!(messages.len(), 1);
     assert_eq!(events.len(), 0);
-    let (messages, events) = space_1.repair_persisted(&[group.id()]).await.unwrap();
+    let (messages, events) = space_1.repair_persisted(&scope).await.unwrap();
     assert_eq!(messages.len(), 1);
     assert_eq!(events.len(), 0);
 
@@ -1255,13 +1256,14 @@ async fn shared_auth_state() {
         .unwrap();
 
     // Both Space 0 and Space 1 need to be made aware of this change.
-    let (messages, events) = space_0.repair_persisted(&[group.id()]).await.unwrap();
+    let scope = GroupsScope::Group(group.id());
+    let (messages, events) = space_0.repair_persisted(&scope).await.unwrap();
     assert_eq!(messages.len(), 1);
     // This change brings claire into the space membership group so we expect one space event
     // signaling this change.
     assert_eq!(events.len(), 1);
 
-    let (messages, events) = space_1.repair_persisted(&[group.id()]).await.unwrap();
+    let (messages, events) = space_1.repair_persisted(&scope).await.unwrap();
     assert_eq!(messages.len(), 1);
     assert_eq!(events.len(), 1);
 
@@ -1596,14 +1598,11 @@ async fn repair_space() {
         .unwrap();
 
     // Trigger repair of the space.
-    let messages = alice_manager
-        .repair_spaces_persisted(&vec![space_id])
-        .await
-        .unwrap();
+    let space = alice_manager.space(space_id).await.unwrap().unwrap();
+    let (messages, _) = space.repair_persisted(&GroupsScope::Space).await.unwrap();
     let message_05 = messages[0].clone();
 
     // Alice's space members now contain Claire (the space was repaired).
-    let space = alice_manager.space(space_id).await.unwrap().unwrap();
     let mut members = space.members().await.unwrap();
     members.sort_by(|(actor_a, _), (actor_b, _)| actor_a.cmp(actor_b));
     let expected_members = vec![
@@ -1713,14 +1712,11 @@ async fn duplicate_auth_state_references() {
         .unwrap();
 
     // Trigger repair of the space.
-    let messages = alice_manager
-        .repair_spaces_persisted(&vec![space_id])
-        .await
-        .unwrap();
+    let space = alice_manager.space(space_id).await.unwrap().unwrap();
+    let (messages, _) = space.repair_persisted(&GroupsScope::Space).await.unwrap();
     let message_05 = messages[0].clone();
 
     // Alice's space members now contain Claire (the space was repaired).
-    let space = alice_manager.space(space_id).await.unwrap().unwrap();
     let members = space.members().await.unwrap();
     let expected_members = vec![
         (alice_id, Access::manage()),
@@ -1742,10 +1738,8 @@ async fn duplicate_auth_state_references() {
     // ~~~~~~~~~~~~
 
     // Trigger repair of the space.
-    let messages = bob_manager
-        .repair_spaces_persisted(&vec![space_id])
-        .await
-        .unwrap();
+    let space = bob_manager.space(space_id).await.unwrap().unwrap();
+    let (messages, _) = space.repair_persisted(&GroupsScope::Space).await.unwrap();
     let _ = messages[0].clone();
 
     // Bob: processes Alice's (duplicate) auth state pointer.
@@ -1755,7 +1749,6 @@ async fn duplicate_auth_state_references() {
     bob_manager.process_persisted(&message_05).await.unwrap();
 
     // Bob arrived at the expected state without error.
-    let space = bob_manager.space(space_id).await.unwrap().unwrap();
     let members = space.members().await.unwrap();
     assert_eq!(members, expected_members);
 }

--- a/p2panda/src/spaces/repair.rs
+++ b/p2panda/src/spaces/repair.rs
@@ -2,12 +2,12 @@
 
 use std::time::Duration;
 
+use p2panda_auth::group::GroupAction;
+use p2panda_core::Topic;
 use p2panda_core::traits::{Provenance, ShortFormat};
-use p2panda_core::{Hash, Topic};
 use p2panda_net::connection_authoriser::ConnectionAuthoriser;
-use p2panda_spaces::manager::GLOBAL_GROUPS_CONTEXT_ID;
-use p2panda_spaces::{AuthGroupState, GroupId, SpaceId, SpacesStoreState};
-use p2panda_store::groups::GroupsStore;
+use p2panda_spaces::space::GroupsScope;
+use p2panda_spaces::{Event, GroupId, SpaceId, SpacesStoreState};
 use p2panda_store::operations::OperationStore;
 use p2panda_store::spaces::SpacesStore as SpacesStoreTrait;
 use p2panda_store::topics::TopicStore;
@@ -21,7 +21,9 @@ use tracing::{debug, trace, warn};
 
 use crate::operation::Operation;
 use crate::spaces::authoriser::update_authoriser;
-use crate::spaces::types::{AuthCapabilities, SpacesArgs, SpacesManager, SpacesStore};
+use crate::spaces::types::{
+    AuthCapabilities, InnerSpace, InnerSpaceError, SpacesArgs, SpacesManager, SpacesStore,
+};
 use crate::spaces::{SpacesManagerError, group_log_id};
 use crate::streams::{
     ImportLocalTx, LocalStreamFuture, ToOutputTx, to_stream_event, to_system_event,
@@ -74,7 +76,7 @@ pub enum RepairStrategy {
 ///
 /// All new messages will be sent into the topic stream to be processed and forwarded to other
 /// peers.
-pub(crate) async fn repair_space<M>(
+pub(crate) async fn sync_and_repair_space<M>(
     space_id: SpaceId,
     strategy: &RepairStrategy,
     manager: &SpacesManager,
@@ -83,142 +85,38 @@ pub(crate) async fn repair_space<M>(
     to_output_tx: &ToOutputTx<M>,
     // TODO: Only required until https://github.com/p2panda/p2panda/issues/1362 is resolved.
     connection_authoriser: &ConnectionAuthoriser,
-) -> Result<bool, RepairError> {
+) -> Result<(), RepairError> {
     let spaces_store = SpacesStore::new(store.clone());
 
-    // Collect all missing groups operations. These will be imported into the space and forwarded
-    // to live-mode peers.
-    let permit = store.begin().await?;
-
-    let Some(space_y): Option<SpacesStoreState<AuthCapabilities>> =
-        spaces_store.get_space_state_tx(&space_id).await?
-    else {
+    let Some(space) = manager.space(space_id).await? else {
         // This can happen if we didn't receive any space control messages yet.
         trace!(
             node_id = manager.id().fmt_short(),
             space_id = space_id.fmt_short(),
             "space not yet materialised"
         );
-        store.commit(permit).await?;
-        return Ok(false);
+        return Ok(());
     };
 
-    let groups_y: AuthGroupState<AuthCapabilities> = spaces_store
-        .get_groups_state_tx(Hash::digest(GLOBAL_GROUPS_CONTEXT_ID))
-        .await?
-        .unwrap_or_default();
-
-    store.commit(permit).await?;
-
-    let group_ids = match strategy {
-        RepairStrategy::Global => groups_y.groups_global(),
-        RepairStrategy::Partial(group_ids) => group_ids.clone(),
+    // TODO: This is a simple conversion between types, we could even get rid of RepairStrategy in
+    // favour of using GroupsScope.
+    let scope = match strategy {
+        RepairStrategy::Global => GroupsScope::Global,
+        RepairStrategy::Partial(_) => unimplemented!(),
     };
 
-    let repair = match manager.space_repair_required(space_id, &group_ids).await {
-        Ok(ids) => ids,
-        Err(err) => {
-            return Err(err.into());
-        }
-    };
+    // Identify and send missing group operations to the pipeline.
+    send_missing_group_operations(&space, store, &scope, import_local_tx).await?;
 
-    if !repair {
-        return Ok(false);
-    }
+    // Incorporate missing group operations into the space.
+    let events = repair_space(&space, &spaces_store, &scope, import_local_tx).await?;
 
-    // Collect all missing groups operations. These will be imported into the space and forwarded to
-    // live-mode peers.
-    let permit = store.begin().await?;
-
-    let mut groups_operations = vec![];
-    for id in groups_y.inner.toposort(&group_ids) {
-        if space_y.groups_y.inner.operations.contains_key(&id) {
-            continue;
-        }
-
-        let Some(operation): Option<Operation> = store.get_operation_tx(&id).await? else {
-            warn!("missing expected auth groups operation");
-            continue;
-        };
-
-        // Ignore non-groups operations.
-        let Some(SpacesArgs::Group {
-            group_id,
-            group_action,
-            ..
-        }) = operation.header.extensions.spaces_args()
-        else {
-            warn!("expected auth groups operation");
-            continue;
-        };
-
-        // If this is a create operation then associate the groups log with this space topic.
-        if group_action.is_create() {
-            store
-                .associate(
-                    &Topic::from(space_id),
-                    &operation.author(),
-                    &group_log_id(group_id),
-                )
-                .await?;
-        }
-
-        groups_operations.push(operation)
-    }
-
-    store.commit(permit).await?;
-
-    // Attempt to repair the space. As we pass in an array containing a single space id there will
-    // be only ever max one result returned.
+    // Update authoriser state.
     //
-    // Forging these spaces messages will also associate any group logs with this space topic.
-    //
-    // @TODO: This method uses transactions internally (eg. in the Forge) and so we can't make
-    // everything part of one transaction on this level yet. It isn't a source of bugs though so
-    // for now this is ok.
-    let (space_y, spaces_messages, events) = manager.repair_space(space_id, &group_ids).await?;
-
-    // If no space messages were forged during repairing then no state change occurred and we
-    // don't need to persist here. This occurs when we are not a _read_ member of the space (yet).
-    //
-    // @TODO: Once control messages are encrypted it will not be possible for non-read members to
-    // receives any control messages and so this logic can be refactored.
-    if !spaces_messages.is_empty() {
-        let permit = store.begin().await?;
-
-        let space_id = space_y.space_id;
-        spaces_store
-            .set_space_state_tx(&space_id, &SpacesStoreState::from(space_y))
-            .await?;
-
-        store.commit(permit).await?;
-    }
-
-    // If there are no messages to send then exit here.
-    if spaces_messages.is_empty() && groups_operations.is_empty() {
-        return Ok(false);
-    }
-
-    // Send all resulting operations into the stream.
-    let op_count = groups_operations.len() + spaces_messages.len();
-    let operations = groups_operations.into_iter().chain(
-        spaces_messages
-            .into_iter()
-            .map(|message| message.into_operation()),
-    );
-    let stream = Box::pin(futures_util::stream::iter(operations));
-    let (ready_tx, ready_rx) = oneshot::channel::<LocalStreamFuture>();
-    import_local_tx
-        .send((stream, ready_tx))
-        .await
-        .map_err(|err| RepairError::SendToProcessor(err.to_string()))?;
-
-    // Await processing of operations to be complete.
-    ready_rx.await?;
-
     // TODO: Only required until https://github.com/p2panda/p2panda/issues/1362 is resolved.
     update_authoriser(connection_authoriser, &events).await;
 
+    // Send resulting enriched space events to the user.
     let events = events
         .into_iter()
         .filter_map(|event| match event {
@@ -233,14 +131,128 @@ pub(crate) async fn repair_space<M>(
         .await
         .map_err(|_| RepairError::AppSend)?;
 
-    debug!(
-        node_id = manager.id().fmt_short(),
-        space_id = space_id.fmt_short(),
-        operations = op_count,
-        "space repaired"
-    );
+    Ok(())
+}
 
-    Ok(true)
+/// Identify group operations which are present in the global groups state but not incorporated
+/// into the space and send them to the pipeline.
+///
+/// We need any running sync sessions to receive these and to associate the group logs with the
+/// space topic.
+async fn send_missing_group_operations(
+    space: &InnerSpace,
+    store: &SqliteStore,
+    scope: &GroupsScope,
+    import_local_tx: &ImportLocalTx,
+) -> Result<(), RepairError> {
+    let missing_group_messages = space.missing_group_messages(scope).await?;
+
+    if missing_group_messages.is_empty() {
+        return Ok(());
+    }
+
+    // Collect all missing groups operations. These will be imported into the space and forwarded to
+    // live-mode peers.
+    let permit = store.begin().await?;
+
+    let mut group_operations = vec![];
+    for id in missing_group_messages {
+        let Some(operation): Option<Operation> = store.get_operation_tx(&id).await? else {
+            warn!("missing expected groups operation");
+            continue;
+        };
+
+        debug!(id=%operation.hash, seq_num=operation.header.seq_num, "import group operation into space topic");
+
+        // TODO: This can happen in spaces processor.
+        associate_group_log(space.id(), store, &operation).await?;
+
+        group_operations.push(operation)
+    }
+
+    store.commit(permit).await?;
+
+    let stream = Box::pin(futures_util::stream::iter(group_operations));
+    let (ready_tx, ready_rx) = oneshot::channel::<LocalStreamFuture>();
+    import_local_tx
+        .send((stream, ready_tx))
+        .await
+        .map_err(|err| RepairError::SendToProcessor(err.to_string()))?;
+
+    // Await processing of operations to be complete.
+    ready_rx.await?;
+
+    Ok(())
+}
+
+async fn associate_group_log(
+    space_id: SpaceId,
+    store: &SqliteStore,
+    operation: &Operation,
+) -> Result<(), SqliteError> {
+    // Only make the association for "create" operations
+    let Some(SpacesArgs::Group {
+        group_id,
+        group_action: GroupAction::Create { .. },
+        ..
+    }) = operation.header.extensions.spaces_args()
+    else {
+        return Ok(());
+    };
+
+    // If this is a create operation then associate the groups log with this space topic.
+    store
+        .associate(
+            &Topic::from(space_id),
+            &operation.author(),
+            &group_log_id(group_id),
+        )
+        .await?;
+    Ok(())
+}
+
+/// Forge SpaceMembership messages for any group operations missing from the space state.
+///
+/// Resulting operations are sent to the pipeline.
+async fn repair_space(
+    space: &InnerSpace,
+    store: &SpacesStore,
+    scope: &GroupsScope,
+    import_local_tx: &ImportLocalTx,
+) -> Result<Vec<Event<AuthCapabilities>>, RepairError> {
+    let (space_y, spaces_messages, events) = space.repair(scope).await?;
+    let operations: Vec<_> = spaces_messages
+        .into_iter()
+        .map(|message| message.into_operation())
+        .collect();
+
+    // If no space messages were forged during repairing then no state change occurred and we can
+    // return here.
+    if operations.is_empty() {
+        return Ok(vec![]);
+    };
+
+    let permit = store.begin().await?;
+
+    let space_id = space_y.space_id;
+    store
+        .set_space_state_tx(&space_id, &SpacesStoreState::from(space_y))
+        .await?;
+
+    store.commit(permit).await?;
+
+    // Send all resulting operations into the stream.
+    let stream = Box::pin(futures_util::stream::iter(operations));
+    let (ready_tx, ready_rx) = oneshot::channel::<LocalStreamFuture>();
+    import_local_tx
+        .send((stream, ready_tx))
+        .await
+        .map_err(|err| RepairError::SendToProcessor(err.to_string()))?;
+
+    // Await processing of operations to be complete.
+    ready_rx.await?;
+
+    Ok(events)
 }
 
 pub type RepairTaskSender = mpsc::UnboundedSender<RepairTaskCommand>;
@@ -277,7 +289,7 @@ impl RepairTask {
                     biased;
 
                     _ = interval.tick() => {
-                        let result = repair_space(
+                        let result = sync_and_repair_space(
                             space_id,
                             &strategy,
                             &manager,
@@ -302,7 +314,7 @@ impl RepairTask {
 
                         match command {
                             RepairTaskCommand::Repair(reply_tx) => {
-                                let result = repair_space(
+                                let result = sync_and_repair_space(
                                     space_id,
                                     &strategy,
                                     &manager,
@@ -329,11 +341,11 @@ impl RepairTask {
         Self { tx }
     }
 
-    pub async fn repair(&self) -> Result<bool, RepairError> {
+    pub async fn repair(&self) -> Result<(), RepairError> {
         let (tx, rx) = oneshot::channel();
         self.tx.send(RepairTaskCommand::Repair(tx))?;
-        let repaired = rx.await??;
-        Ok(repaired)
+        rx.await??;
+        Ok(())
     }
 }
 
@@ -341,7 +353,7 @@ impl RepairTask {
 #[derive(Debug)]
 pub enum RepairTaskCommand {
     /// Repair a space already registered with the task.
-    Repair(Sender<Result<bool, RepairError>>),
+    Repair(Sender<Result<(), RepairError>>),
 }
 
 #[derive(Debug, Error)]
@@ -352,6 +364,9 @@ pub enum RepairError {
 
     #[error(transparent)]
     SpacesManager(#[from] SpacesManagerError),
+
+    #[error(transparent)]
+    Space(#[from] InnerSpaceError),
 
     #[error("could not send to processor pipeline: {0}")]
     SendToProcessor(String),

--- a/p2panda/src/spaces/space.rs
+++ b/p2panda/src/spaces/space.rs
@@ -377,9 +377,9 @@ where
 
     /// Incorporate missing groups messages into the space, any resulting operations are published
     /// live into the space topic.
-    pub(crate) async fn repair(&self) -> Result<bool, RepairError> {
-        let repaired = self.repair_task.repair().await?;
-        Ok(repaired)
+    pub(crate) async fn repair(&self) -> Result<(), RepairError> {
+        self.repair_task.repair().await?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This change introduces a new method on Space which diffs the space state
with the shared groups state and returns the operations missing from the
former. The query can be filtered by newly introduced GroupsScope to a
specific sub-set of group operations. This logic was already implemented
in the RepairTask in p2panda node, we move it onto Space to not leak the
underlying graph query to the higher-level and to give a place to document
the function in detail.

Along with this change the RepairTask has been refactored for improved
readability.

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes

