### PR TITLE
Add a custom_cursor_name param to stream_from, which overrides the default ack cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Highlights are marked with a pancake 🥞
 
 ### Added
 
+- node: Add custom_cursor_name optional param to Node::stream_from [1408](https://github.com/p2panda/p2panda/pull/1408)
 - net: Introduce an `Authoriser` for maintaining and enforcing allow- and blocklists [#1321](https://github.com/p2panda/p2panda/pull/1321)
 - node: API for promoting and demoting space members [#1311](https://github.com/p2panda/p2panda/pull/1311)
 - node: Allow graceful closure of sync sessions [#1307](https://github.com/p2panda/p2panda/pull/1307)

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -37,7 +37,7 @@ use crate::spaces::{
     to_initial_members,
 };
 use crate::streams::{
-    EphemeralStreamPublisher, EphemeralStreamSubscription, Event, ImportError, Pipeline,
+    Acked, EphemeralStreamPublisher, EphemeralStreamSubscription, Event, ImportError, Pipeline,
     StreamFrom, StreamPublisher, StreamSubscription, SystemEvent, TaskTracker, ephemeral_stream,
     event_stream, processed_stream, to_stream_event, to_system_event,
 };
@@ -318,7 +318,7 @@ impl Node {
     where
         M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
     {
-        self.stream_from(topic, StreamFrom::Frontier).await
+        self.stream_from(topic, StreamFrom::Frontier, None).await
     }
 
     /// Eventually consistent publish and subscribe stream of messages from a given position.
@@ -330,11 +330,12 @@ impl Node {
         &self,
         topic: impl Into<Topic>,
         from: StreamFrom,
+        custom_acked: Option<Acked>,
     ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
     where
         M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
     {
-        self.stream_from_inner(topic, from, ProcessorHooksList::new())
+        self.stream_from_inner(topic, from, ProcessorHooksList::new(), custom_acked)
             .await
     }
 
@@ -344,6 +345,7 @@ impl Node {
         topic: impl Into<Topic>,
         from: StreamFrom,
         post_pipeline_hooks: ProcessorHooksList<Event>,
+        custom_acked: Option<Acked>,
     ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
     where
         M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
@@ -375,6 +377,7 @@ impl Node {
             pipeline,
             self.events_tx.clone(),
             from,
+            custom_acked,
         )
         .await
         .map_err(|err| CreateStreamError(err.to_string()))?;
@@ -613,7 +616,8 @@ impl Node {
         ));
         post_pipeline.push(MemberAssociationHook::new(self.id(), self.store.clone()));
 
-        self.stream_from_inner(topic, from, post_pipeline).await
+        self.stream_from_inner(topic, from, post_pipeline, None)
+            .await
     }
 
     pub async fn create_space<M>(

--- a/p2panda/src/node.rs
+++ b/p2panda/src/node.rs
@@ -37,7 +37,7 @@ use crate::spaces::{
     to_initial_members,
 };
 use crate::streams::{
-    Acked, EphemeralStreamPublisher, EphemeralStreamSubscription, Event, ImportError, Pipeline,
+    EphemeralStreamPublisher, EphemeralStreamSubscription, Event, ImportError, Pipeline,
     StreamFrom, StreamPublisher, StreamSubscription, SystemEvent, TaskTracker, ephemeral_stream,
     event_stream, processed_stream, to_stream_event, to_system_event,
 };
@@ -330,12 +330,12 @@ impl Node {
         &self,
         topic: impl Into<Topic>,
         from: StreamFrom,
-        custom_acked: Option<Acked>,
+        custom_cursor_name: Option<String>,
     ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
     where
         M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
     {
-        self.stream_from_inner(topic, from, ProcessorHooksList::new(), custom_acked)
+        self.stream_from_inner(topic, from, ProcessorHooksList::new(), custom_cursor_name)
             .await
     }
 
@@ -345,7 +345,7 @@ impl Node {
         topic: impl Into<Topic>,
         from: StreamFrom,
         post_pipeline_hooks: ProcessorHooksList<Event>,
-        custom_acked: Option<Acked>,
+        custom_cursor_name: Option<String>,
     ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
     where
         M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
@@ -377,7 +377,7 @@ impl Node {
             pipeline,
             self.events_tx.clone(),
             from,
-            custom_acked,
+            custom_cursor_name,
         )
         .await
         .map_err(|err| CreateStreamError(err.to_string()))?;

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -20,7 +20,7 @@ pub use p2panda_core::cbor::DecodeError;
 use crate::operation::{Extensions, LogId};
 use crate::processor::PipelineTaskId;
 
-pub use acked::AckedError;
+pub use acked::{Acked, AckedError};
 pub(crate) use ephemeral_stream::ephemeral_stream;
 pub use ephemeral_stream::{
     EphemeralMessage, EphemeralPublishError, EphemeralStreamPublisher, EphemeralStreamSubscription,

--- a/p2panda/src/streams/mod.rs
+++ b/p2panda/src/streams/mod.rs
@@ -20,7 +20,7 @@ pub use p2panda_core::cbor::DecodeError;
 use crate::operation::{Extensions, LogId};
 use crate::processor::PipelineTaskId;
 
-pub use acked::{Acked, AckedError};
+pub use acked::AckedError;
 pub(crate) use ephemeral_stream::ephemeral_stream;
 pub use ephemeral_stream::{
     EphemeralMessage, EphemeralPublishError, EphemeralStreamPublisher, EphemeralStreamSubscription,

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -109,13 +109,13 @@ pub(crate) async fn processed_stream<M>(
     pipeline: Pipeline,
     event_tx: broadcast::Sender<SystemEvent>,
     from: StreamFrom,
-    custom_acked: Option<Acked>,
+    custom_cursor_name: Option<String>,
 ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
 where
     M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
 {
-    let acked = match custom_acked {
-        Some(cursor) => cursor,
+    let acked = match custom_cursor_name {
+        Some(cursor_name) => Acked::from_name(store.clone(), topic, cursor_name),
         None => Acked::new(store.clone(), topic),
     };
 

--- a/p2panda/src/streams/stream.rs
+++ b/p2panda/src/streams/stream.rs
@@ -109,11 +109,15 @@ pub(crate) async fn processed_stream<M>(
     pipeline: Pipeline,
     event_tx: broadcast::Sender<SystemEvent>,
     from: StreamFrom,
+    custom_acked: Option<Acked>,
 ) -> Result<(StreamPublisher<M>, StreamSubscription<M>), CreateStreamError>
 where
     M: Serialize + for<'a> Deserialize<'a> + Send + 'static,
 {
-    let acked = Acked::new(store.clone(), topic);
+    let acked = match custom_acked {
+        Some(cursor) => cursor,
+        None => Acked::new(store.clone(), topic),
+    };
 
     // Sync handle is used on the publisher and when importing from external streams.
     let sync_handle = Arc::new(sync_handle);

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -310,7 +310,7 @@ mod api {
 mod event_replays {
     use p2panda::node::AckPolicy;
     use p2panda::operation::LogId;
-    use p2panda::streams::{StreamEvent, StreamFrom};
+    use p2panda::streams::{Acked, StreamEvent, StreamFrom};
     use p2panda_core::logs::LogHeights;
     use p2panda_core::test_utils::setup_logging;
     use p2panda_core::{Cursor, Topic};
@@ -426,7 +426,7 @@ mod event_replays {
 
         // Panda subscribes again, this time asking to replay all messages from start.
         let (_panda_tx, mut panda_rx) = panda
-            .stream_from::<String>(chat_id, StreamFrom::Start)
+            .stream_from::<String>(chat_id, StreamFrom::Start, None)
             .await
             .unwrap();
 
@@ -493,7 +493,7 @@ mod event_replays {
 
         // Force re-playing from custom cursor position with new stream subscription.
         let (_tx, mut rx) = node
-            .stream_from::<String>(topic, StreamFrom::Cursor(cursor))
+            .stream_from::<String>(topic, StreamFrom::Cursor(cursor), None)
             .await
             .unwrap();
 
@@ -501,6 +501,57 @@ mod event_replays {
         assert_replay_started(&rx.next().await.unwrap(), 2);
         assert_message_id(&rx.next().await.unwrap(), message_id_2);
         assert_message_id(&rx.next().await.unwrap(), message_id_3);
+        assert_replay_ended(&rx.next().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn replay_stream_from_custom_acked() {
+        setup_logging();
+
+        let topic = Topic::random();
+        let node = p2panda::builder().spawn().await.unwrap();
+
+        let (tx, mut rx) = node.stream::<String>(topic).await.unwrap();
+
+        // Publish two messages and receive them on the main stream. With the default ack policy
+        // this advances the topic's default ack-tracker to the frontier.
+        let message_id_1 = {
+            let processing = tx.publish("first".into()).await.unwrap();
+            let id = processing.hash();
+            processing.await.unwrap();
+            id
+        };
+
+        let message_id_2 = {
+            let processing = tx.publish("second".into()).await.unwrap();
+            let id = processing.hash();
+            processing.await.unwrap();
+            id
+        };
+
+        assert_message_id(&rx.next().await.unwrap(), message_id_1);
+        assert_message_id(&rx.next().await.unwrap(), message_id_2);
+
+        // Await graceful termination of the sync session.
+        let _ = tx.close().await;
+
+        drop(tx);
+        drop(rx);
+
+        let custom_acked = Acked::from_name(node.store(), topic, "custom-replay");
+
+        // Replay from the custom ack-tracker's frontier. Because this tracker has never acked
+        // anything, it replays every message on the topic regardless of what the default stream
+        // already acked above.
+        let (_tx, mut rx) = node
+            .stream_from::<String>(topic, StreamFrom::Frontier, Some(custom_acked))
+            .await
+            .unwrap();
+
+        // We expect to receive both messages, independently of the main stream.
+        assert_replay_started(&rx.next().await.unwrap(), 2);
+        assert_message_id(&rx.next().await.unwrap(), message_id_1);
+        assert_message_id(&rx.next().await.unwrap(), message_id_2);
         assert_replay_ended(&rx.next().await.unwrap());
     }
 }

--- a/p2panda/tests/api.rs
+++ b/p2panda/tests/api.rs
@@ -310,7 +310,7 @@ mod api {
 mod event_replays {
     use p2panda::node::AckPolicy;
     use p2panda::operation::LogId;
-    use p2panda::streams::{Acked, StreamEvent, StreamFrom};
+    use p2panda::streams::{StreamEvent, StreamFrom};
     use p2panda_core::logs::LogHeights;
     use p2panda_core::test_utils::setup_logging;
     use p2panda_core::{Cursor, Topic};
@@ -505,7 +505,7 @@ mod event_replays {
     }
 
     #[tokio::test]
-    async fn replay_stream_from_custom_acked() {
+    async fn replay_stream_with_custom_cursor() {
         setup_logging();
 
         let topic = Topic::random();
@@ -538,13 +538,15 @@ mod event_replays {
         drop(tx);
         drop(rx);
 
-        let custom_acked = Acked::from_name(node.store(), topic, "custom-replay");
-
-        // Replay from the custom ack-tracker's frontier. Because this tracker has never acked
+        // Replay from the custom cursor name's frontier. Because this cursor has never acked
         // anything, it replays every message on the topic regardless of what the default stream
         // already acked above.
         let (_tx, mut rx) = node
-            .stream_from::<String>(topic, StreamFrom::Frontier, Some(custom_acked))
+            .stream_from::<String>(
+                topic,
+                StreamFrom::Frontier,
+                Some("custom-replay".to_string()),
+            )
             .await
             .unwrap();
 


### PR DESCRIPTION
The param gets passed through, allowing independent cursor tracking.

I considered passing in the entire Acked object, but that created complexity. It wouldn't make sense to have a topic different from the one being streamed on. The semaphore is an implementation detail and shouldn't be left to the caller. Custom cursor storage might be nice, but the SqliteStore used as the store param isn't exposed from this crate at present. 

I've changed a couple of existing tests to pass in None for this new param, to get the default behaviour.

I've added one new API test that shows using a custom cursor and getting different results from the default topic cursor.

Closes: https://github.com/p2panda/p2panda/issues/1407

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
