### PR TITLE
Doc-strings and clean-ups for new `api` module

### DIFF
--- a/p2panda-core/src/cursor.rs
+++ b/p2panda-core/src/cursor.rs
@@ -3,7 +3,7 @@
 //! State vector to track and compare logs.
 use std::hash::Hash as StdHash;
 
-use crate::logs::{LogHeights, LogId, LogRanges, SeqNum, compare};
+use crate::logs::{LogHeights, LogId, LogRanges, SeqNum, compare_logs};
 use crate::traits::Author;
 
 /// Cursor to track log heights (state vector).
@@ -45,7 +45,7 @@ where
 
     /// Calculates the difference between two state vectors.
     pub fn compare(&self, other: &LogHeights<A, L>) -> LogRanges<A, L> {
-        compare(other, &self.state)
+        compare_logs(other, &self.state)
     }
 
     /// Advances the state of a specific log.

--- a/p2panda-core/src/logs.rs
+++ b/p2panda-core/src/logs.rs
@@ -37,15 +37,56 @@ pub trait LogId: Clone + Eq + Ord + StdHash + Serialize + for<'de> Deserialize<'
 impl<T> LogId for T where T: Clone + Eq + Ord + StdHash + Serialize + for<'de> Deserialize<'de> {}
 
 /// Sequence number of an entry in an append-only log.
+///
+/// ```text
+/// [0] <- [1] <- [2]
+///                ^
+///            log height
+/// ```
+///
+/// To express the state vector of a log we can use the _log height_ (also HEAD or "frontier") which
+/// is a `SeqNum`.
 pub type SeqNum = u32;
 
 /// Author logs mapping.
+///
+/// Each log is identified with `L` and grouped by author `A`.
+///
+/// ```text
+/// Author "panda":
+/// - "trees" log
+/// - "animals" log
+///
+/// Author "icebear":
+/// - "trees" log
+/// ```
 pub type Logs<A, L> = BTreeMap<A, Vec<L>>;
 
-/// Map of log heights grouped by author.
+/// Map of [`SeqNum`] log heights grouped by author `A`. Each log is identified with `L`.
+///
+/// ```text
+/// Author "panda":
+/// - "trees" log: 6
+/// - "animals" log: 12
+///
+/// Author "icebear":
+/// - "trees" log: 4
+/// ```
 pub type LogHeights<A, L> = BTreeMap<A, BTreeMap<L, SeqNum>>;
 
-/// Map of log ranges grouped by author.
+/// Map of log ranges, grouped by author `A` and each log identified with `L`.
+///
+/// Log ranges are used to express the _difference_ between two [`LogHeights`] state vectors. Use
+/// the [`compare_logs`] method to compute it.
+///
+/// ```text
+/// Author "panda":
+/// - "trees" log: [0..6]
+/// - "animals" log: [4..12]
+///
+/// Author "icebear":
+/// - "trees" log: [3..4]
+/// ```
 pub type LogRanges<A, L> = BTreeMap<A, BTreeMap<L, (Option<SeqNum>, Option<SeqNum>)>>;
 
 /// Compare two sets of logs (local and remote) and calculate the "diff" representing ranges of

--- a/p2panda-core/src/logs.rs
+++ b/p2panda-core/src/logs.rs
@@ -66,7 +66,7 @@ pub type LogRanges<A, L> = BTreeMap<A, BTreeMap<L, (Option<SeqNum>, Option<SeqNu
 /// them to the remote. If both local and remote replicas do this then they will arrive at the
 /// same state. If pruned logs are being replicated and a range has been returned from this
 /// method, then it is expected only the remaining "frontier" will be replicated for each log.
-pub fn compare<A, L>(local: &LogHeights<A, L>, remote: &LogHeights<A, L>) -> LogRanges<A, L>
+pub fn compare_logs<A, L>(local: &LogHeights<A, L>, remote: &LogHeights<A, L>) -> LogRanges<A, L>
 where
     A: Author,
     L: LogId,
@@ -124,7 +124,7 @@ where
 mod tests {
     use std::collections::BTreeMap;
 
-    use crate::logs::compare;
+    use crate::logs::compare_logs;
 
     type Author = u8;
 
@@ -137,7 +137,7 @@ mod tests {
     fn both_empty() {
         let local: BTreeMap<Author, BTreeMap<u32, u32>> = BTreeMap::new();
         let remote: BTreeMap<Author, BTreeMap<u32, u32>> = BTreeMap::new();
-        let result = compare(&local, &remote);
+        let result = compare_logs(&local, &remote);
         assert!(result.is_empty());
     }
 
@@ -149,7 +149,7 @@ mod tests {
 
         let remote: BTreeMap<Author, BTreeMap<u32, u32>> = BTreeMap::new();
 
-        let result = compare(&local, &remote);
+        let result = compare_logs(&local, &remote);
         let needs = result.get(&ALICE).unwrap();
 
         assert_eq!(needs.get(&1), Some(&(None, Some(5))));
@@ -164,7 +164,7 @@ mod tests {
         let mut remote = BTreeMap::new();
         remote.insert(ALICE, BTreeMap::from([(1, 5)]));
 
-        let result = compare(&local, &remote);
+        let result = compare_logs(&local, &remote);
         let needs = result.get(&ALICE).unwrap();
 
         assert_eq!(needs.get(&2), Some(&(None, Some(10))));
@@ -179,7 +179,7 @@ mod tests {
         let mut remote = BTreeMap::new();
         remote.insert(ALICE, BTreeMap::from([(1, 10)]));
 
-        let result = compare(&local, &remote);
+        let result = compare_logs(&local, &remote);
         let needs = result.get(&ALICE).unwrap();
 
         assert_eq!(needs.get(&1), Some(&(Some(10), Some(20))));
@@ -193,7 +193,7 @@ mod tests {
         let mut remote = BTreeMap::new();
         remote.insert(ALICE, BTreeMap::from([(1, 30)]));
 
-        let result = compare(&local, &remote);
+        let result = compare_logs(&local, &remote);
         assert!(result.is_empty());
     }
 
@@ -205,7 +205,7 @@ mod tests {
         let mut remote = BTreeMap::new();
         remote.insert(ALICE, BTreeMap::from([(1, 20)]));
 
-        let result = compare(&local, &remote);
+        let result = compare_logs(&local, &remote);
         assert!(result.is_empty());
     }
 
@@ -217,7 +217,7 @@ mod tests {
         let mut remote = BTreeMap::new();
         remote.insert(ALICE, BTreeMap::from([(1, 5)]));
 
-        let result = compare(&local, &remote);
+        let result = compare_logs(&local, &remote);
         let needs = result.get(&ALICE).unwrap();
 
         assert_eq!(needs.get(&2), Some(&(None, Some(10))));
@@ -234,7 +234,7 @@ mod tests {
         let mut remote = BTreeMap::new();
         remote.insert(ALICE, BTreeMap::from([(1, 5)]));
 
-        let result = compare(&local, &remote);
+        let result = compare_logs(&local, &remote);
         let needs = result.get(&BOB).unwrap();
 
         assert_eq!(needs.get(&1), Some(&(None, Some(5))));

--- a/p2panda-store/src/logs/mod.rs
+++ b/p2panda-store/src/logs/mod.rs
@@ -9,4 +9,4 @@
 mod sqlite;
 mod traits;
 
-pub use traits::{LogStore, StreamItem};
+pub use traits::{LogEntry, LogStore, LogStream};

--- a/p2panda-store/src/logs/sqlite/mod.rs
+++ b/p2panda-store/src/logs/sqlite/mod.rs
@@ -14,7 +14,7 @@ use sqlx::{QueryBuilder, query, query_as};
 
 use crate::logs::LogStore;
 use crate::logs::sqlite::models::{LogHeightRow, LogMetaRow};
-use crate::logs::traits::{LogStream, StreamItem};
+use crate::logs::traits::{LogEntry, LogStream};
 use crate::operations::OperationRow;
 use crate::sqlite::{SqliteError, SqliteStore};
 
@@ -239,7 +239,7 @@ where
             while let Some(row) = rows.try_next().await? {
                 let header = row.header.clone();
                 let operation: AnyOperation = row.try_into()?;
-                yield StreamItem { entry: operation, log_id: log_id.clone(), bytes: header };
+                yield LogEntry { entry: operation, log_id: log_id.clone(), bytes: header };
             }
         };
 

--- a/p2panda-store/src/logs/sqlite/tests.rs
+++ b/p2panda-store/src/logs/sqlite/tests.rs
@@ -6,7 +6,7 @@ use futures_util::StreamExt;
 use p2panda_core::SigningKey;
 use p2panda_core::test_utils::TestLog;
 
-use crate::logs::{LogStore, StreamItem};
+use crate::logs::{LogEntry, LogStore};
 use crate::operations::OperationStore;
 use crate::sqlite::SqliteStore;
 use crate::traits::Transaction;
@@ -194,7 +194,7 @@ async fn get_log_entries() {
         operation_5,
     ];
     for index in 0..=4 {
-        let StreamItem { entry, .. } = log_entries.next().await.unwrap().unwrap();
+        let LogEntry { entry, .. } = log_entries.next().await.unwrap().unwrap();
         assert_eq!(entry, expected[index].clone().into());
     }
 
@@ -260,10 +260,10 @@ async fn prune_entries() {
 
     // Three entries were pruned; the two most recently published entries should
     // remain.
-    let StreamItem { entry, .. } = log_entries.next().await.unwrap().unwrap();
+    let LogEntry { entry, .. } = log_entries.next().await.unwrap().unwrap();
     assert_eq!(entry, operation_4.into());
 
-    let StreamItem { entry, .. } = log_entries.next().await.unwrap().unwrap();
+    let LogEntry { entry, .. } = log_entries.next().await.unwrap().unwrap();
     assert_eq!(entry, operation_5.into());
 
     assert!(log_entries.next().await.is_none());

--- a/p2panda-store/src/logs/traits.rs
+++ b/p2panda-store/src/logs/traits.rs
@@ -5,10 +5,10 @@ use std::error::Error;
 
 use futures_util::stream::BoxStream;
 
-pub(crate) type LogStream<T, L, E> = BoxStream<'static, Result<StreamItem<T, L>, E>>;
+pub type LogStream<T, L, E> = BoxStream<'static, Result<LogEntry<T, L>, E>>;
 
 #[derive(Debug, Clone)]
-pub struct StreamItem<T, L> {
+pub struct LogEntry<T, L> {
     pub entry: T,
     pub log_id: L,
     pub bytes: Vec<u8>,

--- a/p2panda-stream/src/ingest/ooo.rs
+++ b/p2panda-stream/src/ingest/ooo.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 use p2panda_core::{AnyHeader, Extensions, Hash, LogId, Operation};
 use tokio::sync::Mutex;
 
+/// Result of processing an operation with the [`OooBuffer`].
 #[derive(Debug)]
 pub enum OooResult<'a, E> {
     /// Operation is already in-order and doesn't need buffering.

--- a/p2panda-stream/src/ingest/operation.rs
+++ b/p2panda-stream/src/ingest/operation.rs
@@ -13,6 +13,8 @@ use thiserror::Error;
 
 use crate::ingest::ooo::{OooBuffer, OooResult};
 
+/// Result of _ingesting_ an operation (validation, de-duplication, optional ooo-buffering and
+/// writing to store) using [`ingest_operation`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum IngestResult<E> {
     /// Validated and inserted operation into store.

--- a/p2panda-sync/examples/broadcast.rs
+++ b/p2panda-sync/examples/broadcast.rs
@@ -34,7 +34,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
 use futures_util::StreamExt;
-use p2panda_core::logs::{LogHeights, compare};
+use p2panda_core::logs::{LogHeights, compare_logs};
 use p2panda_core::traits::Digest;
 use p2panda_core::{AnyOperation, Hash, Operation, SeqNum, SigningKey, Topic, VerifyingKey};
 use p2panda_store::topics::TopicStore;
@@ -400,7 +400,7 @@ async fn compute_diff(
     their_log_heights: &LogHeights<VerifyingKey, LogId>,
 ) -> Result<LogStream<LogId, SqliteError>> {
     let our_log_heights = get_topic_log_heights(&store, &topic).await?;
-    let diff = compare(&our_log_heights, &their_log_heights);
+    let diff = compare_logs(&our_log_heights, &their_log_heights);
     Ok(log_ranges(store, diff))
 }
 

--- a/p2panda-sync/examples/broadcast.rs
+++ b/p2panda-sync/examples/broadcast.rs
@@ -39,7 +39,7 @@ use p2panda_core::traits::Digest;
 use p2panda_core::{AnyOperation, Hash, Operation, SeqNum, SigningKey, Topic, VerifyingKey};
 use p2panda_store::topics::TopicStore;
 use p2panda_store::{SqliteError, SqliteStore};
-use p2panda_sync::api::{OperationStream, StreamItem, ingest_operation, log_heights, log_ranges};
+use p2panda_sync::api::{LogEntry, LogStream, ingest_operation, log_heights, log_ranges};
 use p2panda_sync::dedup::DeduplicationBuffer;
 use p2panda_sync::protocols::ShortFormat;
 use serde::{Deserialize, Serialize};
@@ -298,9 +298,10 @@ impl Node {
                                 };
 
                                 while let Some(result) = operations.next().await {
-                                    let StreamItem {
+                                    let LogEntry {
                                         entry: operation, ..
                                     } = result.unwrap();
+
                                     mesh.flood(Message::Operation(*topic, operation)).await;
                                 }
                             }
@@ -397,7 +398,7 @@ async fn compute_diff(
     store: &SqliteStore,
     topic: Topic,
     their_log_heights: &LogHeights<VerifyingKey, LogId>,
-) -> Result<OperationStream<LogId, SqliteError>> {
+) -> Result<LogStream<LogId, SqliteError>> {
     let our_log_heights = get_topic_log_heights(&store, &topic).await?;
     let diff = compare(&our_log_heights, &their_log_heights);
     Ok(log_ranges(store, diff))

--- a/p2panda-sync/examples/sneakernet.rs
+++ b/p2panda-sync/examples/sneakernet.rs
@@ -84,7 +84,7 @@ use p2panda_core::{AnyOperation, Hash, Operation, SeqNum, SigningKey, Topic, Ver
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
 use p2panda_store::{SqliteError, SqliteStore};
-use p2panda_sync::api::{StreamItem, ingest_operation, log_ranges};
+use p2panda_sync::api::{ingest_operation, log_ranges};
 use p2panda_sync::protocols::ShortFormat;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -171,14 +171,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let diff = compare(&local_log_heights, &remote_log_heights);
         let mut operation_stream = log_ranges(&store_a, diff);
 
-        if let Some(result) = operation_stream.next().await {
-            let StreamItem {
-                entry: operation,
-                log_id,
-                ..
-            } = result?;
+        if let Some(Ok(log)) = operation_stream.next().await {
+            let operation = log.entry;
             let logs = operations.entry(*topic).or_default();
-            logs.entry((operation.author(), log_id))
+            logs.entry((operation.author(), log.log_id))
                 .or_default()
                 .push(operation);
         }
@@ -324,18 +320,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let diff = compare(&our_log_heights, &their_log_heights);
             let mut operation_stream = log_ranges(&store_a, diff);
 
-            if let Some(result) = operation_stream.next().await {
-                let StreamItem {
-                    entry: operation,
-                    log_id,
-                    ..
-                } = result?;
+            if let Some(Ok(log)) = operation_stream.next().await {
+                let operation = log.entry;
                 let logs = operations.entry(topic).or_default();
 
-                // NOTE: Appending only the "latest" operations to the log allows us to
-                // build some ring-buffer logic here where we would drop old operations when
-                // running full.
-                logs.entry((operation.author(), log_id))
+                // NOTE: Appending only the "latest" operations to the log allows us to build some
+                // ring-buffer logic here where we would drop old operations when running full.
+                logs.entry((operation.author(), log.log_id))
                     .or_default()
                     .push(operation);
             }

--- a/p2panda-sync/examples/sneakernet.rs
+++ b/p2panda-sync/examples/sneakernet.rs
@@ -78,7 +78,7 @@ mod common;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use futures_util::StreamExt;
-use p2panda_core::logs::{LogHeights, LogRanges, compare};
+use p2panda_core::logs::{LogHeights, LogRanges, compare_logs};
 use p2panda_core::traits::Provenance;
 use p2panda_core::{AnyOperation, Hash, Operation, SeqNum, SigningKey, Topic, VerifyingKey};
 use p2panda_store::logs::LogStore;
@@ -168,7 +168,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for topic in &topics_a {
         let local_log_heights = get_topic_log_heights(&store_a, &topic).await?;
         let remote_log_heights = LogHeights::default();
-        let diff = compare(&local_log_heights, &remote_log_heights);
+        let diff = compare_logs(&local_log_heights, &remote_log_heights);
         let mut operation_stream = log_ranges(&store_a, diff);
 
         if let Some(Ok(log)) = operation_stream.next().await {
@@ -268,7 +268,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 //
                 // The docs for `compare()` could maybe be updated to reflect this bidirectional
                 // nature.
-                compare(&their_log_heights, &our_log_heights);
+                compare_logs(&their_log_heights, &our_log_heights);
 
             // Get all stick operations for the announcement topic.
             let mut operations = HashMap::new();
@@ -317,7 +317,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .unwrap_or_default()
             };
 
-            let diff = compare(&our_log_heights, &their_log_heights);
+            let diff = compare_logs(&our_log_heights, &their_log_heights);
             let mut operation_stream = log_ranges(&store_a, diff);
 
             if let Some(Ok(log)) = operation_stream.next().await {

--- a/p2panda-sync/examples/sync_w_live_mode.rs
+++ b/p2panda-sync/examples/sync_w_live_mode.rs
@@ -15,7 +15,7 @@ mod common;
 use std::collections::BTreeMap;
 
 use futures_util::stream::StreamExt;
-use p2panda_core::logs::{LogHeights, compare};
+use p2panda_core::logs::{LogHeights, compare_logs};
 use p2panda_core::traits::Digest;
 use p2panda_core::{AnyOperation, Hash, Operation, SeqNum, SigningKey, Topic, VerifyingKey};
 use p2panda_store::topics::TopicStore;
@@ -111,7 +111,7 @@ impl Node {
         let their_log_heights = &announcement.log_heights;
         let our_log_heights = get_topic_log_heights(&self.store, &topic).await?;
 
-        let diff = compare(&our_log_heights, &their_log_heights);
+        let diff = compare_logs(&our_log_heights, &their_log_heights);
         Ok(log_ranges(&self.store, diff))
     }
 

--- a/p2panda-sync/examples/sync_w_live_mode.rs
+++ b/p2panda-sync/examples/sync_w_live_mode.rs
@@ -20,7 +20,7 @@ use p2panda_core::traits::Digest;
 use p2panda_core::{AnyOperation, Hash, Operation, SeqNum, SigningKey, Topic, VerifyingKey};
 use p2panda_store::topics::TopicStore;
 use p2panda_store::{SqliteError, SqliteStore};
-use p2panda_sync::api::{OperationStream, StreamItem, ingest_operation, log_heights, log_ranges};
+use p2panda_sync::api::{LogStream, ingest_operation, log_heights, log_ranges};
 use p2panda_sync::protocols::ShortFormat;
 use serde::{Deserialize, Serialize};
 
@@ -107,7 +107,7 @@ impl Node {
         &self,
         announcement: Announcement,
         topic: Topic,
-    ) -> Result<OperationStream<LogId, SqliteError>> {
+    ) -> Result<LogStream<LogId, SqliteError>> {
         let their_log_heights = &announcement.log_heights;
         let our_log_heights = get_topic_log_heights(&self.store, &topic).await?;
 
@@ -177,10 +177,9 @@ async fn main() -> Result<()> {
 
     // Node A processes the operations and announcement from node B then sends operations.
 
-    while let Some(result) = log_operations_b.next().await {
-        let StreamItem {
-            entry: operation, ..
-        } = result?;
+    while let Some(Ok(log)) = log_operations_b.next().await {
+        let operation = log.entry;
+
         println!(
             "{}: ingest remote operation {}",
             node_a.id().fmt_short(),
@@ -203,10 +202,9 @@ async fn main() -> Result<()> {
     // Node B processes the operations from node A.
 
     // We only expect operations at this stage; no more announcements.
-    while let Some(result) = log_operations_a.next().await {
-        let StreamItem {
-            entry: operation, ..
-        } = result?;
+    while let Some(Ok(log)) = log_operations_a.next().await {
+        let operation = log.entry;
+
         println!(
             "{}: ingest remote operation {}",
             node_b.id().fmt_short(),

--- a/p2panda-sync/src/api.rs
+++ b/p2panda-sync/src/api.rs
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use futures_util::stream::{self, BoxStream};
+use futures_util::stream;
 use futures_util::{StreamExt, future};
 use p2panda_core::logs::{LogHeights, LogRanges, Logs};
 use p2panda_core::{AnyOperation, Hash, LogId, SeqNum, VerifyingKey};
 use p2panda_store::logs::LogStore;
-pub use p2panda_store::logs::StreamItem;
 use p2panda_store::topics::TopicStore;
 #[cfg(feature = "ingest")]
 pub use p2panda_stream::ingest::ingest_operation;
 use thiserror::Error;
 
-/// Stream of `(AnyOperation, LogId, HeaderBytes)`.
-pub type OperationStream<L, E> = BoxStream<'static, Result<StreamItem<AnyOperation, L>, E>>;
+pub type LogEntry<L> = p2panda_store::logs::LogEntry<AnyOperation, L>;
+
+pub type LogStream<L, E> = p2panda_store::logs::LogStream<AnyOperation, L, E>;
 
 /// Compute log heights of all passed author logs based on what is known in the local store.
 pub async fn log_heights<L, S>(
@@ -38,13 +38,10 @@ where
 ///
 /// This is a memory efficient query with only one stream item staying in memory at a time. If any
 /// error occurs when fetching items the stream will return the error then immediately close.
-pub fn log_ranges<S, L>(
-    store: &S,
-    ranges: LogRanges<VerifyingKey, L>,
-) -> OperationStream<L, S::Error>
+pub fn log_ranges<L, S>(store: &S, ranges: LogRanges<VerifyingKey, L>) -> LogStream<L, S::Error>
 where
-    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash> + Clone + Send + 'static,
     L: LogId + Send + 'static,
+    S: LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash> + Clone + Send + 'static,
 {
     let mut flattened_ranges = vec![];
     for (author, log_heights) in ranges {
@@ -81,7 +78,7 @@ where
 pub async fn topic_log_heights<L, S, T>(
     store: &S,
     topic: &T,
-) -> Result<LogHeights<VerifyingKey, L>, TopicLogHeightsError<L, S, T>>
+) -> Result<LogHeights<VerifyingKey, L>, StoreError<L, S, T>>
 where
     L: LogId,
     S: TopicStore<T, VerifyingKey, L> + LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>,
@@ -89,16 +86,17 @@ where
     let logs: Logs<VerifyingKey, L> = store
         .resolve(topic)
         .await
-        .map_err(|err| TopicLogHeightsError::TopicStore(err))?;
+        .map_err(|err| StoreError::TopicStore(err))?;
     let log_heights = log_heights(store, &logs)
         .await
-        .map_err(|err| TopicLogHeightsError::LogStore(err))?;
+        .map_err(|err| StoreError::LogStore(err))?;
 
     Ok(log_heights)
 }
 
+/// Critical store failure.
 #[derive(Debug, Error)]
-pub enum TopicLogHeightsError<L, S, T>
+pub enum StoreError<L, S, T>
 where
     L: LogId,
     S: TopicStore<T, VerifyingKey, L> + LogStore<AnyOperation, VerifyingKey, L, SeqNum, Hash>,

--- a/p2panda-sync/src/api.rs
+++ b/p2panda-sync/src/api.rs
@@ -7,11 +7,15 @@ use p2panda_core::{AnyOperation, Hash, LogId, SeqNum, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;
 #[cfg(feature = "ingest")]
-pub use p2panda_stream::ingest::ingest_operation;
+pub use p2panda_stream::ingest::{
+    IngestError, IngestResult, OooBuffer, OooResult, ingest_operation,
+};
 use thiserror::Error;
 
+/// Item delivered from a [`LogStream`].
 pub type LogEntry<L> = p2panda_store::logs::LogEntry<AnyOperation, L>;
 
+/// Stream of operations in a log range.
 pub type LogStream<L, E> = p2panda_store::logs::LogStream<AnyOperation, L, E>;
 
 /// Compute log heights of all passed author logs based on what is known in the local store.

--- a/p2panda-sync/src/api.rs
+++ b/p2panda-sync/src/api.rs
@@ -2,7 +2,7 @@
 
 use futures_util::stream;
 use futures_util::{StreamExt, future};
-use p2panda_core::logs::{LogHeights, LogRanges, Logs};
+pub use p2panda_core::logs::{LogHeights, LogRanges, Logs, compare_logs};
 use p2panda_core::{AnyOperation, Hash, LogId, SeqNum, VerifyingKey};
 use p2panda_store::logs::LogStore;
 use p2panda_store::topics::TopicStore;

--- a/p2panda-sync/src/protocols/log_sync.rs
+++ b/p2panda-sync/src/protocols/log_sync.rs
@@ -17,7 +17,7 @@ use tokio::select;
 use tokio::sync::broadcast;
 use tracing::{Instrument, debug, trace};
 
-use crate::api::{StreamItem, log_heights, log_ranges};
+use crate::api::{LogEntry, log_heights, log_ranges};
 use crate::dedup::{DEFAULT_BUFFER_CAPACITY, DeduplicationBuffer};
 use crate::traits::Protocol;
 
@@ -369,7 +369,7 @@ where
                                     continue;
                                 };
 
-                                let StreamItem { entry: operation, bytes: header_bytes, .. } = result.map_err(|err| LogSyncError::LogStore(format!("{err}")))?;
+                                let LogEntry { entry: operation, bytes: header_bytes, .. } = result.map_err(|err| LogSyncError::LogStore(format!("{err}")))?;
 
                                 let header = operation.header;
                                 let body = operation.body;

--- a/p2panda-sync/src/protocols/log_sync.rs
+++ b/p2panda-sync/src/protocols/log_sync.rs
@@ -5,7 +5,7 @@ use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
-use p2panda_core::logs::{LogHeights, LogRanges, Logs, compare};
+use p2panda_core::logs::{LogHeights, LogRanges, Logs, compare_logs};
 use p2panda_core::{
     AnyOperation, Body, Extensions, Hash, Header, LogId, Operation, RawOperation, SeqNum,
     VerifyingKey,
@@ -150,7 +150,7 @@ where
                         return Err(LogSyncError::UnexpectedMessage(message.to_string()));
                     };
 
-                    let remote_needs = compare(&local, &remote);
+                    let remote_needs = compare_logs(&local, &remote);
 
                     self.state = State::SendPreSync { remote_needs };
                     trace!(parent: &state_machine_span, state = ?self.state, "Updated state");

--- a/p2panda/src/streams/replay.rs
+++ b/p2panda/src/streams/replay.rs
@@ -7,7 +7,7 @@ use p2panda_core::logs::LogRanges;
 use p2panda_core::{Cursor, Topic, VerifyingKey};
 use p2panda_net::sync::SyncHandle;
 use p2panda_store::{SqliteError, SqliteStore};
-use p2panda_sync::api::{StreamItem, log_ranges};
+use p2panda_sync::api::{LogEntry, log_ranges};
 use p2panda_sync::protocols::TopicLogSyncEvent;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -73,7 +73,7 @@ where
     let mut operations = log_ranges(store, ranges);
 
     while let Some(result) = operations.next().await {
-        let StreamItem {
+        let LogEntry {
             entry: operation, ..
         } = result?;
 


### PR DESCRIPTION
Whole bunch of doc-strings for the new `api` module in `p2panda-sync` with some minor API changes (mostly renames of types).