### PR TITLE
Add method on `TopicStore` to get all topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Highlights are marked with a pancake 🥞
 - spaces: Validate write authority when processing application messages [#1295](https://github.com/p2panda/p2panda/pull/1295)
 - store: Add `resolve_topics` method to `TopicStore` trait [#1261](https://github.com/p2panda/p2panda/pull/1261)
 - store: Introduce `ProcessorStore` for storing event metadata from p2panda pipeline [#1262](https://github.com/p2panda/p2panda/pull/1262)
+- store: Add method on TopicStore to get all topics - [#1388](https://github.com/p2panda/p2panda/pull/1388)
 - stream: Filter out spaces application messages from concurrently removed members [#1291](https://github.com/p2panda/p2panda/pull/1291)
 - stream: Hooks processor to register event callbacks in streaming pipeline [#1339](https://github.com/p2panda/p2panda/pull/1339)
 - stream: Move orderer processor from node to stream [#1312](https://github.com/p2panda/p2panda/pull/1312)
@@ -62,7 +63,6 @@ Highlights are marked with a pancake 🥞
 ### Added
 
 - net: Support bearer authentication for iroh relays [#1361](https://github.com/p2panda/p2panda/pull/1361)
-- sync: Point-to-point (unicast) sync session with live mode example - [#1385](https://github.com/p2panda/p2panda/pull/1385)
 
 ### Changed
 

--- a/p2panda-store/src/topics/sqlite.rs
+++ b/p2panda-store/src/topics/sqlite.rs
@@ -176,4 +176,33 @@ where
 
         Ok(topics)
     }
+
+    /// Retrieve all topics for which active associations exist.
+    async fn topics(&self) -> Result<Vec<T>, Self::Error> {
+        let topics = self
+            .tx(async |tx| {
+                query_as::<_, (Vec<u8>,)>(
+                    "
+                    SELECT DISTINCT
+                        topic
+                    FROM
+                        topics_v1
+                    ",
+                )
+                .fetch_all(&mut **tx)
+                .await
+                .map_err(SqliteError::Sqlite)
+            })
+            .await?;
+
+        let mut result: Vec<T> = Vec::new();
+
+        for (topic,) in topics {
+            let topic = decode_cbor(&topic[..])
+                .map_err(|err| SqliteError::Decode("topic".into(), err.into()))?;
+            result.push(topic);
+        }
+
+        Ok(result)
+    }
 }

--- a/p2panda-store/src/topics/tests.rs
+++ b/p2panda-store/src/topics/tests.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use p2panda_core::{SigningKey, Topic};
+use p2panda_core::{SigningKey, Topic, VerifyingKey};
 
 use crate::topics::TopicStore;
 use crate::{SqliteStore, Transaction};
@@ -164,4 +164,46 @@ async fn remove_association() {
 
     let logs = store.resolve(&topic).await.unwrap();
     assert_eq!(logs, expected_logs);
+}
+
+#[tokio::test]
+async fn query_associated_topics() {
+    let store = SqliteStore::temporary().await;
+
+    let topic_1 = Topic::random();
+    let topic_2 = Topic::random();
+    let topic_3 = Topic::random();
+
+    let alice = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
+    let bob = SigningKey::from_bytes(&[2u8; 32]).verifying_key();
+    let cat = SigningKey::from_bytes(&[3u8; 32]).verifying_key();
+
+    let log_id: String = "kittens".into();
+
+    let permit = store.begin().await.unwrap();
+
+    let result = store.associate(&topic_1, &alice, &log_id).await.unwrap();
+    assert!(result);
+
+    let result = store.associate(&topic_2, &alice, &log_id).await.unwrap();
+    assert!(result);
+
+    let result = store.associate(&topic_2, &bob, &log_id).await.unwrap();
+    assert!(result);
+
+    let result = store.associate(&topic_3, &cat, &log_id).await.unwrap();
+    assert!(result);
+
+    let expected_topics = Vec::from([topic_1, topic_2, topic_3]);
+
+    let topics: Vec<Topic> =
+        <SqliteStore as TopicStore<Topic, VerifyingKey, String>>::topics(&store)
+            .await
+            .unwrap();
+
+    store.commit(permit).await.unwrap();
+
+    for topic in expected_topics {
+        assert!(topics.contains(&topic));
+    }
 }

--- a/p2panda-store/src/topics/traits.rs
+++ b/p2panda-store/src/topics/traits.rs
@@ -66,4 +66,7 @@ pub trait TopicStore<T, A, D> {
         author: &A,
         data_id: &D,
     ) -> impl Future<Output = Result<Vec<T>, Self::Error>>;
+
+    /// Retrieve all topics for which active associations exist.
+    fn topics(&self) -> impl Future<Output = Result<Vec<T>, Self::Error>>;
 }


### PR DESCRIPTION
Here we add a `topics()` method to the `TopicStore` which returns a deduplicated list of all topics for which active log associations exist. Topics for previously removed associations are not returned.

This query can be helpful for understanding which topics to sync over when you only have access to the SQLite store (for example, in the context of sneakernet sync).

Closes: https://github.com/p2panda/p2panda/issues/1396

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes