### PR TITLE
Resolve log heights from topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Highlights are marked with a pancake 🥞
 - node: E2EE CLI chat example using spaces API [#1288](https://github.com/p2panda/p2panda/pull/1288)
 - sync: `api` module with useful methods to hack your own sync protocols [#1393](https://github.com/p2panda/p2panda/pull/1393)
 - sync: Method for streaming log ranges from the store [#1393](https://github.com/p2panda/p2panda/pull/1393)
+- sync: Method to resolve log heights from topic [#1405](https://github.com/p2panda/p2panda/pull/1405)
 
 ### Changed
 

--- a/p2panda-sync/examples/sync_w_live_mode.rs
+++ b/p2panda-sync/examples/sync_w_live_mode.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 type LogId = Hash;
+
 type LogIds = BTreeMap<VerifyingKey, Vec<LogId>>;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/p2panda-sync/src/api.rs
+++ b/p2panda-sync/src/api.rs
@@ -5,10 +5,12 @@ use futures_util::{StreamExt, future};
 use p2panda_core::logs::{LogHeights, LogRanges, Logs};
 use p2panda_core::{AnyOperation, Hash, LogId, SeqNum, VerifyingKey};
 use p2panda_store::logs::LogStore;
+use p2panda_store::topics::TopicStore;
+use thiserror::Error;
 
 pub use p2panda_store::logs::StreamItem;
 
-/// Stream of `(AnyOperation, LogId, HeaderBytes)`  
+/// Stream of `(AnyOperation, LogId, HeaderBytes)`.
 pub type OperationStream<L, E> = BoxStream<'static, Result<StreamItem<AnyOperation, L>, E>>;
 
 /// Compute log heights of all passed author logs based on what is known in the local store.
@@ -72,4 +74,37 @@ where
         });
 
     Box::pin(stream)
+}
+
+/// Compute log heights for the given topic based on what is known in the local store.
+pub async fn topic_log_heights<L, S, T>(
+    store: &S,
+    topic: &T,
+) -> Result<LogHeights<VerifyingKey, L>, TopicLogHeightsError<L, S, T>>
+where
+    L: LogId,
+    S: TopicStore<T, VerifyingKey, L> + LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>,
+{
+    let logs: Logs<VerifyingKey, L> = store
+        .resolve(topic)
+        .await
+        .map_err(|err| TopicLogHeightsError::TopicStore(err))?;
+    let log_heights = log_heights(store, &logs)
+        .await
+        .map_err(|err| TopicLogHeightsError::LogStore(err))?;
+
+    Ok(log_heights)
+}
+
+#[derive(Debug, Error)]
+pub enum TopicLogHeightsError<L, S, T>
+where
+    L: LogId,
+    S: TopicStore<T, VerifyingKey, L> + LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>,
+{
+    #[error(transparent)]
+    LogStore(<S as LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>>::Error),
+
+    #[error(transparent)]
+    TopicStore(<S as TopicStore<T, VerifyingKey, L>>::Error),
 }


### PR DESCRIPTION
Simply adds a new method to `p2panda-sync/src/api.rs` which resolves a topic to the underlying logs and then returns all relevant heights for those logs.

Closes: https://github.com/p2panda/p2panda/issues/1400

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes