### PR TITLE
Use  `AnyOperation` on `LogStore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Highlights are marked with a pancake 🥞
 - spaces: Remove auth resolver generic parameter [#1298](https://github.com/p2panda/p2panda/pull/1298)
 - store: sqlx 0.9.0, use safer query builder [#1322](https://github.com/p2panda/p2panda/pull/1322)
 - core: Infallible conversion from Operation<E> into AnyOperation [#1389](https://github.com/p2panda/p2panda/pull/1389)
+- store: Use `AnyOperation` on `LogStore` [#1391](https://github.com/p2panda/p2panda/pull/1391)
 
 ### Fixes
 

--- a/p2panda-core/src/operation/any.rs
+++ b/p2panda-core/src/operation/any.rs
@@ -20,7 +20,7 @@ use crate::traits::{Chain, Digest, Offchain, Provenance};
 /// Applications usually want to attach custom extensions to the operation, if you need to know the
 /// type you can easily convert from `AnyOperation` to [`Operation`](crate::Operation) with an
 /// explicit `E` extensions type.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AnyOperation {
     pub hash: Hash,
     pub header: AnyHeader,

--- a/p2panda-net/src/sync/log_sync/api.rs
+++ b/p2panda-net/src/sync/log_sync/api.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, Topic, VerifyingKey};
+use p2panda_core::{AnyOperation, Extensions, Hash, LogId, Operation, SeqNum, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
 use p2panda_sync::protocols::TopicLogSyncEvent;
@@ -40,7 +40,7 @@ use crate::sync::log_sync::Builder;
 #[derive(Clone, Debug)]
 pub struct LogSync<S, L, E>
 where
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<Topic, VerifyingKey, L>
         + Clone
         + Send
@@ -63,7 +63,7 @@ where
 
 impl<S, L, E> LogSync<S, L, E>
 where
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<Topic, VerifyingKey, L>
         + Clone
         + Send

--- a/p2panda-net/src/sync/log_sync/builder.rs
+++ b/p2panda-net/src/sync/log_sync/builder.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
-use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, Topic, VerifyingKey};
+use p2panda_core::{AnyOperation, Extensions, Hash, LogId, SeqNum, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
 use p2panda_sync::manager::TopicSyncManager;
@@ -17,7 +17,7 @@ use crate::sync::log_sync::{LOG_SYNC_PROTOCOL_ID, LogSync, LogSyncError};
 
 pub struct Builder<S, L, E>
 where
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<Topic, VerifyingKey, L>
         + Clone
         + Send
@@ -34,7 +34,7 @@ where
 
 impl<S, L, E> Builder<S, L, E>
 where
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<Topic, VerifyingKey, L>
         + Clone
         + Send

--- a/p2panda-net/src/test_utils.rs
+++ b/p2panda-net/src/test_utils.rs
@@ -293,19 +293,13 @@ impl TestClient {
         log_id: u64,
     ) -> (Header<()>, Vec<u8>, Body) {
         let (header, header_bytes, body) = tx_unwrap!(&self.store, {
-            let (seq_num, backlink) = <SqliteStore as LogStore<
-                Operation<TestExtensions>,
-                VerifyingKey,
-                u64,
-                SeqNum,
-                p2panda_core::Hash,
-            >>::get_latest_entry_tx(
-                &self.store, &self.signing_key.verifying_key(), &log_id
-            )
-            .await
-            .unwrap()
-            .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
-            .unwrap_or((0, None));
+            let (seq_num, backlink) = self
+                .store
+                .get_latest_entry_tx(&self.signing_key.verifying_key(), &log_id)
+                .await
+                .unwrap()
+                .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
+                .unwrap_or((0, None));
 
             create_operation(&self.signing_key, body, seq_num, backlink)
         });

--- a/p2panda-spaces/src/test_utils/forge.rs
+++ b/p2panda-spaces/src/test_utils/forge.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use p2panda_core::{Hash, Header, SigningKey, VerifyingKey};
+use p2panda_core::{Header, SigningKey, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
 use p2panda_store::{SqliteError, SqliteStore, tx};
@@ -10,9 +10,6 @@ use crate::message::SpacesArgs;
 use crate::test_utils::{TestConditions, TestOperation};
 
 pub const DEFAULT_LOG_ID: u32 = 0;
-
-type LogId = u32;
-type SeqNum = u32;
 
 #[derive(Debug, Clone)]
 pub struct TestForge {
@@ -37,20 +34,12 @@ impl Forge<TestConditions> for TestForge {
 
     async fn forge(&self, args: SpacesArgs<TestConditions>) -> Result<Self::Message, Self::Error> {
         let operation = tx!(self.store, {
-            let (seq_num, backlink) = <SqliteStore as LogStore<
-                TestOperation,
-                VerifyingKey,
-                LogId,
-                SeqNum,
-                Hash,
-            >>::get_latest_entry_tx(
-                &self.store,
-                &self.signing_key.verifying_key(),
-                &DEFAULT_LOG_ID,
-            )
-            .await?
-            .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
-            .unwrap_or((0, None));
+            let (seq_num, backlink) = self
+                .store
+                .get_latest_entry_tx(&self.signing_key.verifying_key(), &DEFAULT_LOG_ID)
+                .await?
+                .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
+                .unwrap_or((0, None));
 
             let header = Header::builder()
                 .seq_num(seq_num)

--- a/p2panda-store/src/lib.rs
+++ b/p2panda-store/src/lib.rs
@@ -68,14 +68,8 @@
 //! // Here we acquire a store permit, query the latest log entry, associate the topic with
 //! // the log, insert the operation and commit the transaction before dropping the permit.
 //! let operation = tx!(store, {
-//!     let (seq_num, backlink) = <SqliteStore as LogStore<
-//!         Operation<()>,
-//!         VerifyingKey,
-//!         u64,
-//!         SeqNum,
-//!         Hash,
-//!     >>::get_latest_entry_tx(
-//!         &store, &signing_key.verifying_key(), &log_id
+//!     let (seq_num, backlink) = store.get_latest_entry_tx(
+//!         &signing_key.verifying_key(), &log_id
 //!     )
 //!     .await?
 //!     .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))

--- a/p2panda-store/src/logs/sqlite/mod.rs
+++ b/p2panda-store/src/logs/sqlite/mod.rs
@@ -7,7 +7,7 @@ mod tests;
 use std::collections::BTreeMap;
 
 use p2panda_core::cbor::encode_cbor;
-use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
+use p2panda_core::{AnyOperation, Hash, LogId, SeqNum, VerifyingKey};
 use sqlx::{QueryBuilder, query, query_as};
 
 use crate::logs::LogStore;
@@ -29,9 +29,8 @@ const GET_LATEST_ENTRY: &str = "
         seq_num DESC LIMIT 1
 ";
 
-impl<L, E> LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash> for SqliteStore
+impl<L> LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash> for SqliteStore
 where
-    E: Extensions,
     L: LogId,
 {
     type Error = SqliteError;
@@ -41,7 +40,7 @@ where
         &self,
         author: &VerifyingKey,
         log_id: &L,
-    ) -> Result<Option<Operation<E>>, Self::Error> {
+    ) -> Result<Option<AnyOperation>, Self::Error> {
         if let Some(latest) = query_as::<_, OperationRow>(GET_LATEST_ENTRY)
             .bind(author.to_string())
             .bind(
@@ -71,7 +70,7 @@ where
         &self,
         author: &VerifyingKey,
         log_id: &L,
-    ) -> Result<Option<Operation<E>>, Self::Error> {
+    ) -> Result<Option<AnyOperation>, Self::Error> {
         let result = self
             .tx(async |tx| {
                 query_as::<_, OperationRow>(GET_LATEST_ENTRY)
@@ -194,7 +193,7 @@ where
         log_id: &L,
         after: Option<SeqNum>,
         until: Option<SeqNum>,
-    ) -> Result<Option<Vec<(Operation<E>, Vec<u8>)>>, Self::Error> {
+    ) -> Result<Option<Vec<(AnyOperation, Vec<u8>)>>, Self::Error> {
         let operations = query_as::<_, OperationRow>(
             "
             SELECT

--- a/p2panda-store/src/logs/sqlite/tests.rs
+++ b/p2panda-store/src/logs/sqlite/tests.rs
@@ -2,8 +2,8 @@
 
 use std::collections::BTreeMap;
 
+use p2panda_core::SigningKey;
 use p2panda_core::test_utils::TestLog;
-use p2panda_core::{Operation, SigningKey};
 
 use crate::logs::LogStore;
 use crate::operations::OperationStore;
@@ -35,17 +35,14 @@ async fn get_latest_entry() {
             .unwrap()
     );
 
-    let result = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_latest_entry_tx(
-        &store,
-        &log.author(),
-        &log.id(),
-    )
-    .await
-    .unwrap();
+    let result = store
+        .get_latest_entry_tx(&log.author(), &log.id())
+        .await
+        .unwrap();
 
     store.commit(permit).await.unwrap();
 
-    assert_eq!(result, Some(operation_2));
+    assert_eq!(result, Some(operation_2.into()));
 }
 
 #[tokio::test]
@@ -85,13 +82,10 @@ async fn get_log_heights() {
 
     store.commit(permit).await.unwrap();
 
-    let result = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_log_heights(
-        &store,
-        &signing_key.verifying_key(),
-        &[log_1.id(), log_2.id()],
-    )
-    .await
-    .unwrap();
+    let result = store
+        .get_log_heights(&signing_key.verifying_key(), &[log_1.id(), log_2.id()])
+        .await
+        .unwrap();
 
     let expected_result = BTreeMap::from([(log_1.id(), 1), (log_2.id(), 0)]);
 
@@ -125,16 +119,11 @@ async fn get_log_size() {
 
     store.commit(permit).await.unwrap();
 
-    let (operations_num, size) = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_log_size(
-        &store,
-        &log.author(),
-        &log.id(),
-        None,
-        None,
-    )
-    .await
-    .unwrap()
-    .unwrap();
+    let (operations_num, size) = store
+        .get_log_size(&log.author(), &log.id(), None, None)
+        .await
+        .unwrap()
+        .unwrap();
 
     assert_eq!(operations_num, 2);
 
@@ -192,26 +181,21 @@ async fn get_log_entries() {
 
     store.commit(permit).await.unwrap();
 
-    let log_entries = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_log_entries(
-        &store,
-        &log.author(),
-        &log.id(),
-        None,
-        None,
-    )
-    .await
-    .expect("no errors");
+    let log_entries = store
+        .get_log_entries(&log.author(), &log.id(), None, None)
+        .await
+        .expect("no errors");
 
     assert!(log_entries.is_some());
     let log_entries = log_entries.unwrap();
 
     assert_eq!(log_entries.len(), 5);
 
-    assert_eq!(log_entries[0].0, operation_1);
-    assert_eq!(log_entries[1].0, operation_2);
-    assert_eq!(log_entries[2].0, operation_3);
-    assert_eq!(log_entries[3].0, operation_4);
-    assert_eq!(log_entries[4].0, operation_5);
+    assert_eq!(log_entries[0].0, operation_1.into());
+    assert_eq!(log_entries[1].0, operation_2.into());
+    assert_eq!(log_entries[2].0, operation_3.into());
+    assert_eq!(log_entries[3].0, operation_4.into());
+    assert_eq!(log_entries[4].0, operation_5.into());
 }
 
 #[tokio::test]
@@ -261,26 +245,16 @@ async fn prune_entries() {
 
     store.commit(permit).await.unwrap();
 
-    let prune_entries_num = <SqliteStore as LogStore<Operation, _, _, _, _>>::prune_entries(
-        &store,
-        &log.author(),
-        &log.id(),
-        &3,
-    )
-    .await
-    .expect("no errors");
+    let prune_entries_num = SqliteStore::prune_entries(&store, &log.author(), &log.id(), &3)
+        .await
+        .expect("no errors");
 
     assert_eq!(prune_entries_num, 3);
 
-    let log_entries = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_log_entries(
-        &store,
-        &log.author(),
-        &log.id(),
-        None,
-        None,
-    )
-    .await
-    .expect("no errors");
+    let log_entries = store
+        .get_log_entries(&log.author(), &log.id(), None, None)
+        .await
+        .expect("no errors");
 
     assert!(log_entries.is_some());
     let log_entries = log_entries.unwrap();
@@ -288,6 +262,6 @@ async fn prune_entries() {
     // Three entries were pruned; the two most recently published entries should
     // remain.
     assert_eq!(log_entries.len(), 2);
-    assert_eq!(log_entries[0].0, operation_4);
-    assert_eq!(log_entries[1].0, operation_5);
+    assert_eq!(log_entries[0].0, operation_4.into());
+    assert_eq!(log_entries[1].0, operation_5.into());
 }

--- a/p2panda-store/src/operations/sqlite.rs
+++ b/p2panda-store/src/operations/sqlite.rs
@@ -2,7 +2,7 @@
 
 use p2panda_core::cbor::encode_cbor;
 use p2panda_core::hash::{Hash, HashError};
-use p2panda_core::{Extensions, Header, LogId, Operation};
+use p2panda_core::{AnyHeader, AnyOperation, Extensions, Header, LogId, Operation};
 use sqlx::{FromRow, query, query_as};
 
 use crate::operations::OperationStore;
@@ -216,6 +216,22 @@ where
                 .parse()
                 .map_err(|err: HashError| SqliteError::Decode("hash".to_string(), err.into()))?,
             header: Header::<E>::decode(&row.header)
+                .map_err(|err| SqliteError::Decode("header".into(), err.into()))?,
+            body: row.body.map(|body| body.into()),
+        })
+    }
+}
+
+impl TryFrom<OperationRow> for AnyOperation {
+    type Error = SqliteError;
+
+    fn try_from(row: OperationRow) -> Result<Self, Self::Error> {
+        Ok(AnyOperation {
+            hash: row
+                .hash
+                .parse()
+                .map_err(|err: HashError| SqliteError::Decode("hash".to_string(), err.into()))?,
+            header: AnyHeader::decode(&row.header)
                 .map_err(|err| SqliteError::Decode("header".into(), err.into()))?,
             body: row.body.map(|body| body.into()),
         })

--- a/p2panda-stream/src/ingest/operation.rs
+++ b/p2panda-stream/src/ingest/operation.rs
@@ -4,7 +4,9 @@
 use std::borrow::Borrow;
 
 use p2panda_core::prune::validate_prunable_backlink;
-use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey, validate_operation};
+use p2panda_core::{
+    AnyOperation, Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey, validate_operation,
+};
 use p2panda_store::Transaction;
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
@@ -26,7 +28,7 @@ pub async fn ingest_operation<S, T, L, E, TP>(
 where
     S: Transaction
         + OperationStore<Operation<E>, Hash>
-        + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+        + LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<TP, VerifyingKey, L>,
     T: Borrow<Operation<E>>,
     L: LogId,
@@ -66,8 +68,15 @@ where
 
     // If no pruning flag is set, we expect the log to have integrity with the previously given
     // operation.
-    validate_prunable_backlink(past_header.as_ref(), &operation.header, prune_flag)
-        .map_err(|err| IngestError::InvalidOperation(err.to_string()))?;
+    //
+    // TODO: We can remove the header Clone and Into here once we update OperationStore to use
+    // AnyOperation https://github.com/p2panda/p2panda/issues/1018.
+    validate_prunable_backlink(
+        past_header.as_ref(),
+        &operation.header.clone().into(),
+        prune_flag,
+    )
+    .map_err(|err| IngestError::InvalidOperation(err.to_string()))?;
 
     // Insert operation into store and associate its log with the given topic.
     let verifying_key = operation.header.verifying_key;
@@ -105,7 +114,7 @@ pub enum IngestError {
 #[cfg(test)]
 mod tests {
     use p2panda_core::test_utils::TestLog;
-    use p2panda_core::{Hash, Header, Operation, SeqNum, SigningKey, VerifyingKey};
+    use p2panda_core::{Hash, Header, Operation, SigningKey, VerifyingKey};
     use p2panda_store::SqliteStore;
     use p2panda_store::logs::LogStore;
     use p2panda_store::topics::TopicStore;
@@ -185,16 +194,11 @@ mod tests {
         assert_eq!(*authors.get(&log_0.author()).unwrap(), [0]);
         assert_eq!(*authors.get(&log_1.author()).unwrap(), [1]);
 
-        let operation = <SqliteStore as LogStore<
-            Operation<()>,
-            VerifyingKey,
-            usize,
-            SeqNum,
-            Hash,
-        >>::get_latest_entry(&store, &log_0.author(), &0)
-        .await
-        .unwrap()
-        .unwrap();
+        let operation = store
+            .get_latest_entry(&log_0.author(), &0)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(operation.header.seq_num, 1);
 
         // Topic "cats" contains one log: 2 with four operations.
@@ -204,16 +208,11 @@ mod tests {
                 .unwrap();
         assert_eq!(*authors.get(&log_2.author()).unwrap(), [2]);
 
-        let operation = <SqliteStore as LogStore<
-            Operation<()>,
-            VerifyingKey,
-            usize,
-            SeqNum,
-            Hash,
-        >>::get_latest_entry(&store, &log_2.author(), &2)
-        .await
-        .unwrap()
-        .unwrap();
+        let operation = store
+            .get_latest_entry(&log_2.author(), &2)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(operation.header.seq_num, 2);
     }
 

--- a/p2panda-stream/src/ingest/processor.rs
+++ b/p2panda-stream/src/ingest/processor.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 
-use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
+use p2panda_core::{AnyOperation, Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
 use p2panda_store::Transaction;
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
@@ -28,7 +28,7 @@ impl<S, T, L, E, TP> Ingest<S, T, L, E, TP>
 where
     S: Transaction
         + OperationStore<Operation<E>, Hash>
-        + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+        + LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<TP, VerifyingKey, L>,
     L: LogId,
     E: Extensions,
@@ -47,7 +47,7 @@ impl<S, T, L, E, TP> Processor<T> for Ingest<S, T, L, E, TP>
 where
     S: Transaction
         + OperationStore<Operation<E>, Hash>
-        + LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+        + LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<TP, VerifyingKey, L>,
     T: Borrow<Operation<E>> + Borrow<IngestArgs<L, TP>>,
     L: LogId,

--- a/p2panda-stream/src/log_prune/processor.rs
+++ b/p2panda-stream/src/log_prune/processor.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 
-use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
+use p2panda_core::{AnyOperation, Hash, LogId, SeqNum, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use thiserror::Error;
 use tokio::sync::Notify;
@@ -13,18 +13,17 @@ use tokio::sync::Notify;
 use crate::Processor;
 use crate::log_prune::LogPruneArgs;
 
-pub struct LogPrune<S, T, L, E> {
+pub struct LogPrune<S, T, L> {
     store: S,
     notify: Notify,
     queue: RefCell<VecDeque<(T, LogPruneResult)>>,
-    _marker: PhantomData<(L, E)>,
+    _marker: PhantomData<L>,
 }
 
-impl<S, T, L, E> LogPrune<S, T, L, E>
+impl<S, T, L> LogPrune<S, T, L>
 where
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>,
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>,
     L: LogId,
-    E: Extensions,
 {
     pub fn new(store: S) -> Self {
         Self {
@@ -36,12 +35,11 @@ where
     }
 }
 
-impl<S, T, L, E> Processor<T> for LogPrune<S, T, L, E>
+impl<S, T, L> Processor<T> for LogPrune<S, T, L>
 where
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>,
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>,
     T: Borrow<LogPruneArgs<VerifyingKey, L, SeqNum>>,
     L: LogId,
-    E: Extensions,
 {
     type Output = (T, LogPruneResult);
 

--- a/p2panda-sync/examples/broadcast.rs
+++ b/p2panda-sync/examples/broadcast.rs
@@ -381,18 +381,11 @@ async fn create_operation(
     let extensions = CustomExtensions { log_id };
 
     let operation = tx!(store, {
-        let (seq_num, backlink) = <SqliteStore as LogStore<
-            Operation,
-            VerifyingKey,
-            LogId,
-            SeqNum,
-            Hash,
-        >>::get_latest_entry_tx(
-            &store, &signing_key.verifying_key(), &log_id
-        )
-        .await?
-        .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
-        .unwrap_or((0, None));
+        let (seq_num, backlink) = store
+            .get_latest_entry_tx(&signing_key.verifying_key(), &log_id)
+            .await?
+            .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
+            .unwrap_or((0, None));
 
         let header = {
             let mut builder = Header::builder().seq_num(seq_num).backlink(backlink);
@@ -472,26 +465,12 @@ async fn compute_diff(
 
     for (author, log_heights) in log_ranges {
         for (log_id, (after, until)) in log_heights {
-            let log_operations = <SqliteStore as LogStore<
-                Operation<CustomExtensions>,
-                _,
-                _,
-                _,
-                _,
-            >>::get_log_entries(
-                &store, &author, &log_id, after, until
-            )
-            .await?
-            .unwrap_or_default();
+            let log_operations = store
+                .get_log_entries(&author, &log_id, after, until)
+                .await?
+                .unwrap_or_default();
 
             for (operation, _) in log_operations {
-                let operation = AnyOperation {
-                    hash: operation.hash,
-                    // TODO: This is wrong in p2panda-core and should not be fallible.
-                    header: operation.header.try_into().unwrap(),
-                    body: operation.body,
-                };
-
                 operations.push(operation);
             }
         }
@@ -517,14 +496,7 @@ async fn get_log_heights(
     let mut result = BTreeMap::new();
 
     for (verifying_key, log_ids) in logs {
-        let Some(log_heights) =
-            LogStore::<Operation, VerifyingKey, LogId, SeqNum, Hash>::get_log_heights(
-                store,
-                verifying_key,
-                log_ids,
-            )
-            .await?
-        else {
+        let Some(log_heights) = store.get_log_heights(verifying_key, log_ids).await? else {
             continue;
         };
 

--- a/p2panda-sync/examples/sneakernet.rs
+++ b/p2panda-sync/examples/sneakernet.rs
@@ -184,27 +184,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // TODO: This is ugly.
         for (author, log_heights) in &all_log_heights {
             for log_id in log_heights.keys() {
-                let log_operations = <SqliteStore as LogStore<
-                    Operation<CustomExtensions>,
-                    _,
-                    _,
-                    _,
-                    _,
-                >>::get_log_entries(
-                    &store_a, &node_id_a, log_id, None, None
-                )
-                .await?
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(operation, _)| AnyOperation {
-                    hash: operation.hash,
-                    // TODO: This is maybe wrong in p2panda-core: We should be able to convert from
-                    // Header<E> to AnyHeader without any errors (the extensions are already in CBOR
-                    // AST representation).
-                    header: operation.header.try_into().unwrap(),
-                    body: operation.body,
-                })
-                .collect::<Vec<AnyOperation>>();
+                let log_operations = store_a
+                    .get_log_entries(&node_id_a, log_id, None, None)
+                    .await?
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|(operation, _)| operation)
+                    .collect::<Vec<AnyOperation>>();
 
                 let entry = operations.entry(*topic);
                 let logs = entry.or_default();
@@ -414,24 +400,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             for (author, log_heights) in log_ranges {
                 for (log_id, (after, until)) in log_heights {
-                    let log_operations = <SqliteStore as LogStore<
-                        Operation<CustomExtensions>,
-                        _,
-                        _,
-                        _,
-                        _,
-                    >>::get_log_entries(
-                        &store_b, &node_id_b, &log_id, after, until
-                    )
-                    .await?
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|(operation, _)| AnyOperation {
-                        hash: operation.hash,
-                        header: operation.header.try_into().unwrap(),
-                        body: operation.body,
-                    })
-                    .collect::<Vec<AnyOperation>>();
+                    let log_operations = store_a
+                        .get_log_entries(&node_id_a, &log_id, after, until)
+                        .await?
+                        .unwrap_or_default();
 
                     // NOTE: We could have a flag here to control if we want to already publish
                     // operations of topics nobody published an announcement for.
@@ -439,7 +411,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let entry = operations.entry(topic);
                     let logs = entry.or_default();
 
-                    for operation in log_operations {
+                    for (operation, _) in log_operations {
                         let log_entry = logs.entry((author, log_id));
                         let log = log_entry.or_default();
 
@@ -545,14 +517,7 @@ async fn get_log_heights(
     let mut result = BTreeMap::new();
 
     for (verifying_key, log_ids) in logs {
-        let Some(log_heights) =
-            LogStore::<Operation, VerifyingKey, LogId, SeqNum, Hash>::get_log_heights(
-                store,
-                verifying_key,
-                log_ids,
-            )
-            .await?
-        else {
+        let Some(log_heights) = store.get_log_heights(verifying_key, log_ids).await? else {
             continue;
         };
 

--- a/p2panda-sync/examples/sync_w_live_mode.rs
+++ b/p2panda-sync/examples/sync_w_live_mode.rs
@@ -132,27 +132,13 @@ impl Node {
 
         for (_author, log_heights) in log_ranges {
             for (log_id, (after, until)) in log_heights {
-                let log_operations = <SqliteStore as LogStore<
-                    Operation<CustomExtensions>,
-                    _,
-                    _,
-                    _,
-                    _,
-                >>::get_log_entries(
-                    &self.store, &self.id(), &log_id, after, until
-                )
-                .await?
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(operation, _)| AnyOperation {
-                    hash: operation.hash,
-                    header: operation
-                        .header
-                        .try_into()
-                        .expect("shouldn't be an error in p2panda-core"),
-                    body: operation.body,
-                })
-                .collect::<Vec<AnyOperation>>();
+                let log_operations = self
+                    .store
+                    .get_log_entries(&self.id(), &log_id, after, until)
+                    .await?
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|(operation, _)| operation);
 
                 operations.extend(log_operations);
             }
@@ -316,14 +302,7 @@ async fn get_log_heights(
     let mut result = BTreeMap::new();
 
     for (verifying_key, log_ids) in logs {
-        let Some(log_heights) =
-            LogStore::<Operation, VerifyingKey, LogId, SeqNum, Hash>::get_log_heights(
-                store,
-                verifying_key,
-                log_ids,
-            )
-            .await?
-        else {
+        let Some(log_heights) = store.get_log_heights(verifying_key, log_ids).await? else {
             continue;
         };
 

--- a/p2panda-sync/src/manager/mod.rs
+++ b/p2panda-sync/src/manager/mod.rs
@@ -17,7 +17,7 @@ use futures_channel::mpsc;
 use futures_util::future::ready;
 use futures_util::sink::{Sink, SinkExt};
 use futures_util::stream::{SelectAll, Stream, StreamExt};
-use p2panda_core::{Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
+use p2panda_core::{AnyOperation, Extensions, Hash, LogId, Operation, SeqNum, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
 use serde::{Deserialize, Serialize};
@@ -104,7 +104,7 @@ where
 impl<T, S, L, E> Manager<T> for TopicSyncManager<T, S, L, E>
 where
     T: Clone + Debug + Eq + StdHash + Serialize + for<'a> Deserialize<'a> + Send + 'static,
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<T, VerifyingKey, L>
         + Clone
         + Send

--- a/p2panda-sync/src/protocols/log_sync.rs
+++ b/p2panda-sync/src/protocols/log_sync.rs
@@ -8,7 +8,8 @@ use std::marker::PhantomData;
 use futures_util::{Sink, SinkExt, Stream, StreamExt, stream};
 use p2panda_core::logs::{LogHeights, LogRanges, compare};
 use p2panda_core::{
-    Body, Extensions, Hash, Header, LogId, Operation, RawOperation, SeqNum, VerifyingKey,
+    AnyOperation, Body, Extensions, Hash, Header, LogId, Operation, RawOperation, SeqNum,
+    VerifyingKey,
 };
 use p2panda_store::logs::LogStore;
 use serde::{Deserialize, Serialize};
@@ -96,7 +97,7 @@ impl<L, E, S, Evt> Protocol for LogSync<L, E, S, Evt>
 where
     L: LogId + Debug + Send + 'static,
     E: Extensions + Send + 'static,
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash> + Clone + Send + 'static,
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash> + Clone + Send + 'static,
     Evt: Debug + From<LogSyncEvent<E>> + Send + 'static,
 {
     type Error = LogSyncError;
@@ -450,13 +451,13 @@ where
 }
 
 /// Return the local log heights of all passed logs.
-async fn get_log_heights<L, E, S>(
+async fn get_log_heights<L, S>(
     store: &S,
     logs: &Logs<L>,
 ) -> Result<LogHeights<VerifyingKey, L>, LogSyncError>
 where
     L: LogId,
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash> + Clone + Send + 'static,
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash> + Clone + Send + 'static,
 {
     let mut result = BTreeMap::new();
     for (verifying_key, log_ids) in logs {

--- a/p2panda-sync/src/protocols/topic_log_sync.rs
+++ b/p2panda-sync/src/protocols/topic_log_sync.rs
@@ -11,7 +11,8 @@ use std::task::{Context, Poll};
 use futures_channel::mpsc;
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use p2panda_core::{
-    Body, Extensions, Hash, Header, LogId, Operation, RawOperation, SeqNum, VerifyingKey,
+    AnyOperation, Body, Extensions, Hash, Header, LogId, Operation, RawOperation, SeqNum,
+    VerifyingKey,
 };
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
@@ -55,7 +56,7 @@ pub struct TopicLogSync<T, S, L, E> {
 impl<T, S, L, E> TopicLogSync<T, S, L, E>
 where
     T: Eq + StdHash + Serialize + for<'a> Deserialize<'a>,
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<T, VerifyingKey, L>
         + Clone
         + Send
@@ -102,7 +103,7 @@ where
 impl<T, S, L, E> Protocol for TopicLogSync<T, S, L, E>
 where
     T: Debug + Eq + StdHash + Serialize + for<'a> Deserialize<'a> + Send + 'static,
-    S: LogStore<Operation<E>, VerifyingKey, L, SeqNum, Hash>
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>
         + TopicStore<T, VerifyingKey, L>
         + Clone
         + Send
@@ -244,7 +245,6 @@ where
                                     // connection.
 
                                     debug!("closing sync session");
-
                                     let result = sink
                                         .send(TopicLogSyncMessage::Close)
                                         .await

--- a/p2panda-sync/src/test_utils.rs
+++ b/p2panda-sync/src/test_utils.rs
@@ -119,19 +119,13 @@ impl Peer {
         body: &Body,
         log_id: TestLogId,
     ) -> (Header<TestExtensions>, Vec<u8>) {
-        let (seq_num, backlink) = <SqliteStore as LogStore<
-            Operation<TestExtensions>,
-            VerifyingKey,
-            TestLogId,
-            SeqNum,
-            p2panda_core::Hash,
-        >>::get_latest_entry(
-            &self.store, &self.signing_key.verifying_key(), &log_id
-        )
-        .await
-        .unwrap()
-        .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
-        .unwrap_or((0, None));
+        let (seq_num, backlink) = self
+            .store
+            .get_latest_entry(&self.signing_key.verifying_key(), &log_id)
+            .await
+            .unwrap()
+            .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
+            .unwrap_or((0, None));
 
         let (header, header_bytes) =
             create_operation(&self.signing_key, body, seq_num, backlink, log_id);

--- a/p2panda/src/forge.rs
+++ b/p2panda/src/forge.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error as StdError;
 
-use p2panda_core::{Body, Hash, SeqNum, Topic, VerifyingKey};
+use p2panda_core::{Body, Hash, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::operations::OperationStore;
 use p2panda_store::topics::TopicStore;
@@ -72,18 +72,12 @@ impl Forge<Topic, LogId, Extensions> for OperationForge {
         // Here we acquire a store permit, query the latest log entry, associate the topic with
         // the log, insert the operation and commit the transaction before dropping the permit.
         let operation = tx!(self.store, {
-            let (seq_num, backlink) = <SqliteStore as LogStore<
-                Operation,
-                VerifyingKey,
-                LogId,
-                SeqNum,
-                Hash,
-            >>::get_latest_entry_tx(
-                &self.store, &self.credentials.verifying_key(), &log_id
-            )
-            .await?
-            .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
-            .unwrap_or((0, None));
+            let (seq_num, backlink) = self
+                .store
+                .get_latest_entry_tx(&self.credentials.verifying_key(), &log_id)
+                .await?
+                .map(|operation| (operation.header.seq_num + 1, Some(operation.hash)))
+                .unwrap_or((0, None));
 
             let header = {
                 let mut builder = Header::builder().seq_num(seq_num).backlink(backlink);
@@ -136,7 +130,7 @@ pub enum ForgeError {
 mod tests {
     use std::collections::BTreeMap;
 
-    use p2panda_core::{Operation, Topic};
+    use p2panda_core::Topic;
     use p2panda_store::SqliteStore;
     use p2panda_store::logs::LogStore;
 
@@ -176,13 +170,10 @@ mod tests {
             .await
             .unwrap();
 
-        let result = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_log_heights(
-            &store,
-            &forge.verifying_key(),
-            &[log_id],
-        )
-        .await
-        .unwrap();
+        let result = store
+            .get_log_heights(&forge.verifying_key(), &[log_id])
+            .await
+            .unwrap();
 
         let expected_result = BTreeMap::from([(log_id, 1)]);
 

--- a/p2panda/src/processor/pipeline.rs
+++ b/p2panda/src/processor/pipeline.rs
@@ -208,8 +208,7 @@ where
                     let ingest =
                         Ingest::<SqliteStore, Event<L, E, TP>, L, E, TP>::new(store.clone());
                     let orderer = Orderer::<SqliteStore, Event<L, E, TP>, E>::new(store.clone());
-                    let log_prune =
-                        LogPrune::<SqliteStore, Event<L, E, TP>, L, E>::new(store.clone());
+                    let log_prune = LogPrune::<SqliteStore, Event<L, E, TP>, L>::new(store.clone());
                     let spaces = {
                         let spaces_store = SqliteSpacesStore::new(store);
                         SpacesProcessor::<Event<L, E, TP>>::new(spaces_store, spaces_manager)

--- a/p2panda/src/spaces/member.rs
+++ b/p2panda/src/spaces/member.rs
@@ -449,21 +449,15 @@ mod tests {
 
     use crate::Credentials;
     use crate::forge::OperationForge;
-    use crate::operation::Operation;
     use crate::spaces::forge::member_log_id;
 
     use super::{KeyBundleTask, KeyBundleTaskCommand};
 
     async fn get_op_count(store: &SqliteStore, verifying_key: VerifyingKey) -> u32 {
-        let result = <SqliteStore as LogStore<Operation, _, _, _, _>>::get_log_size(
-            store,
-            &verifying_key,
-            &member_log_id(),
-            None,
-            None,
-        )
-        .await
-        .unwrap();
+        let result = store
+            .get_log_size(&verifying_key, &member_log_id(), None, None)
+            .await
+            .unwrap();
         result.map(|(op_count, _)| op_count).unwrap_or_default()
     }
 

--- a/p2panda/src/streams/acked.rs
+++ b/p2panda/src/streams/acked.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use p2panda_core::logs::{LogHeights, LogRanges};
-use p2panda_core::{Cursor, Hash, SeqNum, Topic, VerifyingKey};
+use p2panda_core::{AnyOperation, Cursor, Hash, SeqNum, Topic, VerifyingKey};
 use p2panda_store::cursors::CursorStore;
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
@@ -13,7 +13,7 @@ use p2panda_store::{SqliteError, SqliteStore, tx};
 use thiserror::Error;
 use tokio::sync::Semaphore;
 
-use crate::operation::{Header, LogId, Operation};
+use crate::operation::{Header, LogId};
 use crate::streams::StreamFrom;
 
 pub type Logs = BTreeMap<VerifyingKey, Vec<LogId>>;
@@ -156,7 +156,7 @@ async fn get_log_heights(
 
     for (verifying_key, log_ids) in logs {
         let Some(log_heights) =
-            LogStore::<Operation, VerifyingKey, LogId, SeqNum, Hash>::get_log_heights(
+            LogStore::<AnyOperation, VerifyingKey, LogId, SeqNum, Hash>::get_log_heights(
                 store,
                 verifying_key,
                 log_ids,

--- a/p2panda/src/streams/replay.rs
+++ b/p2panda/src/streams/replay.rs
@@ -71,7 +71,7 @@ where
 
     for (author, logs) in log_ranges {
         for (log_id, (after, until)) in logs {
-            let Some(operations): Option<Vec<(Operation, _)>> = store
+            let Some(operations) = store
                 .get_log_entries(&author, &log_id, after, until)
                 .await?
             else {
@@ -82,6 +82,9 @@ where
             };
 
             for (operation, _) in operations {
+                let operation = operation
+                    .try_into()
+                    .expect("values from the database are valid");
                 process_operation_in(operation, Source::LocalStore, topic, pipeline, sync_handle)
                     .await;
             }

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -27,9 +27,10 @@ mod api {
     use std::time::Duration;
 
     use mock_instant::thread_local::MockClock;
-    use p2panda::operation::{Extensions, LogId, Operation};
+    use p2panda::operation::{Extensions, LogId};
     use p2panda::streams::{EphemeralMessage, ProcessedOperation, StreamEvent, SystemEvent};
     use p2panda::{Credentials, Topic};
+    use p2panda_core::AnyOperation;
     use p2panda_core::cbor::encode_cbor;
     use p2panda_core::test_utils::{TestLog, setup_logging};
     use p2panda_net::discovery::DiscoveryEvent;
@@ -208,7 +209,7 @@ mod api {
 
         // There should only be 1 message in Panda's and Icebear's database as the log was pruned.
         let log_id = LogId::from_topic(topic);
-        let panda_result: Vec<(Operation, Vec<u8>)> = panda
+        let panda_result: Vec<(AnyOperation, Vec<u8>)> = panda
             .store()
             .get_log_entries(&panda.id(), &log_id, None, None)
             .await
@@ -216,7 +217,7 @@ mod api {
             .expect("result to be Some");
         assert_eq!(panda_result.iter().count(), 1);
 
-        let icebear_result: Vec<(Operation, Vec<u8>)> = icebear
+        let icebear_result: Vec<(AnyOperation, Vec<u8>)> = icebear
             .store()
             .get_log_entries(&panda.id(), &log_id, None, None)
             .await


### PR DESCRIPTION
Use `AnyOperation` on `LogStore` in place of `Operation<E>` and update all affected call sites. 

closes: #1390 

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes

